### PR TITLE
Show navigation warning only when object has been edited

### DIFF
--- a/client/src/pages/admin/authorizationgroup/Form.js
+++ b/client/src/pages/admin/authorizationgroup/Form.js
@@ -19,6 +19,7 @@ import NavigationWarning from 'components/NavigationWarning'
 class AuthorizationGroupForm extends ValidatableFormWrapper {
 	static propTypes = {
 		authorizationGroup: PropTypes.object.isRequired,
+		original: PropTypes.object.isRequired,
 		edit: PropTypes.bool
 	}
 
@@ -84,7 +85,7 @@ class AuthorizationGroupForm extends ValidatableFormWrapper {
 	@autobind
 	onChange() {
 		this.setState({
-			isBlocking: this.formHasUnsavedChanges(this.state.report, this.props.original),
+			isBlocking: this.formHasUnsavedChanges(this.props.authorizationGroup, this.props.original),
 		})
 	}
 

--- a/client/src/pages/admin/authorizationgroup/New.js
+++ b/client/src/pages/admin/authorizationgroup/New.js
@@ -19,6 +19,7 @@ class AuthorizationGroupNew extends Page {
 
 		this.state = {
 			authorizationGroup: new AuthorizationGroup(),
+			originalAuthorizationGroup : new AuthorizationGroup()
 		}
 	}
 
@@ -30,7 +31,7 @@ class AuthorizationGroupNew extends Page {
 				<Breadcrumbs items={[['Create new authorization group', AuthorizationGroup.pathForNew()]]} />
 				<Messages success={this.state.success} error={this.state.error} />
 
-				<AuthorizationGroupForm original={new AuthorizationGroup()} authorizationGroup={authorizationGroup} />
+				<AuthorizationGroupForm original={this.state.originalAuthorizationGroup} authorizationGroup={authorizationGroup} />
 			</div>
 		)
 	}

--- a/client/src/pages/locations/Edit.js
+++ b/client/src/pages/locations/Edit.js
@@ -21,8 +21,8 @@ class LocationEdit extends Page {
 		super(props, PAGE_PROPS_NO_NAV)
 
 		this.state = {
-			location: {},
-			originalLocation : {}
+			location: new Location(),
+			originalLocation : new Location()
 		}
 	}
 

--- a/client/src/pages/locations/Form.js
+++ b/client/src/pages/locations/Form.js
@@ -19,6 +19,7 @@ import NavigationWarning from 'components/NavigationWarning'
 class LocationForm extends ValidatableFormWrapper {
 	static propTypes = {
 		anetLocation: PropTypes.object.isRequired,
+		original: PropTypes.object.isRequired,
 		edit: PropTypes.bool,
 	}
 
@@ -97,7 +98,7 @@ class LocationForm extends ValidatableFormWrapper {
 	@autobind
 	onChange() {
 		this.setState({
-			isBlocking: this.formHasUnsavedChanges(this.state.report, this.props.original),
+			isBlocking: this.formHasUnsavedChanges(this.props.anetLocation, this.props.original),
 		})
 	}
 

--- a/client/src/pages/locations/New.js
+++ b/client/src/pages/locations/New.js
@@ -21,6 +21,7 @@ class LocationNew extends Page {
 
 		this.state = {
 			location: new Location(),
+			originalLocation : new Location()
 		}
 	}
 
@@ -32,7 +33,7 @@ class LocationNew extends Page {
 				<Breadcrumbs items={[['Create new Location', Location.pathForNew()]]} />
 				<Messages success={this.state.success} error={this.state.error} />
 
-				<LocationForm original={new Location()} anetLocation={location} />
+				<LocationForm original={this.state.originalLocation} anetLocation={location} />
 			</div>
 		)
 	}

--- a/client/src/pages/organizations/Edit.js
+++ b/client/src/pages/organizations/Edit.js
@@ -23,6 +23,7 @@ class OrganizationEdit extends Page {
 		super(props, PAGE_PROPS_NO_NAV)
 
 		this.state = {
+			originalOrganization: new Organization(),
 			organization: new Organization(),
 		}
 	}

--- a/client/src/pages/organizations/Form.js
+++ b/client/src/pages/organizations/Form.js
@@ -27,6 +27,7 @@ import NavigationWarning from 'components/NavigationWarning'
 class BaseOrganizationForm extends ValidatableFormWrapper {
 	static propTypes = {
 		organization: PropTypes.object,
+		original: PropTypes.object.isRequired,
 		edit: PropTypes.bool,
 		currentUser: PropTypes.instanceOf(Person),
 	}
@@ -239,7 +240,7 @@ class BaseOrganizationForm extends ValidatableFormWrapper {
 	@autobind
 	onChange() {
 		this.setState({
-			isBlocking: this.formHasUnsavedChanges(this.state.report, this.props.original),
+			isBlocking: this.formHasUnsavedChanges(this.props.organization, this.props.original),
 		})
 	}
 

--- a/client/src/pages/people/Edit.js
+++ b/client/src/pages/people/Edit.js
@@ -26,6 +26,7 @@ class BasePersonEdit extends Page {
 		super(props, PAGE_PROPS_NO_NAV)
 
 		this.state = {
+			originalPerson: new Person(),
 			person: new Person(),
 		}
 	}

--- a/client/src/pages/people/Form.js
+++ b/client/src/pages/people/Form.js
@@ -30,6 +30,7 @@ import NavigationWarning from 'components/NavigationWarning'
 class BasePersonForm extends ValidatableFormWrapper {
 	static propTypes = {
 		person: PropTypes.object.isRequired,
+		original: PropTypes.object.isRequired,
 		edit: PropTypes.bool,
 		legendText: PropTypes.string,
 		saveText: PropTypes.string,
@@ -342,8 +343,9 @@ class BasePersonForm extends ValidatableFormWrapper {
 
 	@autobind
 	onChange() {
+		const person = Object.without(this.props.person, 'firstName', 'lastName')
 		this.setState({
-			isBlocking: this.formHasUnsavedChanges(this.state.report, this.props.original),
+			isBlocking: this.formHasUnsavedChanges(person, this.props.original),
 		})
 	}
 

--- a/client/src/pages/positions/Form.js
+++ b/client/src/pages/positions/Form.js
@@ -22,6 +22,7 @@ import LinkTo from 'components/LinkTo'
 class BasePositionForm extends ValidatableFormWrapper {
 	static propTypes = {
 		position: PropTypes.object.isRequired,
+		original: PropTypes.object.isRequired,
 		edit: PropTypes.bool,
 		error: PropTypes.object,
 		success: PropTypes.object,
@@ -149,7 +150,7 @@ class BasePositionForm extends ValidatableFormWrapper {
 	@autobind
 	onChange() {
 		this.setState({
-			isBlocking: this.formHasUnsavedChanges(this.state.report, this.props.original),
+			isBlocking: this.formHasUnsavedChanges(this.props.position, this.props.original),
 		})
 	}
 

--- a/client/src/pages/reports/Form.js
+++ b/client/src/pages/reports/Form.js
@@ -38,6 +38,7 @@ import 'components/reactToastify.css'
 class BaseReportForm extends ValidatableFormWrapper {
 	static propTypes = {
 		report: PropTypes.instanceOf(Report).isRequired,
+		original: PropTypes.object.isRequired,
 		edit: PropTypes.bool,
 		onDelete: PropTypes.oneOfType([PropTypes.object, PropTypes.bool]),
 		currentUser: PropTypes.instanceOf(Person),
@@ -521,7 +522,7 @@ class BaseReportForm extends ValidatableFormWrapper {
 		this.setState({
 			errors : this.validateReport(),
 			reportChanged: true,
-			isBlocking: this.formHasUnsavedChanges(this.state.report, this.props.original),
+			isBlocking: this.formHasUnsavedChanges(this.props.report, this.props.original),
 		})
 	}
 

--- a/client/src/pages/tasks/Form.js
+++ b/client/src/pages/tasks/Form.js
@@ -37,6 +37,7 @@ const customEnumButtons = (list) => {
 class BaseTaskForm extends ValidatableFormWrapper {
 	static propTypes = {
 		task: PropTypes.object.isRequired,
+		original: PropTypes.object.isRequired,
 		edit: PropTypes.bool,
 		currentUser: PropTypes.instanceOf(Person),
 	}
@@ -156,7 +157,7 @@ class BaseTaskForm extends ValidatableFormWrapper {
 	@autobind
 	onChange() {
 		this.setState({
-			isBlocking: this.formHasUnsavedChanges(this.state.report, this.props.original),
+			isBlocking: this.formHasUnsavedChanges(this.props.task, this.props.original),
 		})
 	}
 


### PR DESCRIPTION
Compare to the correct original object (and make it a required prop).
Fixes bugs introduced in commit aac0d361