### PR TITLE
nci-agency/anet#1597: Do not send emails to addresses not whitelisted as active

### DIFF
--- a/anet.yml
+++ b/anet.yml
@@ -362,6 +362,7 @@ dictionary:
   non_reporting_ORGs: [ANET Administrators]
   tasking_ORGs: [EF 2.2]
   domainNames: [cmil.mil, mission.ita, nato.int, dds.mil, "*.isaf.nato.int"]
+  activeDomainNames: [cmil.mil, mission.ita, nato.int, "*.isaf.nato.int"]
   imagery:
     mapOptions:
       crs: EPSG3857

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -367,6 +367,7 @@ dictionary:
   non_reporting_ORGs: [ANET Administrators]
   tasking_ORGs: [EF 2.2]
   domainNames: [cmil.mil, mission.ita, nato.int, dds.mil, "*.isaf.nato.int"]
+  activeDomainNames: [cmil.mil, mission.ita, nato.int, "*.isaf.nato.int"]
   imagery:
     mapOptions:
       crs: EPSG3857

--- a/docs/anet.yml.production.template
+++ b/docs/anet.yml.production.template
@@ -352,6 +352,7 @@ dictionary:
   non_reporting_ORGs: [ANET Administrators]
   tasking_ORGs: [EF 2.2]
   domainNames: [cmil.mil, mission.ita, nato.int, dds.mil, "*.isaf.nato.int"]
+  activeDomainNames: [cmil.mil, mission.ita, nato.int, "*.isaf.nato.int"]
   imagery:
     mapOptions:
       crs: EPSG3857

--- a/src/main/resources/anet-schema.yml
+++ b/src/main/resources/anet-schema.yml
@@ -59,7 +59,7 @@ definitions:
 #########################################################
 type: object
 additionalProperties: false
-required: [SUPPORT_EMAIL_ADDR, dateFormats, reportWorkflow, maxTextFieldLength, fields, pinned_ORGs, non_reporting_ORGs, domainNames, imagery]
+required: [SUPPORT_EMAIL_ADDR, dateFormats, reportWorkflow, maxTextFieldLength, fields, pinned_ORGs, non_reporting_ORGs, domainNames, activeDomainNames, imagery]
 properties:
   SUPPORT_EMAIL_ADDR:
     type: string
@@ -525,6 +525,16 @@ properties:
     items:
       type: string
       title: The list of possible (email) domain names
+      description: Valid email domain names for this ANET instance; may contain wildcards.
+      examples: ["*.nato.int", dds.mil]
+
+  activeDomainNames:
+    type: array
+    uniqueItems: true
+    minItems: 1
+    items:
+      type: string
+      title: The list of active (email) domain names
       description: Valid email domain names for this ANET instance; may contain wildcards.
       examples: ["*.nato.int", dds.mil]
 


### PR DESCRIPTION
Implements #1597 

### User changes
- advisors with non-active email addresses will not receive email notifications

### System admin changes
- administrators have to define active domain names:
```
  activeDomainNames: [cmil.mil, mission.ita, nato.int, "*.isaf.nato.int"]
```
- [x] anet.yml needs change
- [ ] db needs migration
- [x] documentation has changed
