### PR TITLE
Fix warning on organization details page

### DIFF
--- a/client/src/components/SubNav.js
+++ b/client/src/components/SubNav.js
@@ -5,7 +5,7 @@ import ReactDOM from 'react-dom'
 export default class SubNav extends Component {
 
 	static propTypes = {
-		subnavElemId: PropTypes.string.Required,
+		subnavElemId: PropTypes.string.isRequired,
 	}
 
 	constructor(props) {


### PR DESCRIPTION
This makes sure that the subnavElemId property of the SubNav component
has a proper type, it used to be wrong.

Implements NCI-Agency/anet#915