### PR TITLE
NCI-Agency/anet#278: Change title and description of some insights

### DIFF
--- a/client/src/components/CancelledEngagementReports.js
+++ b/client/src/components/CancelledEngagementReports.js
@@ -68,13 +68,12 @@ export default class CancelledEngagementReports extends Component {
           onBarClick={this.goToOrg}
           updateChart={this.state.updateChart}
           isLoading={this.state.isLoading} />
-        <p className="help-text">{`Number of cancelled engagement reports since ${this.referenceDateLongStr}, grouped by reason of cancelling`}</p>
+        <p className="help-text">{`Number of cancelled engagement reports since ${this.referenceDateLongStr}, grouped by reason for cancellation`}</p>
         <p className="chart-description">
           {`Displays the number of cancelled engagement reports released since
-            ${this.referenceDateLongStr}. The reports are grouped by reason of
-            cancelling. In order to see the list of cancelled engagement
-            reports for a reason of cancelling, click on the bar corresponding
-            to the reason of cancelling.`}
+            ${this.referenceDateLongStr}. The reports are grouped by reason for cancellation. In order to see the list of cancelled engagement
+            reports for a reason for cancellation, click on the bar corresponding
+            to the reason for cancellation.`}
         </p>
         <BarChartWithLoader
           chartId={chartByReasonId}

--- a/client/src/components/PendingApprovalReports.js
+++ b/client/src/components/PendingApprovalReports.js
@@ -50,10 +50,10 @@ export default class PendingApprovalReports extends Component {
     const focusDetails = this.focusDetails
     return (
       <div>
-        <p className="help-text">{`Number of reports pending approval since ${this.referenceDateLongStr}, grouped by advisor organization`}</p>
+        <p className="help-text">{`Number of pending reports, submited on or before ${this.referenceDateLongStr}, by advisor organization`}</p>
         <p className="chart-description">
           {`Displays the number of pending approval reports which have been
-            submitted up till ${this.referenceDateLongStr}. The reports are
+            submitted on or before ${this.referenceDateLongStr}. The reports are
             grouped by advisor organization. In order to see the list of
             pending approval reports for an organization, click on the bar
             corresponding to the organization.`}


### PR DESCRIPTION
This changes the title and description of the PendigApprovalReports and
CancelledEngagementReports insights in order to make them better
understandable.