### PR TITLE
Move coverity scans from candidate branch to dedicated candidate_scan branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ addons:
     notification_email: vassil.iordanov@gmail.com
     build_command_prepend: "./gradlew clean"
     build_command:   "./gradlew build -x test"
-    branch_pattern: candidate
+    branch_pattern: candidate_scan
   sonarcloud:
     organization: "nci-agency-github"
     token:


### PR DESCRIPTION

As we are exceeding our weekly quota and that affects the regular builds