### PR TITLE
Replace react-scrollspy with react-scroll everywhere

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -104,7 +104,6 @@
     "react-router-bootstrap": "^0.24.4",
     "react-router-dom": "^4.3.1",
     "react-scroll": "^1.7.10",
-    "react-scrollspy": "^3.3.5",
     "react-tag-input": "^5.2.3",
     "react-toastify": "^4.5.1",
     "react-ultimate-pagination": "^1.2.0",

--- a/client/src/components/ResponsiveLayout.js
+++ b/client/src/components/ResponsiveLayout.js
@@ -63,6 +63,7 @@ const loadingBar = {
 	backgroundColor: '#29d'
 }
 
+export const ResponsiveLayoutContext = React.createContext()
 
 class ResponsiveLayout extends Component {
 	static propTypes = {
@@ -109,6 +110,12 @@ class ResponsiveLayout extends Component {
 		const sidebarClass = floatingMenu ? "nav-overlay" : "hidden-xs"
 
 		return (
+		<ResponsiveLayoutContext.Provider
+			value={{
+				showFloatingMenu: this.showFloatingMenu,
+				topbarOffset: topbarHeight,
+			}}
+		>
 			<div style={anetContainer} className="anet" >
 				<TopBar
 					topbarHeight={this.handleTopbarHeight}
@@ -131,7 +138,7 @@ class ResponsiveLayout extends Component {
 							className={`main-sidebar ${sidebarClass}`}
 						>
 							<div style={sidebar}>
-								{<Nav showFloatingMenu={this.showFloatingMenu} organizations={sidebarData} topbarOffset={topbarHeight} />}
+								<Nav organizations={sidebarData} />
 							</div>
 						</div>
 					}
@@ -149,6 +156,7 @@ class ResponsiveLayout extends Component {
 					/>
 				</div>
 			</div>
+		</ResponsiveLayoutContext.Provider>
 		)
 	}
 }

--- a/client/src/pages/Search.js
+++ b/client/src/pages/Search.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types'
 import React from 'react'
 import Page, {mapDispatchToProps, propTypes as pagePropTypes} from 'components/Page'
-import {Alert, Table, Modal, Button, Nav, NavItem, Badge} from 'react-bootstrap'
+import {Alert, Table, Modal, Button, Nav, Badge} from 'react-bootstrap'
 import autobind from 'autobind-decorator'
 import pluralize from 'pluralize'
 
@@ -39,8 +39,7 @@ import _isEqualWith from 'lodash/isEqualWith'
 import utils from 'utils'
 import { jumpToTop } from 'components/Page'
 
-import AppContext from 'components/AppContext'
-import Scrollspy from 'react-scrollspy'
+import { AnchorNavItem } from 'components/Nav'
 import { ToastContainer, toast } from 'react-toastify'
 import 'react-toastify/dist/ReactToastify.css'
 import 'components/reactToastify.css'
@@ -90,11 +89,10 @@ const SEARCH_CONFIG = {
 	}
 }
 
-class BaseSearch extends Page {
+class Search extends Page {
 
 	static propTypes = {
 		...pagePropTypes,
-		scrollspyOffset: PropTypes.number,
 	}
 
 	successToastId = 'success-message';
@@ -197,38 +195,35 @@ class BaseSearch extends Page {
 				<SubNav subnavElemId="search-nav">
 					<div><Button onClick={this.props.history.goBack} bsStyle="link">&lt; Return to previous page</Button></div>
 					<Nav stacked bsStyle="pills">
-						<Scrollspy className="nav" currentClassName="active" offset={this.props.scrollspyOffset}
-							items={ ['organizations', 'people', 'positions', 'tasks', 'locations', 'reports'] }>
-							<NavItem href="#organizations" disabled={!numOrganizations}>
-								<img src={ORGANIZATIONS_ICON} alt="" /> Organizations
-								{numOrganizations > 0 && <Badge pullRight>{numOrganizations}</Badge>}
-							</NavItem>
+						<AnchorNavItem to="organizations" disabled={!numOrganizations}>
+							<img src={ORGANIZATIONS_ICON} alt="" /> Organizations
+							{numOrganizations > 0 && <Badge pullRight>{numOrganizations}</Badge>}
+						</AnchorNavItem>
 
-							<NavItem href="#people" disabled={!numPeople}>
-								<img src={PEOPLE_ICON} alt="" /> People
-								{numPeople > 0 && <Badge pullRight>{numPeople}</Badge>}
-							</NavItem>
+						<AnchorNavItem to="people" disabled={!numPeople}>
+							<img src={PEOPLE_ICON} alt="" /> People
+							{numPeople > 0 && <Badge pullRight>{numPeople}</Badge>}
+						</AnchorNavItem>
 
-							<NavItem href="#positions" disabled={!numPositions}>
-								<img src={POSITIONS_ICON} alt="" /> Positions
-								{numPositions > 0 && <Badge pullRight>{numPositions}</Badge>}
-							</NavItem>
+						<AnchorNavItem to="positions" disabled={!numPositions}>
+							<img src={POSITIONS_ICON} alt="" /> Positions
+							{numPositions > 0 && <Badge pullRight>{numPositions}</Badge>}
+						</AnchorNavItem>
 
-							<NavItem href="#tasks" disabled={!numTasks}>
-								<img src={TASKS_ICON} alt="" /> {pluralize(taskShortLabel)}
-								{numTasks > 0 && <Badge pullRight>{numTasks}</Badge>}
-							</NavItem>
+						<AnchorNavItem to="tasks" disabled={!numTasks}>
+							<img src={TASKS_ICON} alt="" /> {pluralize(taskShortLabel)}
+							{numTasks > 0 && <Badge pullRight>{numTasks}</Badge>}
+						</AnchorNavItem>
 
-							<NavItem href="#locations" disabled={!numLocations}>
-								<img src={LOCATIONS_ICON} alt="" /> Locations
-								{numLocations > 0 && <Badge pullRight>{numLocations}</Badge>}
-							</NavItem>
+						<AnchorNavItem to="locations" disabled={!numLocations}>
+							<img src={LOCATIONS_ICON} alt="" /> Locations
+							{numLocations > 0 && <Badge pullRight>{numLocations}</Badge>}
+						</AnchorNavItem>
 
-							<NavItem href="#reports" disabled={!numReports}>
-								<img src={REPORTS_ICON} alt="" /> Reports
-								{numReports > 0 && <Badge pullRight>{numReports}</Badge>}
-							</NavItem>
-						</Scrollspy>
+						<AnchorNavItem to="reports" disabled={!numReports}>
+							<img src={REPORTS_ICON} alt="" /> Reports
+							{numReports > 0 && <Badge pullRight>{numReports}</Badge>}
+						</AnchorNavItem>
 					</Nav>
 				</SubNav>
 
@@ -531,13 +526,5 @@ class BaseSearch extends Page {
 const mapStateToProps = (state, ownProps) => ({
 	searchQuery: state.searchQuery,
 })
-
-const Search = (props) => (
-	<AppContext.Consumer>
-		{context =>
-			<BaseSearch scrollspyOffset={context.scrollspyOffset} {...props} />
-		}
-	</AppContext.Consumer>
-)
 
 export default connect(mapStateToProps, mapDispatchToProps)(withRouter(Search))

--- a/client/src/pages/organizations/Show.js
+++ b/client/src/pages/organizations/Show.js
@@ -5,7 +5,7 @@ import Page, {mapDispatchToProps, propTypes as pagePropTypes} from 'components/P
 import { Formik, Form, Field } from 'formik'
 import * as FieldHelper from 'components/FieldHelper'
 
-import {ListGroup, ListGroupItem, Nav, NavItem} from 'react-bootstrap'
+import {ListGroup, ListGroupItem, Nav} from 'react-bootstrap'
 import pluralize from 'pluralize'
 
 import Breadcrumbs from 'components/Breadcrumbs'
@@ -29,8 +29,8 @@ import {Organization, Person, Position, Report, Task} from 'models'
 import Settings from 'Settings'
 
 import AppContext from 'components/AppContext'
+import { AnchorNavItem } from 'components/Nav'
 import { connect } from 'react-redux'
-import Scrollspy from 'react-scrollspy'
 
 const NO_REPORT_FILTER = 'NO_FILTER'
 
@@ -39,7 +39,6 @@ class BaseOrganizationShow extends Page {
 	static propTypes = {
 		...pagePropTypes,
 		currentUser: PropTypes.instanceOf(Person),
-		scrollspyOffset: PropTypes.number,
 	}
 
 	static modelName = 'Organization'
@@ -175,15 +174,12 @@ class BaseOrganizationShow extends Page {
 		const isMyOrg = myOrg && (organization.uuid === myOrg.uuid)
 		const orgSubNav = (
 			<Nav>
-				<Scrollspy className="nav" currentClassName="active" offset={this.props.scrollspyOffset}
-				items={ ['info', 'supportedPositions', 'vacantPositions', 'approvals', 'tasks', 'reports'] }>
-					<NavItem href="#info">Info</NavItem>
-					<NavItem href="#supportedPositions">Supported positions</NavItem>
-					<NavItem href="#vacantPositions">Vacant positions</NavItem>
-					{!isPrincipalOrg && <NavItem href="#approvals">Approvals</NavItem>}
-					{organization.isTaskEnabled() && <NavItem href="#tasks">{pluralize(Settings.fields.task.shortLabel)}</NavItem> }
-					<NavItem href="#reports">Reports</NavItem>
-				</Scrollspy>
+				<AnchorNavItem to="info">Info</AnchorNavItem>
+				<AnchorNavItem to="supportedPositions">Supported positions</AnchorNavItem>
+				<AnchorNavItem to="vacantPositions">Vacant positions</AnchorNavItem>
+				{!isPrincipalOrg && <AnchorNavItem to="approvals">Approvals</AnchorNavItem>}
+				{organization.isTaskEnabled() && <AnchorNavItem to="tasks">{pluralize(Settings.fields.task.shortLabel)}</AnchorNavItem>}
+				<AnchorNavItem to="reports">Reports</AnchorNavItem>
 			</Nav>
 		)
 		if (currentUser._loaded !== true) {
@@ -230,7 +226,7 @@ class BaseOrganizationShow extends Page {
 					<Messages success={this.state.success} error={this.state.error} />
 					<Form className="form-horizontal" method="post">
 						<Fieldset title={`Organization ${organization.shortName}`} action={action} />
-						<Fieldset>
+						<Fieldset id="info">
 							<Field
 								name="status"
 								component={FieldHelper.renderReadonlyField}
@@ -348,12 +344,10 @@ class BaseOrganizationShow extends Page {
 	}
 }
 
-
-
 const OrganizationShow = (props) => (
 	<AppContext.Consumer>
 		{context =>
-			<BaseOrganizationShow currentUser={context.currentUser} scrollspyOffset={context.scrollspyOffset} {...props} />
+			<BaseOrganizationShow currentUser={context.currentUser} {...props} />
 		}
 	</AppContext.Consumer>
 )

--- a/client/src/pages/reports/MyReports.js
+++ b/client/src/pages/reports/MyReports.js
@@ -7,6 +7,9 @@ import GQL from 'graphqlapi'
 import Fieldset from 'components/Fieldset'
 import autobind from 'autobind-decorator'
 import {Person, Report} from 'models'
+import { Nav } from 'react-bootstrap'
+import SubNav from 'components/SubNav'
+import { AnchorNavItem } from 'components/Nav'
 
 import AppContext from 'components/AppContext'
 import { connect } from 'react-redux'
@@ -82,6 +85,14 @@ class BaseMyReports extends Page {
 	render() {
 		return <div>
 			<Breadcrumbs items={[['My Reports', window.location.pathname]]} />
+			<SubNav subnavElemId="reports-nav">
+				<Nav>
+					<AnchorNavItem to="draft-reports">Draft reports</AnchorNavItem>
+					<AnchorNavItem to="upcoming-engagements">Upcoming Engagements</AnchorNavItem>
+					<AnchorNavItem to="pending-approval">Pending approval</AnchorNavItem>
+					<AnchorNavItem to="published-reports">Published reports</AnchorNavItem>
+				</Nav>
+			</SubNav>
 
 			{this.renderSection('Draft Reports', this.state.draft, this.goToPage.bind(this, 'draft'), 'draft-reports')}
 			{this.renderSection('Upcoming Engagements', this.state.future, this.goToPage.bind(this, 'future'), 'upcoming-engagements')}

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -9978,15 +9978,6 @@ react-scroll@^1.7.10:
     lodash.throttle "^4.1.1"
     prop-types "^15.5.8"
 
-react-scrollspy@^3.3.5:
-  version "3.3.5"
-  resolved "https://registry.yarnpkg.com/react-scrollspy/-/react-scrollspy-3.3.5.tgz#e3e605bfc153a23f5fdf1279dd9f397d6e76e228"
-  integrity sha512-s2wAoFGgeArJ8bSpdxwWiZpVzHc+VN5K7996v35JysXXYqfqSHj+yhLpre6v5kQVAT4DFpTnnMOmrhZqfyxEgA==
-  dependencies:
-    babel-runtime "^6.26.0"
-    classnames "^2.2.5"
-    prop-types "^15.5.10"
-
 react-tag-input@^5.2.3:
   version "5.2.3"
   resolved "https://registry.yarnpkg.com/react-tag-input/-/react-tag-input-5.2.3.tgz#f04d73a81765323b9b515c58ac22550b3dfcf791"


### PR DESCRIPTION
Use a context provider for the responsive parts, and move sub-navigation to where it should be defined.

Closes NCI-Agency/anet#1122