### PR TITLE
NCI-Agency/anet#148: Filter on organization type based on the selected position type

### DIFF
--- a/client/src/components/AdvancedSearch.js
+++ b/client/src/components/AdvancedSearch.js
@@ -23,6 +23,11 @@ export default class AdvancedSearch extends Component {
 	}
 
 	@autobind
+	setOrganizationFilter(el) {
+		this.setState({organizationFilter: el})
+	}
+
+	@autobind
 	getFilters(context) {
 		let filters = {}
 		filters.Reports = {
@@ -132,7 +137,7 @@ export default class AdvancedSearch extends Component {
 				Organization: <OrganizationFilter
 					queryKey="organizationId"
 					queryIncludeChildOrgsKey="includeChildrenOrgs"
-					queryParams={{type: 'ADVISOR_ORG'}}
+					ref={this.setOrganizationFilter}
 				/>,
 				Status: <SelectSearchFilter
 					queryKey="status"
@@ -214,7 +219,7 @@ export default class AdvancedSearch extends Component {
 			</SearchFilter>
 
 			{filters.map(filter =>
-				<SearchFilter key={filter.key} query={this.state} filter={filter} onRemove={this.removeFilter} element={filterDefs[filter.key]} />
+				<SearchFilter key={filter.key} query={this.state} filter={filter} onRemove={this.removeFilter} element={filterDefs[filter.key]} organizationFilter={this.state.organizationFilter} />
 			)}
 
 			<Row>
@@ -264,6 +269,15 @@ export default class AdvancedSearch extends Component {
 		let filters = this.state.filters
 		filters.splice(filters.indexOf(filter), 1)
 		this.setState({filters})
+
+		if (filter.key === "Organization") {
+			this.setOrganizationFilter(null)
+		} else if (filter.key === "Position type") {
+			let organizationFilter = this.state.organizationFilter
+			if (organizationFilter) {
+				organizationFilter.setState({queryParams: {}})
+			}
+		}
 	}
 
 	@autobind
@@ -316,5 +330,19 @@ class SearchFilter extends Component {
 	onChange(value) {
 		let filter = this.props.filter
 		filter.value = value
+
+		if (filter.key === "Position type") {
+			let organizationFilter = this.props.organizationFilter
+			if (organizationFilter) {
+				let positionType = filter.value.value || ""
+				if (positionType === "PRINCIPAL") {
+					organizationFilter.setState({queryParams: {type: "PRINCIPAL_ORG"}})
+				} else if (positionType === "ADVISOR") {
+					organizationFilter.setState({queryParams: {type: "ADVISOR_ORG"}})
+				} else {
+					organizationFilter.setState({queryParams: {}})
+				}
+			}
+		}
 	}
 }

--- a/client/src/components/advancedSearch/OrganizationFilter.js
+++ b/client/src/components/advancedSearch/OrganizationFilter.js
@@ -30,6 +30,7 @@ export default class OrganizationFilter extends Component {
 		this.state = {
 			value: props.value || {},
 			includeChildOrgs: props.value.includeChildOrgs || false,
+			queryParams: props.queryParams || {},
 		}
 
 		this.updateFilter()
@@ -40,7 +41,7 @@ export default class OrganizationFilter extends Component {
 	}
 
 	render() {
-		let autocompleteProps = Object.without(this.props, 'value', 'queryKey', 'queryIncludeChildOrgsKey')
+		let autocompleteProps = Object.without(this.props, 'value', 'queryKey', 'queryIncludeChildOrgsKey', 'queryParams')
 
 		return <div>
 			<Autocomplete
@@ -48,6 +49,7 @@ export default class OrganizationFilter extends Component {
 				valueKey="shortName"
 				url="/api/organizations/search"
 				placeholder="Filter by organization..."
+				queryParams={this.state.queryParams}
 				{...autocompleteProps}
 				onChange={this.onAutocomplete}
 				value={this.state.value}


### PR DESCRIPTION
This adds a relation between the filters on position type and organization
when searching for a position. When both filters are present, the selected
position type determines the organization type for autosuggestions in the
organization filter. If the position type filter is absent, organizations
of any type are suggested.