### PR TITLE
Fix warning about duration field in report form

### DIFF
--- a/client/src/components/FieldHelper.js
+++ b/client/src/components/FieldHelper.js
@@ -138,7 +138,14 @@ export const renderInputField = ({
     extraAddon,
     ...otherProps
   } = props
-  const widgetElem = <FormControl {...field} ref={innerRef} {...otherProps} />
+  const widgetElem = (
+    <FormControl
+      {...Object.without(field, "value")}
+      value={field.value === null ? "" : field.value}
+      ref={innerRef}
+      {...otherProps}
+    />
+  )
   return renderField(
     field,
     label,
@@ -158,7 +165,13 @@ export const renderInputFieldNoLabel = ({
   ...props
 }) => {
   const { children, ...otherProps } = props
-  const widgetElem = <FormControl {...field} {...otherProps} />
+  const widgetElem = (
+    <FormControl
+      {...Object.without(field, "value")}
+      value={field.value === null ? "" : field.value}
+      {...otherProps}
+    />
+  )
   return renderFieldNoLabel(field, form, widgetElem, children)
 }
 


### PR DESCRIPTION
This fixes the following warning: Warning: `value` prop on `input`
should not be null. Consider using an empty string to clear the
component or `undefined` for uncontrolled components.

Closes #1726 
