### PR TITLE
NCI-Agency/anet#588: Remove the progress bar for now

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -78,7 +78,6 @@
     "locale-compare-polyfill": "^0.0.2",
     "lodash": "^4.17.4",
     "moment": "^2.21.0",
-    "nprogress": "^0.2.0",
     "object-assign": "^4.1.1",
     "pluralize": "^7.0.0",
     "promise": "^8.0.1",

--- a/client/src/components/Page.js
+++ b/client/src/components/Page.js
@@ -8,20 +8,9 @@ import {setMessages} from 'components/Messages'
 
 import API from 'api'
 
-import NProgress from 'nprogress'
-import 'nprogress/nprogress.css'
-
 import _isEqual from 'lodash/isEqual'
 
 import { DEFAULT_PAGE_PROPS } from 'actions'
-
-const NPROGRESS_CONTAINER = '.header'
-
-if (process.env.NODE_ENV !== 'test') {
-	NProgress.configure({
-		parent: NPROGRESS_CONTAINER
-	})
-}
 
 export default class Page extends Component {
 
@@ -46,10 +35,6 @@ export default class Page extends Component {
 
 	componentWillMount() {
 		window.scrollTo(0,0)
-
-		if (document.querySelector(NPROGRESS_CONTAINER)) {
-			NProgress.start()
-		}
 	}
 
 	loadData(props, context) {
@@ -63,7 +48,6 @@ export default class Page extends Component {
 			let promise = API.inProgress
 
 			if (promise && promise.then instanceof Function) {
-				NProgress.set(0.5)
 				promise.then(this.doneLoading, this.doneLoading)
 			} else {
 				this.doneLoading()
@@ -77,7 +61,6 @@ export default class Page extends Component {
 
 	@autobind
 	doneLoading(response) {
-		NProgress.done()
 		document.body.classList.remove('loading')
 
 		if (response) {

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -219,19 +219,6 @@ fieldset.danger {
 	max-width: none;
 }
 
-.nprogress-custom-parent .bar {
-	top: 130px !important;
-}
-
-.nprogress-custom-parent .peg {
-	transform: rotate(-3deg) translate(0px, 4px) !important;
-}
-
-.nprogress-custom-parent .spinner {
-	top: 104px !important;
-	right: 8px !important;
-}
-
 .graphiql-container {
 	min-height: 600px;
 }

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -7100,10 +7100,6 @@ npmlog@^4.0.2:
     gauge "~2.7.3"
     set-blocking "~2.0.0"
 
-nprogress@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/nprogress/-/nprogress-0.2.0.tgz#cb8f34c53213d895723fcbab907e9422adbcafb1"
-
 nth-check@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-1.0.1.tgz#9929acdf628fc2c41098deab82ac580cf149aae4"


### PR DESCRIPTION
This is needed as a quick fix because right now because of nprogress we
get an error when trying to load one of the reports (The error is:
Unable to get property 'className' of undefined or null reference) and
this results in a blank page.
We will replace the component later by a different one.