### PR TITLE
Gh 138 - manage node from gradle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,6 @@ cache:
     - client/node_modules
 
 before_install:
-  - nvm install node
-  - nvm use node
   - echo "run.environment(\"DB_DRIVER\", \"sqlserver\")" > localSettings.gradle
   - echo "run.environment(\"ANET_SA_PASSWORD\", \"SA-P@ssw0rd\")" >> localSettings.gradle
   - echo "run.environment(\"ANET_DB_SERVER\", \"localhost\")"  >> localSettings.gradle
@@ -35,14 +33,9 @@ before_install:
 
 #By default travis runs gradle assemble in install. This is too early as we don't want to build yet
 install:
-  - cd client
-  - npm install
-  - cd ..
+  - ./gradlew npmInstall
 
 script:
-  - cd client
-  - npm run build
-  - cd ..
   - ./gradlew dbMigrate
   - docker exec -ti anet-mssql-server /opt/mssql-tools/bin/sqlcmd -S localhost -U anetUser -P 'Test-P@ssw0rd' -d testAnet -i /hostdata/insertBaseData.sql
   - ./gradlew check

--- a/build.gradle
+++ b/build.gradle
@@ -86,8 +86,8 @@ run.args = ["server","anet.yml"]
 
 
 task buildClient(type: NpmTask) {
-    outputs.upToDateWhen { false };
-    args = ['run', 'build']
+	outputs.upToDateWhen { false };
+	args = ['run', 'build']
 }
 
 task dbStatus(dependsOn: 'compileJava', type: JavaExec) {

--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,7 @@ apply plugin: 'checkstyle'
 apply plugin: 'org.kordamp.markdown.convert'
 apply plugin: 'com.bmuschko.docker-java-application'
 apply plugin: "se.bjurr.gitchangelog.git-changelog-gradle-plugin"
+apply plugin: 'com.moowork.node'
 
 apply from: 'localSettings.gradle'
 
@@ -82,6 +83,12 @@ if (dbDriver == "sqlserver") {
 test.environment = run.environment
 
 run.args = ["server","anet.yml"]
+
+
+task buildClient(type: NpmTask) {
+    outputs.upToDateWhen { false };
+    args = ['run', 'build']
+}
 
 task dbStatus(dependsOn: 'compileJava', type: JavaExec) {
 	classpath = sourceSets.main.runtimeClasspath
@@ -160,6 +167,8 @@ task changelog (type: se.bjurr.gitchangelog.plugin.gradle.GitChangelogTask) {
 	templateContent = file('docs/changelog.mustache').getText('UTF-8');
 }
 
+classes.dependsOn buildClient
+
 //Configure the Java Checkstyle settings. Run with ./gradlew check
 checkstyle {
 	configFile = rootProject.file('gradle/checkstyle.xml')
@@ -192,6 +201,7 @@ buildscript {
 		classpath "org.kordamp:markdown-gradle-plugin:1.1.0"
 		classpath 'com.bmuschko:gradle-docker-plugin:3.0.12'
 		classpath "gradle.plugin.se.bjurr.gitchangelog:git-changelog-gradle-plugin:1.50"
+		classpath "com.moowork.gradle:gradle-node-plugin:1.2.0"
 	}
 }
 
@@ -221,3 +231,7 @@ allprojects {
 	markdownToHtml.hardwraps = true
 }
 
+node {
+
+	nodeModulesDir = file("${project.projectDir}/client")
+}

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -1,22 +1,16 @@
 # How to build ANET from Source
 
-ANET must be build in two parts, the client, then the server.  This document assumes you have a complete development environment set up and working.  You should always run all tests before generating a build!
+This document assumes you have a complete development environment set up and working.  You should always run all tests before generating a build!
 
 Linux/Mac:
 ```
 ./gradlew check # Runs checkstyle test and unit tests
-cd client/
-npm run build  # Builds the client
-cd ../
 ./gradlew distZip  # Builds the client, server, and all dependencies into a single .zip file 
 ```
 
 Windows:
 ```
 ./gradlew check # Runs checkstyle test and unit tests
-cd client\
-node.exe scripts\build.js  # Builds the client
-cd ..\
 gradlew.bat distZip  # Builds the client, server, and all dependencies into a single .zip file 
 ```
 

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -4,13 +4,13 @@ This document assumes you have a complete development environment set up and wor
 
 Linux/Mac:
 ```
-./gradlew check # Runs checkstyle test and unit tests
+./gradlew check    # Runs checkstyle test and unit tests
 ./gradlew distZip  # Builds the client, server, and all dependencies into a single .zip file 
 ```
 
 Windows:
 ```
-./gradlew check # Runs checkstyle test and unit tests
+gradlew.bat check    # Runs checkstyle test and unit tests
 gradlew.bat distZip  # Builds the client, server, and all dependencies into a single .zip file 
 ```
 


### PR DESCRIPTION
This simplifies things. Unfortunately, now 'npm run build' is done twice during a travis build - once during gradle dbMigrate and once during gradle check.
To fix this, I need to replace the build.js script or integrate it with upToDateWhen in gradle to avoid running it twice.
I suggest to keep it like this for a while, and then review the webpack set-up