### PR TITLE
Show warnings before submitting or approving report

### DIFF
--- a/client/src/index.css
+++ b/client/src/index.css
@@ -545,6 +545,7 @@ table hr.attendee-divider {
 	margin-left: 0;
 }
 
+.approve-button,
 .submit-buttons .btn-primary {
 	font-weight: bold;
 	height: 38px;

--- a/client/src/models/Report.js
+++ b/client/src/models/Report.js
@@ -1,5 +1,7 @@
+import Settings from 'Settings'
 import Model from 'components/Model'
 import moment from 'moment'
+import _isEmpty from 'lodash/isEmpty'
 import {Organization, Person, Position} from 'models'
 
 export default class Report extends Model {
@@ -59,6 +61,10 @@ export default class Report extends Model {
 		return this.state === Report.STATE.REJECTED
 	}
 
+	isCancelled() {
+		return this.state === Report.STATE.CANCELLED
+	}
+
 	isFuture() {
 		return this.state === Report.STATE.FUTURE
 	}
@@ -72,7 +78,8 @@ export default class Report extends Model {
 	}
 
 	validateForSubmit() {
-		let errors = []
+		const errors = []
+		const warnings = []
 
 		let isCancelled = this.cancelledReason ? true : false
 		if (!isCancelled) {
@@ -104,7 +111,12 @@ export default class Report extends Model {
 		if (!isCancelled && !this.keyOutcomes) {
 			errors.push('You must provide a brief summary of the Key Outcomes')
 		}
-		return errors
+
+		if (_isEmpty(this.tasks)) {
+			warnings.push(`You should provide ${Settings.fields.task.longLabel}`)
+		}
+
+		return {errors, warnings}
 	}
 
 	checkPrimaryAttendee(primaryAttendee, primaryOrg, role, orgType, errors) {

--- a/client/src/models/Report.js
+++ b/client/src/models/Report.js
@@ -113,11 +113,11 @@ export default class Report extends Model {
 		}
 
 		if (_isEmpty(this.tasks)) {
-			warnings.push(`You should provide ${Settings.fields.task.longLabel}`)
+			warnings.push(`You should provide the ${Settings.fields.task.longLabel} that have been addressed in this engagement. Either edit the report to do so, or you are acknowledging that this engagement did not address any ${Settings.fields.task.longLabel}`)
 		}
 
 		if (!_isEmpty(this.reportSensitiveInformation) && !_isEmpty(this.reportSensitiveInformation.text) && _isEmpty(this.authorizationGroups)) {
-			warnings.push(`You should provide authorization groups who can access the sensitive information`)
+			warnings.push(`You should provide authorization groups who can access the sensitive information. If you do not do so, you will remain the only one authorized to see the sensitive information you have entered`)
 		}
 
 		return {errors, warnings}

--- a/client/src/models/Report.js
+++ b/client/src/models/Report.js
@@ -116,6 +116,10 @@ export default class Report extends Model {
 			warnings.push(`You should provide ${Settings.fields.task.longLabel}`)
 		}
 
+		if (!_isEmpty(this.reportSensitiveInformation) && !_isEmpty(this.reportSensitiveInformation.text) && _isEmpty(this.authorizationGroups)) {
+			warnings.push(`You should provide authorization groups who can access the sensitive information`)
+		}
+
 		return {errors, warnings}
 	}
 

--- a/client/src/pages/reports/Minimal.js
+++ b/client/src/pages/reports/Minimal.js
@@ -14,6 +14,7 @@ import LinkTo from 'components/LinkTo'
 import Settings from 'Settings'
 import API from 'api'
 import {Report, Person, Task} from 'models'
+import _isEmpty from 'lodash/isEmpty'
 
 import { PAGE_PROPS_MIN_HEAD } from 'actions'
 import { connect } from 'react-redux'
@@ -96,7 +97,7 @@ class ReportMinimal extends Page {
 	render() {
 		let {report} = this.state
 
-		let errors = report.isDraft() && report.validateForSubmit()
+		const {errors, warnings} = (!report.isReleased() && !report.isCancelled()) && report.validateForSubmit()
 		let isCancelled = (report.cancelledReason) ? true : false
 
 		return (
@@ -114,9 +115,7 @@ class ReportMinimal extends Page {
 						<h4 className="text-danger">This report is in DRAFT state and hasn't been submitted.</h4>
 						<p>You can review the draft below to make sure all the details are correct.</p>
 						<div style={{textAlign: 'left'}}>
-							{errors && errors.length > 0 &&
-								this.renderValidationErrors(errors)
-							}
+							{this.renderValidationMessages(errors, warnings)}
 						</div>
 					</Fieldset>
 				}
@@ -327,12 +326,36 @@ class ReportMinimal extends Page {
 		</div>
 	}
 
+	renderValidationMessages(errors, warnings) {
+		return <React.Fragment>
+			{this.renderValidationErrors(errors)}
+			{this.renderValidationWarnings(warnings)}
+		</React.Fragment>
+	}
+
 	renderValidationErrors(errors) {
+		if (_isEmpty(errors)) {
+			return null
+		}
 		return <Alert bsStyle="danger">
-			The following errors must be fixed before submitting this report
+			The following errors must be fixed before submitting this report:
 			<ul>
 			{ errors.map((error,idx) =>
 				<li key={idx}>{error}</li>
+			)}
+			</ul>
+		</Alert>
+	}
+
+	renderValidationWarnings(warnings) {
+		if (_isEmpty(warnings)) {
+			return null
+		}
+		return <Alert bsStyle="warning">
+			The following warnings should be addressed before submitting this report:
+			<ul>
+			{warnings.map((warning ,idx) =>
+				<li key={idx}>{warning}</li>
 			)}
 			</ul>
 		</Alert>

--- a/client/src/pages/reports/Show.js
+++ b/client/src/pages/reports/Show.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import Page, {mapDispatchToProps, propTypes as pagePropTypes} from 'components/Page'
 import {Alert, Table, Button, Col, HelpBlock, Modal, Checkbox} from 'react-bootstrap'
+import Confirm from 'react-confirm-bootstrap'
 import autobind from 'autobind-decorator'
 import moment from 'moment'
 import utils from 'utils'
@@ -18,6 +19,7 @@ import Tag from 'components/Tag'
 import API from 'api'
 import Settings from 'Settings'
 import {Report, Person, Task, Comment, Position} from 'models'
+import _isEmpty from 'lodash/isEmpty'
 
 import ConfirmDelete from 'components/ConfirmDelete'
 
@@ -156,7 +158,7 @@ class BaseReportShow extends Page {
 		//Anybody can email a report as long as it's not in draft.
 		let canEmail = !report.isDraft()
 
-		let errors = (report.isDraft() || report.isFuture()) && report.validateForSubmit()
+		const {errors, warnings} = (!report.isReleased() && !report.isCancelled()) && report.validateForSubmit()
 
 		let isCancelled = report.cancelledReason ? true : false
 
@@ -178,6 +180,9 @@ class BaseReportShow extends Page {
 					<Fieldset style={{textAlign: 'center' }}>
 						<h4 className="text-danger">This report was REJECTED. </h4>
 						<p>You can review the comments below, fix the report and re-submit</p>
+						<div style={{textAlign: 'left'}}>
+							{this.renderValidationMessages(errors, warnings)}
+						</div>
 					</Fieldset>
 				}
 
@@ -189,9 +194,7 @@ class BaseReportShow extends Page {
 							this.renderNoPositionAssignedText()
 						}
 						<div style={{textAlign: 'left'}}>
-							{errors && errors.length > 0 &&
-								this.renderValidationErrors(errors)
-							}
+							{this.renderValidationMessages(errors, warnings)}
 						</div>
 					</Fieldset>
 				}
@@ -208,9 +211,7 @@ class BaseReportShow extends Page {
 						<h4 className="text-success">This report is for an UPCOMING engagement.</h4>
 						<p>After your engagement has taken place, edit and submit this document as an engagement report.</p>
 						<div style={{textAlign: 'left'}}>
-							{errors && errors.length > 0 &&
-								this.renderValidationErrors(errors)
-							}
+							{this.renderValidationMessages(errors, warnings)}
 						</div>
 					</Fieldset>
 				}
@@ -221,7 +222,7 @@ class BaseReportShow extends Page {
 					<Fieldset title={`Report #${report.id}`} className="show-report-overview" action={<div>
 						{canEmail && <Button onClick={this.toggleEmailModal}>Email report</Button>}
 						{canEdit && <LinkTo report={report} edit button="primary">Edit</LinkTo>}
-						{canSubmit && errors.length === 0 && <Button bsStyle="primary" onClick={this.submitDraft}>Submit report</Button>}
+						{canSubmit && _isEmpty(errors) && this.renderSubmitButton(errors, warnings)}
 					</div>
 					}>
 
@@ -350,24 +351,18 @@ class BaseReportShow extends Page {
 					{canSubmit &&
 						<Fieldset>
 							<Col md={9}>
-								{(errors && errors.length > 0) ?
-									this.renderValidationErrors(errors)
-									:
-										<p>
-											By pressing submit, this report will be sent to
-											<strong> {Object.get(report, 'author.position.organization.name') || 'your organization approver'} </strong>
-											to go through the approval workflow.
-										</p>
+								{_isEmpty(errors) &&
+									<p>
+										By pressing submit, this report will be sent to
+										<strong> {Object.get(report, 'author.position.organization.name') || 'your organization approver'} </strong>
+										to go through the approval workflow.
+									</p>
 								}
+								{this.renderValidationMessages(errors, warnings)}
 							</Col>
 
 							<Col md={3}>
-								<Button type="submit" bsStyle="primary" bsSize="large"
-									onClick={this.submitDraft}
-									disabled={errors && errors.length > 0}
-									id="submitReportButton">
-									Submit report
-								</Button>
+								{this.renderSubmitButton(errors, warnings, "large", "submitReportButton")}
 							</Col>
 						</Fieldset>
 					}
@@ -395,7 +390,7 @@ class BaseReportShow extends Page {
 						</Form>
 					</Fieldset>
 
-					{canApprove && this.renderApprovalForm()}
+					{canApprove && this.renderApprovalForm(errors, warnings)}
 				</Form>
 				{currentUser.isAdmin() &&
 					<div className="submit-buttons"><div>
@@ -431,7 +426,7 @@ class BaseReportShow extends Page {
 	}
 
 	@autobind
-	renderApprovalForm() {
+	renderApprovalForm(errors, warnings) {
 		return <Fieldset className="report-sub-form" title="Report approval">
 			<h5>You can approve, reject, or edit this report</h5>
 
@@ -447,7 +442,7 @@ class BaseReportShow extends Page {
 			<Button bsStyle="warning" onClick={this.handleRejectReport}>Reject with comment</Button>
 			<div className="right-button">
 				<LinkTo report={this.state.report} edit button>Edit report</LinkTo>
-				<Button bsStyle="primary" onClick={this.handleApproveReport} className="approve-button"><strong>Approve</strong></Button>
+				{this.renderApproveButton(errors, warnings)}
 			</div>
 		</Fieldset>
 	}
@@ -688,18 +683,75 @@ class BaseReportShow extends Page {
 		jumpToTop()
 	}
 
+	renderSubmitButton(errors, warnings, size, id) {
+		return this.renderValidationButton("Submit report?", "Submit report", "Submit anyway", "Cancel submit", this.submitDraft, errors, warnings, size, id)
+	}
+
+	renderApproveButton(errors, warnings, size, id) {
+		return this.renderValidationButton("Approve report?", "Approve", "Approve anyway", "Cancel approve", this.handleApproveReport, errors, warnings, size, id, "approve-button")
+	}
+
+	renderValidationButton(title, label, confirmText, cancelText, handler, errors, warnings, size, id, className) {
+		return _isEmpty(warnings)
+			?
+			<Button type="submit" bsStyle="primary" bsSize={size} className={className}
+				onClick={handler}
+				disabled={!_isEmpty(errors)}
+				id={id}>
+				{label}
+			</Button>
+			:
+			<Confirm
+				onConfirm={handler}
+				title={title}
+				body={this.renderValidationWarnings(warnings)}
+				confirmText={confirmText}
+				cancelText={cancelText}
+				dialogClassName="react-confirm-bootstrap-modal"
+				confirmBSStyle="primary">
+				<Button type="submit" bsStyle="primary" bsSize={size} className={className}
+					disabled={!_isEmpty(errors)}
+					id={id}>
+					{label}
+				</Button>
+			</Confirm>
+	}
+
+	renderValidationMessages(errors, warnings) {
+		return <React.Fragment>
+			{this.renderValidationErrors(errors)}
+			{this.renderValidationWarnings(warnings)}
+		</React.Fragment>
+	}
 
 	renderValidationErrors(errors) {
+		if (_isEmpty(errors)) {
+			return null
+		}
 		let warning = this.state.report.isFuture() ?
 			'You\'ll need to fill out these required fields before you can submit your final report:'
 			:
-			'The following errors must be fixed before submitting this report'
+			'The following errors must be fixed before submitting this report:'
 		let style = this.state.report.isFuture() ? "info" : "danger"
 		return <Alert bsStyle={style}>
 			{warning}
 			<ul>
 			{ errors.map((error,idx) =>
 				<li key={idx}>{error}</li>
+			)}
+			</ul>
+		</Alert>
+	}
+
+	renderValidationWarnings(warnings) {
+		if (_isEmpty(warnings)) {
+			return null
+		}
+		return <Alert bsStyle="warning">
+			The following warnings should be addressed before submitting this report:
+			<ul>
+			{warnings.map((warning ,idx) =>
+				<li key={idx}>{warning}</li>
 			)}
 			</ul>
 		</Alert>


### PR DESCRIPTION
Show a warning when no Tasks and Milestones have been filled in.
Show a warning when a report has sensitive information but no authorization groups.
Also ask for confirmation before submitting or approving such reports.

Closes NCI-Agency/anet#235
Closes NCI-Agency/anet#1077