### PR TITLE
Improve use of position code

### DIFF
--- a/client/src/models/Person.js
+++ b/client/src/models/Person.js
@@ -43,12 +43,12 @@ export default class Person extends Model {
 		position: {},
 	}
 
-	static autocompleteQuery = "id, name, role, rank, position { id, name, organization { id, shortName }, location {id, name} }"
+	static autocompleteQuery = "id, name, role, rank, position { id, name, code, organization { id, shortName }, location {id, name} }"
 
 	static autocompleteTemplate(person) {
 		return <span>
 			<img src={(new Person(person)).iconUrl()} alt={person.role} height={20} className="person-icon" />
-			<LinkTo person={person} isLink={false}/> {person.position && (`- ( ${person.position.name}` + (person.position.location ? `, ${ person.position.location.name} )` : ` )` ) )}
+			<LinkTo person={person} isLink={false}/> {person.position && (`- (${person.position.name}` + (person.position.code ? `, ${person.position.code}` : ``) + (person.position.location ? `, ${ person.position.location.name}` : ``) + `)` )}
 		</span>
 	}
 

--- a/client/src/pages/App.js
+++ b/client/src/pages/App.js
@@ -41,7 +41,7 @@ class App extends Page {
 			me {
 				id, name, role, emailAddress, rank, status
 				position {
-					id, name, type, status, isApprover
+					id, name, code, type, status, isApprover
 					organization { id, shortName , allDescendantOrgs { id }}
 					location {id, name}
 				}

--- a/client/src/pages/reports/Edit.js
+++ b/client/src/pages/reports/Edit.js
@@ -46,7 +46,7 @@ class BaseReportEdit extends Page {
 				location { id, name },
 				attendees {
 					id, name, role, primary
-					position { id, name, organization { id, shortName}, location {id, name} }
+					position { id, name, code, organization { id, shortName}, location {id, name} }
 				}
 				tasks { id, shortName, longName, responsibleOrg { id, shortName} }
 				tags { id, name, description }

--- a/client/src/pages/reports/Form.js
+++ b/client/src/pages/reports/Form.js
@@ -459,7 +459,7 @@ class BaseReportForm extends ValidatableFormWrapper {
 				<img src={person.iconUrl()} alt={person.role} height={20} className="person-icon" />
 				<LinkTo person={person}/>
 			</td>
-			<td><LinkTo position={person.position} /></td>
+			<td><LinkTo position={person.position} />{person.position && person.position.code ? `, ${person.position.code}`: ``}</td>
 			<td><LinkTo whenUnspecified="" position={person.position && person.position.location} /></td>
 			<td><LinkTo whenUnspecified="" organization={person.position && person.position.organization} /> </td>
 			<td onClick={this.removeAttendee.bind(this, person)} id={'attendeeDelete_' + person.role + "_" + idx} >

--- a/client/src/pages/reports/Show.js
+++ b/client/src/pages/reports/Show.js
@@ -76,7 +76,7 @@ class BaseReportShow extends Page {
 
 				attendees {
 					id, name, role, primary, rank, status, endOfTourDate
-					position { id, name, status, organization { id, shortName}, location {id, name} }
+					position { id, name, code, status, organization { id, shortName}, location {id, name} }
 				}
 				primaryAdvisor { id }
 				primaryPrincipal { id }
@@ -458,7 +458,7 @@ class BaseReportShow extends Page {
 				<img src={person.iconUrl()} alt={person.role} height={20} width={20} className="person-icon" />
 				<LinkTo person={person} />
 			</td>
-			<td><LinkTo position={person.position} /></td>
+			<td><LinkTo position={person.position} />{person.position && person.position.code ? `, ${person.position.code}`: ``}</td>
 			<td><LinkTo whenUnspecified="" position={person.position && person.position.location} /></td>
 			<td><LinkTo whenUnspecified="" organization={person.position && person.position.organization} /> </td>
 		</tr>

--- a/src/main/java/mil/dds/anet/search/mssql/MssqlPersonSearcher.java
+++ b/src/main/java/mil/dds/anet/search/mssql/MssqlPersonSearcher.java
@@ -57,9 +57,11 @@ public class MssqlPersonSearcher implements IPersonSearcher {
 					+ "c_people.rank IS NOT NULL"
 					+ " OR f_people.rank IS NOT NULL");
 			if (query.getMatchPositionName()) {
-				sql.append(" LEFT JOIN CONTAINSTABLE(positions, (name, code), :containsQuery) c_positions"
+				sql.append(" LEFT JOIN CONTAINSTABLE(positions, (name), :containsQuery) c_positions"
 						+ " ON positions.id = c_positions.[Key]");
-				whereRank.append(" OR c_positions.rank IS NOT NULL");
+				whereRank.append(" OR c_positions.rank IS NOT NULL"
+						+ " OR positions.code LIKE :likeQuery");
+				sqlArgs.put("likeQuery", Utils.prepForLikeQuery(text) + "%");
 			}
 			whereRank.append(")");
 			whereClauses.add(whereRank.toString());

--- a/src/main/java/mil/dds/anet/search/mssql/MssqlPositionSearcher.java
+++ b/src/main/java/mil/dds/anet/search/mssql/MssqlPositionSearcher.java
@@ -49,10 +49,11 @@ public class MssqlPositionSearcher implements IPositionSearcher {
 		}
 
 		if (doFullTextSearch) {
-			sql.append(" LEFT JOIN CONTAINSTABLE (positions, (name, code), :containsQuery) c_positions"
+			sql.append(" LEFT JOIN CONTAINSTABLE (positions, (name), :containsQuery) c_positions"
 					+ " ON positions.id = c_positions.[Key]");
 			final StringBuilder whereRank = new StringBuilder("("
-					+ "c_positions.rank IS NOT NULL");
+					+ "c_positions.rank IS NOT NULL"
+					+ " OR positions.code LIKE :likeQuery");
 			if (Boolean.TRUE.equals(query.getMatchPersonName())) {
 				sql.append(" LEFT JOIN CONTAINSTABLE(people, (name), :containsQuery) c_people"
 						+ " ON people.id = c_people.[Key]");
@@ -61,6 +62,7 @@ public class MssqlPositionSearcher implements IPositionSearcher {
 			whereRank.append(")");
 			whereClauses.add(whereRank.toString());
 			sqlArgs.put("containsQuery", Utils.getSqlServerFullTextQuery(text));
+			sqlArgs.put("likeQuery", Utils.prepForLikeQuery(text) + "%");
 		}
 
 		if (query.getType() != null) {


### PR DESCRIPTION
Search for position code using prefix match. As position codes do not contain real text, don't use the full-text index for querying, since the results would then be sub-optimal.
Closes NCI-Agency/anet#1017

Show position code for attendees.
Closes NCI-Agency/anet#1018