### PR TITLE
Use Buffer.from() instead of deprecated new Buffer()

### DIFF
--- a/client/src/api.js
+++ b/client/src/api.js
@@ -130,7 +130,7 @@ const API = {
 	getAuthHeader: function() {
 		const creds = API._getAuthParams()
 		if (creds) {
-			return ['Authorization', 'Basic ' + new Buffer(`${creds.user}:${creds.pass}`).toString('base64')]
+			return ['Authorization', 'Basic ' + Buffer.from(`${creds.user}:${creds.pass}`).toString('base64')]
 		}
 		return null
 	}


### PR DESCRIPTION
See https://nodejs.org/docs/latest-v8.x/api/buffer.html#buffer_buffer_from_buffer_alloc_and_buffer_allocunsafe