### PR TITLE
Disable sourceclear scans

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ after_script:
   - docker logs anet-mssql-server
 
 addons:
-  srcclr: true
+  srcclr: false
   coverity_scan:
     project:
       name: "NCI-Agency/anet"


### PR DESCRIPTION
Due to a limit to the number of weekly scans, we are diabling sourceclear until we find a way to restrict the scans to a specific branch