### PR TITLE
nci-agency/anet#1666: Limit graphql batching pool to 3 threads.

### DIFF
--- a/src/main/java/mil/dds/anet/resources/GraphQlResource.java
+++ b/src/main/java/mil/dds/anet/resources/GraphQlResource.java
@@ -193,7 +193,7 @@ public class GraphQlResource {
         // Wait a while, giving other threads the chance to do some work
         try {
           Thread.yield();
-          Thread.sleep(25);
+          Thread.sleep(50);
         } catch (InterruptedException ignored) {
         }
 

--- a/src/main/java/mil/dds/anet/utils/BatchingUtils.java
+++ b/src/main/java/mil/dds/anet/utils/BatchingUtils.java
@@ -42,7 +42,7 @@ public final class BatchingUtils {
         .setMaxBatchSize(1000);
     final DataLoaderRegistry dataLoaderRegistry = new DataLoaderRegistry();
     // Give each registry its own thread pool
-    final ExecutorService dispatcherService = Executors.newCachedThreadPool();
+    final ExecutorService dispatcherService = Executors.newFixedThreadPool(3);
 
     dataLoaderRegistry.register("approvalSteps",
         new DataLoader<>(new BatchLoader<String, ApprovalStep>() {


### PR DESCRIPTION
ANET will not hang with some types of requests
Improves #1666 

### User changes
When executing complex queries, ANET will still be slow, but will not crash the entire system

- [ ] anet.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
