### PR TITLE
Fix promise check

### DIFF
--- a/client/src/components/Page.js
+++ b/client/src/components/Page.js
@@ -49,7 +49,7 @@ export default class Page extends Component {
 
 			let promise = API.inProgress
 
-			if (promise && promise instanceof Promise) {
+			if (promise && promise.then instanceof Function) {
 				NProgress.set(0.5)
 				promise.then(this.doneLoading, this.doneLoading)
 			} else {


### PR DESCRIPTION
Here, promise is not an instance of Promise. But since we are only
interested in calling the 'then()' method, just check for that.
This makes the progress bar work again, and also show errors again for
non-existing objects.