### PR TITLE
NCI-Agency/anet#844: Fix display of location status

### DIFF
--- a/client/src/pages/locations/Show.js
+++ b/client/src/pages/locations/Show.js
@@ -49,7 +49,7 @@ class BaseLocationShow extends Page {
 
 		let locationQuery = new GQL.Part(/* GraphQL */`
 			location(id:${props.match.params.id}) {
-				id, name, lat, lng
+				id, name, lat, lng, status
 			}
 		`)
 


### PR DESCRIPTION
Make sure the location preview page shows the correct status for a location. It used to show status active for all locations, even for the inactive ones.