### PR TITLE
NCI-Agency/anet#525: Improve insights performance

### DIFF
--- a/client/src/components/CancelledEngagementReports.js
+++ b/client/src/components/CancelledEngagementReports.js
@@ -17,7 +17,7 @@ const chartByOrgId = 'cancelled_reports_by_org'
 const chartByReasonId = 'cancelled_reports_by_reason'
 const GQL_CHART_FIELDS =  /* GraphQL */`
   id
-  advisorOrg { id, shortName}
+  advisorOrg { id, shortName }
   cancelledReason
 `
 const BarChartWithLoader = LoaderHOC('isLoading')('data')(BarChart)

--- a/client/src/components/CancelledEngagementReports.js
+++ b/client/src/components/CancelledEngagementReports.js
@@ -15,7 +15,11 @@ import LoaderHOC from '../HOC/LoaderHOC'
 const d3 = require('d3')
 const chartByOrgId = 'cancelled_reports_by_org'
 const chartByReasonId = 'cancelled_reports_by_reason'
-
+const GQL_CHART_FIELDS =  /* GraphQL */`
+  id
+  advisorOrg { id, shortName}
+  cancelledReason
+`
 const BarChartWithLoader = LoaderHOC('isLoading')('data')(BarChart)
 
 /*
@@ -138,7 +142,7 @@ export default class CancelledEngagementReports extends Component {
     const chartQuery = API.query(/* GraphQL */`
         reportList(f:search, query:$chartQueryParams) {
           totalCount, list {
-            ${ReportCollection.GQL_REPORT_FIELDS}
+            ${GQL_CHART_FIELDS}
           }
         }
       `, {chartQueryParams}, '($chartQueryParams: ReportSearchQuery)')

--- a/client/src/components/FutureEngagementsByLocation.js
+++ b/client/src/components/FutureEngagementsByLocation.js
@@ -13,9 +13,12 @@ import LoaderHOC from '../HOC/LoaderHOC'
 
 const d3 = require('d3')
 const chartId = 'future_engagements_by_location'
-
+const GQL_CHART_FIELDS =  /* GraphQL */`
+  id
+  engagementDate
+  location { id, name }
+`
 const BarChartWithLoader = LoaderHOC('isLoading')('data')(HorizontalBarChart)
-
 
 /*
  * Component displaying a chart with number of future engagements per date and
@@ -210,7 +213,7 @@ export default class FutureEngagementsByLocation extends Component {
     return API.query(/* GraphQL */`
     reportList(f:search, query:$chartQueryParams) {
       totalCount, list {
-        ${ReportCollection.GQL_REPORT_FIELDS}
+        ${GQL_CHART_FIELDS}
       }
     }
   `, {chartQueryParams}, '($chartQueryParams: ReportSearchQuery)')

--- a/client/src/components/PendingApprovalReports.js
+++ b/client/src/components/PendingApprovalReports.js
@@ -16,7 +16,7 @@ const d3 = require('d3')
 const chartId = 'not_approved_reports_chart'
 const GQL_CHART_FIELDS =  /* GraphQL */`
   id
-  advisorOrg { id, shortName}
+  advisorOrg { id, shortName }
 `
 const BarChartWithLoader = LoaderHOC('isLoading')('data')(BarChart)
 

--- a/client/src/components/PendingApprovalReports.js
+++ b/client/src/components/PendingApprovalReports.js
@@ -56,7 +56,7 @@ export default class PendingApprovalReports extends Component {
     const focusDetails = this.focusDetails
     return (
       <div>
-        <p className="help-text">{`Number of pending reports, submited on or before ${this.referenceDateLongStr}, by advisor organization`}</p>
+        <p className="help-text">{`Number of pending reports, submitted on or before ${this.referenceDateLongStr}, by advisor organization`}</p>
         <p className="chart-description">
           {`Displays the number of pending approval reports which have been
             submitted on or before ${this.referenceDateLongStr}. The reports are

--- a/client/src/components/PendingApprovalReports.js
+++ b/client/src/components/PendingApprovalReports.js
@@ -14,8 +14,12 @@ import LoaderHOC from 'HOC/LoaderHOC'
 
 const d3 = require('d3')
 const chartId = 'not_approved_reports_chart'
-
+const GQL_CHART_FIELDS =  /* GraphQL */`
+  id
+  advisorOrg { id, shortName}
+`
 const BarChartWithLoader = LoaderHOC('isLoading')('data')(BarChart)
+
 /*
  * Component displaying reports submitted for approval up to the given date but
  * which have not been approved yet. They are displayed in different
@@ -110,7 +114,7 @@ export default class PendingApprovalReports extends Component {
     const chartQuery = API.query(/* GraphQL */`
         reportList(f:search, query:$chartQueryParams) {
           totalCount, list {
-            ${ReportCollection.GQL_REPORT_FIELDS}
+            ${GQL_CHART_FIELDS}
           }
         }
       `, {chartQueryParams}, '($chartQueryParams: ReportSearchQuery)')

--- a/client/src/components/ReportCollection.js
+++ b/client/src/components/ReportCollection.js
@@ -16,21 +16,20 @@ const GQL_REPORT_FIELDS =  /* GraphQL */`
 	id, intent, engagementDate, keyOutcomes, nextSteps, cancelledReason
 	atmosphere, atmosphereDetails, state
 	author { id, name }
-	primaryAdvisor { id, name, role, position { organization { id, shortName}}},
-	primaryPrincipal { id, name, role, position { organization { id, shortName}}},
-	advisorOrg { id, shortName},
-	principalOrg { id, shortName},
-	location { id, name, lat, lng},
-	tasks {id, shortName, longName},
-	tags {id, name, description}
+	primaryAdvisor { id, name },
+	primaryPrincipal { id, name },
+	advisorOrg { id, shortName },
+	principalOrg { id, shortName },
+	location { id, name, lat, lng },
+	tasks { id, shortName },
+	tags { id, name, description }
 	approvalStatus {
 		type, createdAt
 		step { id , name
 			approvers { id, name, person { id, name, rank } }
 		},
-		person { id, name, rank}
+		person { id, name, rank }
 	}
-	engagementDayOfWeek
 `
 
 

--- a/client/src/components/ReportsByDayOfWeek.js
+++ b/client/src/components/ReportsByDayOfWeek.js
@@ -14,7 +14,10 @@ import LoaderHOC from '../HOC/LoaderHOC'
 
 const d3 = require('d3')
 const chartByDayOfWeekId = 'reports_by_day_of_week'
-
+const GQL_CHART_FIELDS =  /* GraphQL */`
+  id
+  engagementDayOfWeek
+`
 const BarChartWithLoader = LoaderHOC('isLoading')('data')(BarChart)
 
 /*
@@ -152,7 +155,7 @@ export default class ReportsByDayOfWeek extends Component {
     return API.query(/* GraphQL */`
       reportList(f:search, query:$chartQueryParams) {
         totalCount, list {
-          ${ReportCollection.GQL_REPORT_FIELDS}
+          ${GQL_CHART_FIELDS}
         }
       }`, {chartQueryParams}, '($chartQueryParams: ReportSearchQuery)')
   }

--- a/client/src/components/ReportsByTask.js
+++ b/client/src/components/ReportsByTask.js
@@ -16,7 +16,10 @@ import pluralize from 'pluralize'
 
 const d3 = require('d3')
 const chartByTaskId = 'reports_by_task'
-
+const GQL_CHART_FIELDS =  /* GraphQL */`
+  id
+  tasks { id, shortName }
+`
 const BarChartWithLoader = LoaderHOC('isLoading')('data')(BarChart)
 
 /*
@@ -110,7 +113,7 @@ export default class ReportsByTask extends Component {
     const chartQuery = API.query(/* GraphQL */`
         reportList(f:search, query:$chartQueryParams) {
           totalCount, list {
-            ${ReportCollection.GQL_REPORT_FIELDS}
+            ${GQL_CHART_FIELDS}
           }
         }
       `, {chartQueryParams}, '($chartQueryParams: ReportSearchQuery)')

--- a/client/src/pages/reports/Show.js
+++ b/client/src/pages/reports/Show.js
@@ -486,7 +486,7 @@ export default class ReportShow extends Page {
 		API.send(`/api/reports/${this.state.report.id}/submit`).then(data => {
 			this.updateReport()
 			this.setState({error:null})
-			this.setState({success:'Successfully submited report'})
+			this.setState({success:'Successfully submitted report'})
 		}, data => {
 			this.handleError(data)
 		})


### PR DESCRIPTION
This makes sure that the GraphQL queries for the insights charts only
retrieve the used field. This should improve the performance of the
insights. We also removed a few fields from the GraphQL fields of the
ReportCollection, they were not used.