### PR TITLE
Close advanced search on click outside overlay

### DIFF
--- a/client/src/components/CustomDateInput.js
+++ b/client/src/components/CustomDateInput.js
@@ -74,6 +74,7 @@ export default class CustomDateInput extends Component {
         showActionsBar
         closeOnSelection={!withTime}
         timePickerProps={timePickerProps}
+        popoverProps={{ usePortal: false }}
       />
     )
   }

--- a/client/src/components/SearchBar.js
+++ b/client/src/components/SearchBar.js
@@ -126,6 +126,7 @@ class SearchBar extends Component {
           onHide={() => this.setState({ showAdvancedSearch: false })}
           placement="bottom"
           target={this.advancedSearchLink}
+          rootClose
         >
           <Popover id="advanced-search" placement="bottom" title="Filters">
             <AdvancedSearch


### PR DESCRIPTION
And make sure the DateInput is inside the overlay so closing that won't close the overlay.

Closes NCI-Agency/anet#1636