### PR TITLE
Fix warning "Unexpected value NaN parsing width attribute"

### DIFF
--- a/client/src/components/HorizontalBarChart.js
+++ b/client/src/components/HorizontalBarChart.js
@@ -203,6 +203,7 @@ class HorizontalBarChart extends Component {
         return [d]
       })
       .enter()
+      .filter(d => d.value !== undefined)
       .append('rect')
       .attr('class', 'bar')
       .attr('id', function(d, i) { return 'bar_' + d.key + d.parentKey })


### PR DESCRIPTION
By filtering out elements that don't have a value.