### PR TITLE
Harmonise report email templates a little

### DIFF
--- a/src/main/java/mil/dds/anet/emails/AnetEmailAction.java
+++ b/src/main/java/mil/dds/anet/emails/AnetEmailAction.java
@@ -7,6 +7,8 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, property = "@class")
 public abstract class AnetEmailAction {
 
+	protected static final int MAX_REPORT_INTENT_LENGTH = 50;
+
 	String templateName;
 	String subject;
 	

--- a/src/main/java/mil/dds/anet/emails/ApprovalNeededEmail.java
+++ b/src/main/java/mil/dds/anet/emails/ApprovalNeededEmail.java
@@ -3,6 +3,8 @@ package mil.dds.anet.emails;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.commons.lang3.StringUtils;
+
 import mil.dds.anet.AnetObjectEngine;
 import mil.dds.anet.beans.ApprovalStep;
 import mil.dds.anet.beans.Report;
@@ -23,6 +25,7 @@ public class ApprovalNeededEmail extends AnetEmailAction {
 		
 		Map<String,Object> context = new HashMap<String,Object>();
 		context.put("report", r);
+		context.put("reportIntent", StringUtils.abbreviate(r.getIntent(), MAX_REPORT_INTENT_LENGTH));
 		context.put("approvalStepName", (step != null) ? step.getName() : "");
 		return context;
 	}

--- a/src/main/java/mil/dds/anet/emails/FutureEngagementUpdated.java
+++ b/src/main/java/mil/dds/anet/emails/FutureEngagementUpdated.java
@@ -3,6 +3,8 @@ package mil.dds.anet.emails;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.commons.lang3.StringUtils;
+
 import mil.dds.anet.AnetObjectEngine;
 import mil.dds.anet.beans.Report;
 
@@ -20,6 +22,7 @@ public class FutureEngagementUpdated extends AnetEmailAction {
 		Report r = AnetObjectEngine.getInstance().getReportDao().getById(report.getId());
 		Map<String,Object> context = new HashMap<String,Object>();
 		context.put("report", r);
+		context.put("reportIntent", StringUtils.abbreviate(r.getIntent(), MAX_REPORT_INTENT_LENGTH));
 		return context;
 	}
 

--- a/src/main/java/mil/dds/anet/emails/NewReportCommentEmail.java
+++ b/src/main/java/mil/dds/anet/emails/NewReportCommentEmail.java
@@ -3,6 +3,8 @@ package mil.dds.anet.emails;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.commons.lang3.StringUtils;
+
 import mil.dds.anet.AnetObjectEngine;
 import mil.dds.anet.beans.Comment;
 import mil.dds.anet.beans.Report;
@@ -23,6 +25,7 @@ public class NewReportCommentEmail extends AnetEmailAction {
 		
 		Map<String,Object> context = new HashMap<String,Object>();
 		context.put("report", r);
+		context.put("reportIntent", StringUtils.abbreviate(r.getIntent(), MAX_REPORT_INTENT_LENGTH));
 		context.put("comment", comment);
 		return context;
 	}

--- a/src/main/java/mil/dds/anet/emails/ReportEditedEmail.java
+++ b/src/main/java/mil/dds/anet/emails/ReportEditedEmail.java
@@ -3,6 +3,8 @@ package mil.dds.anet.emails;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.commons.lang3.StringUtils;
+
 import mil.dds.anet.AnetObjectEngine;
 import mil.dds.anet.beans.Person;
 import mil.dds.anet.beans.Report;
@@ -23,6 +25,7 @@ public class ReportEditedEmail extends AnetEmailAction {
 		
 		Map<String,Object> context = new HashMap<String,Object>();
 		context.put("report", r);
+		context.put("reportIntent", StringUtils.abbreviate(r.getIntent(), MAX_REPORT_INTENT_LENGTH));
 		context.put("editor", editor);
 		return context;
 	}

--- a/src/main/java/mil/dds/anet/emails/ReportEmail.java
+++ b/src/main/java/mil/dds/anet/emails/ReportEmail.java
@@ -3,6 +3,8 @@ package mil.dds.anet.emails;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.commons.lang3.StringUtils;
+
 import mil.dds.anet.AnetObjectEngine;
 import mil.dds.anet.beans.Person;
 import mil.dds.anet.beans.Report;
@@ -23,6 +25,7 @@ public class ReportEmail extends AnetEmailAction {
 		sender = AnetObjectEngine.getInstance().getPersonDao().getById(sender.getId());
 		Map<String,Object> context = new HashMap<String,Object>();
 		context.put("report", r);
+		context.put("reportIntent", StringUtils.abbreviate(r.getIntent(), MAX_REPORT_INTENT_LENGTH));
 		context.put("sender", sender);
 		context.put("comment", comment);
 		return context;

--- a/src/main/java/mil/dds/anet/emails/ReportRejectionEmail.java
+++ b/src/main/java/mil/dds/anet/emails/ReportRejectionEmail.java
@@ -3,6 +3,8 @@ package mil.dds.anet.emails;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.commons.lang3.StringUtils;
+
 import mil.dds.anet.AnetObjectEngine;
 import mil.dds.anet.beans.Comment;
 import mil.dds.anet.beans.Person;
@@ -15,7 +17,7 @@ public class ReportRejectionEmail extends AnetEmailAction {
 	
 	public ReportRejectionEmail() { 
 		templateName = "/emails/reportRejection.ftl";
-		subject = "ANET Report Rejected";
+		subject = "ANET Report Returned to You for Editing";
 	}
 	
 	@Override
@@ -26,6 +28,7 @@ public class ReportRejectionEmail extends AnetEmailAction {
 		
 		Map<String,Object> context = new HashMap<String,Object>();
 		context.put("report", r);
+		context.put("reportIntent", StringUtils.abbreviate(r.getIntent(), MAX_REPORT_INTENT_LENGTH));
 		context.put("rejector", rejector);
 		context.put("comment", comment);
 		return context;

--- a/src/main/java/mil/dds/anet/emails/ReportReleasedEmail.java
+++ b/src/main/java/mil/dds/anet/emails/ReportReleasedEmail.java
@@ -3,6 +3,8 @@ package mil.dds.anet.emails;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.commons.lang3.StringUtils;
+
 import mil.dds.anet.AnetObjectEngine;
 import mil.dds.anet.beans.Report;
 
@@ -20,6 +22,7 @@ public class ReportReleasedEmail extends AnetEmailAction {
 		
 		Map<String,Object> context = new HashMap<String,Object>();
 		context.put("report", r);
+		context.put("reportIntent", StringUtils.abbreviate(r.getIntent(), MAX_REPORT_INTENT_LENGTH));
 		return context;
 	}
 

--- a/src/main/resources/emails/approvalNeeded.ftl
+++ b/src/main/resources/emails/approvalNeeded.ftl
@@ -22,7 +22,7 @@
 Dear ${approvalStepName},
 <br><br>
 <div>
-  ${report.author.name}'s report, <em><strong>${report.intent}</strong></em>, is ready for your review.<br>
+  ${report.author.name}'s report, <a href="${serverUrl}/reports/${report.id?c}"><em><strong>"${reportIntent}"</strong></em></a>, is ready for your review.<br>
   Using <a href="${serverUrl}/reports/${report.id?c}" />this link</a>,
   you can either <em>Approve</em>, <em>Reject</em> or <em>Edit</em> the report.
 </div>
@@ -131,7 +131,7 @@ Dear ${approvalStepName},
 
 <div class="row">
   <div class="col-md-8">
-    <p><strong>Meeting purpose:</strong> ${(report.intent)!}</p>
+    <p><strong>Meeting goal:</strong> ${report.intent}</p>
     <#if report.keyOutcomes??>
       <p><strong>Key outcomes:</strong> ${(report.keyOutcomes)!}</p>
     </#if>

--- a/src/main/resources/emails/futureEngagementUpdated.ftl
+++ b/src/main/resources/emails/futureEngagementUpdated.ftl
@@ -19,11 +19,11 @@ a {
 <body>
 <p style="color:red; font-size:12px; font-weight: bold;" align="center"><i>Classification: ${SECURITY_BANNER_TEXT}</i></p>
 
-Hi ${(report.author.name)!},<br><br>
+Hi ${report.author.name},<br><br>
 
-<p>The date of your upcoming engagement, "<i>${report.intent}</i>", is today. We've changed this upcoming engagement 
+<p>The date of your upcoming engagement, <a href="${serverUrl}/reports/${report.id?c}"><em><strong>"${reportIntent}"</strong></em></a>, is today. We've changed this upcoming engagement 
 into a draft engagement report. You can find and edit it by going to the "My drafts" on the "My reports" page, 
-or by clicking here: <a href="${serverUrl}/reports/${report.id?c}">${serverUrl}/reports/${report.id?c}</a>.</p>
+or by <a href="${serverUrl}/reports/${report.id?c}">clicking here</a>.</p>
 
 ANET Support Team
 <#if SUPPORT_EMAIL_ADDR??>

--- a/src/main/resources/emails/newReportComment.ftl
+++ b/src/main/resources/emails/newReportComment.ftl
@@ -19,9 +19,9 @@ a {
 <body>
 <p style="color:red; font-size:12px; font-weight: bold;" align="center"><i>Classification: ${SECURITY_BANNER_TEXT}</i></p>
 
-Hi, ${report.author.name},
+Hi ${report.author.name},
 
-<p>The following comment was added to your "${report.intent}" report by ${comment.author.rank!} ${comment.author.name}:</p>
+<p>The following comment was added to your report, <a href="${serverUrl}/reports/${report.id?c}"><em><strong>"${reportIntent}"</strong></em></a>, by ${comment.author.rank!} ${comment.author.name}:</p>
 
 <p><i>"${comment.text}"</i></p>
 

--- a/src/main/resources/emails/reportEdited.ftl
+++ b/src/main/resources/emails/reportEdited.ftl
@@ -19,9 +19,9 @@ a {
 <body>
 <p style="color:red; font-size:12px; font-weight: bold;" align="center"><i>Classification: ${SECURITY_BANNER_TEXT}</i></p>
 
-Hello ${report.author.name},
+Hi ${report.author.name},
 
-<p>${editor.name} edited your report "${report.intent}". To review the changes, <a href="${serverUrl}/reports/${report.id?c}">click here</a>.</p>
+<p>${editor.name} edited your report, <a href="${serverUrl}/reports/${report.id?c}"><em><strong>"${reportIntent}"</strong></em></a>. To review the changes, <a href="${serverUrl}/reports/${report.id?c}">click here</a>.</p>
 
 ANET Support Team
 <#if SUPPORT_EMAIL_ADDR??>

--- a/src/main/resources/emails/reportRejection.ftl
+++ b/src/main/resources/emails/reportRejection.ftl
@@ -19,10 +19,12 @@ a {
 <body>
 <p style="color:red; font-size:12px; font-weight: bold;" align="center"><i>Classification: ${SECURITY_BANNER_TEXT}</i></p>
 
-Hi, ${report.author.name},
+Hi ${report.author.name},
 
-<p>Your report "<i>${report.intent}</i>" has been rejected by ${rejector.name}. The following comment was provided:</p>
+<p>Your report, <a href="${serverUrl}/reports/${report.id?c}"><em><strong>"${reportIntent}"</strong></em></a>, has been returned by ${rejector.name} &lt;${rejector.emailAddress}&gt;. The following comment was provided:</p>
 <p>"${comment.text}"</p>
+
+<p><strong>Engagement date and location:</strong> ${(report.engagementDate.toString('dd MMM yyyy'))!} @ ${(report.loadLocation().name)!}</p>
 
 <p>You can edit and re-submit your report by <a href="${serverUrl}/reports/${report.id?c}">clicking here</a>.</p>
 

--- a/src/main/resources/emails/reportReleased.ftl
+++ b/src/main/resources/emails/reportReleased.ftl
@@ -19,11 +19,13 @@ a {
 <body>
 <p style="color:red; font-size:12px; font-weight: bold;" align="center"><i>Classification: ${SECURITY_BANNER_TEXT}</i></p>
 
-Hi, ${report.author.name},
+Hi ${report.author.name},
 
-<p>Your report, "<i>${report.intent}</i>," has been approved and added to the daily rollup. </p>
+<p>Your report, <a href="${serverUrl}/reports/${report.id?c}"><em><strong>"${reportIntent}"</strong></em></a>, has been approved and added to the daily rollup. </p>
 
 <p>You can view the daily rollup by <a href="${serverUrl}/rollup">clicking here</a>.</p>
+
+<p>You can view your report by <a href="${serverUrl}/reports/${report.id?c}">clicking here</a>.</p>
 
 ANET Support Team
 <#if SUPPORT_EMAIL_ADDR??>


### PR DESCRIPTION
Add a link to the report using the abbreviated report intent, and also always include a direct link to the report.
Implements NCI-Agency/anet#729 and NCI-Agency/anet#248