### PR TITLE
NCI-Agency/anet#1425: Add datetime formatting including time for emails

### DIFF
--- a/anet.yml
+++ b/anet.yml
@@ -167,7 +167,9 @@ dictionary:
   SUPPORT_EMAIL_ADDR: support@example.com
 
   dateFormats:
-    email: d MMMM yyyy
+    email:
+      short: d MMMM YYYY
+      withTime: d MMMM YYYY @ HH:mm
     excel: d MMMM yyyy
     forms:
       input: [DD-MM-YYYY, DD-MM-YY, DD/MM/YYYY, DD/MM/YY, DD MM YYYY, DD MM YY,

--- a/anet.yml
+++ b/anet.yml
@@ -168,8 +168,8 @@ dictionary:
 
   dateFormats:
     email:
-      short: d MMMM YYYY
-      withTime: d MMMM YYYY @ HH:mm
+      short: d MMMM yyyy
+      withTime: d MMMM yyyy @ HH:mm
     excel: d MMMM yyyy
     forms:
       input: [DD-MM-YYYY, DD-MM-YY, DD/MM/YYYY, DD/MM/YY, DD MM YYYY, DD MM YY,

--- a/client/src/components/ReportApprovals.js
+++ b/client/src/components/ReportApprovals.js
@@ -96,8 +96,7 @@ export default class ReportApprovals extends Component {
                 <div className="approval-details">
                     <span>By <LinkTo person={action.person} /></span><br/>
                     <small>
-                        On {moment(action.createdAt).format(Settings.dateFormats.forms.short)}<br/>
-                        At {moment(action.createdAt).format('h:mm a')}
+                        On {moment(action.createdAt).format(Settings.dateFormats.forms.withTime)}
                     </small>
                 </div>
             )

--- a/docs/anet.yml.production.template
+++ b/docs/anet.yml.production.template
@@ -156,9 +156,9 @@ dictionary:
   SUPPORT_EMAIL_ADDR: support@example.com
 
   dateFormats:
-    email: d MMMM yyyy
-      short: d MMMM YYYY
-      withTime: d MMMM YYYY @ H:m
+    email:
+      short: d MMMM yyyy
+      withTime: d MMMM yyyy @ HH:mm
     excel: d MMMM yyyy
     forms:
       input: [DD-MM-YYYY, DD-MM-YY, DD/MM/YYYY, DD/MM/YY, DD MM YYYY, DD MM YY,

--- a/docs/anet.yml.production.template
+++ b/docs/anet.yml.production.template
@@ -157,6 +157,8 @@ dictionary:
 
   dateFormats:
     email: d MMMM yyyy
+      short: d MMMM YYYY
+      withTime: d MMMM YYYY @ H:m
     excel: d MMMM yyyy
     forms:
       input: [DD-MM-YYYY, DD-MM-YY, DD/MM/YYYY, DD/MM/YY, DD MM YYYY, DD MM YY,

--- a/src/main/java/mil/dds/anet/resources/ReportResource.java
+++ b/src/main/java/mil/dds/anet/resources/ReportResource.java
@@ -107,7 +107,7 @@ public class ReportResource {
 		this.engine = engine;
 		this.dao = engine.getReportDao();
 		this.config = config;
-		this.dtf = DateTimeFormatter.ofPattern((String) this.config.getDictionaryEntry("dateFormats.email")).withZone(DaoUtils.getDefaultZoneId());
+		this.dtf = DateTimeFormatter.ofPattern((String) this.config.getDictionaryEntry("dateFormats.email.short")).withZone(DaoUtils.getDefaultZoneId());
 		@SuppressWarnings("unchecked")
 		List<String> pinnedOrgNames = (List<String>)this.config.getDictionaryEntry("pinned_ORGs");
 		this.rollupGraphComparator = new RollupGraphComparator(pinnedOrgNames);

--- a/src/main/java/mil/dds/anet/threads/AnetEmailWorker.java
+++ b/src/main/java/mil/dds/anet/threads/AnetEmailWorker.java
@@ -63,6 +63,7 @@ public class AnetEmailWorker implements Runnable {
 	private ScheduledExecutorService scheduler;
 	private final String supportEmailAddr;
 	private final DateTimeFormatter dtf;
+	private final DateTimeFormatter dttf;
 	private final Integer nbOfHoursForStaleEmails;
 	private final boolean disabled;
 	private boolean noEmailConfiguration;
@@ -75,7 +76,8 @@ public class AnetEmailWorker implements Runnable {
 		this.fromAddr = config.getEmailFromAddr();
 		this.serverUrl = config.getServerUrl();
 		this.supportEmailAddr = (String) config.getDictionaryEntry("SUPPORT_EMAIL_ADDR");
-		this.dtf = DateTimeFormatter.ofPattern((String) config.getDictionaryEntry("dateFormats.email")).withZone(DaoUtils.getDefaultZoneId());
+		this.dtf = DateTimeFormatter.ofPattern((String) config.getDictionaryEntry("dateFormats.email.short")).withZone(DaoUtils.getDefaultZoneId());
+		this.dttf = DateTimeFormatter.ofPattern((String) config.getDictionaryEntry("dateFormats.email.withTime")).withZone(DaoUtils.getDefaultZoneId());
 		this.fields = (Map<String, Object>) config.getDictionaryEntry("fields");
 		instance = this;
 
@@ -181,6 +183,7 @@ public class AnetEmailWorker implements Runnable {
 			context.put(AdminSettingKeys.SECURITY_BANNER_COLOR.name(), engine.getAdminSetting(AdminSettingKeys.SECURITY_BANNER_COLOR));
 			context.put("SUPPORT_EMAIL_ADDR", supportEmailAddr);
 			context.put("dateFormatter", dtf);
+			context.put("dateTimeFormatter", dttf);
 			context.put("fields", fields);
 			Template temp = freemarkerConfig.getTemplate(email.getAction().getTemplateName());
 

--- a/src/main/resources/anet-schema.yml
+++ b/src/main/resources/anet-schema.yml
@@ -62,10 +62,20 @@ properties:
     required: [email, excel, forms]
     properties:
       email:
-        type: string
-        title: The date format for email
-        description: Used in report emails, e.g. "6 December 1998"; see https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html#patterns for format specifiers.
-        examples: ["d MMMM yyyy"]
+        type: object
+        additionalProperties: false
+        required: [short, withTime]
+        properties:
+          short:
+            type: string
+            title: The short date format for email
+            description: Used in report emails; should be easy to read, e.g. "6 December 1998"; see https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html#patterns for format specifiers.
+            examples: ["D MMMM YYYY"]
+          withTime:
+            type: string
+            title: The date format including the time for email
+            description: Used in report emails; should be easy to read, e.g. "6 December 1998 @ 13:45"; see see https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html#patterns for format specifiers.
+            examples: ["d MMMM YYYY @ H:m"]
       excel:
         type: string
         title: The date format for Excel export

--- a/src/main/resources/anet-schema.yml
+++ b/src/main/resources/anet-schema.yml
@@ -70,12 +70,12 @@ properties:
             type: string
             title: The short date format for email
             description: Used in report emails; should be easy to read, e.g. "6 December 1998"; see https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html#patterns for format specifiers.
-            examples: ["D MMMM YYYY"]
+            examples: ["d MMMM yyyy"]
           withTime:
             type: string
             title: The date format including the time for email
             description: Used in report emails; should be easy to read, e.g. "6 December 1998 @ 13:45"; see see https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html#patterns for format specifiers.
-            examples: ["d MMMM YYYY @ H:m"]
+            examples: ["d MMMM yyyy @ HH:mm"]
       excel:
         type: string
         title: The date format for Excel export

--- a/src/main/resources/emails/emailReport.ftlh
+++ b/src/main/resources/emails/emailReport.ftlh
@@ -506,8 +506,7 @@ ${sender.name} sent you a report from ANET:
                 <#assign person = approvalAction.getPerson()>
                 <div class="approval-details">
                   <span>By ${(person.name)!}</span><br>
-                  <small>On ${(dateFormatter.format(approvalAction.createdAt))!}
-                  <br>At ${(approvalAction.createdAt.toString('h:mm a'))!}</small>
+                  <small>On ${(dateTimeFormatter.format(approvalAction.createdAt))!}</small>
                 </div>
               </#if>
             </#if>


### PR DESCRIPTION
This adds the possibility to format a datetime for e-mails by also
displaying the time (before it was only possible to display the date in
e-mails). When displaying the time in the report email we were getting an
error but this is now fixed by the current commit.