### PR TITLE
Fix advanced search organization filter

### DIFF
--- a/client/src/components/advancedSearch/OrganizationFilter.js
+++ b/client/src/components/advancedSearch/OrganizationFilter.js
@@ -83,8 +83,10 @@ export default class OrganizationFilter extends Component {
 	@autobind
 	updateFilter() {
 		let value = this.state.value
-		value.includeChildOrgs = this.state.includeChildOrgs
-		value.toQuery = this.toQuery
+		if (typeof value === 'object') {
+			value.includeChildOrgs = this.state.includeChildOrgs
+			value.toQuery = this.toQuery
+		}
 		this.props.onChange(value)
 	}
 }


### PR DESCRIPTION
App would crash if text was entered in organization filter of advanced search and then leaving the field without selecting a suggestion from the list.