### PR TITLE
Change how report text is shown

### DIFF
--- a/anet.yml
+++ b/anet.yml
@@ -209,6 +209,9 @@ dictionary:
       atmosphereDetails: Atmospherics details
       cancelled: ''
       reportTags: Tags
+      nextSteps: Next steps
+      keyOutcomes: Key outcomes
+      reportText: Engagement details
 
     person:
       firstName: First name

--- a/build.gradle
+++ b/build.gradle
@@ -67,6 +67,9 @@ dependencies {
 	compile group: 'org.apache.poi', name: 'poi', version: '4.0.1'
 	compile group: 'org.apache.poi', name: 'poi-ooxml', version: '4.0.1'
 
+	// For parsing HTML to check for 'empty' input
+	compile 'org.jsoup:jsoup:1.11.3'
+
 	testCompile group: 'io.dropwizard', name: 'dropwizard-testing', version: '1.3.8'
 	testCompile group: 'io.dropwizard', name: 'dropwizard-client', version: '1.3.8'
 	testCompile 'org.apache.commons:commons-io:1.3.2'

--- a/client/src/components/MultiSelector.js
+++ b/client/src/components/MultiSelector.js
@@ -9,6 +9,7 @@ export default class MultiSelector extends Component {
 		objectType: PropTypes.func.isRequired,
 		onChange: PropTypes.func.isRequired,
 		shortcuts: PropTypes.array,
+		shortcutsTitle: PropTypes.string,
 		queryParams: PropTypes.object,
 		addFieldName: PropTypes.string,
 		addFieldLabel: PropTypes.string,
@@ -28,7 +29,7 @@ export default class MultiSelector extends Component {
 	}
 
 	render() {
-		const { items, objectType, shortcuts, queryParams, addFieldName, addFieldLabel, renderSelected, placeholder, addon, fields, template, renderExtraCol } = this.props
+		const { items, objectType, shortcuts, shortcutsTitle, queryParams, addFieldName, addFieldLabel, renderSelected, placeholder, addon, fields, template, renderExtraCol } = this.props
 		return (
 			<MultiSelectAutocomplete
 				addFieldName={addFieldName}
@@ -38,6 +39,7 @@ export default class MultiSelector extends Component {
 				onAddItem={this.addItem}
 				onRemoveItem={this.removeItem}
 				shortcuts={shortcuts}
+				shortcutsTitle={shortcutsTitle}
 				renderExtraCol={renderExtraCol}
 				addon={addon}
 				objectType={objectType}

--- a/client/src/components/ReportSummary.js
+++ b/client/src/components/ReportSummary.js
@@ -94,22 +94,22 @@ export default class ReportSummary extends Component {
 			}
 			<Row>
 				<Col md={12}>
-					{report.intent && <span><strong>Meeting goal:</strong> {report.intent}</span> }
+					{report.intent && <span><strong>{Settings.fields.report.intent}:</strong> {report.intent}</span> }
 				</Col>
 			</Row>
 			<Row>
 				<Col md={12}>
-					{report.keyOutcomes && <span><strong>Key outcomes:</strong> {report.keyOutcomes}</span> }
+					{report.keyOutcomes && <span><strong>{Settings.fields.report.keyOutcomes}:</strong> {report.keyOutcomes}</span> }
 				</Col>
 			</Row>
 			<Row>
 				<Col md={12}>
-					{report.nextSteps && <span><strong>Next steps:</strong> {report.nextSteps}</span> }
+					{report.nextSteps && <span><strong>{Settings.fields.report.nextSteps}:</strong> {report.nextSteps}</span> }
 				</Col>
 			</Row>
 			<Row>
 				<Col md={12}>
-					{report.atmosphere && <span><strong>Atmospherics:</strong> {utils.sentenceCase(report.atmosphere)}
+					{report.atmosphere && <span><strong>{Settings.fields.report.atmosphere}:</strong> {utils.sentenceCase(report.atmosphere)}
 						{report.atmosphereDetails && ` – ${report.atmosphereDetails}`}</span> }
 				</Col>
 			</Row>

--- a/client/src/components/SearchFilters.js
+++ b/client/src/components/SearchFilters.js
@@ -184,7 +184,7 @@ export default {
 				State: {
 					component: ReportStateSearch,
 				},
-				Atmospherics: {
+				[Settings.fields.report.atmosphere]: {
 					component: SelectSearchFilter,
 					props: {
 						queryKey: "atmosphere",

--- a/client/src/models/Report.js
+++ b/client/src/models/Report.js
@@ -55,13 +55,13 @@ export default class Report extends Model {
 			.default(null),
 		atmosphere: yup.string().nullable()
 			.when('cancelled', (cancelled, schema) => (
-				cancelled ? schema.nullable() : schema.required('You must provide the overall atmospherics of the engagement')
+				cancelled ? schema.nullable() : schema.required(`You must provide the overall ${Settings.fields.report.atmosphere} of the engagement`)
 			))
 			.default(null)
 			.label(Settings.fields.report.atmosphere),
 		atmosphereDetails: yup.string().nullable()
 			.when(['cancelled', 'atmosphere'], (cancelled, atmosphere, schema) => (
-				cancelled ? schema.nullable() : (atmosphere === Report.ATMOSPHERE.POSITIVE) ? schema.nullable() : schema.required('You must provide atmospherics details if the engagement was not Positive')
+				cancelled ? schema.nullable() : (atmosphere === Report.ATMOSPHERE.POSITIVE) ? schema.nullable() : schema.required(`You must provide ${Settings.fields.report.atmosphereDetails} if the engagement was not Positive`)
 			))
 			.default('')
 			.label(Settings.fields.report.atmosphereDetails),
@@ -86,16 +86,17 @@ export default class Report extends Model {
 		advisorOrg: yup.object().nullable().default({}),
 		tasks: yup.array().nullable().default([]),
 		comments: yup.array().nullable().default([]),
-		reportText: yup.string().nullable().default(''),
-		nextSteps: yup.string().nullable().required('You must provide a brief summary of the Next Steps')
+		reportText: yup.string().nullable().default('')
+			.label(Settings.fields.report.reportText),
+		nextSteps: yup.string().nullable().required(`You must provide a brief summary of the ${Settings.fields.report.nextSteps}`)
 			.default('')
-			.label('Next steps description'),
+			.label(Settings.fields.report.nextSteps),
 		keyOutcomes: yup.string().nullable()
 			.when('cancelled', (cancelled, schema) => (
-				cancelled ? schema.nullable() : schema.required('You must provide a brief summary of the Key Outcomes')
+				cancelled ? schema.nullable() : schema.required(`You must provide a brief summary of the ${Settings.fields.report.keyOutcomes}`)
 			))
 			.default('')
-			.label('Key outcome description'),
+			.label(Settings.fields.report.keyOutcomes),
 		tags: yup.array().nullable().default([]),
 		reportTags: yup.array().nullable().default([])
 			.label(Settings.fields.report.reportTags),

--- a/client/src/pages/HopscotchTour.js
+++ b/client/src/pages/HopscotchTour.js
@@ -113,7 +113,7 @@ const reportTour = (currentUser, history) => {
 	id: 'report',
 	steps: [
 		{
-			title: 'Meeting goal(s)',
+			title: Settings.fields.report.intent,
 			content: `Use this section to tell readers why you met with your ${principalSingular}. Were you working on a specific goal or problem with them? This will be part of your report's summary, so use this space to tell readers the high-level purpose of your engagement.`,
 			target: 'intent',
 			placement: 'bottom',
@@ -132,8 +132,8 @@ const reportTour = (currentUser, history) => {
 			placement: 'right',
 		},
 		{
-			title: 'Atmospherics',
-			content: 'Select the atmospherics of your meeting. This information is used in threat assessments. Highlight specific issues or concerns in the details section below.',
+			title: Settings.fields.report.atmosphere,
+			content: `Select the ${Settings.fields.report.atmosphere} of your meeting. This information is used in threat assessments. Highlight specific issues or concerns in the details section below.`,
 			target: '#neutralAtmos',
 			placement: 'bottom',
 		},
@@ -162,21 +162,27 @@ const reportTour = (currentUser, history) => {
 			placement: 'right',
 		},
 		{
-			title: 'Key outcomes',
+			title: Settings.fields.report.keyOutcomes,
 			content: "Use this section to tell readers what the main information or results from your engagement were. This will be displayed in your report's summary, so include information that you think would be valuable for leadership and other organizations to know.",
 			target: '#keyOutcomes',
 			placement: 'right',
 		},
 		{
-			title: 'Next steps',
+			title: Settings.fields.report.nextSteps,
 			content: "Here, tell readers about the next concrete steps that you'll be taking to build on the progress made in your engagement. This will be displayed in your report's summary, so include information that will explain to leadership what you are doing next, as a result of your meeting's outcomes.",
 			target: '#nextSteps',
 			placement: 'right',
 		},
 		{
-			title: 'Detailed report',
-			content: `If there's more information from your meeting that you'd like to include, click on the "Add detailed comments" button. You will have additional space to record discussion topics and notes that may be helpful to you, your organization, or leadership later on. This section does not display in the report summary.`,
-			target: '#toggleReportDetails',
+			title: Settings.fields.report.reportText,
+			content: "Record here discussion topics and notes that may be helpful to you, your organization, or leadership later on. This section does not display in the report summary.",
+			target: '.reportTextField',
+			placement: 'right',
+		},
+		{
+			title: 'Sensitive information',
+			content: `If there's sensitive information from your meeting that you'd like to include, click on the "Add sensitive information" button. You will have additional space to record sensitive information, visible only to the groups that you authorize. This section does not display in the report summary.`,
+			target: '#toggleSensitiveInfo',
 			placement: 'right',
 		},
 		{

--- a/client/src/pages/reports/Edit.js
+++ b/client/src/pages/reports/Edit.js
@@ -55,13 +55,12 @@ class ReportEdit extends Page {
 
 	render() {
 		const { report } = this.state
-		const showReportText = !!report.reportText || !!report.reportSensitiveInformation
 
 		return (
 			<div className="report-edit">
 				<RelatedObjectNotes notes={report.notes} relatedObject={report.uuid && {relatedObjectType: 'reports', relatedObjectUuid: report.uuid}} />
 				<Breadcrumbs items={[[`Report #${report.uuid}`, Report.pathForEdit(report)]]} />
-				<ReportForm edit initialValues={report} title={`Report #${report.uuid}`} showReportText={showReportText} />
+				<ReportForm edit initialValues={report} title={`Report #${report.uuid}`} showSensitiveInfo={!!report.reportSensitiveInformation} />
 			</div>
 		)
 	}

--- a/client/src/pages/reports/Edit.js
+++ b/client/src/pages/reports/Edit.js
@@ -60,7 +60,7 @@ class ReportEdit extends Page {
 			<div className="report-edit">
 				<RelatedObjectNotes notes={report.notes} relatedObject={report.uuid && {relatedObjectType: 'reports', relatedObjectUuid: report.uuid}} />
 				<Breadcrumbs items={[[`Report #${report.uuid}`, Report.pathForEdit(report)]]} />
-				<ReportForm edit initialValues={report} title={`Report #${report.uuid}`} showSensitiveInfo={!!report.reportSensitiveInformation} />
+				<ReportForm edit initialValues={report} title={`Report #${report.uuid}`} showSensitiveInfo={!!report.reportSensitiveInformation && !!report.reportSensitiveInformation.text} />
 			</div>
 		)
 	}

--- a/client/src/pages/reports/Form.js
+++ b/client/src/pages/reports/Form.js
@@ -9,6 +9,7 @@ import * as FieldHelper from 'components/FieldHelper'
 import moment from 'moment'
 import _isEmpty from 'lodash/isEmpty'
 import _cloneDeep from 'lodash/cloneDeep'
+import pluralize from 'pluralize'
 
 import Settings from 'Settings'
 
@@ -351,7 +352,7 @@ class BaseReportForm extends Component {
 								addon={PEOPLE_ICON}
 								renderSelected={<AttendeesTable attendees={values.attendees} onChange={value => setFieldValue('attendees', value)} showDelete={true} />}
 								onChange={value => this.updateAttendees(setFieldValue, 'attendees', value)}
-								shortcutsTitle={`Recent attendees`}
+								shortcutsTitle="Recent Attendees"
 								shortcuts={recents.persons}
 								renderExtraCol={true}
 							/>
@@ -363,7 +364,7 @@ class BaseReportForm extends Component {
 									items={values.tasks}
 									objectType={Task}
 									queryParams={{status: Task.STATUS.ACTIVE}}
-									placeholder={`Start typing to search for ${Settings.fields.task.shortLabel}...`}
+									placeholder={`Start typing to search for ${pluralize(Settings.fields.task.shortLabel)}...`}
 									fields={Task.autocompleteQuery}
 									template={Task.autocompleteTemplate}
 									addFieldName='tasks'
@@ -371,7 +372,7 @@ class BaseReportForm extends Component {
 									addon={TASK_ICON}
 									renderSelected={<TaskTable tasks={values.tasks} showDelete={true} showOrganization={true} />}
 									onChange={value => setFieldValue('tasks', value)}
-									shortcutsTitle={`Recent ${Settings.fields.task.shortLabel}`}
+									shortcutsTitle={`Recent ${pluralize(Settings.fields.task.shortLabel)}`}
 									shortcuts={recents.tasks}
 									renderExtraCol={true}
 								/>
@@ -432,14 +433,14 @@ class BaseReportForm extends Component {
 											items={values.authorizationGroups}
 											objectType={AuthorizationGroup}
 											queryParams={{status: AuthorizationGroup.STATUS.ACTIVE}}
-											placeholder="Start typing to search for a group..."
+											placeholder="Start typing to search for authorization groups..."
 											fields={AuthorizationGroup.autocompleteQuery}
 											template={AuthorizationGroup.autocompleteTemplate}
 											addFieldName='authorizationGroups'
 											addFieldLabel='Authorization Groups'
 											renderSelected={<AuthorizationGroupTable authorizationGroups={values.authorizationGroups} showDelete={true} />}
 											onChange={value => setFieldValue('authorizationGroups', value)}
-											shortcutsTitle={`Recent Authorization Groups`}
+											shortcutsTitle="Recent Authorization Groups"
 											shortcuts={recents.authorizationGroups}
 											renderExtraCol={true}
 										/>

--- a/client/src/pages/reports/Form.js
+++ b/client/src/pages/reports/Form.js
@@ -46,7 +46,7 @@ class BaseReportForm extends Component {
 		initialValues: PropTypes.object,
 		title: PropTypes.string,
 		edit: PropTypes.bool,
-		showReportText: PropTypes.bool,
+		showSensitiveInfo: PropTypes.bool,
 		currentUser: PropTypes.instanceOf(Person),
 	}
 
@@ -54,7 +54,7 @@ class BaseReportForm extends Component {
 		initialValues: new Report(),
 		title: '',
 		edit: false,
-		showReportText: false,
+		showSensitiveInfo: false,
 	}
 
 	atmosphereButtons = [
@@ -116,7 +116,7 @@ class BaseReportForm extends Component {
 			authorizationGroups: [],
 		},
 		tagSuggestions: [],
-		showReportText: this.props.showReportText,
+		showSensitiveInfo: this.props.showSensitiveInfo,
 	}
 
 	componentDidMount() {
@@ -382,6 +382,7 @@ class BaseReportForm extends Component {
 							{!values.cancelled &&
 								<Field
 									name="keyOutcomes"
+									label={Settings.fields.report.keyOutcomes}
 									component={FieldHelper.renderInputField}
 									componentClass="textarea"
 									maxLength={250}
@@ -392,6 +393,7 @@ class BaseReportForm extends Component {
 
 							<Field
 								name="nextSteps"
+								label={Settings.fields.report.nextSteps}
 								component={FieldHelper.renderInputField}
 								componentClass="textarea"
 								maxLength={250}
@@ -399,50 +401,50 @@ class BaseReportForm extends Component {
 								extraColElem={<React.Fragment><span id="nextStepsCharsLeft">{250 - this.props.initialValues.nextSteps.length}</span> characters remaining</React.Fragment>}
 							/>
 
-							<Button className="center-block toggle-section-button" onClick={this.toggleReportText} id="toggleReportDetails" >
-								{this.state.showReportText ? 'Hide' : 'Add'} detailed report
+							<Field
+								id="reportText"
+								name="reportText"
+								label={Settings.fields.report.reportText}
+								component={FieldHelper.renderSpecialField}
+								onChange={value => setFieldValue('reportText', value)}
+								widget={
+									<RichTextEditor className="reportTextField" />
+								}
+							/>
+
+							<Button className="center-block toggle-section-button" onClick={this.toggleReportText} id="toggleSensitiveInfo" >
+								{this.state.showSensitiveInfo ? 'Hide' : 'Add'} sensitive information
 							</Button>
 
-							<Collapse in={this.state.showReportText}>
-								<div>
-									<Field
-										name="reportText"
-										component={FieldHelper.renderSpecialField}
-										onChange={value => setFieldValue('reportText', value)}
-										widget={
-											<RichTextEditor className="reportTextField" />
-										}
-									/>
-
-									{(values.reportSensitiveInformation || !this.props.edit) &&
-										<div>
-											<Field
-												name="reportSensitiveInformation.text"
-												component={FieldHelper.renderSpecialField}
-												label="Report sensitive information text"
-												onChange={value => setFieldValue('reportSensitiveInformation.text', value)}
-												widget={
-													<RichTextEditor className="reportSensitiveInformationField" />
-												}
-											/>
-											<MultiSelector
-												items={values.authorizationGroups}
-												objectType={AuthorizationGroup}
-												queryParams={{status: AuthorizationGroup.STATUS.ACTIVE}}
-												placeholder="Start typing to search for a group..."
-												fields={AuthorizationGroup.autocompleteQuery}
-												template={AuthorizationGroup.autocompleteTemplate}
-												addFieldName='authorizationGroups'
-												addFieldLabel='Authorization Groups'
-												renderSelected={<AuthorizationGroupTable authorizationGroups={values.authorizationGroups} showDelete={true} />}
-												onChange={value => setFieldValue('authorizationGroups', value)}
-												shortcutsTitle={`Recent Authorization Groups`}
-												shortcuts={recents.authorizationGroups}
-												renderExtraCol={true}
-											/>
-										</div>
-									}
-								</div>
+							<Collapse in={this.state.showSensitiveInfo}>
+								{(values.reportSensitiveInformation || !this.props.edit) &&
+									<div>
+										<Field
+											name="reportSensitiveInformation.text"
+											component={FieldHelper.renderSpecialField}
+											label="Report sensitive information text"
+											onChange={value => setFieldValue('reportSensitiveInformation.text', value)}
+											widget={
+												<RichTextEditor className="reportSensitiveInformationField" />
+											}
+										/>
+										<MultiSelector
+											items={values.authorizationGroups}
+											objectType={AuthorizationGroup}
+											queryParams={{status: AuthorizationGroup.STATUS.ACTIVE}}
+											placeholder="Start typing to search for a group..."
+											fields={AuthorizationGroup.autocompleteQuery}
+											template={AuthorizationGroup.autocompleteTemplate}
+											addFieldName='authorizationGroups'
+											addFieldLabel='Authorization Groups'
+											renderSelected={<AuthorizationGroupTable authorizationGroups={values.authorizationGroups} showDelete={true} />}
+											onChange={value => setFieldValue('authorizationGroups', value)}
+											shortcutsTitle={`Recent Authorization Groups`}
+											shortcuts={recents.authorizationGroups}
+											renderExtraCol={true}
+										/>
+									</div>
+								}
 							</Collapse>
 						</Fieldset>
 
@@ -496,7 +498,7 @@ class BaseReportForm extends Component {
 	}
 
 	toggleReportText = () => {
-		this.setState({showReportText: !this.state.showReportText})
+		this.setState({showSensitiveInfo: !this.state.showSensitiveInfo})
 	}
 
 	autoSave = (form) => {
@@ -580,7 +582,7 @@ class BaseReportForm extends Component {
 	}
 
 	save = (values, sendEmail) => {
-		const report = Object.without(new Report(values), 'cancelled', 'reportTags', 'showReportText')
+		const report = Object.without(new Report(values), 'cancelled', 'reportTags', 'showSensitiveInfo')
 		if (!values.cancelled) {
 			delete report.cancelledReason
 		}

--- a/client/src/pages/reports/Form.js
+++ b/client/src/pages/reports/Form.js
@@ -379,7 +379,7 @@ class BaseReportForm extends Component {
 							</Fieldset>
 						}
 
-						<Fieldset title={!values.cancelled ? "Meeting discussion" : "Next steps and details"}>
+						<Fieldset title={!values.cancelled ? "Meeting discussion" : "Next steps and details"} id="meeting-details">
 							{!values.cancelled &&
 								<Field
 									name="keyOutcomes"

--- a/client/src/pages/reports/Minimal.js
+++ b/client/src/pages/reports/Minimal.js
@@ -162,8 +162,8 @@ class ReportMinimal extends Page {
 								widget={
 									<div id="intent" className="form-control-static">
 										<p><strong>{Settings.fields.report.intent}:</strong> {report.intent}</p>
-										{report.keyOutcomes && <p><span><strong>Key outcomes:</strong> {report.keyOutcomes}&nbsp;</span></p>}
-										<p><strong>Next steps:</strong> {report.nextSteps}</p>
+										{report.keyOutcomes && <p><span><strong>{Settings.fields.report.keyOutcomes}:</strong> {report.keyOutcomes}&nbsp;</span></p>}
+										<p><strong>{Settings.fields.report.nextSteps}:</strong> {report.nextSteps}</p>
 									</div>
 								}
 							/>
@@ -242,7 +242,7 @@ class ReportMinimal extends Page {
 						</Fieldset>
 
 						{report.reportText &&
-							<Fieldset title="Meeting discussion">
+							<Fieldset title={Settings.fields.report.reportText}>
 								<div dangerouslySetInnerHTML={{__html: report.reportText}} />
 							</Fieldset>
 						}

--- a/client/src/pages/reports/Show.js
+++ b/client/src/pages/reports/Show.js
@@ -261,8 +261,8 @@ class BaseReportShow extends Page {
 								widget={
 									<div id="intent" className="form-control-static">
 										<p><strong>{Settings.fields.report.intent}:</strong> {report.intent}</p>
-										{report.keyOutcomes && <p><span><strong>Key outcomes:</strong> {report.keyOutcomes}&nbsp;</span></p>}
-										<p><strong>Next steps:</strong> {report.nextSteps}</p>
+										{report.keyOutcomes && <p><span><strong>{Settings.fields.report.keyOutcomes}:</strong> {report.keyOutcomes}&nbsp;</span></p>}
+										<p><strong>{Settings.fields.report.nextSteps}:</strong> {report.nextSteps}</p>
 									</div>
 								}
 							/>
@@ -341,7 +341,7 @@ class BaseReportShow extends Page {
 						</Fieldset>
 
 						{report.reportText &&
-							<Fieldset title="Meeting discussion">
+							<Fieldset title={Settings.fields.report.reportText}>
 								<div dangerouslySetInnerHTML={{__html: report.reportText}} />
 							</Fieldset>
 						}

--- a/client/tests/e2e/position.js
+++ b/client/tests/e2e/position.js
@@ -17,13 +17,17 @@ test('Move someone in and out of a position', async t => {
     await t.context.pageHelpers.clickPersonNameFromSupportedPositionsFieldset(personName, positionName)
 
     let $changeAssignedPositionButton = await $('.change-assigned-position')
+    await t.context.driver.wait(until.elementIsVisible($changeAssignedPositionButton))
     await $changeAssignedPositionButton.click()
 
     let $removePersonButton = await $('.remove-person-from-position')
+    await t.context.driver.wait(until.elementIsVisible($removePersonButton))
     await $removePersonButton.click()
     await t.context.driver.wait(until.stalenessOf($removePersonButton))
 
-    await assertElementText(t, await $('p.not-assigned-to-position-message'), 'ERINSON, Erin is not assigned to a position.')
+    let $notAssignedMsg = await $('p.not-assigned-to-position-message')
+    await t.context.driver.wait(until.elementIsVisible($notAssignedMsg))
+    await assertElementText(t, $notAssignedMsg, 'ERINSON, Erin is not assigned to a position.')
     
     await t.context.pageHelpers.clickMyOrgLink()
 

--- a/client/tests/e2e/report.js
+++ b/client/tests/e2e/report.js
@@ -60,14 +60,14 @@ test('Draft and submit a report', async t => {
     await pageHelpers.writeInForm('#keyOutcomes', 'key outcomes')
     await pageHelpers.writeInForm('#nextSteps', 'next steps')
 
-    let $reportTextField = await $('.reportTextField')
-    t.false(await $reportTextField.isDisplayed(), 'Add details field should not be present before "add details" button is clicked"')
+    let $reportSensitiveInformationField = await $('.reportSensitiveInformationField')
+    t.false(await $reportSensitiveInformationField.isDisplayed(), 'Report sensitive info should not be present before "add sensitive information" button is clicked"')
 
-    let $addDetailsButton = await $('#toggleReportDetails')
-    await $addDetailsButton.click()
+    let $addSensitiveInfoButton = await $('#toggleSensitiveInfo')
+    await $addSensitiveInfoButton.click()
 
-    await t.context.driver.wait(until.elementIsVisible($reportTextField))
-    await pageHelpers.writeInForm('.reportTextField .public-DraftEditor-content', 'report details')
+    await t.context.driver.wait(until.elementIsVisible($reportSensitiveInformationField))
+    await pageHelpers.writeInForm('.reportSensitiveInformationField .public-DraftEditor-content', 'sensitive info')
 
     let $formButtonSubmit = await $('#formBottomSubmit')
     await t.context.driver.wait(until.elementIsEnabled($formButtonSubmit))

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -215,6 +215,9 @@ dictionary:
       atmosphereDetails: Atmospherics details
       cancelled: ''
       reportTags: Tags
+      nextSteps: Next steps
+      keyOutcomes: Key outcomes
+      reportText: Engagement details
 
     person:
       firstName: First name

--- a/docs/anet.yml.production.template
+++ b/docs/anet.yml.production.template
@@ -200,6 +200,9 @@ dictionary:
       atmosphereDetails: Atmospherics details
       cancelled: ''
       reportTags: Tags
+      nextSteps: Next steps
+      keyOutcomes: Key outcomes
+      reportText: Engagement details
 
     person:
       firstName: First name

--- a/src/main/java/mil/dds/anet/database/ReportSensitiveInformationDao.java
+++ b/src/main/java/mil/dds/anet/database/ReportSensitiveInformationDao.java
@@ -62,7 +62,7 @@ public class ReportSensitiveInformationDao implements IAnetDao<ReportSensitiveIn
 	}
 
 	public ReportSensitiveInformation insert(ReportSensitiveInformation rsi, Person user, Report report) {
-		if (rsi == null || !isAuthorized(user, report)) {
+		if (rsi == null || !isAuthorized(user, report) || Utils.isEmptyHtml(rsi.getText())) {
 			return null;
 		}
 		DaoUtils.setInsertFields(rsi);
@@ -87,15 +87,25 @@ public class ReportSensitiveInformationDao implements IAnetDao<ReportSensitiveIn
 		if (rsi == null || !isAuthorized(user, report)) {
 			return 0;
 		}
-		// Update relevant fields, but do not allow the reportUuid to be updated by the query!
-		rsi.setUpdatedAt(Instant.now());
-		final int numRows = dbHandle.createUpdate(
-				"/* updateReportsSensitiveInformation */ UPDATE \"" + tableName + "\""
-					+ " SET text = :text, \"updatedAt\" = :updatedAt WHERE uuid = :uuid")
-				.bindBean(rsi)
-				.bind("updatedAt", DaoUtils.asLocalDateTime(rsi.getUpdatedAt()))
-				.execute();
-		AnetAuditLogger.log("ReportSensitiveInformation {} updated by {} ", rsi, user);
+		final int numRows;
+		if (Utils.isEmptyHtml(rsi.getText())) {
+			numRows = dbHandle.createUpdate(
+					"/* deleteReportsSensitiveInformation */ DELETE FROM \"" + tableName + "\""
+							+ " WHERE uuid = :uuid")
+							.bind("uuid", rsi.getUuid())
+							.execute();
+			AnetAuditLogger.log("Empty ReportSensitiveInformation {} deleted by {} ", rsi, user);
+		} else {
+			// Update relevant fields, but do not allow the reportUuid to be updated by the query!
+			rsi.setUpdatedAt(Instant.now());
+			numRows = dbHandle.createUpdate(
+					"/* updateReportsSensitiveInformation */ UPDATE \"" + tableName + "\""
+							+ " SET text = :text, \"updatedAt\" = :updatedAt WHERE uuid = :uuid")
+							.bindBean(rsi)
+							.bind("updatedAt", DaoUtils.asLocalDateTime(rsi.getUpdatedAt()))
+							.execute();
+			AnetAuditLogger.log("ReportSensitiveInformation {} updated by {} ", rsi, user);
+		}
 		return numRows;
 	}
 

--- a/src/main/java/mil/dds/anet/resources/ReportResource.java
+++ b/src/main/java/mil/dds/anet/resources/ReportResource.java
@@ -224,14 +224,6 @@ public class ReportResource {
 			}
 		}
 
-		// Possibly load sensitive information; needed in case of autoSave by the client form
-		r.setUser(editor);
-		try {
-			r.loadReportSensitiveInformation(engine.getContext()).get();
-		} catch (InterruptedException | ExecutionException e) {
-			throw new WebApplicationException("failed to load ReportSensitiveInformation", e);
-		}
-
 		// Return the report in the response; used in autoSave by the client form
 		return r;
 	}
@@ -394,9 +386,10 @@ public class ReportResource {
 			}
 		}
 
-		// Possibly load sensitive information; needed in case of autoSave by the client form
+		// Clear and re-load sensitive information; needed in case of autoSave by the client form, or when sensitive info is 'empty' HTML
 		r.setUser(editor);
 		try {
+			r.setReportSensitiveInformation(null);
 			r.loadReportSensitiveInformation(engine.getContext()).get();
 		} catch (InterruptedException | ExecutionException e) {
 			throw new WebApplicationException("failed to load ReportSensitiveInformation", e);

--- a/src/main/java/mil/dds/anet/utils/Utils.java
+++ b/src/main/java/mil/dds/anet/utils/Utils.java
@@ -13,6 +13,7 @@ import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
 
+import org.jsoup.Jsoup;
 import org.owasp.html.HtmlPolicyBuilder;
 import org.owasp.html.PolicyFactory;
 
@@ -188,6 +189,18 @@ public class Utils {
 	public static String trimStringReturnNull(String input) {
 		if (input == null) { return null; }
 		return input.trim();
+	}
+
+	/**
+	 * @param s string
+	 * @return true if string renders to 'empty' HTML, i.e. just whitespace
+	 */
+	public static boolean isEmptyHtml(String s) {
+		return isEmptyOrNull(trimStringReturnNull(s)) || isEmptyOrNull(trimStringReturnNull(htmlToText(s)));
+	}
+
+	private static String htmlToText(String s) {
+		return Jsoup.parse(s).text();
 	}
 
 	/**

--- a/src/main/resources/anet-schema.yml
+++ b/src/main/resources/anet-schema.yml
@@ -149,7 +149,7 @@ properties:
       report:
         type: object
         additionalProperties: false
-        required: [intent,atmosphere,atmosphereDetails,cancelled,reportTags]
+        required: [intent,atmosphere,atmosphereDetails,cancelled,reportTags,nextSteps,keyOutcomes,reportText]
         properties:
           intent:
             type: string
@@ -171,6 +171,18 @@ properties:
             type: string
             title: The label for report's tags
             description: Used in the UI where report's tags are shown.
+          nextSteps:
+            type: string
+            title: The label for report's next steps
+            description: Used in the UI where report's next steps are shown.
+          keyOutcomes:
+            type: string
+            title: The label for report's key outcomes
+            description: Used in the UI where report's key outcomes are shown.
+          reportText:
+            type: string
+            title: The label for report's engagement details
+            description: Used in the UI where report's engagement details are shown.
 
       person:
         type: object

--- a/src/main/resources/emails/approvalNeeded.ftlh
+++ b/src/main/resources/emails/approvalNeeded.ftlh
@@ -95,7 +95,7 @@ Dear ${approvalStepName},
 </div>
 
 <div>
-  <strong>Atmospherics:</strong> ${(report.atmosphere)!}
+  <strong>${fields.report.atmosphere}:</strong> ${(report.atmosphere)!}
   <#if report.atmosphereDetails??>
 	  - ${(report.atmosphereDetails)!}
   </#if>
@@ -104,7 +104,7 @@ Dear ${approvalStepName},
 <#if report.loadTags(context).get()??>
   <#assign tags = report.getTags()>
   <div>
-    <strong>Tags:</strong>
+    <strong>${fields.report.reportTags}:</strong>
     <ul>
       <#list tags as tag>
         <li>
@@ -132,12 +132,12 @@ Dear ${approvalStepName},
 
 <div class="row">
   <div class="col-md-8">
-    <p><strong>Meeting goal:</strong> ${report.intent}</p>
+    <p><strong>${fields.report.intent}:</strong> ${report.intent}</p>
     <#if report.keyOutcomes??>
-      <p><strong>Key outcomes:</strong> ${(report.keyOutcomes)!}</p>
+      <p><strong>${fields.report.keyOutcomes}:</strong> ${(report.keyOutcomes)!}</p>
     </#if>
     <#if report.nextSteps??>
-      <p><strong>Next steps:</strong> ${(report.nextSteps)!}</p>
+      <p><strong>${fields.report.nextSteps}:</strong> ${(report.nextSteps)!}</p>
     </#if>
   </div>
 </div>

--- a/src/main/resources/emails/emailReport.ftlh
+++ b/src/main/resources/emails/emailReport.ftlh
@@ -249,13 +249,13 @@ ${sender.name} sent you a report from ANET:
         <div class="col-sm-7">
           <div id="intent" class="form-control-static">
             <p>
-              <strong>Meeting goal:</strong> ${(report.intent)!}
+              <strong>${fields.report.intent}:</strong> ${(report.intent)!}
             </p>
             <p>
-              <span><strong>Key outcomes:</strong> ${(report.keyOutcomes)!}</span>
+              <span><strong>${fields.report.keyOutcomes}:</strong> ${(report.keyOutcomes)!}</span>
             </p>
             <p>
-              <strong>Next steps:</strong> ${(report.nextSteps)!}
+              <strong>${fields.report.nextSteps}:</strong> ${(report.nextSteps)!}
             </p>
           </div>
         </div>
@@ -292,7 +292,7 @@ ${sender.name} sent you a report from ANET:
             </div>
           </div>
         <#else>
-          <label for="atmosphere" class="col-sm-2 control-label">Atmospherics</label>
+          <label for="atmosphere" class="col-sm-2 control-label">${fields.report.atmosphere}</label>
           <div class="col-sm-7">
             <div id="atmosphere" class="form-control-static">
               ${(report.atmosphere)!?capitalize} - ${(report.atmosphereDetails)!}
@@ -304,7 +304,7 @@ ${sender.name} sent you a report from ANET:
       <#if report.loadTags(context).get()??>
         <#assign tags = report.getTags()>
         <div class="form-group">
-          <label for="tags" class="col-sm-2 control-label">Tags</label>
+          <label for="tags" class="col-sm-2 control-label">${fields.report.reportTags}</label>
           <div class="col-sm-7">
             <div id="tags" class="form-control-static">
               <#list tags as tag>
@@ -458,7 +458,7 @@ ${sender.name} sent you a report from ANET:
   <#if report.reportText??>
     <div>
       <h2 class="legend">
-        <span class="title-text">Meeting discussion</span>
+        <span class="title-text">${fields.report.reportText}</span>
       </h2>
       <fieldset>
         <div>

--- a/src/main/resources/emails/rollup.ftlh
+++ b/src/main/resources/emails/rollup.ftlh
@@ -136,7 +136,7 @@ a {
 	</div>
 
 	<div>
-		<strong>Atmospherics:</strong> ${(report.atmosphere)!}
+		<strong>${fields.report.atmosphere}:</strong> ${(report.atmosphere)!}
 		<#if report.atmosphereDetails??>
 			- ${(report.atmosphereDetails)!}
 		</#if>
@@ -169,15 +169,15 @@ a {
 
     <div class="row">
         <div class="col-md-8">
-            <p><strong>Meeting Goal:</strong> ${(report.intent)!}</p>
+            <p><strong>${fields.report.intent}:</strong> ${(report.intent)!}</p>
             <#if report.keyOutcomes??>
-                <p><strong>Key outcomes:</strong> ${(report.keyOutcomes)!}</p>
+                <p><strong>${fields.report.keyOutcomes}:</strong> ${(report.keyOutcomes)!}</p>
             </#if>
             <#if report.nextSteps??>
-                <p><strong>Next steps:</strong> ${(report.nextSteps)!}</p>
+                <p><strong>${fields.report.nextSteps}:</strong> ${(report.nextSteps)!}</p>
             </#if>
             <#if showReportText >
-                <p><strong>Report Details</strong> ${(report.reportText)!?no_esc}</p>
+                <p><strong>${fields.report.reportText}</strong> ${(report.reportText)!?no_esc}</p>
             </#if>
         </div>
     </div>


### PR DESCRIPTION
Always show report text (as "Engagement details"), but use toggle button for sensitive information.
Also use the report labels from the dictionary throughout.
Update the documentation and the Hopscotch Tour.

Closes NCI-Agency/anet#1160
Closes NCI-Agency/anet#1289