### PR TITLE
Do no extra search on click on search nav

### DIFF
--- a/client/src/components/Nav.js
+++ b/client/src/components/Nav.js
@@ -72,7 +72,7 @@ class BaseNav extends Component {
 
 				<NavWrap id="myorg-nav"></NavWrap>
 
-				<NavDropdown title={Settings.fields.advisor.org.allOrgName} id="organizations" active={inOrg && orgId !== myOrgId}>
+				<NavDropdown title={Settings.fields.advisor.org.allOrgName} id="advisor-organizations" active={inOrg && orgId !== myOrgId}>
 					{Organization.map(organizations, org =>
 						<LinkTo organization={org} componentClass={Link} key={org.id}>
 							<MenuItem>{org.shortName}</MenuItem>

--- a/client/src/components/Page.js
+++ b/client/src/components/Page.js
@@ -129,7 +129,11 @@ export default class Page extends Component {
 		} else {
 			// Location always has a new key. In order to check whether the location
 			// really changed filter out the key.
-			const locationFilterProps = ['key']
+			// When location has a changed has we do not need to reload the data.
+			// We do not make use of the location state, therefore we ignore it for now
+			// as otherwise a change from no state to empty state would result in
+			// reloading the data and we do not want that.
+			const locationFilterProps = ['key', 'hash', 'state']
 			const nextPropsFilteredLocation = Object.without(this.props.location, ...locationFilterProps)
 			const propsFilteredLocation = Object.without(prevProps.location, ...locationFilterProps)
 			if (!_isEqualWith(propsFilteredLocation, nextPropsFilteredLocation, utils.treatFunctionsAsEqual)) {

--- a/client/src/pages/Search.js
+++ b/client/src/pages/Search.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types'
 import React, { Component } from 'react'
 import Page, {mapDispatchToProps, propTypes as pagePropTypes} from 'components/Page'
 import {Alert, Table, Modal, Button, Nav, NavItem, Badge} from 'react-bootstrap'
@@ -37,6 +38,9 @@ import { connect } from 'react-redux'
 import _isEqualWith from 'lodash/isEqualWith'
 import utils from 'utils'
 import ReactDOM from 'react-dom'
+
+import AppContext from 'components/AppContext'
+import Scrollspy from 'react-scrollspy'
 
 const SEARCH_CONFIG = {
 	reports : {
@@ -83,10 +87,11 @@ const SEARCH_CONFIG = {
 	}
 }
 
-class Search extends Page {
+class BaseSearch extends Page {
 
 	static propTypes = {
 		...pagePropTypes,
+		scrollspyOffset: PropTypes.number,
 	}
 
 	constructor(props) {
@@ -94,7 +99,6 @@ class Search extends Page {
 
 		Object.assign(this.state, {
 			query: props.searchQuery.text || null,
-			queryType: null,
 			pageNum: {
 				reports: 0,
 				people: 0,
@@ -183,49 +187,45 @@ class Search extends Page {
 		const noResults = numResults === 0
 
 		const qs = utils.parseQueryString(this.props.location.search)
-		const queryType = this.state.queryType || 'everything'
 
 		const taskShortLabel = Settings.fields.task.shortLabel
-
 		return (
 			<div>
 				<SubNav subnavElemId="search-nav">
 					<div><Button onClick={this.props.history.goBack} bsStyle="link">&lt; Return to previous page</Button></div>
-					<Nav stacked bsStyle="pills" activeKey={queryType} onSelect={this.onSelectQueryType}>
-						<NavItem eventKey="everything" disabled={!numResults}>
-							<img src={EVERYTHING_ICON} alt="" /> Everything
-							{numResults > 0 && <Badge pullRight>{numResults}</Badge>}
-						</NavItem>
+					<Nav stacked bsStyle="pills">
+						<Scrollspy className="nav" currentClassName="active" offset={this.props.scrollspyOffset}
+							items={ ['organizations', 'people', 'positions', 'tasks', 'locations', 'reports'] }>
+							<NavItem href="#organizations" disabled={!numOrganizations}>
+								<img src={ORGANIZATIONS_ICON} alt="" /> Organizations
+								{numOrganizations > 0 && <Badge pullRight>{numOrganizations}</Badge>}
+							</NavItem>
 
-						<NavItem eventKey="organizations" disabled={!numOrganizations}>
-							<img src={ORGANIZATIONS_ICON} alt="" /> Organizations
-							{numOrganizations > 0 && <Badge pullRight>{numOrganizations}</Badge>}
-						</NavItem>
+							<NavItem href="#people" disabled={!numPeople}>
+								<img src={PEOPLE_ICON} alt="" /> People
+								{numPeople > 0 && <Badge pullRight>{numPeople}</Badge>}
+							</NavItem>
 
-						<NavItem eventKey="people" disabled={!numPeople}>
-							<img src={PEOPLE_ICON} alt="" /> People
-							{numPeople > 0 && <Badge pullRight>{numPeople}</Badge>}
-						</NavItem>
+							<NavItem href="#positions" disabled={!numPositions}>
+								<img src={POSITIONS_ICON} alt="" /> Positions
+								{numPositions > 0 && <Badge pullRight>{numPositions}</Badge>}
+							</NavItem>
 
-						<NavItem eventKey="positions" disabled={!numPositions}>
-							<img src={POSITIONS_ICON} alt="" /> Positions
-							{numPositions > 0 && <Badge pullRight>{numPositions}</Badge>}
-						</NavItem>
+							<NavItem href="#tasks" disabled={!numTasks}>
+								<img src={TASKS_ICON} alt="" /> {pluralize(taskShortLabel)}
+								{numTasks > 0 && <Badge pullRight>{numTasks}</Badge>}
+							</NavItem>
 
-						<NavItem eventKey="tasks" disabled={!numTasks}>
-							<img src={TASKS_ICON} alt="" /> {pluralize(taskShortLabel)}
-							{numTasks > 0 && <Badge pullRight>{numTasks}</Badge>}
-						</NavItem>
+							<NavItem href="#locations" disabled={!numLocations}>
+								<img src={LOCATIONS_ICON} alt="" /> Locations
+								{numLocations > 0 && <Badge pullRight>{numLocations}</Badge>}
+							</NavItem>
 
-						<NavItem eventKey="locations" disabled={!numLocations}>
-							<img src={LOCATIONS_ICON} alt="" /> Locations
-							{numLocations > 0 && <Badge pullRight>{numLocations}</Badge>}
-						</NavItem>
-
-						<NavItem eventKey="reports" disabled={!numReports}>
-							<img src={REPORTS_ICON} alt="" /> Reports
-							{numReports > 0 && <Badge pullRight>{numReports}</Badge>}
-						</NavItem>
+							<NavItem href="#reports" disabled={!numReports}>
+								<img src={REPORTS_ICON} alt="" /> Reports
+								{numReports > 0 && <Badge pullRight>{numReports}</Badge>}
+							</NavItem>
+						</Scrollspy>
 					</Nav>
 				</SubNav>
 
@@ -250,37 +250,37 @@ class Search extends Page {
 					</Alert>
 				}
 
-				{numOrganizations > 0 && (queryType === 'everything' || queryType === 'organizations') &&
-					<Fieldset title="Organizations">
+				{numOrganizations > 0 &&
+					<Fieldset id="organizations" title="Organizations">
 						{this.renderOrgs()}
 					</Fieldset>
 				}
 
-				{numPeople > 0 && (queryType === 'everything' || queryType === 'people') &&
-					<Fieldset title="People" >
+				{numPeople > 0 &&
+					<Fieldset id="people" title="People" >
 						{this.renderPeople()}
 					</Fieldset>
 				}
 
-				{numPositions > 0 && (queryType === 'everything' || queryType === 'positions') &&
-					<Fieldset title="Positions">
+				{numPositions > 0 &&
+					<Fieldset id="positions" title="Positions">
 						{this.renderPositions()}
 					</Fieldset>
 				}
 
-				{numTasks > 0 && (queryType === 'everything' || queryType === 'tasks') &&
-					<Fieldset title={pluralize(taskShortLabel)}>
+				{numTasks > 0 &&
+					<Fieldset id="tasks" title={pluralize(taskShortLabel)}>
 						{this.renderTasks()}
 					</Fieldset>
 				}
 
-				{numLocations > 0 && (queryType === 'everything' || queryType === 'locations') &&
-					<Fieldset title="Locations">
+				{numLocations > 0 &&
+					<Fieldset id="locations" title="Locations">
 						{this.renderLocations()}
 					</Fieldset>
 				}
-				{numReports > 0 && (queryType === 'everything' || queryType === 'reports') &&
-					<Fieldset title="Reports">
+				{numReports > 0 &&
+					<Fieldset id="reports" title="Reports">
 						<ReportCollection paginatedReports={results.reports} goToPage={this.goToPage.bind(this, 'reports')} />
 					</Fieldset>
 				}
@@ -502,16 +502,18 @@ class Search extends Page {
 	closeSaveModal() {
 		this.setState({saveSearch: {show: false}})
 	}
-
-	@autobind
-	onSelectQueryType(type) {
-		this.setState({queryType: type}, () => this.loadData())
-	}
-
 }
 
 const mapStateToProps = (state, ownProps) => ({
 	searchQuery: state.searchQuery,
 })
+
+const Search = (props) => (
+	<AppContext.Consumer>
+		{context =>
+			<BaseSearch scrollspyOffset={context.scrollspyOffset} {...props} />
+		}
+	</AppContext.Consumer>
+)
 
 export default connect(mapStateToProps, mapDispatchToProps)(withRouter(Search))

--- a/client/src/pages/organizations/Show.js
+++ b/client/src/pages/organizations/Show.js
@@ -36,6 +36,7 @@ class BaseOrganizationShow extends Page {
 	static propTypes = {
 		...pagePropTypes,
 		currentUser: PropTypes.instanceOf(Person),
+		scrollspyOffset: PropTypes.number,
 	}
 
 	static modelName = 'Organization'
@@ -183,7 +184,6 @@ class BaseOrganizationShow extends Page {
 				</Scrollspy>
 			</Nav>
 		)
-
 		return (
 			<div>
 				<SubNav subnavElemId="myorg-nav">


### PR DESCRIPTION
This makes sure that when clicking on an item of the search navigation
we no longer perform a new search but just go to the anchor of the
selected search result type.

The search navigation now also uses scrollspy and the everything option
has been removed from the navigation as the page always contains all
results.

This also makes sure that clicking an anchor link no longer results in
the page being reloaded.

Implements NCI-Agency/anet#890