### PR TITLE
Super users can change a person's status to INACTIVE

### DIFF
--- a/client/src/pages/people/Form.js
+++ b/client/src/pages/people/Form.js
@@ -117,8 +117,8 @@ class BasePersonForm extends ValidatableFormWrapper {
 		const { currentUser } = this.props
 		const isAdmin = currentUser && currentUser.isAdmin()
 		const isSelf = Person.isEqual(currentUser, person)
-		// status can only be changed by admins (but not of self!)
-		const disableStatusChange = !isAdmin || isSelf
+		// anyone with edit permissions can change status to INACTIVE, only admins can change back to ACTIVE (but nobody can change status of self!)
+		const disableStatusChange = (this.state.originalStatus === Person.STATUS.INACTIVE && !isAdmin) || isSelf
 		// admins can edit all persons, new users can be edited by super users or themselves
 		const canEditName = isAdmin || (
 				(person.isNewUser() || !edit) && currentUser && (


### PR DESCRIPTION
Only admins can change back to ACTIVE (but nobody can change status of self!).

Fixes NCI-Agency/anet#969 (was interpreted too strictly in previous PR)