### PR TITLE
NCI-Agency/anet#657: Move show/hide loading from LoaderHOC

### DIFF
--- a/client/src/HOC/LoaderHOC.js
+++ b/client/src/HOC/LoaderHOC.js
@@ -11,11 +11,6 @@ export const mapDispatchToProps = (dispatch, ownProps) => ({
 const LoaderHOC = (isLoading) => (dataPropName) => (WrappedComponent) => {
     return class LoaderHOC extends Component {
 
-        static propTypes = {
-            showLoading: PropTypes.func.isRequired,
-            hideLoading: PropTypes.func.isRequired,
-        }
-
         isEmpty(prop) {
             return (
                 prop === null ||
@@ -37,14 +32,8 @@ const LoaderHOC = (isLoading) => (dataPropName) => (WrappedComponent) => {
             const showLoader =  dataIsEmpty && this.isLoadingData(this.props[isLoading])
 
             if (showLoader) {
-                if (typeof this.props.showLoading === 'function') {
-                    this.props.showLoading()
-                }
                 return <div className='loader'></div>
             } else {
-                if (typeof this.props.hideLoading === 'function') {
-                    this.props.hideLoading()
-                }
                 if (dataIsEmpty) {
                     return <div></div>
                 }

--- a/client/src/components/AdvisorReports/FilterableAdvisorReportsTable.js
+++ b/client/src/components/AdvisorReports/FilterableAdvisorReportsTable.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types'
 import React, { Component } from 'react'
 import OrganizationAdvisorsTable from 'components/AdvisorReports/OrganizationAdvisorsTable'
 import Toolbar from 'components/AdvisorReports/Toolbar'
@@ -14,6 +15,12 @@ const advisorReportsQueryUrl = `/api/reports/insights/advisors` // ?weeksAgo=3 d
 const OrganizationAdvisorsTableWithLoader = connect(null, mapDispatchToProps)(LoaderHOC('isLoading')('data')(OrganizationAdvisorsTable))
 
 class FilterableAdvisorReportsTable extends Component {
+    static propTypes = {
+        date: PropTypes.object,
+        showLoading: PropTypes.func.isRequired,
+        hideLoading: PropTypes.func.isRequired,
+    }
+
     constructor() {
         super()
         this.state = {
@@ -30,12 +37,14 @@ class FilterableAdvisorReportsTable extends Component {
 
     componentDidMount() {
         this.setState( {isLoading: true} )
+        this.props.showLoading()
         let advisorReportsQuery = API.fetch(advisorReportsQueryUrl)
         Promise.resolve(advisorReportsQuery).then(value => {
             this.setState({
                 isLoading: false,
                 data: value
             })
+            this.props.hideLoading()
         })
     }
 
@@ -162,4 +171,4 @@ class FilterableAdvisorReportsTable extends Component {
     }
 }
 
-export default FilterableAdvisorReportsTable
+export default connect(null, mapDispatchToProps)(FilterableAdvisorReportsTable)

--- a/client/src/components/CancelledEngagementReports.js
+++ b/client/src/components/CancelledEngagementReports.js
@@ -13,6 +13,7 @@ import {Report} from 'models'
 
 import { connect } from 'react-redux'
 import LoaderHOC, {mapDispatchToProps} from 'HOC/LoaderHOC'
+import { showLoading, hideLoading } from 'react-redux-loading-bar'
 
 const d3 = require('d3')
 const chartByOrgId = 'cancelled_reports_by_org'
@@ -28,9 +29,11 @@ const BarChartWithLoader = connect(null, mapDispatchToProps)(LoaderHOC('isLoadin
  * Component displaying a chart with reports cancelled since
  * the given date.
  */
-export default class CancelledEngagementReports extends Component {
+class CancelledEngagementReports extends Component {
   static propTypes = {
     date: PropTypes.object,
+    showLoading: PropTypes.func.isRequired,
+    hideLoading: PropTypes.func.isRequired,
   }
 
   constructor(props) {
@@ -134,6 +137,7 @@ export default class CancelledEngagementReports extends Component {
 
   fetchData() {
     this.setState( {isLoading: true} )
+    this.props.showLoading()
     const pinned_ORGs = Settings.pinned_ORGs
     const chartQueryParams = {}
     Object.assign(chartQueryParams, this.queryParams)
@@ -178,6 +182,7 @@ export default class CancelledEngagementReports extends Component {
             return a.reason.localeCompare(b.reason)
         })
       })
+      this.props.hideLoading()
     })
     this.fetchOrgData()
   }
@@ -284,3 +289,5 @@ export default class CancelledEngagementReports extends Component {
     }
   }
 }
+
+export default connect(null, mapDispatchToProps)(CancelledEngagementReports)

--- a/client/src/components/FutureEngagementsByLocation.js
+++ b/client/src/components/FutureEngagementsByLocation.js
@@ -25,10 +25,12 @@ const BarChartWithLoader = connect(null, mapDispatchToProps)(LoaderHOC('isLoadin
  * Component displaying a chart with number of future engagements per date and
  * location. Locations are grouped per date.
  */
-export default class FutureEngagementsByLocation extends Component {
+class FutureEngagementsByLocation extends Component {
   static propTypes = {
     startDate: PropTypes.object.isRequired,
     endDate: PropTypes.object.isRequired,
+    showLoading: PropTypes.func.isRequired,
+    hideLoading: PropTypes.func.isRequired,
   }
 
   constructor(props) {
@@ -116,6 +118,7 @@ export default class FutureEngagementsByLocation extends Component {
 
   fetchData() {
     this.setState( {isLoading: true} )
+    this.props.showLoading()
     // Query used by the chart
     const chartQuery = this.runChartQuery(this.chartQueryParams())
     const noLocation = {
@@ -163,6 +166,7 @@ export default class FutureEngagementsByLocation extends Component {
         graphData: graphData,
         isLoading: false
       })
+      this.props.hideLoading()
     })
     this.fetchFocusData()
 
@@ -270,3 +274,5 @@ export default class FutureEngagementsByLocation extends Component {
     return startDateChanged || endDateChanged
   }
 }
+
+export default connect(null, mapDispatchToProps)(FutureEngagementsByLocation)

--- a/client/src/components/PendingApprovalReports.js
+++ b/client/src/components/PendingApprovalReports.js
@@ -27,9 +27,11 @@ const BarChartWithLoader = connect(null, mapDispatchToProps)(LoaderHOC('isLoadin
  * which have not been approved yet. They are displayed in different
  * presentation forms: chart, summary, table and map.
  */
-export default class PendingApprovalReports extends Component {
+class PendingApprovalReports extends Component {
   static propTypes = {
     date: PropTypes.object,
+    showLoading: PropTypes.func.isRequired,
+    hideLoading: PropTypes.func.isRequired,
   }
 
   constructor(props) {
@@ -106,6 +108,7 @@ export default class PendingApprovalReports extends Component {
 
   fetchData() {
     this.setState( {isLoading: true} )
+    this.props.showLoading()
     const pinned_ORGs = Settings.pinned_ORGs
     const chartQueryParams = {}
     Object.assign(chartQueryParams, this.queryParams)
@@ -143,6 +146,7 @@ export default class PendingApprovalReports extends Component {
               return (b_index < 0) ? -1 : a_index-b_index
           })
       })
+      this.props.hideLoading()
     })
     this.fetchOrgData()
   }
@@ -209,3 +213,5 @@ export default class PendingApprovalReports extends Component {
   }
 
 }
+
+export default connect(null, mapDispatchToProps)(PendingApprovalReports)

--- a/client/src/components/ReportsByDayOfWeek.js
+++ b/client/src/components/ReportsByDayOfWeek.js
@@ -25,10 +25,12 @@ const BarChartWithLoader = connect(null, mapDispatchToProps)(LoaderHOC('isLoadin
  * Component displaying a chart with number of reports released within a certain
  * period. The counting is done grouped by day of the week. 
  */
-export default class ReportsByDayOfWeek extends Component {
+class ReportsByDayOfWeek extends Component {
   static propTypes = {
     startDate: PropTypes.object.isRequired,
     endDate: PropTypes.object.isRequired,
+    showLoading: PropTypes.func.isRequired,
+    hideLoading: PropTypes.func.isRequired,
   }
 
   constructor(props) {
@@ -107,6 +109,7 @@ export default class ReportsByDayOfWeek extends Component {
 
   fetchData() {
     this.setState( {isLoading: true} )
+    this.props.showLoading()
     // Query used by the chart
     const chartQuery = this.runChartQuery(this.chartQueryParams())
     Promise.all([chartQuery]).then(values => {
@@ -128,6 +131,7 @@ export default class ReportsByDayOfWeek extends Component {
             r.reportsCount = simplifiedValues.filter(item => item.dayOfWeek === r.dayOfWeekInt).length
             return r})
       })
+      this.props.hideLoading()
     })
     this.fetchDayOfWeekData()
   }
@@ -224,3 +228,5 @@ export default class ReportsByDayOfWeek extends Component {
     return startDateChanged || endDateChanged
   }
 }
+
+export default connect(null, mapDispatchToProps)(ReportsByDayOfWeek)

--- a/client/src/components/ReportsByTask.js
+++ b/client/src/components/ReportsByTask.js
@@ -27,9 +27,11 @@ const BarChartWithLoader = connect(null, mapDispatchToProps)(LoaderHOC('isLoadin
 /*
  * Component displaying a chart with number of reports per Task.
  */
-export default class ReportsByTask extends Component {
+class ReportsByTask extends Component {
   static propTypes = {
     date: PropTypes.object,
+    showLoading: PropTypes.func.isRequired,
+    hideLoading: PropTypes.func.isRequired,
   }
 
   constructor(props) {
@@ -106,6 +108,7 @@ export default class ReportsByTask extends Component {
 
   fetchData() {
     this.setState( {isLoading: true} )
+    this.props.showLoading()
     const chartQueryParams = {}
     Object.assign(chartQueryParams, this.queryParams)
     Object.assign(chartQueryParams, {
@@ -143,6 +146,7 @@ export default class ReportsByTask extends Component {
             r.reportsCount = (d.id ? simplifiedValues.filter(item => item.tasks.indexOf(d.id) > -1).length : simplifiedValues.filter(item => item.tasks.length === 0).length)
             return r}),
       })
+      this.props.hideLoading()
     })
     this.fetchTaskData()
   }
@@ -208,3 +212,5 @@ export default class ReportsByTask extends Component {
     }
   }
 }
+
+export default connect(null, mapDispatchToProps)(ReportsByTask)


### PR DESCRIPTION
This moves the showLoading and hideLoading dispatch call from the render
method of the LoaderHOC component to the insight components. This way we
avoid the warning "Cannot update during an existing state transition
(such as within render or another component's constructor)." We keep the
LoaderHOC in order to display the loading on the bar charts too.