### PR TITLE
Use a computed instead of hard-coded offset for Scrollspy

### DIFF
--- a/client/src/components/Nav.js
+++ b/client/src/components/Nav.js
@@ -16,6 +16,20 @@ class Nav extends Component {
 		app: PropTypes.object.isRequired,
 	}
 
+	constructor(props) {
+		super(props)
+		this.state = {
+			scrollspyOffset: 0
+		}
+	}
+
+	componentWillReceiveProps(nextProps) {
+		const scrollspyOffset = -(nextProps.topbarOffset + 20)
+		if (this.state.scrollspyOffset !== scrollspyOffset) {
+			this.setState({scrollspyOffset: scrollspyOffset})
+		}
+	}
+
 	render() {
 		const appData = this.context.app.state
 		const currentUser = appData.currentUser
@@ -40,7 +54,7 @@ class Nav extends Component {
 
 		const orgSubNav = (
 			<li>
-				<Scrollspy className="nav" currentClassName="active" offset={-152}
+				<Scrollspy className="nav" currentClassName="active" offset={this.state.scrollspyOffset}
 					items={ ['info', 'supportedPositions', 'vacantPositions', 'approvals', 'tasks', 'reports'] }>
 					<NavItem href="#info">Info</NavItem>
 					<NavItem href="#supportedPositions">Supported positions</NavItem>
@@ -66,7 +80,7 @@ class Nav extends Component {
 
 				{inMyReports &&
 					<li>
-						<Scrollspy className="nav" currentClassName="active" offset={-152}
+						<Scrollspy className="nav" currentClassName="active" offset={this.state.scrollspyOffset}
 							items={ ['draft-reports', 'upcoming-engagements', 'pending-approval', 'published-reports'] }>
 							<NavItem href="#draft-reports">Draft reports</NavItem>
 							<NavItem href="#upcoming-engagements">Upcoming Engagements</NavItem>

--- a/client/src/components/TopBar.js
+++ b/client/src/components/TopBar.js
@@ -44,6 +44,7 @@ export default class TopBar extends Component {
         let topbarPaddingHeight = document.getElementById('topbar').offsetHeight + 20
         if (this.state.bodyPaddingTop !== topbarPaddingHeight){
             document.body.style.paddingTop =`${topbarPaddingHeight}px` 
+            this.props.updateTopbarOffset(topbarPaddingHeight)
             this.setState({ bodyPaddingTop: topbarPaddingHeight })
         }
     }

--- a/client/src/pages/App.js
+++ b/client/src/pages/App.js
@@ -85,14 +85,22 @@ class App extends Page {
 			currentUser: new Person(),
 			settings: {},
 			organizations: [],
+			topbarOffset: 0
 		}
 
+		this.updateTopbarOffset = this.updateTopbarOffset.bind(this)
 		Object.assign(this.state, this.processData(window.ANET_DATA))
 	}
 
 	componentWillReceiveProps(nextProps) {
 		if (!_isEqual(this.state.pageProps, nextProps.pageProps)) {
 			this.setState({pageProps: nextProps.pageProps})
+		}
+	}
+
+	updateTopbarOffset(topbarOffset) {
+		if (this.state.topbarOffset !== topbarOffset){
+			this.setState({ topbarOffset: topbarOffset })
 		}
 	}
 
@@ -243,6 +251,7 @@ class App extends Page {
 		return (
 			<div className="anet">
 				<TopBar
+					updateTopbarOffset={this.updateTopbarOffset}
 					currentUser={this.state.currentUser}
 					settings={this.state.settings}
 					minimalHeader={this.state.pageProps.minimalHeader}
@@ -257,7 +266,7 @@ class App extends Page {
 							</Row>
 						: <Row>
 								<Col sm={4} md={3} lg={2} className="hide-for-print">
-									<Nav />
+									<Nav topbarOffset={this.state.topbarOffset} />
 								</Col>
 								<Col sm={8} md={9} lg={10} className="primary-content">
 									{routing}


### PR DESCRIPTION
At least then, when we have a high top-bar (e.g. with a long message), the offset is correct.