### PR TITLE
nci-agency/anet#37: Add descriptions to rank dropdown

### DIFF
--- a/anet.yml
+++ b/anet.yml
@@ -231,7 +231,57 @@ dictionary:
       phoneNumber: Phone
       country: Nationality
       rank: Rank
-      ranks: [CIV, CTR, OR-1, OR-2, OR-3, OR-4, OR-5, OR-6, OR-7, OR-8, OR-9, WO-1, WO-2, WO-3, WO-4, WO-5, OF-1, OF-2, OF-3, OF-4, OF-5, OF-6, OF-7, OF-8, OF-9, OF-10]
+      ranks:
+        - value: CIV
+          description: the rank of CIV
+        - value: CTR
+          description: the rank of CTR
+        - value: OR-1
+          description: the rank of OR-1
+        - value: OR-2
+          description: the rank of OR-2
+        - value: OR-3
+          description: the rank of OR-3
+        - value: OR-4
+          description: the rank of OR-4
+        - value: OR-5
+          description: the rank of OR-5
+        - value: OR-6
+          description: the rank of OR-6
+        - value: OR-7
+          description: the rank of OR-7
+        - value: OR-8
+          description: the rank of OR-8
+        - value: OR-9
+          description: the rank of OR-9
+        - value: WO-1
+          description: the rank of WO-1
+        - value: WO-2
+          description: the rank of WO-2
+        - value: WO-3
+          description: the rank of WO-3
+        - value: WO-4
+          description: the rank of WO-4
+        - value: WO-5
+          description: the rank of WO-5
+        - value: OF-1
+          description: the rank of OF-1
+        - value: OF-2
+          description: the rank of OF-2
+        - value: OF-3
+          description: the rank of OF-3
+        - value: OF-4
+          description: the rank of OF-4
+        - value: OF-5
+          description: the rank of OF-5
+        - value: OF-6
+          description: the rank of OF-6
+        - value: OF-7
+          description: the rank of OF-7
+        - value: OF-8
+          description: the rank of OF-8
+        - value: OF-9
+          description: the rank of OF-9
       gender: Gender
       endOfTourDate: End of tour
 

--- a/client/src/components/SearchFilters.js
+++ b/client/src/components/SearchFilters.js
@@ -226,7 +226,7 @@ export default {
     }
 
     const countries = Settings.fields.advisor.person.countries || [] // TODO: make search also work with principal countries
-    const ranks = Settings.fields.person.ranks || []
+    const ranks = (Settings.fields.person.ranks || []).map(f => f.value)
     filters.People = {
       filters: {
         Organization: {

--- a/client/src/pages/people/Form.js
+++ b/client/src/pages/people/Form.js
@@ -415,7 +415,8 @@ class BasePersonForm extends Component {
                         <option />
                         {ranks.map(rank => (
                           <option key={rank.value} value={rank.value}>
-                            {rank.value} {rank.description && ` - ( ${rank.description} )`}
+                            {rank.value}{" "}
+                            {rank.description && ` - ( ${rank.description} )`}
                           </option>
                         ))}
                       </Field>

--- a/client/src/pages/people/Form.js
+++ b/client/src/pages/people/Form.js
@@ -414,8 +414,8 @@ class BasePersonForm extends Component {
                       <Field component="select" className="form-control">
                         <option />
                         {ranks.map(rank => (
-                          <option key={rank} value={rank}>
-                            {rank}
+                          <option key={rank.value} value={rank.value}>
+                            {rank.value} {rank.description && ` - ( ${rank.description} )`}
                           </option>
                         ))}
                       </Field>

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -234,7 +234,57 @@ dictionary:
       phoneNumber: Phone
       country: Nationality
       rank: Rank
-      ranks: [CIV, CTR, OR-1, OR-2, OR-3, OR-4, OR-5, OR-6, OR-7, OR-8, OR-9, WO-1, WO-2, WO-3, WO-4, WO-5, OF-1, OF-2, OF-3, OF-4, OF-5, OF-6, OF-7, OF-8, OF-9, OF-10]
+      ranks:
+        - value: CIV
+          description: the rank of CIV
+        - value: CTR
+          description: the rank of CTR
+        - value: OR-1
+          description: the rank of OR-1
+        - value: OR-2
+          description: the rank of OR-2
+        - value: OR-3
+          description: the rank of OR-3
+        - value: OR-4
+          description: the rank of OR-4
+        - value: OR-5
+          description: the rank of OR-5
+        - value: OR-6
+          description: the rank of OR-6
+        - value: OR-7
+          description: the rank of OR-7
+        - value: OR-8
+          description: the rank of OR-8
+        - value: OR-9
+          description: the rank of OR-9
+        - value: WO-1
+          description: the rank of WO-1
+        - value: WO-2
+          description: the rank of WO-2
+        - value: WO-3
+          description: the rank of WO-3
+        - value: WO-4
+          description: the rank of WO-4
+        - value: WO-5
+          description: the rank of WO-5
+        - value: OF-1
+          description: the rank of OF-1
+        - value: OF-2
+          description: the rank of OF-2
+        - value: OF-3
+          description: the rank of OF-3
+        - value: OF-4
+          description: the rank of OF-4
+        - value: OF-5
+          description: the rank of OF-5
+        - value: OF-6
+          description: the rank of OF-6
+        - value: OF-7
+          description: the rank of OF-7
+        - value: OF-8
+          description: the rank of OF-8
+        - value: OF-9
+          description: the rank of OF-9
       gender: Gender
       endOfTourDate: End of tour
 

--- a/docs/anet.yml.production.template
+++ b/docs/anet.yml.production.template
@@ -219,7 +219,57 @@ dictionary:
       phoneNumber: Phone
       country: Nationality
       rank: Rank
-      ranks: [CIV, CTR, OR-1, OR-2, OR-3, OR-4, OR-5, OR-6, OR-7, OR-8, OR-9, WO-1, WO-2, WO-3, WO-4, WO-5, OF-1, OF-2, OF-3, OF-4, OF-5, OF-6, OF-7, OF-8, OF-9, OF-10]
+      ranks:
+        - value: CIV
+          description: the rank of CIV
+        - value: CTR
+          description: the rank of CTR
+        - value: OR-1
+          description: the rank of OR-1
+        - value: OR-2
+          description: the rank of OR-2
+        - value: OR-3
+          description: the rank of OR-3
+        - value: OR-4
+          description: the rank of OR-4
+        - value: OR-5
+          description: the rank of OR-5
+        - value: OR-6
+          description: the rank of OR-6
+        - value: OR-7
+          description: the rank of OR-7
+        - value: OR-8
+          description: the rank of OR-8
+        - value: OR-9
+          description: the rank of OR-9
+        - value: WO-1
+          description: the rank of WO-1
+        - value: WO-2
+          description: the rank of WO-2
+        - value: WO-3
+          description: the rank of WO-3
+        - value: WO-4
+          description: the rank of WO-4
+        - value: WO-5
+          description: the rank of WO-5
+        - value: OF-1
+          description: the rank of OF-1
+        - value: OF-2
+          description: the rank of OF-2
+        - value: OF-3
+          description: the rank of OF-3
+        - value: OF-4
+          description: the rank of OF-4
+        - value: OF-5
+          description: the rank of OF-5
+        - value: OF-6
+          description: the rank of OF-6
+        - value: OF-7
+          description: the rank of OF-7
+        - value: OF-8
+          description: the rank of OF-8
+        - value: OF-9
+          description: the rank of OF-9
       gender: Gender
       endOfTourDate: End of tour
 

--- a/src/main/resources/anet-schema.yml
+++ b/src/main/resources/anet-schema.yml
@@ -6,6 +6,17 @@
 #########################################################
 definitions:
 
+# base definition for a value with a description
+  describedValue:
+    type: object
+    additionalProperties: true
+    required: [value,description]
+    properties:
+      value:
+        type: string
+      description:
+        type: string
+
 # base definition for all Fields. Every field is assumed to have a label
   labeledField:
     type: object
@@ -251,10 +262,7 @@ properties:
             uniqueItems: true
             minItems: 1
             items:
-              type: string
-              title: The list of possible ranks
-              description: Used in the UI where a rank can be selected for a person.
-              examples: [CIV, CTR, OF-1, OF-2, OF-3]
+              "$ref": "#/definitions/describedValue"
           gender:
             type: string
             title: The label for a person's gender


### PR DESCRIPTION
Add descriptions to ranks

Fixes #37

### User changes
- Users will see rank descriptions when choosing their rank

### System admin changes
- need to define ranks in anet.yml
```
      ranks:
        - value: CIV
          description: the rank of CIV
        - value: CTR
          description: the rank of CTR
        - value: OR-1
          description: the rank of OR-1
          ....
```

- [x] anet.yml needs change
- [ ] db needs migration
- [x] documentation has changed
