### PR TITLE
NCI-Agency/anet#519: Use separate labels for position type/permissons

### DIFF
--- a/anet.yml
+++ b/anet.yml
@@ -262,6 +262,7 @@ dictionary:
           - United States of America
       position:
         name: NATO Billet
+        type: ANET User
       org:
         name: Advisor Organization
         allOrgName: All EFs / AOs
@@ -278,6 +279,7 @@ dictionary:
           - Afghanistan
       position:
         name: Afghan Tashkil
+        type: Afghan Partner
       org:
         name: Afghan Government Organization
         longName:
@@ -288,10 +290,10 @@ dictionary:
           placeholder: the six character code
     superUser:
       position:
-        name: ANET Super User
+        type: ANET Super User
     administrator:
       position:
-        name: ANET Administrator
+        type: ANET Administrator
   pinned_ORGs:
     - Key Leader Engagement
   non_reporting_ORGs:

--- a/client/src/models/Position.js
+++ b/client/src/models/Position.js
@@ -45,13 +45,13 @@ export default class Position extends Model {
 
 	static humanNameOfType(type) {
 		if (type === Position.TYPE.PRINCIPAL) {
-			return Settings.fields.principal.position.name
+			return Settings.fields.principal.position.type
 		} else if (type === Position.TYPE.ADVISOR) {
-			return Settings.fields.advisor.position.name
+			return Settings.fields.advisor.position.type
 		} else if (type === Position.TYPE.SUPER_USER) {
-			return Settings.fields.superUser.position.name
+			return Settings.fields.superUser.position.type
 		} else if (type === Position.TYPE.ADMINISTRATOR) {
-			return Settings.fields.administrator.position.name
+			return Settings.fields.administrator.position.type
 		}
 	}
 

--- a/client/src/pages/positions/Form.js
+++ b/client/src/pages/positions/Form.js
@@ -119,12 +119,12 @@ class BasePositionForm extends ValidatableFormWrapper {
 					{position.type !== Position.TYPE.PRINCIPAL &&
 						<Form.Field id="permissions">
 							<ButtonToggleGroup>
-								<Button id="permsAdvisorButton" value={Position.TYPE.ADVISOR}>{Settings.fields.advisor.position.name}</Button>
+								<Button id="permsAdvisorButton" value={Position.TYPE.ADVISOR}>{Settings.fields.advisor.position.type}</Button>
 								{isAdmin &&
-									<Button id="permsSuperUserButton" value={Position.TYPE.SUPER_USER}>{Settings.fields.superUser.position.name}</Button>
+									<Button id="permsSuperUserButton" value={Position.TYPE.SUPER_USER}>{Settings.fields.superUser.position.type}</Button>
 								}
 								{isAdmin &&
-									<Button id="permsAdminButton" value={Position.TYPE.ADMINISTRATOR}>{Settings.fields.administrator.position.name}</Button>
+									<Button id="permsAdminButton" value={Position.TYPE.ADMINISTRATOR}>{Settings.fields.administrator.position.type}</Button>
 								}
 							</ButtonToggleGroup>
 						</Form.Field>

--- a/client/src/pages/positions/Show.js
+++ b/client/src/pages/positions/Show.js
@@ -72,7 +72,7 @@ class BasePositionShow extends Page {
 
 	render() {
 		const position = this.state.position
-		const assignedRole = position.type === Position.TYPE.PRINCIPAL ? Settings.fields.advisor.person.name : Settings.fields.principal.person.name // TODO: shouldn't this be Position.humanNameOfType instead of a person title?
+		const assignedRole = position.type === Position.TYPE.PRINCIPAL ? Settings.fields.advisor.person.name : Settings.fields.principal.person.name
 
 		const { currentUser } = this.props
 		const canEdit =

--- a/src/main/resources/anet-schema.yml
+++ b/src/main/resources/anet-schema.yml
@@ -155,8 +155,15 @@ properties:
                 description: Used in the UI where a position inside an advisor organization is shown.
                 examples:
                 - NATO Billet
+              type:
+                type: string
+                title: The permissions type of this field
+                description: Used in the UI for the type/permissions of an advisor position.
+                examples:
+                - ANET User
             required:
             - name
+            - type
           org:
             type: object
             additionalProperties: false
@@ -222,8 +229,15 @@ properties:
                 description: Used in the UI where a position inside a principal organization is shown.
                 examples:
                 - Afghan Tashkil
+              type:
+                type: string
+                title: The permissions type of this field
+                description: Used in the UI for the type/permissions of a principal position.
+                examples:
+                - Afghan Partner
             required:
             - name
+            - type
           org:
             type: object
             additionalProperties: false
@@ -253,14 +267,14 @@ properties:
             type: object
             additionalProperties: false
             properties:
-              name:
+              type:
                 type: string
-                title: The name of this field
-                description: The name of the super user role.
+                title: The permissions type of this field
+                description: Used in the UI for the type/permissions of a super user position.
                 examples:
                 - ANET Super User
             required:
-            - name
+            - type
         required:
         - position
       administrator:
@@ -271,14 +285,14 @@ properties:
             type: object
             additionalProperties: false
             properties:
-              name:
+              type:
                 type: string
-                title: The name of this field
-                description: The name of the administrator role.
+                title: The permissions type of this field
+                description: Used in the UI for the type/permissions of an administrator position.
                 examples:
                 - ANET Administrator
             required:
-            - name
+            - type
         required:
         - position
     required:


### PR DESCRIPTION
For advisor positions, this makes the labeling more consistent, either:
ANET User, Anet Super User or ANET Administrator.
Closes NCI-Agency/anet#519