### PR TITLE
Fix issues resulting from GraphQL upgrade

### DIFF
--- a/client/src/components/SavedSearchTable.js
+++ b/client/src/components/SavedSearchTable.js
@@ -42,7 +42,7 @@ export default class SavedSearchTable extends Component {
 					${fields}
 				}
 			}
-		`, {query}, '($query: ReportSearchQuery)').then(data =>
+		`, {query}, '($query: ReportSearchQueryInput)').then(data =>
 			this.setState({reports: data.reports})
 		)
 	}

--- a/src/main/java/mil/dds/anet/beans/ApprovalStep.java
+++ b/src/main/java/mil/dds/anet/beans/ApprovalStep.java
@@ -87,7 +87,6 @@ public class ApprovalStep extends AbstractAnetBean {
 	public static ApprovalStep createWithId(Integer id) {
 		ApprovalStep step = new ApprovalStep();
 		step.setId(id);
-		step.setLoadLevel(LoadLevel.ID_ONLY);
 		return step;
 	}
 	

--- a/src/main/java/mil/dds/anet/beans/Comment.java
+++ b/src/main/java/mil/dds/anet/beans/Comment.java
@@ -69,7 +69,6 @@ public class Comment extends AbstractAnetBean {
 	public static Comment createWithId(Integer id) {
 		Comment c = new Comment();
 		c.setId(id);
-		c.setLoadLevel(LoadLevel.ID_ONLY);
 		return c;
 	}
 	

--- a/src/main/java/mil/dds/anet/beans/Location.java
+++ b/src/main/java/mil/dds/anet/beans/Location.java
@@ -79,7 +79,6 @@ public class Location extends AbstractAnetBean {
 	public static Location createWithId(Integer id) {
 		Location l = new Location();
 		l.setId(id);
-		l.setLoadLevel(LoadLevel.ID_ONLY);
 		return l;
 	}
 	

--- a/src/main/java/mil/dds/anet/beans/Organization.java
+++ b/src/main/java/mil/dds/anet/beans/Organization.java
@@ -182,7 +182,6 @@ public class Organization extends AbstractAnetBean {
 	public static Organization createWithId(Integer id) { 
 		Organization ao = new Organization();
 		ao.setId(id);
-		ao.setLoadLevel(LoadLevel.ID_ONLY);
 		return ao;
 	}
 	

--- a/src/main/java/mil/dds/anet/beans/Person.java
+++ b/src/main/java/mil/dds/anet/beans/Person.java
@@ -225,7 +225,6 @@ public class Person extends AbstractAnetBean implements Principal {
 		if (id == null) { return null; } 
 		Person p = new Person();
 		p.setId(id);
-		p.setLoadLevel(LoadLevel.ID_ONLY);
 		return p;
 	}
 	

--- a/src/main/java/mil/dds/anet/beans/Report.java
+++ b/src/main/java/mil/dds/anet/beans/Report.java
@@ -511,7 +511,6 @@ public class Report extends AbstractAnetBean {
 	public static Report createWithId(Integer id) {
 		Report r = new Report();
 		r.setId(id);
-		r.setLoadLevel(LoadLevel.ID_ONLY);
 		return r;
 	}
 	

--- a/src/main/java/mil/dds/anet/beans/ReportPerson.java
+++ b/src/main/java/mil/dds/anet/beans/ReportPerson.java
@@ -39,7 +39,6 @@ public class ReportPerson extends Person {
 	public static ReportPerson createWithId(Integer id) {
 		ReportPerson rp = new ReportPerson();
 		rp.setId(id);
-		rp.setLoadLevel(LoadLevel.ID_ONLY);
 		return rp;
 	}
 	

--- a/src/main/java/mil/dds/anet/beans/Task.java
+++ b/src/main/java/mil/dds/anet/beans/Task.java
@@ -149,7 +149,6 @@ public class Task extends AbstractAnetBean {
 	public static Task createWithId(Integer id) { 
 		Task p = new Task();
 		p.setId(id);
-		p.setLoadLevel(LoadLevel.ID_ONLY);
 		return p;
 	}
 

--- a/src/main/java/mil/dds/anet/beans/lists/AnetBeanList.java
+++ b/src/main/java/mil/dds/anet/beans/lists/AnetBeanList.java
@@ -2,19 +2,14 @@ package mil.dds.anet.beans.lists;
 
 import io.leangen.graphql.annotations.GraphQLQuery;
 
-import java.lang.invoke.MethodHandles;
 import java.util.List;
 
 import org.skife.jdbi.v2.Query;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import mil.dds.anet.beans.Person;
 import mil.dds.anet.beans.Report;
 
 public class AnetBeanList<T> {
-
-	private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
 	List<T> list;
 	Integer pageNum;
@@ -42,7 +37,6 @@ public class AnetBeanList<T> {
 		} else if (resultSize == 0) {
 			setTotalCount(0);
 		} else {
-			logger.debug("Bulk query context attributes are {}", query.getContext().getAttributes());
 			Integer foundCount = (Integer) query.getContext().getAttribute("totalCount");
 			setTotalCount(foundCount == null ? resultSize : foundCount);
 		}

--- a/src/main/java/mil/dds/anet/database/mappers/ApprovalActionMapper.java
+++ b/src/main/java/mil/dds/anet/database/mappers/ApprovalActionMapper.java
@@ -12,7 +12,6 @@ import mil.dds.anet.beans.ApprovalAction.ApprovalType;
 import mil.dds.anet.beans.ApprovalStep;
 import mil.dds.anet.beans.Person;
 import mil.dds.anet.beans.Report;
-import mil.dds.anet.views.AbstractAnetBean.LoadLevel;
 
 public class ApprovalActionMapper implements ResultSetMapper<ApprovalAction> {
 
@@ -29,7 +28,6 @@ public class ApprovalActionMapper implements ResultSetMapper<ApprovalAction> {
 		
 		aa.setCreatedAt(new DateTime(rs.getTimestamp("createdAt")));
 		aa.setType(MapperUtils.getEnumIdx(rs, "type", ApprovalType.class));
-		aa.setLoadLevel(LoadLevel.PROPERTIES);
 	
 		return aa;
 	}

--- a/src/main/java/mil/dds/anet/database/mappers/ApprovalStepMapper.java
+++ b/src/main/java/mil/dds/anet/database/mappers/ApprovalStepMapper.java
@@ -7,7 +7,6 @@ import org.skife.jdbi.v2.StatementContext;
 import org.skife.jdbi.v2.tweak.ResultSetMapper;
 
 import mil.dds.anet.beans.ApprovalStep;
-import mil.dds.anet.views.AbstractAnetBean.LoadLevel;
 
 public class ApprovalStepMapper implements ResultSetMapper<ApprovalStep> {
 
@@ -19,7 +18,6 @@ public class ApprovalStepMapper implements ResultSetMapper<ApprovalStep> {
 		step.setAdvisorOrganizationId(MapperUtils.getInteger(r, "advisorOrganizationId"));
 		step.setName(r.getString("name"));
 		
-		step.setLoadLevel(LoadLevel.PROPERTIES);
 		return step;
 	}
 

--- a/src/main/java/mil/dds/anet/database/mappers/AuthorizationGroupMapper.java
+++ b/src/main/java/mil/dds/anet/database/mappers/AuthorizationGroupMapper.java
@@ -9,7 +9,6 @@ import org.skife.jdbi.v2.tweak.ResultSetMapper;
 
 import mil.dds.anet.beans.AuthorizationGroup;
 import mil.dds.anet.beans.AuthorizationGroup.AuthorizationGroupStatus;
-import mil.dds.anet.views.AbstractAnetBean.LoadLevel;
 
 public class AuthorizationGroupMapper implements ResultSetMapper<AuthorizationGroup> {
 
@@ -22,7 +21,6 @@ public class AuthorizationGroupMapper implements ResultSetMapper<AuthorizationGr
 		a.setStatus(MapperUtils.getEnumIdx(rs, "status", AuthorizationGroupStatus.class));
 		a.setCreatedAt(new DateTime(rs.getTimestamp("createdAt")));
 		a.setUpdatedAt(new DateTime(rs.getTimestamp("updatedAt")));
-		a.setLoadLevel(LoadLevel.PROPERTIES);
 
 		if (MapperUtils.containsColumnNamed(rs, "totalCount")) {
 			ctx.setAttribute("totalCount", rs.getInt("totalCount"));

--- a/src/main/java/mil/dds/anet/database/mappers/CommentMapper.java
+++ b/src/main/java/mil/dds/anet/database/mappers/CommentMapper.java
@@ -9,7 +9,6 @@ import org.skife.jdbi.v2.tweak.ResultSetMapper;
 
 import mil.dds.anet.beans.Comment;
 import mil.dds.anet.beans.Person;
-import mil.dds.anet.views.AbstractAnetBean.LoadLevel;
 
 public class CommentMapper implements ResultSetMapper<Comment> {
 
@@ -33,7 +32,6 @@ public class CommentMapper implements ResultSetMapper<Comment> {
 		c.setText(r.getString("text"));
 		c.setCreatedAt(new DateTime(r.getTimestamp("c_createdAt")));
 		c.setUpdatedAt(new DateTime(r.getTimestamp("c_updatedAt")));
-		c.setLoadLevel(LoadLevel.PROPERTIES);
 		return c;
 	}
 

--- a/src/main/java/mil/dds/anet/database/mappers/LocationMapper.java
+++ b/src/main/java/mil/dds/anet/database/mappers/LocationMapper.java
@@ -10,7 +10,6 @@ import org.skife.jdbi.v2.tweak.ResultSetMapper;
 import mil.dds.anet.beans.Location;
 import mil.dds.anet.beans.Location.LocationStatus;
 import mil.dds.anet.utils.DaoUtils;
-import mil.dds.anet.views.AbstractAnetBean.LoadLevel;
 
 public class LocationMapper implements ResultSetMapper<Location> {
 
@@ -25,7 +24,6 @@ public class LocationMapper implements ResultSetMapper<Location> {
 		l.setLng(DaoUtils.getOptionalDouble(rs, "lng"));
 		l.setCreatedAt(new DateTime(rs.getTimestamp("createdAt")));
 		l.setUpdatedAt(new DateTime(rs.getTimestamp("updatedAt")));
-		l.setLoadLevel(LoadLevel.PROPERTIES);
 		
 		if (MapperUtils.containsColumnNamed(rs, "totalCount")) { 
 			ctx.setAttribute("totalCount", rs.getInt("totalCount"));

--- a/src/main/java/mil/dds/anet/database/mappers/OrganizationMapper.java
+++ b/src/main/java/mil/dds/anet/database/mappers/OrganizationMapper.java
@@ -10,7 +10,6 @@ import org.skife.jdbi.v2.tweak.ResultSetMapper;
 import mil.dds.anet.beans.Organization;
 import mil.dds.anet.beans.Organization.OrganizationStatus;
 import mil.dds.anet.beans.Organization.OrganizationType;
-import mil.dds.anet.views.AbstractAnetBean.LoadLevel;
 
 public class OrganizationMapper implements ResultSetMapper<Organization> {
 
@@ -31,7 +30,6 @@ public class OrganizationMapper implements ResultSetMapper<Organization> {
 		
 		org.setCreatedAt(new DateTime(r.getTimestamp("organizations_createdAt")));
 		org.setUpdatedAt(new DateTime(r.getTimestamp("organizations_updatedAt")));
-		org.setLoadLevel(LoadLevel.PROPERTIES);
 		
 		if (MapperUtils.containsColumnNamed(r, "totalCount")) { 
 			ctx.setAttribute("totalCount", r.getInt("totalCount"));

--- a/src/main/java/mil/dds/anet/database/mappers/PersonMapper.java
+++ b/src/main/java/mil/dds/anet/database/mappers/PersonMapper.java
@@ -12,7 +12,6 @@ import mil.dds.anet.beans.Person;
 import mil.dds.anet.beans.Person.PersonStatus;
 import mil.dds.anet.beans.Person.Role;
 import mil.dds.anet.beans.Position;
-import mil.dds.anet.views.AbstractAnetBean.LoadLevel;
 
 public class PersonMapper implements ResultSetMapper<Person> {
 
@@ -54,7 +53,6 @@ public class PersonMapper implements ResultSetMapper<Person> {
 		a.setCreatedAt(new DateTime(r.getTimestamp("people_createdAt")));
 		a.setUpdatedAt(new DateTime(r.getTimestamp("people_updatedAt")));	
 		
-		a.setLoadLevel(LoadLevel.PROPERTIES);
 		return a;
 	}
 }

--- a/src/main/java/mil/dds/anet/database/mappers/PositionMapper.java
+++ b/src/main/java/mil/dds/anet/database/mappers/PositionMapper.java
@@ -13,7 +13,6 @@ import mil.dds.anet.beans.Person;
 import mil.dds.anet.beans.Position;
 import mil.dds.anet.beans.Position.PositionStatus;
 import mil.dds.anet.beans.Position.PositionType;
-import mil.dds.anet.views.AbstractAnetBean.LoadLevel;
 
 public class PositionMapper implements ResultSetMapper<Position> {
 
@@ -56,7 +55,6 @@ public class PositionMapper implements ResultSetMapper<Position> {
 		}
 		
 		p.setCreatedAt(new DateTime(rs.getTimestamp("positions_createdAt")));
-		p.setLoadLevel(LoadLevel.PROPERTIES);
 		return p;
 	}
 

--- a/src/main/java/mil/dds/anet/database/mappers/ReportMapper.java
+++ b/src/main/java/mil/dds/anet/database/mappers/ReportMapper.java
@@ -16,7 +16,6 @@ import mil.dds.anet.beans.Report;
 import mil.dds.anet.beans.Report.Atmosphere;
 import mil.dds.anet.beans.Report.ReportCancelledReason;
 import mil.dds.anet.beans.Report.ReportState;
-import mil.dds.anet.views.AbstractAnetBean.LoadLevel;
 
 public class ReportMapper implements ResultSetMapper<Report> {
 
@@ -63,7 +62,6 @@ public class ReportMapper implements ResultSetMapper<Report> {
 		Person author = Person.createWithId((MapperUtils.getInteger(rs, "reports_authorId")));
 		PersonMapper.fillInFields(author, rs);
 		r.setAuthor(author);
-		r.setLoadLevel(LoadLevel.PROPERTIES);
 		
 		Integer advisorOrgId = MapperUtils.getInteger(rs, "reports_advisorOrganizationId");
 		if (advisorOrgId != null) { 

--- a/src/main/java/mil/dds/anet/database/mappers/ReportSensitiveInformationMapper.java
+++ b/src/main/java/mil/dds/anet/database/mappers/ReportSensitiveInformationMapper.java
@@ -8,7 +8,6 @@ import org.skife.jdbi.v2.StatementContext;
 import org.skife.jdbi.v2.tweak.ResultSetMapper;
 
 import mil.dds.anet.beans.ReportSensitiveInformation;
-import mil.dds.anet.views.AbstractAnetBean.LoadLevel;
 
 public class ReportSensitiveInformationMapper implements ResultSetMapper<ReportSensitiveInformation> {
 
@@ -19,7 +18,6 @@ public class ReportSensitiveInformationMapper implements ResultSetMapper<ReportS
 		rsi.setText(rs.getString("reportsSensitiveInformation_text"));
 		rsi.setCreatedAt(new DateTime(rs.getTimestamp("reportsSensitiveInformation_createdAt")));
 		rsi.setUpdatedAt(new DateTime(rs.getTimestamp("reportsSensitiveInformation_updatedAt")));
-		rsi.setLoadLevel(LoadLevel.PROPERTIES);
 		return rsi;
 	}
 

--- a/src/main/java/mil/dds/anet/database/mappers/TagMapper.java
+++ b/src/main/java/mil/dds/anet/database/mappers/TagMapper.java
@@ -8,7 +8,6 @@ import org.skife.jdbi.v2.StatementContext;
 import org.skife.jdbi.v2.tweak.ResultSetMapper;
 
 import mil.dds.anet.beans.Tag;
-import mil.dds.anet.views.AbstractAnetBean.LoadLevel;
 
 public class TagMapper implements ResultSetMapper<Tag> {
 
@@ -20,7 +19,6 @@ public class TagMapper implements ResultSetMapper<Tag> {
 		t.setDescription(rs.getString("description"));
 		t.setCreatedAt(new DateTime(rs.getTimestamp("createdAt")));
 		t.setUpdatedAt(new DateTime(rs.getTimestamp("updatedAt")));
-		t.setLoadLevel(LoadLevel.PROPERTIES);
 		
 		if (MapperUtils.containsColumnNamed(rs, "totalCount")) { 
 			ctx.setAttribute("totalCount", rs.getInt("totalCount"));

--- a/src/main/java/mil/dds/anet/utils/BatchingUtils.java
+++ b/src/main/java/mil/dds/anet/utils/BatchingUtils.java
@@ -31,7 +31,8 @@ public final class BatchingUtils {
 	public static DataLoaderRegistry registerDataLoaders(AnetObjectEngine engine, boolean batchingEnabled, boolean cachingEnabled) {
 		final DataLoaderOptions dataLoaderOptions = DataLoaderOptions.newOptions()
 				.setBatchingEnabled(batchingEnabled)
-				.setCachingEnabled(cachingEnabled);
+				.setCachingEnabled(cachingEnabled)
+				.setMaxBatchSize(1000);
 		final DataLoaderRegistry dataLoaderRegistry = new DataLoaderRegistry();
 	
 		dataLoaderRegistry.register("approvalSteps", new DataLoader<>(new BatchLoader<Integer, ApprovalStep>() {

--- a/src/main/java/mil/dds/anet/views/AbstractAnetBean.java
+++ b/src/main/java/mil/dds/anet/views/AbstractAnetBean.java
@@ -1,39 +1,19 @@
 package mil.dds.anet.views;
 
-import io.leangen.graphql.annotations.GraphQLIgnore;
 import io.leangen.graphql.annotations.GraphQLQuery;
 
 import java.util.Objects;
 
 import org.joda.time.DateTime;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-
 public abstract class AbstractAnetBean {
 
-	protected LoadLevel loadLevel;
 	protected Integer id;
 	protected DateTime createdAt;
 	protected DateTime updatedAt;
 
 	public AbstractAnetBean() { 
 		id = null;
-	}
-		
-	public static enum LoadLevel { ID_ONLY, PROPERTIES, INCLUDE;
-		public boolean contains(LoadLevel other) { 
-			return other.ordinal() <= this.ordinal();
-		}
-	}
-	
-	@JsonIgnore
-	@GraphQLIgnore
-	public LoadLevel getLoadLevel() { 
-		return loadLevel;
-	}
-	
-	public void setLoadLevel(LoadLevel ll) { 
-		this.loadLevel = ll;
 	}
 	
 	@GraphQLQuery(name="id")

--- a/src/test/java/mil/dds/anet/test/beans/PersonTest.java
+++ b/src/test/java/mil/dds/anet/test/beans/PersonTest.java
@@ -129,7 +129,6 @@ public class PersonTest extends BeanTester<Person> {
 		rp.setEmailAddress(p.getEmailAddress());
 		rp.setBiography(p.getBiography());
 		rp.setDomainUsername(p.getDomainUsername());
-		rp.setLoadLevel(p.getLoadLevel());
 		rp.setCreatedAt(p.getCreatedAt());
 		rp.setUpdatedAt(p.getUpdatedAt());
 		rp.setRank(p.getRank());

--- a/src/test/java/mil/dds/anet/test/beans/ReportTest.java
+++ b/src/test/java/mil/dds/anet/test/beans/ReportTest.java
@@ -21,7 +21,6 @@ import mil.dds.anet.beans.ReportSensitiveInformation;
 import mil.dds.anet.beans.Tag;
 import mil.dds.anet.beans.AuthorizationGroup;
 import mil.dds.anet.test.TestData;
-import mil.dds.anet.views.AbstractAnetBean.LoadLevel;
 
 public class ReportTest extends BeanTester<Report> {
 
@@ -107,7 +106,6 @@ public class ReportTest extends BeanTester<Report> {
 	public void staticCreatorTest() { 
 		Report r = Report.createWithId(4);
 		assertThat(r.getId()).isEqualTo(4);
-		assertThat(r.getLoadLevel()).isEqualTo(LoadLevel.ID_ONLY);
 		assertThat(r.getReportText()).isNull();
 		assertThat(r.getApprovalStep()).isNull();
 		assertThat(r.getNextSteps()).isNull();

--- a/src/test/java/mil/dds/anet/test/beans/TaskTest.java
+++ b/src/test/java/mil/dds/anet/test/beans/TaskTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.Test;
 
 import mil.dds.anet.beans.Task;
-import mil.dds.anet.views.AbstractAnetBean.LoadLevel;
 
 public class TaskTest extends BeanTester<Task> {
 
@@ -31,7 +30,6 @@ public class TaskTest extends BeanTester<Task> {
 	public void staticCreatorTest() { 
 		Task p = Task.createWithId(4);
 		assertThat(p.getId()).isEqualTo(4);
-		assertThat(p.getLoadLevel()).isEqualTo(LoadLevel.ID_ONLY);
 		assertThat(p.getLongName()).isNull();
 	}
 }

--- a/src/test/java/mil/dds/anet/test/resources/ReportsResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/ReportsResourceTest.java
@@ -60,7 +60,6 @@ import mil.dds.anet.database.AdminDao.AdminSettingKeys;
 import mil.dds.anet.test.TestData;
 import mil.dds.anet.test.beans.OrganizationTest;
 import mil.dds.anet.test.beans.PersonTest;
-import mil.dds.anet.views.AbstractAnetBean.LoadLevel;
 
 public class ReportsResourceTest extends AbstractResourceTest {
 
@@ -968,7 +967,6 @@ public class ReportsResourceTest extends AbstractResourceTest {
 				.get(new GenericType<List<RollupGraph>>() {});
 
 		final Position pos = admin.loadPosition();
-		pos.getOrganization().setLoadLevel(LoadLevel.ID_ONLY);
 		final Organization org = pos.loadOrganization(context).get();
 		final Map<String, Object> dictionary = RULE.getConfiguration().getDictionary();
 		@SuppressWarnings("unchecked")
@@ -1032,7 +1030,6 @@ public class ReportsResourceTest extends AbstractResourceTest {
 				.get(new GenericType<List<RollupGraph>>() {});
 
 		final Position pos = elizabeth.loadPosition();
-		pos.getOrganization().setLoadLevel(LoadLevel.ID_ONLY);
 		final Organization org = pos.loadOrganization(context).get();
 		final Map<String, Object> dictionary = RULE.getConfiguration().getDictionary();
 		@SuppressWarnings("unchecked")


### PR DESCRIPTION
Fix type of GraphQL input parameter for saved search requests.
Set max batch size to avoid query errors with SQL Server.
Remove left-over debug logging.
Remove all traces of LoadLevel as it is no longer used.