### PR TITLE
Update MS SQL Server to 2017 CU1

### DIFF
--- a/docker/anet-mssql-linux/Dockerfile
+++ b/docker/anet-mssql-linux/Dockerfile
@@ -8,10 +8,10 @@ RUN export DEBIAN_FRONTEND=noninteractive ACCEPT_EULA=Y && \
     apt-get update && \
     apt-get install -y apt-transport-https curl  && \
     curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - && \
-    curl https://packages.microsoft.com/config/ubuntu/16.04/mssql-server.list | tee /etc/apt/sources.list.d/mssql-server.list && \
+    curl https://packages.microsoft.com/config/ubuntu/16.04/mssql-server-2017.list | tee /etc/apt/sources.list.d/mssql-server.list && \
     curl https://packages.microsoft.com/config/ubuntu/16.04/prod.list | tee /etc/apt/sources.list.d/msprod.list && \
     apt-get update && \
-    apt-get install -y mssql-server=14.0.600.250-2 mssql-server-fts=14.0.600.250-2 mssql-tools unixodbc-dev locales && \
+    apt-get install -y mssql-server=14.0.3006.16-3 mssql-server-fts=14.0.3006.16-3 mssql-tools unixodbc-dev locales sudo && \
     rm -rf /var/lib/apt/lists/* && \
     locale-gen en_US.UTF-8
     


### PR DESCRIPTION
See https://docs.microsoft.com/is-is/sql/linux/sql-server-linux-release-notes#CU1
This version (when run in Developer mode, which is the default) has no evaluation time limit.

Also install sudo as it is required when you want to run e.g.
  /opt/mssql/bin/mssql-conf setup
manually inside the container.