### PR TITLE
NCI-Agency/anet#468: Prevent updating the original object

### DIFF
--- a/client/src/components/EditAssociatedPositionsModal.js
+++ b/client/src/components/EditAssociatedPositionsModal.js
@@ -25,12 +25,12 @@ export default class EditAssociatedPositionsModal extends Component {
 	constructor(props, context) {
 		super(props, context)
 		this.state = {
-			associatedPositions: props.position.associatedPositions
+			associatedPositions: props.position.associatedPositions.slice()
 		}
 	}
 
 	componentWillReceiveProps(nextProps, nextContext) {
-		let assoc = nextProps.position.associatedPositions
+		let assoc = nextProps.position.associatedPositions.slice()
 		this.setState({associatedPositions: assoc})
 	}
 

--- a/client/src/components/EditAssociatedPositionsModal.js
+++ b/client/src/components/EditAssociatedPositionsModal.js
@@ -25,13 +25,14 @@ export default class EditAssociatedPositionsModal extends Component {
 	constructor(props, context) {
 		super(props, context)
 		this.state = {
+			error: null,
 			associatedPositions: props.position.associatedPositions.slice()
 		}
 	}
 
 	componentWillReceiveProps(nextProps, nextContext) {
 		let assoc = nextProps.position.associatedPositions.slice()
-		this.setState({associatedPositions: assoc})
+		this.setState({error: null, associatedPositions: assoc})
 	}
 
 	render() {


### PR DESCRIPTION
Make a copy of the associatedPositions array to prevent updating the original object passed by the caller.
Fixes NCI-Agency/anet#468