### PR TITLE
Fix loading of autocomplete suggestions

### DIFF
--- a/client/src/components/Autocomplete.js
+++ b/client/src/components/Autocomplete.js
@@ -58,6 +58,7 @@ export default class Autocomplete extends Component {
       stringValue: stringValue,
       originalStringValue: stringValue
     }
+    this.latestRequest = null
   }
 
   componentDidUpdate(prevProps, prevState) {
@@ -194,9 +195,17 @@ export default class Autocomplete extends Component {
     if (this.props.queryParams) {
       Object.assign(queryVars, this.props.queryParams)
     }
-    API.query(graphQlQuery, { query: queryVars }, variableDef).then(data => {
+    const thisRequest = (this.latestRequest = API.query(
+      graphQlQuery,
+      { query: queryVars },
+      variableDef
+    ).then(data => {
+      // If this is true there's a newer request happening, stop everything
+      if (thisRequest !== this.latestRequest) {
+        return
+      }
       this._setSuggestions(data[listName].list)
-    })
+    }))
   }
 
   @autobind


### PR DESCRIPTION
For searches in a person autocomplete type of field we used to have the following problem:
- the user was typing the first letter, a request was started to get the results
- the user was typing a second letter, another search request was started
- the latest was earlier ready than the first one
- the autocomplete was first loading the suggestions for the 2 letters
and when the first request was also ready it was loading the suggestions
for only one letter

We fixed it by making sure that if an old request returned results for
the autocomplete, we do not load the suggestions.