### PR TITLE
Remove container requirement from travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,6 @@ language: java
 jdk:
   - oraclejdk8
 
-sudo: false
-
 services:
   - docker
 


### PR DESCRIPTION
In support of the anounced migration by the travis team: https://blog.travis-ci.com/2018-10-04-combining-linux-infrastructures