### PR TITLE
NCI-Agency/anet#470: Prevent error when user has no position

### DIFF
--- a/client/src/pages/Help.js
+++ b/client/src/pages/Help.js
@@ -23,7 +23,10 @@ export default class Help extends Page {
 
 	fetchData() {
 		let {currentUser} = this.context.app.state
-		if (!currentUser.id) { return }
+		if (!currentUser.id || !currentUser.position || !currentUser.position.organization) {
+			// No super users to be found
+			return
+		}
 
 		let orgId = currentUser.position.organization.id
 		API.query(/* GraphQL */`


### PR DESCRIPTION
Or when position has no organization.
In either case, there are no super users to be found, so don't do the API call.