### PR TITLE
Include organizations with no reports in the daily rollup graph

### DIFF
--- a/anet.yml
+++ b/anet.yml
@@ -157,6 +157,8 @@ dictionary:
   NAV_BAR_ALL_ADVISOR_ORGS: All EFs / AOs
   pinned_ORGs:
     - Key Leader Engagement
+  non_reporting_ORGs:
+    - ANET Administrators
   countries:
     - Afghanistan
     - Albania

--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,7 @@ dependencies {
 	compile group: 'io.dropwizard', name: 'dropwizard-auth', version: '1.0.2'
 	compile group: 'io.dropwizard', name: 'dropwizard-views-freemarker', version: '1.0.2'
 	compile group: 'io.dropwizard', name: 'dropwizard-assets', version: '1.0.2'
+	compile group: 'org.antlr', name: 'stringtemplate', version: '3.2.1'
 
 	compile 'org.xerial:sqlite-jdbc:3.14.2.1' //If using SQLite
 	compile 'javax.mail:mail:1.4.7'

--- a/client/src/pages/rollup/Show.js
+++ b/client/src/pages/rollup/Show.js
@@ -140,10 +140,13 @@ export default class RollupShow extends Page {
 					.sort((a, b) => {
 						let a_index = pinned_ORGs.indexOf(a.org.shortName)
 						let b_index = pinned_ORGs.indexOf(b.org.shortName)
-						if (a_index<0)
-							return (b_index<0) ?  a.org.shortName.localeCompare(b.org.shortName) : 1
-						else
+						if (a_index<0) {
+							let nameOrder = a.org.shortName.localeCompare(b.org.shortName)
+							return (b_index<0) ?  (nameOrder === 0 ? a.org.id - b.org.id : nameOrder)  : 1
+						}
+						else {
 							return (b_index<0) ? -1 : a_index-b_index
+						}
 					})
 			})
 		})

--- a/client/src/pages/rollup/Show.js
+++ b/client/src/pages/rollup/Show.js
@@ -244,8 +244,12 @@ export default class RollupShow extends Page {
 						.domain([0, maxNumberOfReports])
 						.range([0, width])
 
+		let yLabels = {}
 		let yScale = d3.scaleBand()
-						.domain(graphData.map(d => d.org.shortName))
+						.domain(graphData.map(function(d) {
+							yLabels[d.org.id] = d.org.shortName
+							return d.org.id
+						}))
 						.range([0, height])
 
 		let graph = d3.select(this.graph)
@@ -258,6 +262,9 @@ export default class RollupShow extends Page {
 
 		let xAxis = d3.axisBottom(xScale).ticks(Math.min(maxNumberOfReports, 10), 'd')
 		let yAxis = d3.axisLeft(yScale)
+						.tickFormat(function(d) {
+							return yLabels[d]
+						})
 
 		graph.append('g').call(yAxis)
 		graph.append('g')

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -156,6 +156,96 @@ If needed, see https://github.com/Waffle/waffle/blob/master/Docs/ServletSingleSi
 
 - **logging**: See the Dropwizard documentation for all the details of how to use this section.  This controls the classes that you want to collect logs from and where to send them.  Set the `currentLogFilename` paramters to the location that you want the logs to appear.  
 
+Finally, you can define a deployment-specific dictionary inside the `anet.yml` file.
+Currently, the recognized entries in the dictionary (and suggested values for each of them) are:
+```
+dictionary:
+  PRINCIPAL_PERSON_TITLE: Afghan Partner
+  ADVISOR_PERSON_TITLE: NATO Member
+  PRINCIPAL_POSITION_NAME: Afghan Tashkil
+  ADVISOR_POSITION_NAME: NATO Billet
+  ADVISOR_POSITION_TYPE_TITLE: NATO Advisor
+  SUPER_USER_POSITION_TYPE_TITLE: ANET Super User
+  ADMINISTRATOR_POSITION_TYPE_TITLE: ANET Administrator
+  PRINCIPAL_ORG_NAME: Afghan Government Organization
+  ADVISOR_ORG_NAME: Advisor Organization
+  POAM_LONG_NAME: Plan of Action and Milestones / Pillars
+  POAM_SHORT_NAME: PoAM
+  NAV_BAR_ALL_ADVISOR_ORGS: All EFs / AOs
+  pinned_ORGs:
+    - Key Leader Engagement
+  non_reporting_ORGs:
+    - ANET Administrators
+  countries:
+    - Afghanistan
+    - Albania
+    - Armenia
+    - Australia
+    - Austria
+    - Azerbaijan
+    - Belgium
+    - Bosnia-Herzegovina
+    - Bulgaria
+    - Croatia
+    - Czech Republic
+    - Denmark
+    - Estonia
+    - Finland
+    - Georgia
+    - Germany
+    - Greece
+    - Hungary
+    - Iceland
+    - Italy
+    - Latvia
+    - Lithuania
+    - Luxembourg
+    - Macedonia
+    - Mongolia
+    - Montenegro
+    - Netherlands
+    - New Zealand
+    - Norway
+    - Poland
+    - Portugal
+    - Romania
+    - Slovakia
+    - Slovenia
+    - Spain
+    - Sweden
+    - Turkey
+    - Ukraine
+    - United Kingdom
+    - United States of America
+  ranks:
+    - CIV
+    - CTR
+    - OR-1
+    - OR-2
+    - OR-3
+    - OR-4
+    - OR-5
+    - OR-6
+    - OR-7
+    - OR-8
+    - OR-9
+    - WO-1
+    - WO-2
+    - WO-3
+    - WO-4
+    - WO-5
+    - OF-1
+    - OF-2
+    - OF-3
+    - OF-4
+    - OF-5
+    - OF-6
+    - OF-7
+    - OF-8
+    - OF-9
+    - OF-10
+```
+As can be seen from the example above, the entries `pinned_ORGs`, `non_reporting_ORGs`, `countries` and `ranks` are lists of values; the others are simple key/value pairs. The values in the `pinned_ORGs` and `non_reporting_ORGs` lists should match the shortName field of organizations in the database. The key/value pairs are mostly used as deployment-specific labels for fields in the user interface.
 
 # How to enable SSL
 Below is a subset from the complete Dropwizard Documentation that can be found here: http://www.dropwizard.io/1.0.5/docs/manual/core.html#ssl

--- a/docs/anet.yml.production.template
+++ b/docs/anet.yml.production.template
@@ -132,3 +132,89 @@ logging:
       currentLogFilename: ./logs/anet.log
       archivedLogFilenamePattern: ./logs/anet-%d.log.zip
       archivedFileCount: 2
+
+dictionary:
+  PRINCIPAL_PERSON_TITLE: Afghan Partner
+  ADVISOR_PERSON_TITLE: NATO Member
+  PRINCIPAL_POSITION_NAME: Afghan Tashkil
+  ADVISOR_POSITION_NAME: NATO Billet
+  ADVISOR_POSITION_TYPE_TITLE: NATO Advisor
+  SUPER_USER_POSITION_TYPE_TITLE: ANET Super User
+  ADMINISTRATOR_POSITION_TYPE_TITLE: ANET Administrator
+  PRINCIPAL_ORG_NAME: Afghan Government Organization
+  ADVISOR_ORG_NAME: Advisor Organization
+  POAM_LONG_NAME: Plan of Action and Milestones / Pillars
+  POAM_SHORT_NAME: PoAM
+  NAV_BAR_ALL_ADVISOR_ORGS: All EFs / AOs
+  pinned_ORGs:
+    - Key Leader Engagement
+  non_reporting_ORGs:
+    - ANET Administrators
+  countries:
+    - Afghanistan
+    - Albania
+    - Armenia
+    - Australia
+    - Austria
+    - Azerbaijan
+    - Belgium
+    - Bosnia-Herzegovina
+    - Bulgaria
+    - Croatia
+    - Czech Republic
+    - Denmark
+    - Estonia
+    - Finland
+    - Georgia
+    - Germany
+    - Greece
+    - Hungary
+    - Iceland
+    - Italy
+    - Latvia
+    - Lithuania
+    - Luxembourg
+    - Macedonia
+    - Mongolia
+    - Montenegro
+    - Netherlands
+    - New Zealand
+    - Norway
+    - Poland
+    - Portugal
+    - Romania
+    - Slovakia
+    - Slovenia
+    - Spain
+    - Sweden
+    - Turkey
+    - Ukraine
+    - United Kingdom
+    - United States of America
+  ranks:
+    - CIV
+    - CTR
+    - OR-1
+    - OR-2
+    - OR-3
+    - OR-4
+    - OR-5
+    - OR-6
+    - OR-7
+    - OR-8
+    - OR-9
+    - WO-1
+    - WO-2
+    - WO-3
+    - WO-4
+    - WO-5
+    - OF-1
+    - OF-2
+    - OF-3
+    - OF-4
+    - OF-5
+    - OF-6
+    - OF-7
+    - OF-8
+    - OF-9
+    - OF-10

--- a/src/main/java/mil/dds/anet/database/OrganizationDao.java
+++ b/src/main/java/mil/dds/anet/database/OrganizationDao.java
@@ -7,6 +7,10 @@ import org.joda.time.DateTime;
 import org.skife.jdbi.v2.GeneratedKeys;
 import org.skife.jdbi.v2.Handle;
 import org.skife.jdbi.v2.Query;
+import org.skife.jdbi.v2.sqlobject.SqlQuery;
+import org.skife.jdbi.v2.sqlobject.customizers.Mapper;
+import org.skife.jdbi.v2.sqlobject.stringtemplate.UseStringTemplate3StatementLocator;
+import org.skife.jdbi.v2.unstable.BindIn;
 
 import mil.dds.anet.AnetObjectEngine;
 import mil.dds.anet.beans.Organization;
@@ -62,7 +66,25 @@ public class OrganizationDao implements IAnetDao<Organization> {
 			.map(new OrganizationMapper())
 			.list();
 	}
-	
+
+	@UseStringTemplate3StatementLocator
+	public interface OrgListQueries {
+		@Mapper(OrganizationMapper.class)
+		@SqlQuery("SELECT id AS organizations_id" +
+				", shortName AS organizations_shortName" +
+				", longName AS organizations_longName" +
+				", type AS organizations_type" +
+				", parentOrgId AS organizations_parentOrgId" +
+				", createdAt AS organizations_createdAt" +
+				", updatedAt AS organizations_updatedAt" +
+				" FROM organizations WHERE shortName IN ( <shortNames> )")
+		public List<Organization> getOrgsByShortNames(@BindIn("shortNames") List<String> shortNames);
+	}
+
+	public List<Organization> getOrgsByShortNames(List<String> shortNames) {
+		return dbHandle.attach(OrgListQueries.class).getOrgsByShortNames(shortNames);
+	}
+
 	public Organization insert(Organization org) {
 		org.setCreatedAt(DateTime.now());
 		org.setUpdatedAt(org.getCreatedAt());

--- a/src/main/java/mil/dds/anet/database/OrganizationDao.java
+++ b/src/main/java/mil/dds/anet/database/OrganizationDao.java
@@ -1,5 +1,6 @@
 package mil.dds.anet.database;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -82,6 +83,9 @@ public class OrganizationDao implements IAnetDao<Organization> {
 	}
 
 	public List<Organization> getOrgsByShortNames(List<String> shortNames) {
+		if (shortNames == null || shortNames.isEmpty()) {
+			return Collections.emptyList();
+		}
 		return dbHandle.attach(OrgListQueries.class).getOrgsByShortNames(shortNames);
 	}
 

--- a/src/main/java/mil/dds/anet/database/ReportDao.java
+++ b/src/main/java/mil/dds/anet/database/ReportDao.java
@@ -342,7 +342,7 @@ public class ReportDao implements IAnetDao<Report> {
 		return generateRollupGraphFromResults(results, orgMap);
 	}
 	
-	/* Generates a Rollup graph for a particular organiztaion.  Starting with a given parent Organization */
+	/* Generates a Rollup graph for a particular organization.  Starting with a given parent Organization */
 	public List<RollupGraph> getDailyRollupGraph(DateTime start, DateTime end, Integer parentOrgId, OrganizationType orgType) {
 		List<Organization> orgList = null;
 		Map<Integer,Organization> orgMap;
@@ -571,11 +571,23 @@ public class ReportDao implements IAnetDao<Report> {
 			Map<ReportState,Integer> orgBar = rollup.get(parentOrgId);
 			if (orgBar == null) { 
 				orgBar = new HashMap<ReportState,Integer>();
-				rollup.put(parentOrgId,  orgBar);
+				rollup.put(parentOrgId, orgBar);
 			}
 			orgBar.put(state,  Utils.orIfNull(orgBar.get(state), 0) + count);
 		}
-		
+
+		// Add all (top-level) organizations without any reports
+		for (final Map.Entry<Integer, Organization> entry : orgMap.entrySet()) {
+			final Integer orgId = entry.getKey();
+			final Integer parentOrgId = (orgId== null) ? null : DaoUtils.getId(orgMap.get(orgId));
+			if (!rollup.keySet().contains(parentOrgId)) {
+				final Map<ReportState, Integer> orgBar = new HashMap<ReportState, Integer>();
+				orgBar.put(ReportState.RELEASED, 0);
+				orgBar.put(ReportState.CANCELLED, 0);
+				rollup.put(parentOrgId, orgBar);
+			}
+		}
+
 		List<RollupGraph> result = new LinkedList<RollupGraph>();
 		for (Map.Entry<Integer, Map<ReportState,Integer>> entry : rollup.entrySet()) { 
 			Map<ReportState,Integer> values = entry.getValue();

--- a/src/main/java/mil/dds/anet/database/ReportDao.java
+++ b/src/main/java/mil/dds/anet/database/ReportDao.java
@@ -335,15 +335,15 @@ public class ReportDao implements IAnetDao<Report> {
 	}
 	
 	/* Generates the Rollup Graph for a particular Organization Type, starting at the root of the org hierarchy */
-	public List<RollupGraph> getDailyRollupGraph(DateTime start, DateTime end, OrganizationType orgType) {
+	public List<RollupGraph> getDailyRollupGraph(DateTime start, DateTime end, OrganizationType orgType, Map<Integer, Organization> nonReportingOrgs) {
 		List<Map<String, Object>> results = rollupQuery(start, end, orgType, null, false);
 		Map<Integer,Organization> orgMap = AnetObjectEngine.getInstance().buildTopLevelOrgHash(orgType);
 		
-		return generateRollupGraphFromResults(results, orgMap);
+		return generateRollupGraphFromResults(results, orgMap, nonReportingOrgs);
 	}
 	
 	/* Generates a Rollup graph for a particular organization.  Starting with a given parent Organization */
-	public List<RollupGraph> getDailyRollupGraph(DateTime start, DateTime end, Integer parentOrgId, OrganizationType orgType) {
+	public List<RollupGraph> getDailyRollupGraph(DateTime start, DateTime end, Integer parentOrgId, OrganizationType orgType, Map<Integer, Organization> nonReportingOrgs) {
 		List<Organization> orgList = null;
 		Map<Integer,Organization> orgMap;
 		if (parentOrgId.equals(-1) == false) { // -1 is code for no parent org.  
@@ -364,7 +364,7 @@ public class ReportDao implements IAnetDao<Report> {
 		
 		List<Map<String,Object>> results = rollupQuery(start, end, orgType, orgList, parentOrgId.equals(-1));
 		
-		return generateRollupGraphFromResults(results, orgMap);
+		return generateRollupGraphFromResults(results, orgMap, nonReportingOrgs);
 	}
 
 	/* Generates Advisor Report Insights for Organizations */
@@ -559,15 +559,19 @@ public class ReportDao implements IAnetDao<Report> {
 	 * And the map of each organization to the organization that their reports roll up to
 	 * this method returns the final rollup graph information. 
 	 */
-	private List<RollupGraph> generateRollupGraphFromResults(List<Map<String,Object>> dbResults, Map<Integer, Organization> orgMap) { 
+	private List<RollupGraph> generateRollupGraphFromResults(List<Map<String,Object>> dbResults, Map<Integer, Organization> orgMap, Map<Integer, Organization> nonReportingOrgs) {
 		Map<Integer,Map<ReportState,Integer>> rollup = new HashMap<Integer,Map<ReportState,Integer>>();
 		
 		for (Map<String,Object> result : dbResults) { 
 			Integer orgId = (Integer) result.get("orgId");
+			if (nonReportingOrgs.containsKey(orgId)) {
+				// Skip non-reporting organizations
+				continue;
+			}
 			Integer count = (Integer) result.get("count");
 			ReportState state = ReportState.values()[(Integer) result.get("state")];
 		
-			Integer parentOrgId = (orgId == null) ? null : DaoUtils.getId(orgMap.get(orgId));
+			Integer parentOrgId = DaoUtils.getId(orgMap.get(orgId));
 			Map<ReportState,Integer> orgBar = rollup.get(parentOrgId);
 			if (orgBar == null) { 
 				orgBar = new HashMap<ReportState,Integer>();
@@ -579,7 +583,11 @@ public class ReportDao implements IAnetDao<Report> {
 		// Add all (top-level) organizations without any reports
 		for (final Map.Entry<Integer, Organization> entry : orgMap.entrySet()) {
 			final Integer orgId = entry.getKey();
-			final Integer parentOrgId = (orgId== null) ? null : DaoUtils.getId(orgMap.get(orgId));
+			if (nonReportingOrgs.containsKey(orgId)) {
+				// Skip non-reporting organizations
+				continue;
+			}
+			final Integer parentOrgId = DaoUtils.getId(orgMap.get(orgId));
 			if (!rollup.keySet().contains(parentOrgId)) {
 				final Map<ReportState, Integer> orgBar = new HashMap<ReportState, Integer>();
 				orgBar.put(ReportState.RELEASED, 0);

--- a/src/main/java/mil/dds/anet/resources/ReportResource.java
+++ b/src/main/java/mil/dds/anet/resources/ReportResource.java
@@ -4,6 +4,7 @@ import java.io.StringWriter;
 import java.lang.invoke.MethodHandles;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -638,14 +639,16 @@ public class ReportResource implements IGraphQLResource {
 			@QueryParam("principalOrganizationId") Integer principalOrgId) {
 		DateTime startDate = new DateTime(start);
 		DateTime endDate = new DateTime(end);
+		final List<String> nonReportingOrgsShortNames = (List<String>) config.getDictionary().get("non_reporting_ORGs");
+		final Map<Integer, Organization> nonReportingOrgs = getOrgsByShortNames(nonReportingOrgsShortNames);
 		if (principalOrgId != null) { 
-			return dao.getDailyRollupGraph(startDate, endDate, principalOrgId, OrganizationType.PRINCIPAL_ORG);
+			return dao.getDailyRollupGraph(startDate, endDate, principalOrgId, OrganizationType.PRINCIPAL_ORG, nonReportingOrgs);
 		} else if (advisorOrgId != null) { 
-			return dao.getDailyRollupGraph(startDate, endDate, advisorOrgId, OrganizationType.ADVISOR_ORG);
+			return dao.getDailyRollupGraph(startDate, endDate, advisorOrgId, OrganizationType.ADVISOR_ORG, nonReportingOrgs);
 		}
 		
 		if (orgType == null) { orgType = OrganizationType.ADVISOR_ORG; } 
-		return dao.getDailyRollupGraph(startDate, endDate, orgType);
+		return dao.getDailyRollupGraph(startDate, endDate, orgType, nonReportingOrgs);
 	}
 
 	@POST
@@ -743,5 +746,13 @@ public class ReportResource implements IGraphQLResource {
 			final Set<String> tlf = Stream.of("name").collect(Collectors.toSet());
 			return Utils.resultGrouper(list, "stats", "personId", tlf);
 		}
+	}
+
+	private Map<Integer, Organization> getOrgsByShortNames(List<String> orgShortNames) {
+		final Map<Integer, Organization> result = new HashMap<>();
+		for (final Organization organization : engine.getOrganizationDao().getOrgsByShortNames(orgShortNames)) {
+			result.put(organization.getId(), organization);
+		}
+		return result;
 	}
 }

--- a/src/main/java/mil/dds/anet/resources/ReportResource.java
+++ b/src/main/java/mil/dds/anet/resources/ReportResource.java
@@ -639,6 +639,7 @@ public class ReportResource implements IGraphQLResource {
 			@QueryParam("principalOrganizationId") Integer principalOrgId) {
 		DateTime startDate = new DateTime(start);
 		DateTime endDate = new DateTime(end);
+		@SuppressWarnings("unchecked")
 		final List<String> nonReportingOrgsShortNames = (List<String>) config.getDictionary().get("non_reporting_ORGs");
 		final Map<Integer, Organization> nonReportingOrgs = getOrgsByShortNames(nonReportingOrgsShortNames);
 		if (principalOrgId != null) { 


### PR DESCRIPTION
Show all organizations in the daily rollup graph except those defined in the list `non_reporting_ORGs` in the dictionary inside `anet.yml`.
Closes NCI-Agency/anet#190.