### PR TITLE
NCI-Agency/anet#279: Fix FutureEngagementsByLocation chart

### DIFF
--- a/client/src/components/FutureEngagementsByLocation.js
+++ b/client/src/components/FutureEngagementsByLocation.js
@@ -14,7 +14,7 @@ import LoaderHOC from '../HOC/LoaderHOC'
 const d3 = require('d3')
 const chartId = 'future_engagements_by_location'
 
-const BarChartWithLoader = LoaderHOC('isLoading')('graphData')(HorizontalBarChart)
+const BarChartWithLoader = LoaderHOC('isLoading')('data')(HorizontalBarChart)
 
 
 /*


### PR DESCRIPTION
It was no longer loading the chart because of using a wrong property name.