### PR TITLE
Add a sleep to the autocomplete page helper

### DIFF
--- a/client/tests/util/test.js
+++ b/client/tests/util/test.js
@@ -250,6 +250,7 @@ test.beforeEach(t => {
         async chooseAutocompleteOption(autocompleteSelector, text) {
             let $autocompleteTextbox = await t.context.$(autocompleteSelector)
             await $autocompleteTextbox.sendKeys(text)
+            t.context.driver.sleep(shortWaitMs) // give the autocomplete some time to send the request (debounce!)
             let $autocompleteSuggestion = await t.context.$('#react-autowhatever-1--item-0')
             await $autocompleteSuggestion.click()
             return $autocompleteTextbox


### PR DESCRIPTION
Avoid selecting a value too soon; autocomplete requests are debounced, so after typing the final characters, wait long enough for another autocomplete request.