### PR TITLE
GH-403: Fix future engagements insight chart

### DIFF
--- a/client/src/components/FutureEngagementsByLocation.js
+++ b/client/src/components/FutureEngagementsByLocation.js
@@ -135,7 +135,7 @@ export default class FutureEngagementsByLocation extends Component {
         .rollup(function(leaves) { return leaves.length })
         .entries(reportsList)
       let groupedData = allCategories.map((d)=> {
-        let categData = categoriesWithData.find((x) => { return x.key === d.key })
+        let categData = categoriesWithData.find((x) => {return Number(x.key) === d.key })
         return Object.assign({}, d, categData)
       })
       let graphData = {}


### PR DESCRIPTION
The chart was not showing any items any more since the last commit which
changed the comparison operator from "==" to "===". This because a type
conversion was also needed.