### PR TITLE
Add basic search based on a gazetteer to ANET

### DIFF
--- a/anet.yml
+++ b/anet.yml
@@ -320,6 +320,9 @@ dictionary:
         zoomLevel: 10
       leafletOptions:
         attributionControl: false
+    geoSearcher:
+      provider: ESRI
+      url: "geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer/find"
     baseLayers:
       - name: OSM
         default: true

--- a/client/package.json
+++ b/client/package.json
@@ -76,6 +76,7 @@
     "hopscotch": "^0.3.1",
     "imports-loader": "^0.8.0",
     "leaflet": "^1.3.4",
+    "leaflet-geosearch": "^2.7.0",
     "locale-compare-polyfill": "^0.0.2",
     "lodash": "^4.17.11",
     "moment": "^2.22.2",

--- a/client/src/components/Leaflet.js
+++ b/client/src/components/Leaflet.js
@@ -29,20 +29,19 @@ class CustomUrlEsriProvider extends EsriProvider {
 	}
 
 	endpoint({ query, protocol } = {}) {
-	  const { params } = this.options
-	  const paramString = this.getParamString({
-		...params,
-		f: 'json',
-		text: query,
-	  })
-	  return `${protocol}//${this.options.url}?${paramString}`
+		const { params } = this.options
+		const paramString = this.getParamString({
+			...params,
+			f: 'json',
+			text: query,
+		})
+		return `${protocol}//${this.options.url}?${paramString}`
 	}
   }
 
 const geoSearcherProviders = {
-	ESRI : () => { return new CustomUrlEsriProvider({url: Settings.imagery.geoSearcher.url,
-                                                     params: {maxLocations : 10}})},
-	OSM :  () => { return new OpenStreetMapProvider()}
+	ESRI: () => { return new CustomUrlEsriProvider({url: Settings.imagery.geoSearcher.url, params: {maxLocations: 10}}) },
+	OSM: () => { return new OpenStreetMapProvider() },
 }
 
 const searchProvider = Settings.imagery.geoSearcher && geoSearcherProviders[Settings.imagery.geoSearcher.provider]()
@@ -64,11 +63,11 @@ class BaseLeaflet extends Component {
 		}
 
 		this.icon = new Icon({
-			iconUrl:       MARKER_ICON,
+			iconUrl: MARKER_ICON,
 			iconRetinaUrl: MARKER_ICON_2X,
-			shadowUrl:     MARKER_SHADOW,
-			iconSize:    [25, 41],
-			iconAnchor:  [12, 41],
+			shadowUrl: MARKER_SHADOW,
+			iconSize: [25, 41],
+			iconAnchor: [12, 41],
 			popupAnchor: [1, -34],
 			tooltipAnchor: [16, -28],
 			shadowSize: [41, 41]
@@ -84,10 +83,10 @@ class BaseLeaflet extends Component {
 		const mapOptions = Object.assign({zoomControl:true},
 										 Settings.imagery.mapOptions.leafletOptions,
 										 Settings.imagery.mapOptions.crs && { crs: CRS[Settings.imagery.mapOptions.crs] })
-		const map = new Map(this.mapId, mapOptions).setView( Settings.imagery.mapOptions.homeView.location,
-															 Settings.imagery.mapOptions.homeView.zoomLevel)
-        if (searchProvider) {
-            new GeoSearchControl({ provider: searchProvider }).addTo(map)
+		const map = new Map(this.mapId, mapOptions).setView(Settings.imagery.mapOptions.homeView.location,
+															Settings.imagery.mapOptions.homeView.zoomLevel)
+		if (searchProvider) {
+			new GeoSearchControl({ provider: searchProvider }).addTo(map)
 		}
 
 		const layerControl = new Control.Layers({}, {}, {collapsed:false})

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -7614,6 +7614,14 @@ lcid@^2.0.0:
   dependencies:
     invert-kv "^2.0.0"
 
+leaflet-geosearch@^2.7.0:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/leaflet-geosearch/-/leaflet-geosearch-2.7.0.tgz#0f7b319486ea344b00639b84b338b4087bf6b839"
+  integrity sha512-6rZIZ5mp9Ifp3R37DKe7ipHV6/qnUY5kP1gNDz3oMT4hp5FqKyB2V4enoTDT1iziE8yrn0hy/OP9oI4HG1dKEw==
+  dependencies:
+    lodash.debounce "^4.0.8"
+    nodent-runtime "^3.0.4"
+
 leaflet@^1.3.4:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/leaflet/-/leaflet-1.3.4.tgz#7f006ea5832603b53d7269ef5c595fd773060a40"
@@ -7759,7 +7767,7 @@ lodash.clonedeepwith@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.clonedeepwith/-/lodash.clonedeepwith-4.5.0.tgz#6ee30573a03a1a60d670a62ef33c10cf1afdbdd4"
   integrity sha1-buMFc6A6GmDWcKYu8zwQzxr9vdQ=
 
-lodash.debounce@^4.0.3:
+lodash.debounce@^4.0.3, lodash.debounce@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
   integrity sha1-gteb/zCmfEAF/9XiUVMArZyk168=
@@ -8518,6 +8526,11 @@ node-request-by-swagger@^1.0.6:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/node-request-by-swagger/-/node-request-by-swagger-1.1.3.tgz#d49bb9adc74eff1ce8c70d075e4d8f2e4b365805"
   integrity sha512-granjsEA0c+1GnJaKnOjJy1E3wWLADUnAg+x1eopWOo+oMDfRYKJjCBaInUgrli/yEnvUAJoymGhExP/6tcOyQ==
+
+nodent-runtime@^3.0.4:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/nodent-runtime/-/nodent-runtime-3.2.1.tgz#9e2755d85e39f764288f0d4752ebcfe3e541e00e"
+  integrity sha512-7Ws63oC+215smeKJQCxzrK21VFVlCFBkwl0MOObt0HOpVQXs3u483sAmtkF33nNqZ5rSOQjB76fgyPBmAUrtCA==
 
 nomnom@1.5.2:
   version "1.5.2"

--- a/src/main/resources/anet-schema.yml
+++ b/src/main/resources/anet-schema.yml
@@ -370,6 +370,17 @@ properties:
         additionalProperties: false
         required:
           - homeView
+      geoSearcher:
+        properties:
+          provider:
+            type: string
+            enum:
+              - ESRI
+              - OSM
+          url:
+            type: string
+        required:
+          - provider
       baseLayers:
         type: array
         uniqueItems: true


### PR DESCRIPTION
This functionality allows users to search for geo names on a map, based on a geoSearcher service (ESRI, or others)

implements nci-agency/anet#999