### PR TITLE
NCI-Agency/anet#416: Fix cursor behaviour in person firstname field

### DIFF
--- a/client/src/pages/people/Form.js
+++ b/client/src/pages/people/Form.js
@@ -215,8 +215,8 @@ export default class PersonForm extends ValidatableFormWrapper {
 
 	handleOnKeyDown = (event) => {
 		if (event.key === ',') {
-			let nameInput = document.getElementById("firstName")
-			nameInput.focus()
+			event.preventDefault()
+			document.getElementById('firstName').focus()
 		}
 	}
 
@@ -228,17 +228,15 @@ export default class PersonForm extends ValidatableFormWrapper {
 	}
 
 	handleOnChangeFirstName = (event) => {
+		const value = event.target.value
 		const { person } = this.state
-		const target = event.target
-		const value = target.value
 
-		target.value = value.replace(/,/, '')
 		this.savePersonWithFullName(person, { firstName: value })
 	}
 
 	fullName = (person) => {
 		if (person.lastName && person.firstName) {
-			return(`${this.formattedLastName(person.lastName)}, ${person.firstName.trim()}`)
+			return(`${this.formattedLastName(person.lastName)}, ${this.formattedFirstName(person.firstName)}`)
 		}
 		else if (person.lastName) {
 			return this.formattedLastName(person.lastName)
@@ -250,6 +248,10 @@ export default class PersonForm extends ValidatableFormWrapper {
 
 	formattedLastName = (lastName) => {
 		return lastName.toUpperCase().trim()
+	}
+
+	formattedFirstName = (firstName) => {
+		return firstName.trim()
 	}
 
 	parseFullName = (name) => {


### PR DESCRIPTION
The issue was that whenever something was typed in the firstname field,
the cursor would go immediately to the end of the input. This was
happening because the event target value was being changed by the JS
code in order to remove the eventual comma added through the lastname
field. I fixed this by changing the way the comma is removed.