### PR TITLE
NCI-Agency/anet#262: Explicitly return BAD_REQUEST for validation errors

### DIFF
--- a/src/main/java/mil/dds/anet/resources/OrganizationResource.java
+++ b/src/main/java/mil/dds/anet/resources/OrganizationResource.java
@@ -230,10 +230,10 @@ public class OrganizationResource implements IGraphQLResource {
 
 	private void validateApprovalStep(ApprovalStep step) {
 		if (Utils.isEmptyOrNull(step.getName())) {
-			throw new WebApplicationException("A name is required for every approval step");
+			throw new WebApplicationException("A name is required for every approval step", Status.BAD_REQUEST);
 		}
 		if (Utils.isEmptyOrNull(step.loadApprovers())) {
-			throw new WebApplicationException("An approver is required for every approval step");
+			throw new WebApplicationException("An approver is required for every approval step", Status.BAD_REQUEST);
 		}
 	}
 }


### PR DESCRIPTION
Otherwise the user will see the default "Internal Server Error" which is confusing.