### PR TITLE
NCI-Agency/anet#573: Avoid DataCloneError under IE11

### DIFF
--- a/client/src/components/AdvancedSearch.js
+++ b/client/src/components/AdvancedSearch.js
@@ -340,7 +340,7 @@ class AdvancedSearch extends Component {
 
 	@autobind
 	resolveToQuery(value) {
-		if (typeof value === 'function' && value.name && value.name.startsWith('bound ')) {
+		if (typeof value === 'function') {
 			return value()
 		}
 	}


### PR DESCRIPTION
Function name is not available under (webpacked version for) IE11, so if it's a function, just call it.
Fixes NCI-Agency/anet#573