### PR TITLE
NCI-Agency/anet#732: Get rid of derived state

### DIFF
--- a/client/src/pages/reports/Form.js
+++ b/client/src/pages/reports/Form.js
@@ -46,6 +46,7 @@ class BaseReportForm extends ValidatableFormWrapper {
 	constructor(props) {
 		super(props)
 
+		const { report, currentUser } = props
 		this.state = {
 			isBlocking: false,
 			recents: {
@@ -54,15 +55,15 @@ class BaseReportForm extends ValidatableFormWrapper {
 				tasks: [],
 				authorizationGroups: [],
 			},
-			reportTags: [],
+			reportTags: (report.tags || []).map(tag => ({id: tag.id.toString(), text: tag.name})),
 			suggestionList: [],
 
-			showReportText: !!props.report.reportText || !!props.report.reportSensitiveInformation,
-			isCancelled: (props.report.cancelledReason ? true : false),
+			showReportText: !!report.reportText || !!report.reportSensitiveInformation,
+			isCancelled: !!report.cancelledReason,
 			errors: {},
 
-			showAssignedPositionWarning: false,
-			showActivePositionWarning: false,
+			showAssignedPositionWarning: !currentUser.hasAssignedPosition(),
+			showActivePositionWarning: currentUser.hasAssignedPosition() && !currentUser.hasActivePosition(),
 
 			disableOnSubmit: false,
 
@@ -113,26 +114,28 @@ class BaseReportForm extends ValidatableFormWrapper {
 		window.clearTimeout(this.state.timeoutId)
 	}
 
-	static getDerivedStateFromProps(props, state) {
-		const stateUpdate = {}
-		const { report, currentUser } = props
-		if (report.cancelledReason) {
-			Object.assign(stateUpdate, {isCancelled: true})
-		}
-		const reportTags = report.tags.map(tag => ({id: tag.id.toString(), text: tag.name}))
-		Object.assign(stateUpdate, {
-			showAssignedPositionWarning: !currentUser.hasAssignedPosition(),
-			showActivePositionWarning: currentUser.hasAssignedPosition() && !currentUser.hasActivePosition(),
-			reportTags: reportTags,
-		})
-		return stateUpdate
-	}
-
 	componentDidUpdate(prevProps, prevState) {
-		const showReportText = !!this.props.report.reportText || !!this.props.report.reportSensitiveInformation
-		const prevShowReportText = !!prevProps.report.reportText || !!prevProps.report.reportSensitiveInformation
+		const { report, currentUser } = this.props
+		const prevReport = prevProps.report
+		const prevCurrentUser = prevProps.currentUser
+		if (report.id !== prevReport.id) {
+			this.setState({reportTags: (report.tags || []).map(tag => ({id: tag.id.toString(), text: tag.name}))})
+		}
+		const showReportText = !!report.reportText || !!report.reportSensitiveInformation
+		const prevShowReportText = !!prevReport.reportText || !!prevReport.reportSensitiveInformation
 		if (showReportText !== prevShowReportText) {
 			this.setState({showReportText: showReportText})
+		}
+		const isCancelled = !!report.cancelledReason
+		const prevIsCancelled = !!prevReport.cancelledReason
+		if (isCancelled !== prevIsCancelled) {
+			this.setState({isCancelled: isCancelled})
+		}
+		if (currentUser !== prevCurrentUser) {
+			this.setState({
+				showAssignedPositionWarning: !currentUser.hasAssignedPosition(),
+				showActivePositionWarning: currentUser.hasAssignedPosition() && !currentUser.hasActivePosition(),
+			})
 		}
 	}
 


### PR DESCRIPTION
Move functionality to constructor() and componentDidUpdate().
Fixes NCI-Agency/anet#732