### PR TITLE
NCI-Agency/anet#1636: Close advanced search on click outside overlay

### DIFF
--- a/client/src/components/SearchBar.js
+++ b/client/src/components/SearchBar.js
@@ -126,6 +126,7 @@ class SearchBar extends Component {
           onHide={() => this.setState({ showAdvancedSearch: false })}
           placement="bottom"
           target={this.advancedSearchLink}
+          rootClose
         >
           <Popover id="advanced-search" placement="bottom" title="Filters">
             <AdvancedSearch


### PR DESCRIPTION
Close the advanced search overlay when the user clicks outside the overlay.

Closes #1636 

### User changes
- When the user is clicking outside the overlay of the advanced search, the overlay closes.

- [ ] anet.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
