### PR TITLE
Make subnavigation for organization page content dependent

### DIFF
--- a/client/src/components/Nav.js
+++ b/client/src/components/Nav.js
@@ -19,21 +19,7 @@ class BaseNav extends Component {
 		currentUser: PropTypes.instanceOf(Person),
 		appSettings: PropTypes.object,
 		organizations: PropTypes.array,
-	}
-
-	constructor(props) {
-		super(props)
-		this.state = {
-			scrollspyOffset: 0
-		}
-	}
-
-	static getDerivedStateFromProps(props, state) {
-		const scrollspyOffset = -(props.topbarOffset + 20)
-		if (state.scrollspyOffset !== scrollspyOffset) {
-			return {scrollspyOffset: scrollspyOffset}
-		}
-		return null
+		scrollspyOffset: PropTypes.number,
 	}
 
 	render() {
@@ -56,20 +42,6 @@ class BaseNav extends Component {
 			myOrgId = myOrg && +myOrg.id
 		}
 
-		const orgSubNav = (
-			<NavWrap>
-				<Scrollspy className="nav" currentClassName="active" offset={this.state.scrollspyOffset}
-					items={ ['info', 'supportedPositions', 'vacantPositions', 'approvals', 'tasks', 'reports'] }>
-					<NavItem href="#info">Info</NavItem>
-					<NavItem href="#supportedPositions">Supported positions</NavItem>
-					<NavItem href="#vacantPositions">Vacant positions</NavItem>
-					<NavItem href="#approvals">Approvals</NavItem>
-					<NavItem href="#tasks">{pluralize(Settings.fields.task.shortLabel)}</NavItem>
-					<NavItem href="#reports">Reports</NavItem>
-				</Scrollspy>
-			</NavWrap>
-		)
-
 		return (
 			<BSNav bsStyle="pills" stacked id="leftNav" className="nav-fixed">
 				<Link to="/">
@@ -84,7 +56,7 @@ class BaseNav extends Component {
 
 				{inMyReports &&
 					<NavWrap>
-						<Scrollspy className="nav" currentClassName="active" offset={this.state.scrollspyOffset}
+						<Scrollspy className="nav" currentClassName="active" offset={this.props.scrollspyOffset}
 							items={ ['draft-reports', 'upcoming-engagements', 'pending-approval', 'published-reports'] }>
 							<NavItem href="#draft-reports">Draft reports</NavItem>
 							<NavItem href="#upcoming-engagements">Upcoming Engagements</NavItem>
@@ -98,7 +70,7 @@ class BaseNav extends Component {
 					<NavItem id="my-organization">My organization <br /><small>{myOrg.shortName}</small></NavItem>
 				</Link>}
 
-				{inOrg && orgId === myOrgId && orgSubNav}
+				<NavWrap id="myorg-nav"></NavWrap>
 
 				<NavDropdown title={Settings.fields.advisor.org.allOrgName} id="organizations" active={inOrg && orgId !== myOrgId}>
 					{Organization.map(organizations, org =>
@@ -108,7 +80,7 @@ class BaseNav extends Component {
 					)}
 				</NavDropdown>
 
-				{inOrg && orgId !== myOrgId && orgSubNav}
+				<NavWrap id="org-nav"></NavWrap>
 
 				<Link to="/rollup">
 					<NavItem>Daily rollup</NavItem>
@@ -160,7 +132,7 @@ class BaseNav extends Component {
 const Nav = (props) => (
 	<AppContext.Consumer>
 		{context =>
-			<BaseNav appSettings={context.appSettings} currentUser={context.currentUser} {...props} />
+			<BaseNav appSettings={context.appSettings} currentUser={context.currentUser} scrollspyOffset={context.scrollspyOffset} {...props} />
 		}
 	</AppContext.Consumer>
 )

--- a/client/src/components/SubNav.js
+++ b/client/src/components/SubNav.js
@@ -1,0 +1,35 @@
+import PropTypes from 'prop-types'
+import React, { Component } from 'react'
+import ReactDOM from 'react-dom'
+
+export default class SubNav extends Component {
+
+	static propTypes = {
+		subnavElemId: PropTypes.string.Required,
+	}
+
+	constructor(props) {
+		super(props)
+
+		this.state = {
+			subnavElem: document.getElementById(this.props.subnavElemId),
+		}
+	}
+
+	componentDidMount() {
+		const elem = document.getElementById(this.props.subnavElemId)
+		if (elem !== this.state.subnavElem) {
+			this.setState({subnavElem: elem})
+		}
+	}
+
+	render() {
+		return (this.state.subnavElem &&
+			ReactDOM.createPortal(
+				this.props.children,
+				this.state.subnavElem
+			)
+		)
+	}
+
+}

--- a/client/src/pages/App.js
+++ b/client/src/pages/App.js
@@ -76,16 +76,25 @@ class App extends Page {
 			currentUser: new Person(),
 			settings: {},
 			organizations: [],
-			topbarOffset: 0
+			topbarOffset: 0,
+			scrollspyOffset: 0
 		}
 
 		this.updateTopbarOffset = this.updateTopbarOffset.bind(this)
+		this.updateScrollspyOffset = this.updateScrollspyOffset.bind(this)
 		Object.assign(this.state, this.processData(window.ANET_DATA))
 	}
 
 	updateTopbarOffset(topbarOffset) {
 		if (this.state.topbarOffset !== topbarOffset){
-			this.setState({ topbarOffset: topbarOffset })
+			this.setState({ topbarOffset: topbarOffset }, this.updateScrollspyOffset)
+		}
+	}
+
+	updateScrollspyOffset() {
+		const scrollspyOffset = -(this.state.topbarOffset + 20)
+		if (this.state.scrollspyOffset !== scrollspyOffset) {
+			this.setState({scrollspyOffset: scrollspyOffset})
 		}
 	}
 
@@ -252,6 +261,7 @@ class App extends Page {
 				appSettings: this.state.settings,
 				currentUser: this.state.currentUser,
 				loadAppData: this.loadData,
+				scrollspyOffset: this.state.scrollspyOffset
 			}}>
 				<div className="anet">
 					<TopBar
@@ -265,9 +275,7 @@ class App extends Page {
 						<Row>
 							{this.props.pageProps.useNavigation === true &&
 								<Col sm={navWidths.sm} md={navWidths.md} lg={navWidths.lg} className="hide-for-print">
-									<Nav
-										organizations={this.state.organizations}
-										topbarOffset={this.state.topbarOffset} />
+									<Nav organizations={this.state.organizations} />
 								</Col>
 							}
 							<Col sm={primaryWidths.sm} md={primaryWidths.md} lg={primaryWidths.lg} className="primary-content">

--- a/client/src/pages/Search.js
+++ b/client/src/pages/Search.js
@@ -29,6 +29,8 @@ import TASKS_ICON from 'resources/tasks.png'
 import POSITIONS_ICON from 'resources/positions.png'
 import ORGANIZATIONS_ICON from 'resources/organizations.png'
 
+import SubNav from 'components/SubNav'
+
 import { DEFAULT_PAGE_PROPS, DEFAULT_SEARCH_PROPS } from 'actions'
 import { withRouter } from 'react-router-dom'
 import { connect } from 'react-redux'
@@ -79,34 +81,6 @@ const SEARCH_CONFIG = {
 		variableType: 'OrganizationSearchQueryInput',
 		fields: 'id, shortName, longName, identificationCode, type'
 	}
-}
-
-class SearchNav extends Component {
-
-	constructor(props) {
-		super(props)
-
-		this.state = {
-			searchNavElem: document.getElementById('search-nav'),
-		}
-	}
-
-	componentDidMount() {
-		const elem = document.getElementById('search-nav')
-		if (elem !== this.state.searchNavElem) {
-			this.setState({searchNavElem: elem})
-		}
-	}
-
-	render() {
-		return (this.state.searchNavElem &&
-			ReactDOM.createPortal(
-				this.props.children,
-				this.state.searchNavElem
-			)
-		)
-	}
-
 }
 
 class Search extends Page {
@@ -215,7 +189,7 @@ class Search extends Page {
 
 		return (
 			<div>
-				<SearchNav>
+				<SubNav subnavElemId="search-nav">
 					<div><Button onClick={this.props.history.goBack} bsStyle="link">&lt; Return to previous page</Button></div>
 					<Nav stacked bsStyle="pills" activeKey={queryType} onSelect={this.onSelectQueryType}>
 						<NavItem eventKey="everything" disabled={!numResults}>
@@ -253,7 +227,7 @@ class Search extends Page {
 							{numReports > 0 && <Badge pullRight>{numReports}</Badge>}
 						</NavItem>
 					</Nav>
-				</SearchNav>
+				</SubNav>
 
 				<div className="pull-right">
 					{!noResults &&


### PR DESCRIPTION
This makes sure that when we are on an organization page we only show the approvals and the tasks submenu  items when they also exist on the page.

Implements nci-agency/anet#549