### PR TITLE
Make AuthUtils::isAdmin work for users without position

### DIFF
--- a/src/main/java/mil/dds/anet/utils/AuthUtils.java
+++ b/src/main/java/mil/dds/anet/utils/AuthUtils.java
@@ -93,7 +93,7 @@ public class AuthUtils {
 
 	public static boolean isAdmin(Person user) {
 		Position position = user.loadPosition();
-		return position.getType() == PositionType.ADMINISTRATOR;
+		return (position != null) && (position.getType() == PositionType.ADMINISTRATOR);
 	}
 	
 }


### PR DESCRIPTION
Fix exception in `isAdmin` when user is not an admin and invoked from `runSearch`