### PR TITLE
NCI-Agency/anet#574: Fix autosuggest disappearing on autosave of report

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -86,7 +86,7 @@
     "rc-progress": "^2.2.5",
     "react": "^16.2.0",
     "react-16-bootstrap-date-picker": "^5.1.2",
-    "react-autosuggest-ie11-compatible": "^9.3.1",
+    "react-autosuggest": "^9.3.4",
     "react-bootstrap": "^0.31.0",
     "react-confirm-bootstrap": "^5.2.1",
     "react-dom": "^16.2.0",

--- a/client/src/components/Autocomplete.js
+++ b/client/src/components/Autocomplete.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
 import {FormControl} from 'react-bootstrap'
-import Autosuggest from 'react-autosuggest-ie11-compatible'
+import Autosuggest from 'react-autosuggest'
 import autobind from 'autobind-decorator'
 import _debounce from 'lodash/debounce'
 

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -8224,9 +8224,9 @@ react-16-bootstrap-date-picker@^5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/react-16-bootstrap-date-picker/-/react-16-bootstrap-date-picker-5.1.2.tgz#2f41b925e2a97f8925dd4fe3087f578b86223d3c"
 
-react-autosuggest-ie11-compatible@^9.3.1:
-  version "9.3.1"
-  resolved "https://registry.yarnpkg.com/react-autosuggest-ie11-compatible/-/react-autosuggest-ie11-compatible-9.3.1.tgz#405416462c51d93d111988136d441fd40c1cc101"
+react-autosuggest@^9.3.4:
+  version "9.3.4"
+  resolved "https://registry.yarnpkg.com/react-autosuggest/-/react-autosuggest-9.3.4.tgz#e47ff800081b2f7c678165bfb7cc84b07f462336"
   dependencies:
     prop-types "^15.5.10"
     react-autowhatever "^10.1.0"


### PR DESCRIPTION
Upgrade to the latest release of react-autosuggest (instead of the ie11 fork).
Fixes NCI-Agency/anet#574