### PR TITLE
NCI-Agency/anet#449: Fix duplicating approval step name bug

### DIFF
--- a/client/src/pages/organizations/Form.js
+++ b/client/src/pages/organizations/Form.js
@@ -113,7 +113,7 @@ export default class OrganizationForm extends ValidatableFormWrapper {
 				X
 			</Button>
 
-			<RequiredField id="approvalStepName"
+			<RequiredField id={`approvalStepName${index}`}
 				label="Step name"
 				value={step.name}
 				onChange={(event) => this.setStepName(index, event)} />
@@ -217,7 +217,11 @@ export default class OrganizationForm extends ValidatableFormWrapper {
 
 	@autobind
 	onSubmit(event) {
-		let organization = Object.without(this.props.organization, 'childrenOrgs', 'positions', 'approvalStepName')
+		let organization = Object.without(this.props.organization, 'childrenOrgs', 'positions')
+		for (var i = 0; i < this.props.organization.approvalSteps.length; i++) {
+			organization = Object.without(organization, 'approvalStepName' + i)
+		}
+
 		if (organization.parentOrg) {
 			organization.parentOrg = {id: organization.parentOrg.id}
 		}


### PR DESCRIPTION
This makes sure that when adding approval steps to an organization the
steps added after the first one do not automatically get the name of the
first step.