### PR TITLE
NCI-Agency/anet#554: Fix blank report

### DIFF
--- a/client/src/models/Report.js
+++ b/client/src/models/Report.js
@@ -108,7 +108,7 @@ export default class Report extends Model {
 			errors.push('The primary ' + roleName + ' - ' + primaryAttendee.name + ' - needs to be assigned to a position')
 		} else if (primaryAttendee.position.status !== Position.STATUS.ACTIVE) {
 			errors.push('The primary ' + roleName + ' - ' + primaryAttendee.name + ' - needs to be in an active position')
-		} else if (primaryOrg.type !== orgType) {
+		} else if (primaryOrg && (primaryOrg.type !== orgType)) {
 			errors.push('The primary ' + roleName + '\'s - ' + primaryAttendee.name + ' - organization should be ' + Organization.humanNameOfType(orgType))
 		}
 	}


### PR DESCRIPTION
This makes sure that the report no longer appears blank when it doesn't
have a principalOrg or an advisorOrg.