### PR TITLE
NCI-Agency/anet#479: Fix assigning a principal to an advisor

### DIFF
--- a/client/src/components/EditAssociatedPositionsModal.js
+++ b/client/src/components/EditAssociatedPositionsModal.js
@@ -146,7 +146,7 @@ export default class EditAssociatedPositionsModal extends Component {
 		delete position.previousPeople
 		delete position.person //prevent any changes to person.
 
-		API.send('/api/positions/update', position)
+		API.send('/api/positions/updateAssociatedPosition', position)
 			.then(resp =>
 				this.props.onSuccess()
 			).catch(error => {


### PR DESCRIPTION
This makes sure that changing the associated principal for an advisor no
longer depends on wherther the advisor is a super user or admin.