### PR TITLE
Add temporary height fix to make graphiql work in IE11

### DIFF
--- a/client/src/pages/GraphiQL.js
+++ b/client/src/pages/GraphiQL.js
@@ -38,7 +38,8 @@ class GraphiQL extends Page {
 	}
 
 	render() {
-		return <div>
+		// TODO: fix the below hack with inlined height after layout refactoring in NCI-Agency/anet#551
+		return <div style={{height:'600px'}}>
 			<Breadcrumbs items={[['Run GraphQL queries', '/graphiql']]} />
 			{GraphiQLreq ? <GraphiQLreq fetcher={this.fetch} /> : 'Loading...'}
 		</div>


### PR DESCRIPTION
this is a fix to make the /graphiql interface work again
fixes NCI-Agency/anet#3 