### PR TITLE
Fix pagination and width

### DIFF
--- a/client/src/components/ReportCollection.js
+++ b/client/src/components/ReportCollection.js
@@ -65,7 +65,7 @@ export default class ReportCollection extends Component {
 
 		if (this.props.paginatedReports) {
 			var {pageSize, pageNum, totalCount} = this.props.paginatedReports
-			var numPages = Math.ceil(totalCount / pageSize)
+			var numPages = (pageSize <= 0) ? 1 : Math.ceil(totalCount / pageSize)
 			reports = this.props.paginatedReports.list
 			pageNum++
 		} else {

--- a/client/src/export.js
+++ b/client/src/export.js
@@ -81,8 +81,7 @@ export class CSVExport {
 
 	getSearchAll(type, query) {
 //		query = Object.without(query, 'type')
-		query.pageSize = 100000
-		query.pageNum = 0
+		query.pageSize = 0  // retrieve all the filtered reports
 
 		let config = this.search_config[type]
 		let part = new GQL.Part(/* GraphQL */`

--- a/client/src/pages/rollup/Show.js
+++ b/client/src/pages/rollup/Show.js
@@ -102,6 +102,7 @@ export default class RollupShow extends Page {
 			sortBy: "ENGAGEMENT_DATE",
 			sortOrder: "DESC",
 			pageNum: this.state.reportsPageNum,
+			pageSize: 10,
 		}
 
 		let graphQueryUrl = `/api/reports/rollupGraph?startDate=${rollupQuery.releasedAtStart}&endDate=${rollupQuery.releasedAtEnd}`

--- a/client/src/pages/rollup/Show.js
+++ b/client/src/pages/rollup/Show.js
@@ -229,7 +229,9 @@ export default class RollupShow extends Page {
 		const BAR_HEIGHT = 24
 		const BAR_PADDING = 8
 		const MARGIN = {top: 0, right: 10, bottom: 20, left: 150}
-		let width = this.graph.clientWidth - MARGIN.left - MARGIN.right
+		let box = this.graph.getBoundingClientRect()
+		let boxWidth = box.right - box.left
+		let width = boxWidth - MARGIN.left - MARGIN.right
 		let height = (BAR_HEIGHT + BAR_PADDING) * graphData.length - BAR_PADDING
 
 		let maxNumberOfReports = Math.max.apply(Math, graphData.map(d => d.released + d.cancelled))


### PR DESCRIPTION
Fix pagination on the daily rollup, and make sure all reports are exported (and not just the first 100000).
Also set the chart width for the daily rollup in a more cross-browser compatible way.