### PR TITLE
NCI-Agency/anet#382: Fix jsx-a11y/href-no-hash warning

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -27,7 +27,7 @@
     "css-loader": "^0.28.7",
     "dotenv": "^5.0.1",
     "eslint": "^4.18.2",
-    "eslint-config-react-app": "^2.1.0",
+    "eslint-config-react-app": "^3.0.0-next.66cc7a90",
     "eslint-loader": "^2.0.0",
     "eslint-plugin-flowtype": "^2.48.0",
     "eslint-plugin-import": "^2.12.0",

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -2595,6 +2595,10 @@ configstore@^3.0.0:
     write-file-atomic "^2.0.0"
     xdg-basedir "^3.0.0"
 
+confusing-browser-globals@2.0.0-next.b2fd8db8:
+  version "2.0.0-next.b2fd8db8"
+  resolved "https://registry.yarnpkg.com/confusing-browser-globals/-/confusing-browser-globals-2.0.0-next.b2fd8db8.tgz#76206be12de4e1ac8b07e8b71b6daea697ba8d73"
+
 connect-history-api-fallback@^1.3.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/connect-history-api-fallback/-/connect-history-api-fallback-1.5.0.tgz#b06873934bc5e344fef611a196a6faae0aee015a"
@@ -3742,9 +3746,11 @@ escodegen@^1.6.1, escodegen@^1.9.0:
   optionalDependencies:
     source-map "~0.6.1"
 
-eslint-config-react-app@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-react-app/-/eslint-config-react-app-2.1.0.tgz#23c909f71cbaff76b945b831d2d814b8bde169eb"
+eslint-config-react-app@^3.0.0-next.66cc7a90:
+  version "3.0.0-next.b2fd8db8"
+  resolved "https://registry.yarnpkg.com/eslint-config-react-app/-/eslint-config-react-app-3.0.0-next.b2fd8db8.tgz#9c53f55bcfe11c03ff7075d9c4f113beca85191d"
+  dependencies:
+    confusing-browser-globals "2.0.0-next.b2fd8db8"
 
 eslint-import-resolver-node@^0.3.1:
   version "0.3.2"


### PR DESCRIPTION
By upgrading to the latest version of eslint-config-react-app (currently 3.0.0-next.66cc7a90).