### PR TITLE
NCI-Agency/anet#529: Re-add missing key attribute

### DIFF
--- a/client/src/components/ReportApprovals.js
+++ b/client/src/components/ReportApprovals.js
@@ -139,7 +139,7 @@ export default class ReportApprovals extends Component {
                 <Modal.Body>
                     <ul>
                     {step.approvers.map(position =>
-                        <li>
+                        <li key={position.id}>
                             <LinkTo position={position} /> - <LinkTo person={position.person} />
                         </li>
                     )}


### PR DESCRIPTION
It was inadvertently removed in commit c6f4383