### PR TITLE
Remove the ability of non-admin users to approve their own reports

### DIFF
--- a/client/src/pages/reports/Show.js
+++ b/client/src/pages/reports/Show.js
@@ -140,9 +140,11 @@ class BaseReportShow extends Page {
 	render() {
 		const {report} = this.state
 		const { currentUser } = this.props
+		const isAdmin = currentUser && currentUser.isAdmin()
+		const isAuthor = Person.isEqual(currentUser, report.author)
 
-		//User can approve if report is pending approval and user is one of the approvers in the current approval step
-		const canApprove = report.isPending() && currentUser.position &&
+		//When either admin or not the author, user can approve if report is pending approval and user is one of the approvers in the current approval step
+		const canApprove = (isAdmin || !isAuthor) && report.isPending() && currentUser.position &&
 			report.approvalStep && report.approvalStep.approvers.find(member => Position.isEqual(member, currentUser.position))
 
 		//Authors can edit in draft mode (also future engagements) or rejected mode

--- a/src/main/java/mil/dds/anet/search/mssql/MssqlReportSearcher.java
+++ b/src/main/java/mil/dds/anet/search/mssql/MssqlReportSearcher.java
@@ -168,6 +168,7 @@ public class MssqlReportSearcher implements IReportSearcher {
 		}
 
 		if (query.getPendingApprovalOf() != null) {
+			whereClauses.add("reports.authorId != :approverId");
 			whereClauses.add("reports.approvalStepId IN "
 				+ "(SELECT approvalStepId from approvers where positionId IN "
 				+ "(SELECT id FROM positions where currentPersonId = :approverId))");

--- a/src/main/java/mil/dds/anet/search/sqlite/SqliteReportSearcher.java
+++ b/src/main/java/mil/dds/anet/search/sqlite/SqliteReportSearcher.java
@@ -194,6 +194,7 @@ public class SqliteReportSearcher implements IReportSearcher {
 		}
 		
 		if (query.getPendingApprovalOf() != null) { 
+			whereClauses.add("reports.\"authorId\" != :approverId");
 			whereClauses.add("reports.\"approvalStepId\" IN "
 				+ "(SELECT \"approvalStepId\" from approvers where \"positionId\" IN "
 				+ "(SELECT id FROM positions where \"currentPersonId\" = :approverId))");


### PR DESCRIPTION
This is a stripped-down commit from a larger change in ANET 2.1

caveats (until the larger change is fielded):
- appovers trying to approve their own reports will not get feedback as of why they are not allowed to
- admin approvers trying to approve their own reports will be able to but will not get a warning

implements nci-agency/anet#1179