### PR TITLE
NCI-Agency/anet#805: Fix reports by day of the week chart

### DIFF
--- a/client/src/components/SearchFilters.js
+++ b/client/src/components/SearchFilters.js
@@ -351,5 +351,11 @@ export default {
 		}
 
 		return filters
+	},
+	// filters not being displayed in the advanced search but being used in the search
+	extraFilters: function(positionTypeFilterRef, organizationFilterRef) {
+		const filters = {}
+		filters.Reports = ["includeEngagementDayOfWeek", "sortOrder"]
+		return filters
 	}
 }

--- a/client/src/searchUtils.js
+++ b/client/src/searchUtils.js
@@ -7,6 +7,14 @@ export function deserializeQueryParams(objType, queryParams, callbackFunction) {
 	var usedFilters = []
 	var promises = []
 	if (objType) {
+		const EXTRA_FILTERS = searchFilters.extraFilters()
+		const extraFilterDefs = EXTRA_FILTERS[objType]
+		extraFilterDefs.map(filterKey => {
+			if (queryParams.hasOwnProperty(filterKey)) {
+				usedFilters.push({key: filterKey, value: queryParams[filterKey]})
+			}
+			return null
+		})
 		const ALL_FILTERS = searchFilters.searchFilters()
 		const filterDefs = ALL_FILTERS[objType].filters
 		Object.keys(filterDefs).map(filterKey => {


### PR DESCRIPTION
The chart was empty because the search query was missing a parameter,
which was not being added as it was not part of the reports advanced
filters.

Fixes NCI-Agency/anet#805.