### PR TITLE
Only use the autocompleted value if it refers to an object

### DIFF
--- a/client/src/components/AssignPositionModal.js
+++ b/client/src/components/AssignPositionModal.js
@@ -162,7 +162,9 @@ export default class AssignPositionModal extends Component {
 
 	@autobind
 	onPositionSelect(position) {
-		this.setState({position})
+		if (position.id) {
+			this.setState({position})
+		}
 	}
 
 }

--- a/client/src/components/EditAssociatedPositionsModal.js
+++ b/client/src/components/EditAssociatedPositionsModal.js
@@ -119,13 +119,15 @@ export default class EditAssociatedPositionsModal extends Component {
 
 	@autobind
 	addPositionRelationship(newRelatedPos)  {
-		let rels = this.state.associatedPositions
+		if (newRelatedPos.id) {
+			let rels = this.state.associatedPositions
 
-		if (!rels.find(relPos => relPos.id === newRelatedPos.id)) {
-			let newRels = rels.slice()
-			newRels.push(new Position(newRelatedPos))
+			if (!rels.find(relPos => relPos.id === newRelatedPos.id)) {
+				let newRels = rels.slice()
+				newRels.push(new Position(newRelatedPos))
 
-			this.setState({associatedPositions: newRels})
+				this.setState({associatedPositions: newRels})
+			}
 		}
 	}
 

--- a/client/src/components/advancedSearch/AutocompleteFilter.js
+++ b/client/src/components/advancedSearch/AutocompleteFilter.js
@@ -46,7 +46,9 @@ export default class AutocompleteFilter extends Component {
 
 	@autobind
 	onChange(event) {
-		this.setState({value: event}, this.updateFilter)
+		if (typeof event === 'object') {
+			this.setState({value: event}, this.updateFilter)
+		}
 	}
 
 	@autobind

--- a/client/src/pages/positions/Form.js
+++ b/client/src/pages/positions/Form.js
@@ -165,6 +165,7 @@ class PositionForm extends ValidatableFormWrapper {
 		// Remove permissions property, was added temporarily in order to be able
 		// to select a specific advisor type.
 		delete position.permissions
+		position.location = {id: position.location.id}
 		position.organization = {id: position.organization.id}
 		position.person = (position.person && position.person.id) ? {id: position.person.id} : {}
 		position.code = position.code || null //Need to null out empty position codes

--- a/client/src/pages/reports/Form.js
+++ b/client/src/pages/reports/Form.js
@@ -550,6 +550,10 @@ class ReportForm extends ValidatableFormWrapper {
 			Object.without(a, 'position')
 		)
 
+		if (report.location) {
+			report.location = {id: report.location.id}
+		}
+
 		if (!isCancelled) {
 			delete report.cancelledReason
 		}
@@ -557,7 +561,6 @@ class ReportForm extends ValidatableFormWrapper {
 		if (disableSubmits) {
 			this.setState({disableOnSubmit: disableSubmits})
 		}
-
 		let url = `/api/reports/${edit ? 'update' : 'new'}?sendEditEmail=${disableSubmits}`
 		return API.send(url, report, {disableSubmits})
 	}

--- a/client/src/pages/tasks/Form.js
+++ b/client/src/pages/tasks/Form.js
@@ -167,10 +167,10 @@ class TaskForm extends ValidatableFormWrapper {
 	@autobind
 	onSubmit(event) {
 		let {task, edit} = this.props
-		if (task.responsibleOrg && task.responsibleOrg.id) {
+		if (task.responsibleOrg) {
 			task.responsibleOrg = {id: task.responsibleOrg.id}
 		}
-		if (task.customFieldRef1 && task.customFieldRef1.id) {
+		if (task.customFieldRef1) {
 			task.customFieldRef1 = {id: task.customFieldRef1.id}
 		}
 


### PR DESCRIPTION
Prevents (auto)save errors.