### PR TITLE
nci-agency/anet#1457: Do not clear tasks when saving cancelled reports

### DIFF
--- a/client/src/pages/reports/Form.js
+++ b/client/src/pages/reports/Form.js
@@ -605,7 +605,6 @@ class BaseReportForm extends Component {
 			//They might have been set before the report has been marked as cancelled.
 			report.atmosphere = null
 			report.atmosphereDetails = ''
-			report.tasks = null
 			report.keyOutcomes = ''
 		}
 		//reportTags contains id's instead of uuid's (as that is what the ReactTags component expects)


### PR DESCRIPTION
Users were enable to submit cancelled reports, this is fixed now