### PR TITLE
Fix advisor reports show on insights page

### DIFF
--- a/client/src/components/Nav.js
+++ b/client/src/components/Nav.js
@@ -138,6 +138,9 @@ class Nav extends Component {
 						<Link to="/insights/reports-by-poam">
 							<MenuItem>Reports by PoAM</MenuItem>
 						</Link>
+						<Link to="/insights/advisor-reports">
+							<MenuItem>Advisor reports</MenuItem>
+						</Link>
 					</NavDropdown>
 				}
 			</BSNav>

--- a/client/src/pages/insights/Show.js
+++ b/client/src/pages/insights/Show.js
@@ -18,24 +18,24 @@ const insightDetails = {
     component: NotApprovedReports,
     title: 'Not Approved Reports',
     help: 'Number of reports not approved since',
-    showCalander: true
+    showCalendar: true
   },
   'cancelled-reports': {
     component: CancelledReports,
     title: 'Cancelled Reports',
     help: 'Number of reports cancelled since',
-    showCalander: true
+    showCalendar: true
   },
   'reports-by-poam': {
     component: ReportsByPoam,
     title: 'Reports by PoAM',
     help: 'Number of reports by PoAM',
-    showCalander: true
+    showCalendar: true
   },
   'advisor-reports': {
     component: FilterableAdvisorReportsTable,
     title: 'Advisor Reports',
-    showCalander: false
+    showCalendar: false
   },
 }
 const calendarButtonCss = {
@@ -90,7 +90,7 @@ export default class InsightsShow extends Page {
     let insightPath = '/insights/' + this.state.insight
 
     const help = insightDetails[this.state.insight].help
-    const showCalander = insightDetails[this.state.insight].showCalander
+    const showCalendar = insightDetails[this.state.insight].showCalendar
     return (
       <div>
         <Breadcrumbs items={[['Insights ' + insightTitle, insightPath]]} />
@@ -100,7 +100,7 @@ export default class InsightsShow extends Page {
           <Fieldset id={this.state.insight} data-jumptarget title={
             <span>
               {insightTitle} - {this.referenceDateLongStr}
-            {showCalander &&
+            {showCalendar &&
               <CalendarButton onChange={this.changeReferenceDate} value={this.state.referenceDate.toISOString()} style={calendarButtonCss} />
             }
             </span>

--- a/client/src/pages/insights/Show.js
+++ b/client/src/pages/insights/Show.js
@@ -17,17 +17,25 @@ const insightDetails = {
   'not-approved-reports': {
     component: NotApprovedReports,
     title: 'Not Approved Reports',
-    help: 'Number of reports not approved since'
+    help: 'Number of reports not approved since',
+    showCalander: true
   },
   'cancelled-reports': {
     component: CancelledReports,
     title: 'Cancelled Reports',
-    help: 'Number of reports cancelled since'
+    help: 'Number of reports cancelled since',
+    showCalander: true
   },
   'reports-by-poam': {
     component: ReportsByPoam,
     title: 'Reports by PoAM',
-    help: 'Number of reports by PoAM'
+    help: 'Number of reports by PoAM',
+    showCalander: true
+  },
+  'advisor-reports': {
+    component: FilterableAdvisorReportsTable,
+    title: 'Advisor Reports',
+    showCalander: false
   },
 }
 const calendarButtonCss = {
@@ -80,6 +88,9 @@ export default class InsightsShow extends Page {
     let InsightComponent = insightDetails[this.state.insight].component
     let insightTitle = insightDetails[this.state.insight].title
     let insightPath = '/insights/' + this.state.insight
+
+    const help = insightDetails[this.state.insight].help
+    const showCalander = insightDetails[this.state.insight].showCalander
     return (
       <div>
         <Breadcrumbs items={[['Insights ' + insightTitle, insightPath]]} />
@@ -89,21 +100,15 @@ export default class InsightsShow extends Page {
           <Fieldset id={this.state.insight} data-jumptarget title={
             <span>
               {insightTitle} - {this.referenceDateLongStr}
+            {showCalander &&
               <CalendarButton onChange={this.changeReferenceDate} value={this.state.referenceDate.toISOString()} style={calendarButtonCss} />
+            }
             </span>
             }>
-              <p className="help-text">{insightDetails[this.state.insight].help} {this.referenceDateLongStr}</p>
+              {help && <p className="help-text">{help} {this.referenceDateLongStr}</p> }
               <InsightComponent date={this.state.referenceDate.clone().startOf('day')} />
           </Fieldset>
         }
-
-        <Fieldset id="advisor-reports" data-jumptarget title={
-          <span>
-            Advisor Reports
-          </span>
-          }>
-          <FilterableAdvisorReportsTable />
-        </Fieldset>
       </div>
     )
   }


### PR DESCRIPTION
Advisor reports table is called dynamically from the insights menu. Show
calander parameter is added to toggle the calander filter, since it is
not needed in the Advisor Reports table.