### PR TITLE
NCI-Agency/anet#475: Add parent task to the task pages

### DIFF
--- a/client/src/pages/tasks/Edit.js
+++ b/client/src/pages/tasks/Edit.js
@@ -35,7 +35,8 @@ export default class TaskEdit extends Page {
 				id, shortName, longName, status,
 				customField, customFieldEnum,
 				plannedCompletion, projectedCompletion,
-				responsibleOrg {id,shortName, longName, identificationCode}
+				responsibleOrg {id,shortName, longName, identificationCode},
+				parentTask { id, shortName, longName }
 			}
 		`).then(data => {
 			if (data.task.plannedCompletion) {

--- a/client/src/pages/tasks/Form.js
+++ b/client/src/pages/tasks/Form.js
@@ -97,6 +97,14 @@ export default class TaskForm extends ValidatableFormWrapper {
 							/>
 						</Form.Field>
 
+						<Form.Field id="parentTask" label="Parent task">
+							<Autocomplete valueKey="shortName"
+								placeholder="Start typing to search for a higher level task..."
+								url="/api/tasks/search"
+								queryParams={{}}
+							/>
+						</Form.Field>
+
 						<this.TaskCustomField dictProps={Settings.fields.task.customField} id="customField"/>
 
 						{plannedCompletion &&
@@ -136,6 +144,10 @@ export default class TaskForm extends ValidatableFormWrapper {
 		if (task.responsibleOrg && task.responsibleOrg.id) {
 			task.responsibleOrg = {id: task.responsibleOrg.id}
 		}
+		if (task.parentTask && task.parentTask.id) {
+			task.parentTask = {id: task.parentTask.id}
+		}
+
 		let url = `/api/tasks/${edit ? 'update' : 'new'}`
 		API.send(url, task, {disableSubmits: true})
 			.then(response => {

--- a/client/src/pages/tasks/Show.js
+++ b/client/src/pages/tasks/Show.js
@@ -62,7 +62,8 @@ export default class TaskShow extends Page {
 				id, shortName, longName, status,
 				customField, customFieldEnum,
 				plannedCompletion, projectedCompletion,
-				responsibleOrg {id, shortName, longName, identificationCode}
+				responsibleOrg {id, shortName, longName, identificationCode},
+				parentTask { id, shortName, longName }
 			}
 		`)
 
@@ -96,6 +97,12 @@ export default class TaskShow extends Page {
 
 						{task.responsibleOrg && task.responsibleOrg.id && 
 							this.renderOrg()
+						}
+
+						{task.parentTask && task.parentTask.id &&
+							<Form.Field id="parentTask" label="Parent task">
+								<LinkTo task={task.parentTask} >{task.parentTask.shortName} {task.parentTask.longName}</LinkTo>
+							</Form.Field>
 						}
 
 						<this.TaskCustomField dictProps={Settings.fields.task.customField} id="customField"/>


### PR DESCRIPTION
This adds the possibility to set and view the parent task of a task via
the interface.