### PR TITLE
Minor test tweaks

### DIFF
--- a/src/test/java/mil/dds/anet/test/resources/AbstractResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/AbstractResourceTest.java
@@ -130,7 +130,7 @@ public abstract class AbstractResourceTest {
 			InputStream is = (InputStream) resp.getEntity();
 			return IOUtils.toString(is);
 		} catch (Exception e) {
-			logger.error("Exception getting repsonse entity", e);
+			logger.error("Exception getting response entity", e);
 			return null;
 		}
 	}

--- a/src/test/java/mil/dds/anet/test/resources/ReportsResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/ReportsResourceTest.java
@@ -738,6 +738,13 @@ public class ReportsResourceTest extends AbstractResourceTest {
 		query.setUpdatedAtEnd(actualReportDate);
 		results = httpQuery("/api/reports/search", admin).post(Entity.json(query), ReportList.class);
 		assertThat(results.getList().size()).isEqualTo(1);
+
+		// A day before the startDate and startDate (no results expected)
+		query.setUpdatedAtStart(startDate.minusDays(1));
+		query.setUpdatedAtEnd(startDate);
+		query.setPageSize(0);
+		results = httpQuery("/api/reports/search", admin).post(Entity.json(query), ReportList.class);
+		assertThat(results.getList().size()).isEqualTo(0);
 	}
 
 	@Test


### PR DESCRIPTION
Fixed a few things that don't really need to get mixed up with the functional changes in other PRs:

* fixed a typo in AbstractResourceTest
* added some assertions to the `createReport` test, which were useful in finding a weird infrastructure-related issue I was having, and are not bad assertions in themselves
* added a sort order to the search in testSensitiveInformationByAuthorizedPosition to avoid having the test suddenly start failing after tests have been run a few times without reloading base data
* tweaked searchUpdatedAtStartAndEndTest to actually do the searches it says it's going to do, instead of doing closely related ones and expecting them to fail.