### PR TITLE
NCI-Agency/anet#903: Change placeholder for first name field

### DIFF
--- a/client/src/pages/people/Form.js
+++ b/client/src/pages/people/Form.js
@@ -108,7 +108,7 @@ class BasePersonForm extends ValidatableFormWrapper {
 			id: "firstName",
 			type: "text",
 			display: "inline",
-			placeholder: "First name(s)",
+			placeholder: "First name(s) - Lower-case except for the first letter of each name",
 			value: this.state.splitName.firstName,
 			onChange: this.handleOnChangeFirstName
 		}


### PR DESCRIPTION
Indicate to the user that they should use only initial caps on first names (not all caps).
Closes NCI-Agency/anet#903