### PR TITLE
Specify an explicit log format for all appenders

### DIFF
--- a/anet.yml
+++ b/anet.yml
@@ -92,8 +92,10 @@ server:
         currentLogFilename: ./logs/access.log
         archivedLogFilenamePattern: ./logs/access-%d.log.zip
         archivedFileCount: 5
+        logFormat: '[%t{yyyy-MM-dd HH:mm:ss.SSS,UTC}] %h %l %u "%r" %s %b "%i{Referer}" "%i{User-Agent}" %D'
       - type: console
         target: stdout
+        logFormat: '[%t{yyyy-MM-dd HH:mm:ss.SSS,UTC}] %h %l %u "%r" %s %b "%i{Referer}" "%i{User-Agent}" %D'
 
 # Configuration for the Freemarker templating library
 views:
@@ -112,6 +114,7 @@ logging:
           currentLogFilename: ./logs/dbLog.log
           archivedLogFilenamePattern: ./logs/dbLog-%d.log.zip
           archivedFileCount: 2
+          logFormat: '[%d{yyyy-MM-dd HH:mm:ss.SSS,UTC}] %p %c: %m%n'
     "org.sqlite.JDBC" : INFO
     "io.dropwizard.assets.AssetsBundle" : TRACE
     "io.dropwizard.assets.*" : TRACE
@@ -126,6 +129,7 @@ logging:
           currentLogFilename: ./logs/testingLogger.log
           archivedLogFilenamePattern: ./logs/testingLogger-%d.log.zip
           archivedFileCount: 2
+          logFormat: '[%d{yyyy-MM-dd HH:mm:ss.SSS,UTC}] %p %c: %m%n'
     "mil.dds.anet.utils.AnetAuditLogger" :
       level: INFO
       appenders:
@@ -133,15 +137,18 @@ logging:
           currentLogFilename: ./logs/auditLogger.log
           archivedLogFilenamePattern: ./logs/auditLogger-%d.log.zip
           archivedFileCount: 2
+          logFormat: '[%d{yyyy-MM-dd HH:mm:ss.SSS,UTC}] %p %c: %m%n'
   appenders:
     - type: console
       threshold: TRACE
       target: stdout
+      logFormat: '[%d{yyyy-MM-dd HH:mm:ss.SSS,UTC}] %p %c: %m%n'
     - type: file
       threshold: INFO
       currentLogFilename: ./logs/anet.log
       archivedLogFilenamePattern: ./logs/anet-%d.log.zip
       archivedFileCount: 2
+      logFormat: '[%d{yyyy-MM-dd HH:mm:ss.SSS,UTC}] %p %c: %m%n'
 
 dictionary:
   PRINCIPAL_PERSON_TITLE: Afghan Partner

--- a/docs/anet.yml.production.template
+++ b/docs/anet.yml.production.template
@@ -84,8 +84,10 @@ server:
         currentLogFilename: ./logs/access.log
         archivedLogFilenamePattern: ./logs/access-%d.log.zip
         archivedFileCount: 5
+        logFormat: '[%t{yyyy-MM-dd HH:mm:ss.SSS,UTC}] %h %l %u "%r" %s %b "%i{Referer}" "%i{User-Agent}" %D'
       - type: console
         target: stdout
+        logFormat: '[%t{yyyy-MM-dd HH:mm:ss.SSS,UTC}] %h %l %u "%r" %s %b "%i{Referer}" "%i{User-Agent}" %D'
 
 # Configuration for the Freemarker templating library
 views:
@@ -104,6 +106,7 @@ logging:
           currentLogFilename: ./logs/dbLog.log
           archivedLogFilenamePattern: ./logs/dbLog-%d.log.zip
           archivedFileCount: 2
+          logFormat: '[%d{yyyy-MM-dd HH:mm:ss.SSS,UTC}] %p %c: %m%n'
     "org.sqlite.JDBC" : INFO
     "io.dropwizard.assets.AssetsBundle" : INFO
     "io.dropwizard.assets.*" : INFO
@@ -117,6 +120,7 @@ logging:
           currentLogFilename: ./logs/testingLogger.log
           archivedLogFilenamePattern: ./logs/testingLogger-%d.log.zip
           archivedFileCount: 2
+          logFormat: '[%d{yyyy-MM-dd HH:mm:ss.SSS,UTC}] %p %c: %m%n'
     "mil.dds.anet.utils.AnetAuditLogger" :
       level: INFO
       appenders:
@@ -124,15 +128,18 @@ logging:
           currentLogFilename: ./logs/auditLogger.log
           archivedLogFilenamePattern: ./logs/auditLogger-%d.log.zip
           archivedFileCount: 2
+          logFormat: '[%d{yyyy-MM-dd HH:mm:ss.SSS,UTC}] %p %c: %m%n'
   appenders:
     - type: console
       threshold: INFO
       target: stdout
+      logFormat: '[%d{yyyy-MM-dd HH:mm:ss.SSS,UTC}] %p %c: %m%n'
     - type: file
       threshold: INFO
       currentLogFilename: ./logs/anet.log
       archivedLogFilenamePattern: ./logs/anet-%d.log.zip
       archivedFileCount: 2
+      logFormat: '[%d{yyyy-MM-dd HH:mm:ss.SSS,UTC}] %p %c: %m%n'
 
 dictionary:
   PRINCIPAL_PERSON_TITLE: Afghan Partner


### PR DESCRIPTION
Put a common timestamp at the front of all log messages, so we can
easily sort them in chronological logging order.