### PR TITLE
NCI-Agency/anet#414: Fix link for 0 reports with sensitive info

### DIFF
--- a/client/src/pages/Home.js
+++ b/client/src/pages/Home.js
@@ -112,9 +112,10 @@ export default class Home extends Page {
 	}
 
 	mySensitiveInfo() {
+		console.log(this.state.userAuthGroups)
 		return {
 			title: "Reports with sensitive information",
-			query: { state: ["RELEASED"], authorizationGroupId: this.state.userAuthGroups.map(f => f.id) }
+			query: { state: ["RELEASED"], authorizationGroupId: (this.state.userAuthGroups.length ? this.state.userAuthGroups.map(f => f.id) : [-1]) }
 		}
 	}
 


### PR DESCRIPTION
The link for 0 reports with sensitive info from the homepage was
resulting on listing all released reports. This was because the
authorizationGroupId filter was missing from the search query.