### PR TITLE
NCI-Agency/anet#440: Insert join condition at the end

### DIFF
--- a/src/main/java/mil/dds/anet/search/mssql/MssqlReportSearcher.java
+++ b/src/main/java/mil/dds/anet/search/mssql/MssqlReportSearcher.java
@@ -71,8 +71,7 @@ public class MssqlReportSearcher implements IReportSearcher {
 			args.put("freetextQuery", text);
 		}
 
-		sql.append(", people");
-		whereClauses.add("reports.authorId = people.id");
+		sql.append(", people");  // join condition added at the end
 
 		if (query.getAuthorId() != null) {
 			whereClauses.add("reports.authorId = :authorId");
@@ -277,6 +276,7 @@ public class MssqlReportSearcher implements IReportSearcher {
 		}
 
 		sql.append(" WHERE ");
+		whereClauses.add(0, "reports.authorId = people.id");  // add join condition at the front
 		sql.append(Joiner.on(" AND ").join(whereClauses));
 		sql.append(" ) l");
 


### PR DESCRIPTION
This is so empty searches (i.e. without conditions) are really empty (i.e. return no results).