### PR TITLE
GraphQL search updates

### DIFF
--- a/client/src/components/ReportsVisualisation.js
+++ b/client/src/components/ReportsVisualisation.js
@@ -100,7 +100,6 @@ export default class ReportsVisualisation extends Component {
     const chartQueryParams = {}
     Object.assign(chartQueryParams, this.props.queryParams)
     Object.assign(chartQueryParams, {
-      pageNum: 0,
       pageSize: 0 // retrieve all the filtered reports
     })
     return chartQueryParams

--- a/client/src/models/Person.js
+++ b/client/src/models/Person.js
@@ -266,7 +266,7 @@ export default class Person extends Model {
     if (!this.position || !this.position.organization) {
       return false
     }
-    let orgs = this.position.organization.allDescendantOrgs || []
+    let orgs = this.position.organization.descendantOrgs || []
     orgs.push(this.position.organization)
     let orgUuids = orgs.map(o => o.uuid)
 

--- a/client/src/pages/App.js
+++ b/client/src/pages/App.js
@@ -49,7 +49,7 @@ class App extends Page {
           uuid, name, code, type, status, isApprover
           organization {
             uuid, shortName,
-            descendantOrgs (query: { pageNum: 0, pageSize: 0 }) {
+            descendantOrgs (query: { pageSize: 0 }) {
               uuid
             }
           }

--- a/client/src/pages/App.js
+++ b/client/src/pages/App.js
@@ -47,7 +47,12 @@ class App extends Page {
         uuid, name, rank, role, emailAddress, status
         position {
           uuid, name, code, type, status, isApprover
-          organization { uuid, shortName , allDescendantOrgs { uuid }}
+          organization {
+            uuid, shortName,
+            descendantOrgs (query: { pageNum: 0, pageSize: 0 }) {
+              uuid
+            }
+          }
           location {uuid, name}
           associatedPositions {
             uuid, name,

--- a/client/src/pages/Help.js
+++ b/client/src/pages/Help.js
@@ -42,7 +42,6 @@ class BaseHelp extends Page {
     }
 
     const positionQuery = {
-      pageNum: 0,
       pageSize: 0, // retrieve all these positions
       type: [Position.TYPE.SUPER_USER, Position.TYPE.ADMINISTRATOR],
       status: Position.STATUS.ACTIVE,

--- a/client/src/pages/Home.js
+++ b/client/src/pages/Home.js
@@ -203,7 +203,6 @@ class BaseHome extends Page {
     let queries = this.getQueriesForUser(currentUser)
     let queryParts = [] // GQL query parts
     queries.forEach((q, index) => {
-      q.query.pageNum = 0
       q.query.pageSize = 1 // we're only interested in the totalCount, so just get at most one report
       queryParts.push(
         new GQL.Part(

--- a/client/src/pages/admin/AuthorizationGroups.js
+++ b/client/src/pages/admin/AuthorizationGroups.js
@@ -21,7 +21,6 @@ class AuthorizationGroups extends Page {
 
   fetchData(props) {
     const query = {
-      pageNum: 0,
       pageSize: 0 // retrieve all
     }
     return API.query(

--- a/client/src/pages/admin/MergePeople.js
+++ b/client/src/pages/admin/MergePeople.js
@@ -70,8 +70,8 @@ class MergePeople extends Page {
   render() {
     const personFields = `uuid, name, emailAddress, domainUsername, createdAt, role, status, rank,
       position { uuid, name, type, organization { uuid, shortName, longName, identificationCode }},
-      authoredReports(query: {pageNum: 0, pageSize: 1}) { totalCount }
-      attendedReports(query: {pageNum: 0, pageSize: 1}) { totalCount }`
+      authoredReports(query: {pageSize: 1}) { totalCount }
+      attendedReports(query: {pageSize: 1}) { totalCount }`
 
     return (
       <div>

--- a/client/src/pages/admin/MergePeople.js
+++ b/client/src/pages/admin/MergePeople.js
@@ -70,8 +70,8 @@ class MergePeople extends Page {
   render() {
     const personFields = `uuid, name, emailAddress, domainUsername, createdAt, role, status, rank,
       position { uuid, name, type, organization { uuid, shortName, longName, identificationCode }},
-      authoredReports(pageNum:0,pageSize:1) { totalCount }
-      attendedReports(pageNum:0,pageSize:1) { totalCount }`
+      authoredReports(query: {pageNum: 0, pageSize: 1}) { totalCount }
+      attendedReports(query: {pageNum: 0, pageSize: 1}) { totalCount }`
 
     return (
       <div>

--- a/client/src/pages/organizations/Show.js
+++ b/client/src/pages/organizations/Show.js
@@ -112,7 +112,9 @@ class BaseOrganizationShow extends Page {
       organization(uuid:"${props.match.params.uuid}") {
         uuid, shortName, longName, status, identificationCode, type
         parentOrg { uuid, shortName, longName, identificationCode }
-        childrenOrgs { uuid, shortName, longName, identificationCode },
+        childrenOrgs(query: { pageNum: 0, pageSize: 0 }) {
+          uuid, shortName, longName, identificationCode
+        },
         positions {
           uuid, name, code, status, type,
           person { uuid, name, status, rank, role }

--- a/client/src/pages/organizations/Show.js
+++ b/client/src/pages/organizations/Show.js
@@ -112,7 +112,7 @@ class BaseOrganizationShow extends Page {
       organization(uuid:"${props.match.params.uuid}") {
         uuid, shortName, longName, status, identificationCode, type
         parentOrg { uuid, shortName, longName, identificationCode }
-        childrenOrgs(query: { pageNum: 0, pageSize: 0 }) {
+        childrenOrgs(query: { pageSize: 0 }) {
           uuid, shortName, longName, identificationCode
         },
         positions {

--- a/client/src/pages/reports/Form.js
+++ b/client/src/pages/reports/Form.js
@@ -119,7 +119,6 @@ class BaseReportForm extends Component {
 
   componentDidMount() {
     const tagQuery = {
-      pageNum: 0,
       pageSize: 0 // retrieve all
     }
     API.query(

--- a/client/src/pages/rollup/Show.js
+++ b/client/src/pages/rollup/Show.js
@@ -246,7 +246,6 @@ class BaseRollupShow extends Page {
     chartQuery += ")"
     chartQueryParamsDef += ")"
     Object.assign(chartQueryParams, {
-      pageNum: 0,
       pageSize: 0 // retrieve all the filtered reports
     })
     return [chartQuery, chartQueryParams, chartQueryParamsDef]

--- a/src/main/java/mil/dds/anet/AnetObjectEngine.java
+++ b/src/main/java/mil/dds/anet/AnetObjectEngine.java
@@ -240,7 +240,7 @@ public class AnetObjectEngine {
    */
   public Map<String, Organization> buildTopLevelOrgHash(OrganizationType orgType) {
     OrganizationSearchQuery orgQuery = new OrganizationSearchQuery();
-    orgQuery.setPageSize(Integer.MAX_VALUE);
+    orgQuery.setPageSize(0);
     orgQuery.setType(orgType);
     List<Organization> orgs = getOrganizationDao().search(orgQuery).getList();
 
@@ -256,7 +256,7 @@ public class AnetObjectEngine {
     final OrganizationSearchQuery query = new OrganizationSearchQuery();
     query.setParentOrgUuid(parentOrgUuid);
     query.setParentOrgRecursively(true);
-    query.setPageSize(Integer.MAX_VALUE);
+    query.setPageSize(0);
     final List<Organization> orgList =
         AnetObjectEngine.getInstance().getOrganizationDao().search(query).getList();
     return Utils.buildParentOrgMapping(orgList, parentOrgUuid);
@@ -271,7 +271,7 @@ public class AnetObjectEngine {
     final TaskSearchQuery query = new TaskSearchQuery();
     query.setCustomFieldRef1Uuid(parentTaskUuid);
     query.setCustomFieldRef1Recursively(true);
-    query.setPageSize(Integer.MAX_VALUE);
+    query.setPageSize(0);
     final List<Task> taskList = AnetObjectEngine.getInstance().getTaskDao().search(query).getList();
     return Utils.buildParentTaskMapping(taskList, parentTaskUuid);
   }

--- a/src/main/java/mil/dds/anet/beans/AuthorizationGroup.java
+++ b/src/main/java/mil/dds/anet/beans/AuthorizationGroup.java
@@ -1,18 +1,13 @@
 package mil.dds.anet.beans;
 
-import io.leangen.graphql.annotations.GraphQLArgument;
 import io.leangen.graphql.annotations.GraphQLIgnore;
 import io.leangen.graphql.annotations.GraphQLQuery;
 import io.leangen.graphql.annotations.GraphQLRootContext;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import mil.dds.anet.AnetObjectEngine;
-import mil.dds.anet.beans.lists.AnetBeanList;
-import mil.dds.anet.beans.search.PositionSearchQuery;
-import mil.dds.anet.beans.search.ReportSearchQuery;
 import mil.dds.anet.utils.Utils;
 import mil.dds.anet.views.AbstractAnetBean;
 
@@ -74,28 +69,6 @@ public class AuthorizationGroup extends AbstractAnetBean {
 
   public void setStatus(AuthorizationGroupStatus status) {
     this.status = status;
-  }
-
-  // TODO: batch load? (appears to be unused)
-  @GraphQLQuery(name = "reports")
-  public AnetBeanList<Report> fetchReports(@GraphQLArgument(name = "pageNum") int pageNum,
-      @GraphQLArgument(name = "pageSize") int pageSize) {
-    ReportSearchQuery query = new ReportSearchQuery();
-    query.setPageNum(pageNum);
-    query.setPageSize(pageSize);
-    query.setAuthorizationGroupUuid(Arrays.asList(uuid));
-    return AnetObjectEngine.getInstance().getReportDao().search(query);
-  }
-
-  // TODO: batch load? (appears to be unused)
-  @GraphQLQuery(name = "paginatedPositions")
-  public AnetBeanList<Position> fetchPositions(@GraphQLArgument(name = "pageNum") int pageNum,
-      @GraphQLArgument(name = "pageSize") int pageSize) {
-    PositionSearchQuery query = new PositionSearchQuery();
-    query.setPageNum(pageNum);
-    query.setPageSize(pageSize);
-    query.setAuthorizationGroupUuid(uuid);
-    return AnetObjectEngine.getInstance().getPositionDao().search(query);
   }
 
   @Override

--- a/src/main/java/mil/dds/anet/beans/Comment.java
+++ b/src/main/java/mil/dds/anet/beans/Comment.java
@@ -7,6 +7,7 @@ import io.leangen.graphql.annotations.GraphQLRootContext;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
+import mil.dds.anet.utils.BatchingUtils;
 import mil.dds.anet.utils.Utils;
 import mil.dds.anet.views.AbstractAnetBean;
 import mil.dds.anet.views.UuidFetcher;
@@ -32,7 +33,8 @@ public class Comment extends AbstractAnetBean {
     if (author.hasForeignObject()) {
       return CompletableFuture.completedFuture(author.getForeignObject());
     }
-    return new UuidFetcher<Person>().load(context, "people", author.getForeignUuid())
+    return new UuidFetcher<Person>()
+        .load(context, BatchingUtils.DataLoaderKey.ID_PEOPLE, author.getForeignUuid())
         .thenApply(o -> {
           author.setForeignObject(o);
           return o;

--- a/src/main/java/mil/dds/anet/beans/Note.java
+++ b/src/main/java/mil/dds/anet/beans/Note.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import mil.dds.anet.AnetObjectEngine;
+import mil.dds.anet.utils.BatchingUtils;
 import mil.dds.anet.utils.Utils;
 import mil.dds.anet.views.AbstractAnetBean;
 import mil.dds.anet.views.UuidFetcher;
@@ -47,7 +48,8 @@ public class Note extends AbstractAnetBean {
     if (author.hasForeignObject()) {
       return CompletableFuture.completedFuture(author.getForeignObject());
     }
-    return new UuidFetcher<Person>().load(context, "people", author.getForeignUuid())
+    return new UuidFetcher<Person>()
+        .load(context, BatchingUtils.DataLoaderKey.ID_PEOPLE, author.getForeignUuid())
         .thenApply(o -> {
           author.setForeignObject(o);
           return o;

--- a/src/main/java/mil/dds/anet/beans/Organization.java
+++ b/src/main/java/mil/dds/anet/beans/Organization.java
@@ -13,6 +13,7 @@ import mil.dds.anet.AnetObjectEngine;
 import mil.dds.anet.beans.search.OrganizationSearchQuery;
 import mil.dds.anet.beans.search.PositionSearchQuery;
 import mil.dds.anet.beans.search.TaskSearchQuery;
+import mil.dds.anet.utils.BatchingUtils;
 import mil.dds.anet.utils.Utils;
 import mil.dds.anet.views.AbstractAnetBean;
 import mil.dds.anet.views.UuidFetcher;
@@ -87,7 +88,8 @@ public class Organization extends AbstractAnetBean {
       return CompletableFuture.completedFuture(parentOrg.getForeignObject());
     }
     return new UuidFetcher<Organization>()
-        .load(context, "organizations", parentOrg.getForeignUuid()).thenApply(o -> {
+        .load(context, BatchingUtils.DataLoaderKey.ID_ORGANIZATIONS, parentOrg.getForeignUuid())
+        .thenApply(o -> {
           parentOrg.setForeignObject(o);
           return o;
         });

--- a/src/main/java/mil/dds/anet/beans/Organization.java
+++ b/src/main/java/mil/dds/anet/beans/Organization.java
@@ -1,7 +1,6 @@
 package mil.dds.anet.beans;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import io.leangen.graphql.annotations.GraphQLArgument;
 import io.leangen.graphql.annotations.GraphQLIgnore;
 import io.leangen.graphql.annotations.GraphQLQuery;
 import io.leangen.graphql.annotations.GraphQLRootContext;
@@ -10,9 +9,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import mil.dds.anet.AnetObjectEngine;
-import mil.dds.anet.beans.lists.AnetBeanList;
 import mil.dds.anet.beans.search.OrganizationSearchQuery;
-import mil.dds.anet.beans.search.ReportSearchQuery;
 import mil.dds.anet.utils.Utils;
 import mil.dds.anet.views.AbstractAnetBean;
 import mil.dds.anet.views.UuidFetcher;
@@ -196,21 +193,6 @@ public class Organization extends AbstractAnetBean {
 
   public void setTasks(List<Task> tasks) {
     this.tasks = tasks;
-  }
-
-  // TODO: batch load? (appears to be unused)
-  @GraphQLQuery(name = "reports")
-  public AnetBeanList<Report> fetchReports(@GraphQLArgument(name = "pageNum") int pageNum,
-      @GraphQLArgument(name = "pageSize") int pageSize) {
-    ReportSearchQuery query = new ReportSearchQuery();
-    query.setPageNum(pageNum);
-    query.setPageSize(pageSize);
-    if (this.getType() == OrganizationType.ADVISOR_ORG) {
-      query.setAdvisorOrgUuid(uuid);
-    } else {
-      query.setPrincipalOrgUuid(uuid);
-    }
-    return AnetObjectEngine.getInstance().getReportDao().search(query);
   }
 
   @Override

--- a/src/main/java/mil/dds/anet/beans/Organization.java
+++ b/src/main/java/mil/dds/anet/beans/Organization.java
@@ -11,6 +11,8 @@ import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import mil.dds.anet.AnetObjectEngine;
 import mil.dds.anet.beans.search.OrganizationSearchQuery;
+import mil.dds.anet.beans.search.PositionSearchQuery;
+import mil.dds.anet.beans.search.TaskSearchQuery;
 import mil.dds.anet.utils.Utils;
 import mil.dds.anet.views.AbstractAnetBean;
 import mil.dds.anet.views.UuidFetcher;
@@ -125,7 +127,10 @@ public class Organization extends AbstractAnetBean {
   @GraphQLQuery(name = "positions")
   public synchronized List<Position> loadPositions() {
     if (positions == null) {
-      positions = AnetObjectEngine.getInstance().getPositionDao().getByOrganization(uuid);
+      final PositionSearchQuery query = new PositionSearchQuery();
+      query.setPageSize(0);
+      query.setOrganizationUuid(uuid);
+      positions = AnetObjectEngine.getInstance().getPositionDao().search(query).getList();
     }
     return positions;
   }
@@ -179,8 +184,10 @@ public class Organization extends AbstractAnetBean {
   @GraphQLQuery(name = "tasks")
   public synchronized List<Task> loadTasks() {
     if (tasks == null) {
-      tasks =
-          AnetObjectEngine.getInstance().getTaskDao().getTasksByOrganizationUuid(this.getUuid());
+      final TaskSearchQuery query = new TaskSearchQuery();
+      query.setPageSize(0);
+      query.setResponsibleOrgUuid(uuid);
+      tasks = AnetObjectEngine.getInstance().getTaskDao().search(query).getList();
     }
     return tasks;
   }

--- a/src/main/java/mil/dds/anet/beans/Organization.java
+++ b/src/main/java/mil/dds/anet/beans/Organization.java
@@ -1,6 +1,7 @@
 package mil.dds.anet.beans;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.leangen.graphql.annotations.GraphQLArgument;
 import io.leangen.graphql.annotations.GraphQLIgnore;
 import io.leangen.graphql.annotations.GraphQLQuery;
 import io.leangen.graphql.annotations.GraphQLRootContext;
@@ -152,10 +153,9 @@ public class Organization extends AbstractAnetBean {
 
   // TODO: batch load? (used in organizations/Show.js)
   @GraphQLQuery(name = "childrenOrgs")
-  public synchronized List<Organization> loadChildrenOrgs() {
+  public synchronized List<Organization> loadChildrenOrgs(
+      @GraphQLArgument(name = "query") OrganizationSearchQuery query) {
     if (childrenOrgs == null) {
-      OrganizationSearchQuery query = new OrganizationSearchQuery();
-      query.setPageSize(Integer.MAX_VALUE);
       query.setParentOrgUuid(uuid);
       query.setParentOrgRecursively(false);
       childrenOrgs = AnetObjectEngine.getInstance().getOrganizationDao().search(query).getList();
@@ -164,11 +164,10 @@ public class Organization extends AbstractAnetBean {
   }
 
   // TODO: batch load? (used in App.js for me → position → organization)
-  @GraphQLQuery(name = "allDescendantOrgs")
-  public synchronized List<Organization> loadAllDescendants() {
+  @GraphQLQuery(name = "descendantOrgs")
+  public synchronized List<Organization> loadDescendantOrgs(
+      @GraphQLArgument(name = "query") OrganizationSearchQuery query) {
     if (descendants == null) {
-      OrganizationSearchQuery query = new OrganizationSearchQuery();
-      query.setPageSize(Integer.MAX_VALUE);
       query.setParentOrgUuid(uuid);
       query.setParentOrgRecursively(true);
       descendants = AnetObjectEngine.getInstance().getOrganizationDao().search(query).getList();

--- a/src/main/java/mil/dds/anet/beans/Person.java
+++ b/src/main/java/mil/dds/anet/beans/Person.java
@@ -213,11 +213,7 @@ public class Person extends AbstractAnetBean implements Principal {
   // TODO: batch load? (used in admin/MergePeople.js)
   @GraphQLQuery(name = "authoredReports")
   public AnetBeanList<Report> loadAuthoredReports(
-      @GraphQLArgument(name = "pageNum") Integer pageNum,
-      @GraphQLArgument(name = "pageSize") Integer pageSize) {
-    ReportSearchQuery query = new ReportSearchQuery();
-    query.setPageNum(pageNum);
-    query.setPageSize(pageSize);
+      @GraphQLArgument(name = "query") ReportSearchQuery query) {
     query.setAuthorUuid(uuid);
     return AnetObjectEngine.getInstance().getReportDao().search(query);
   }
@@ -225,11 +221,7 @@ public class Person extends AbstractAnetBean implements Principal {
   // TODO: batch load? (used in admin/MergePeople.js)
   @GraphQLQuery(name = "attendedReports")
   public AnetBeanList<Report> loadAttendedReports(
-      @GraphQLArgument(name = "pageNum") Integer pageNum,
-      @GraphQLArgument(name = "pageSize") Integer pageSize) {
-    ReportSearchQuery query = new ReportSearchQuery();
-    query.setPageNum(pageNum);
-    query.setPageSize(pageSize);
+      @GraphQLArgument(name = "query") ReportSearchQuery query) {
     query.setAttendeeUuid(uuid);
     return AnetObjectEngine.getInstance().getReportDao().search(query);
   }

--- a/src/main/java/mil/dds/anet/beans/Person.java
+++ b/src/main/java/mil/dds/anet/beans/Person.java
@@ -210,7 +210,7 @@ public class Person extends AbstractAnetBean implements Principal {
     this.previousPositions = previousPositions;
   }
 
-  // TODO: batch load? (used in people/Show.js, admin/MergePeople.js)
+  // TODO: batch load? (used in admin/MergePeople.js)
   @GraphQLQuery(name = "authoredReports")
   public AnetBeanList<Report> loadAuthoredReports(
       @GraphQLArgument(name = "pageNum") Integer pageNum,

--- a/src/main/java/mil/dds/anet/beans/PersonPositionHistory.java
+++ b/src/main/java/mil/dds/anet/beans/PersonPositionHistory.java
@@ -10,6 +10,7 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import javax.ws.rs.WebApplicationException;
+import mil.dds.anet.utils.BatchingUtils;
 import mil.dds.anet.views.AbstractAnetBean;
 import mil.dds.anet.views.UuidFetcher;
 
@@ -38,7 +39,8 @@ public class PersonPositionHistory extends AbstractAnetBean {
     if (person.hasForeignObject()) {
       return CompletableFuture.completedFuture(person.getForeignObject());
     }
-    return new UuidFetcher<Person>().load(context, "people", person.getForeignUuid())
+    return new UuidFetcher<Person>()
+        .load(context, BatchingUtils.DataLoaderKey.ID_PEOPLE, person.getForeignUuid())
         .thenApply(o -> {
           person.setForeignObject(o);
           return o;
@@ -71,7 +73,8 @@ public class PersonPositionHistory extends AbstractAnetBean {
     if (position.hasForeignObject()) {
       return CompletableFuture.completedFuture(position.getForeignObject());
     }
-    return new UuidFetcher<Position>().load(context, "positions", position.getForeignUuid())
+    return new UuidFetcher<Position>()
+        .load(context, BatchingUtils.DataLoaderKey.ID_POSITIONS, position.getForeignUuid())
         .thenApply(o -> {
           position.setForeignObject(o);
           return o;

--- a/src/main/java/mil/dds/anet/beans/Position.java
+++ b/src/main/java/mil/dds/anet/beans/Position.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import mil.dds.anet.AnetObjectEngine;
+import mil.dds.anet.utils.BatchingUtils;
 import mil.dds.anet.utils.Utils;
 import mil.dds.anet.views.AbstractAnetBean;
 import mil.dds.anet.views.UuidFetcher;
@@ -78,7 +79,8 @@ public class Position extends AbstractAnetBean {
       return CompletableFuture.completedFuture(organization.getForeignObject());
     }
     return new UuidFetcher<Organization>()
-        .load(context, "organizations", organization.getForeignUuid()).thenApply(o -> {
+        .load(context, BatchingUtils.DataLoaderKey.ID_ORGANIZATIONS, organization.getForeignUuid())
+        .thenApply(o -> {
           organization.setForeignObject(o);
           return o;
         });
@@ -110,7 +112,8 @@ public class Position extends AbstractAnetBean {
     if (person.hasForeignObject()) {
       return CompletableFuture.completedFuture(person.getForeignObject());
     }
-    return new UuidFetcher<Person>().load(context, "people", person.getForeignUuid())
+    return new UuidFetcher<Person>()
+        .load(context, BatchingUtils.DataLoaderKey.ID_PEOPLE, person.getForeignUuid())
         .thenApply(o -> {
           person.setForeignObject(o);
           return o;
@@ -165,7 +168,8 @@ public class Position extends AbstractAnetBean {
     if (location.hasForeignObject()) {
       return CompletableFuture.completedFuture(location.getForeignObject());
     }
-    return new UuidFetcher<Location>().load(context, "locations", location.getForeignUuid())
+    return new UuidFetcher<Location>()
+        .load(context, BatchingUtils.DataLoaderKey.ID_LOCATIONS, location.getForeignUuid())
         .thenApply(o -> {
           location.setForeignObject(o);
           return o;

--- a/src/main/java/mil/dds/anet/beans/Report.java
+++ b/src/main/java/mil/dds/anet/beans/Report.java
@@ -17,6 +17,7 @@ import javax.ws.rs.WebApplicationException;
 import mil.dds.anet.AnetObjectEngine;
 import mil.dds.anet.beans.AuthorizationGroup;
 import mil.dds.anet.beans.Person.Role;
+import mil.dds.anet.utils.BatchingUtils;
 import mil.dds.anet.utils.DaoUtils;
 import mil.dds.anet.utils.Utils;
 import mil.dds.anet.views.AbstractAnetBean;
@@ -78,7 +79,8 @@ public class Report extends AbstractAnetBean {
       return CompletableFuture.completedFuture(approvalStep.getForeignObject());
     }
     return new UuidFetcher<ApprovalStep>()
-        .load(context, "approvalSteps", approvalStep.getForeignUuid()).thenApply(o -> {
+        .load(context, BatchingUtils.DataLoaderKey.ID_APPROVAL_STEPS, approvalStep.getForeignUuid())
+        .thenApply(o -> {
           approvalStep.setForeignObject(o);
           return o;
         });
@@ -161,7 +163,8 @@ public class Report extends AbstractAnetBean {
     if (location.hasForeignObject()) {
       return CompletableFuture.completedFuture(location.getForeignObject());
     }
-    return new UuidFetcher<Location>().load(context, "locations", location.getForeignUuid())
+    return new UuidFetcher<Location>()
+        .load(context, BatchingUtils.DataLoaderKey.ID_LOCATIONS, location.getForeignUuid())
         .thenApply(o -> {
           location.setForeignObject(o);
           return o;
@@ -353,7 +356,8 @@ public class Report extends AbstractAnetBean {
     if (author.hasForeignObject()) {
       return CompletableFuture.completedFuture(author.getForeignObject());
     }
-    return new UuidFetcher<Person>().load(context, "people", author.getForeignUuid())
+    return new UuidFetcher<Person>()
+        .load(context, BatchingUtils.DataLoaderKey.ID_PEOPLE, author.getForeignUuid())
         .thenApply(o -> {
           author.setForeignObject(o);
           return o;
@@ -388,7 +392,8 @@ public class Report extends AbstractAnetBean {
       return CompletableFuture.completedFuture(advisorOrg.getForeignObject());
     }
     return new UuidFetcher<Organization>()
-        .load(context, "organizations", advisorOrg.getForeignUuid()).thenApply(o -> {
+        .load(context, BatchingUtils.DataLoaderKey.ID_ORGANIZATIONS, advisorOrg.getForeignUuid())
+        .thenApply(o -> {
           advisorOrg.setForeignObject(o);
           return o;
         });
@@ -422,7 +427,8 @@ public class Report extends AbstractAnetBean {
       return CompletableFuture.completedFuture(principalOrg.getForeignObject());
     }
     return new UuidFetcher<Organization>()
-        .load(context, "organizations", principalOrg.getForeignUuid()).thenApply(o -> {
+        .load(context, BatchingUtils.DataLoaderKey.ID_ORGANIZATIONS, principalOrg.getForeignUuid())
+        .thenApply(o -> {
           principalOrg.setForeignObject(o);
           return o;
         });

--- a/src/main/java/mil/dds/anet/beans/ReportAction.java
+++ b/src/main/java/mil/dds/anet/beans/ReportAction.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import javax.ws.rs.WebApplicationException;
+import mil.dds.anet.utils.BatchingUtils;
 import mil.dds.anet.views.AbstractAnetBean;
 import mil.dds.anet.views.UuidFetcher;
 
@@ -34,7 +35,8 @@ public class ReportAction extends AbstractAnetBean {
     if (step.hasForeignObject()) {
       return CompletableFuture.completedFuture(step.getForeignObject());
     }
-    return new UuidFetcher<ApprovalStep>().load(context, "approvalSteps", step.getForeignUuid())
+    return new UuidFetcher<ApprovalStep>()
+        .load(context, BatchingUtils.DataLoaderKey.ID_APPROVAL_STEPS, step.getForeignUuid())
         .thenApply(o -> {
           step.setForeignObject(o);
           return o;
@@ -67,7 +69,8 @@ public class ReportAction extends AbstractAnetBean {
     if (person.hasForeignObject()) {
       return CompletableFuture.completedFuture(person.getForeignObject());
     }
-    return new UuidFetcher<Person>().load(context, "people", person.getForeignUuid())
+    return new UuidFetcher<Person>()
+        .load(context, BatchingUtils.DataLoaderKey.ID_PEOPLE, person.getForeignUuid())
         .thenApply(o -> {
           person.setForeignObject(o);
           return o;

--- a/src/main/java/mil/dds/anet/beans/Task.java
+++ b/src/main/java/mil/dds/anet/beans/Task.java
@@ -10,6 +10,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import mil.dds.anet.AnetObjectEngine;
+import mil.dds.anet.utils.BatchingUtils;
 import mil.dds.anet.utils.Utils;
 import mil.dds.anet.views.AbstractAnetBean;
 import mil.dds.anet.views.UuidFetcher;
@@ -118,7 +119,8 @@ public class Task extends AbstractAnetBean {
     if (customFieldRef1.hasForeignObject()) {
       return CompletableFuture.completedFuture(customFieldRef1.getForeignObject());
     }
-    return new UuidFetcher<Task>().load(context, "tasks", customFieldRef1.getForeignUuid())
+    return new UuidFetcher<Task>()
+        .load(context, BatchingUtils.DataLoaderKey.ID_TASKS, customFieldRef1.getForeignUuid())
         .thenApply(o -> {
           customFieldRef1.setForeignObject(o);
           return o;
@@ -161,8 +163,9 @@ public class Task extends AbstractAnetBean {
     if (responsibleOrg.hasForeignObject()) {
       return CompletableFuture.completedFuture(responsibleOrg.getForeignObject());
     }
-    return new UuidFetcher<Organization>()
-        .load(context, "organizations", responsibleOrg.getForeignUuid()).thenApply(o -> {
+    return new UuidFetcher<Organization>().load(context,
+        BatchingUtils.DataLoaderKey.ID_ORGANIZATIONS, responsibleOrg.getForeignUuid())
+        .thenApply(o -> {
           responsibleOrg.setForeignObject(o);
           return o;
         });

--- a/src/main/java/mil/dds/anet/beans/search/AbstractSearchQuery.java
+++ b/src/main/java/mil/dds/anet/beans/search/AbstractSearchQuery.java
@@ -8,6 +8,7 @@ public abstract class AbstractSearchQuery implements ISearchQuery {
   private String text;
   private int pageNum;
   private int pageSize;
+  private SortOrder sortOrder;
 
   public AbstractSearchQuery() {
     this.pageNum = 0;
@@ -42,6 +43,16 @@ public abstract class AbstractSearchQuery implements ISearchQuery {
   @Override
   public void setPageSize(int pageSize) {
     this.pageSize = pageSize;
+  }
+
+  @Override
+  public SortOrder getSortOrder() {
+    return sortOrder;
+  }
+
+  @Override
+  public void setSortOrder(SortOrder sortOrder) {
+    this.sortOrder = sortOrder;
   }
 
 }

--- a/src/main/java/mil/dds/anet/beans/search/AbstractSearchQuery.java
+++ b/src/main/java/mil/dds/anet/beans/search/AbstractSearchQuery.java
@@ -6,8 +6,8 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 public abstract class AbstractSearchQuery implements ISearchQuery {
 
   private String text;
-  private int pageNum;
-  private int pageSize;
+  private Integer pageNum;
+  private Integer pageSize;
   private SortOrder sortOrder;
 
   public AbstractSearchQuery() {
@@ -31,7 +31,7 @@ public abstract class AbstractSearchQuery implements ISearchQuery {
   }
 
   @Override
-  public void setPageNum(int pageNum) {
+  public void setPageNum(Integer pageNum) {
     this.pageNum = pageNum;
   }
 
@@ -41,7 +41,7 @@ public abstract class AbstractSearchQuery implements ISearchQuery {
   }
 
   @Override
-  public void setPageSize(int pageSize) {
+  public void setPageSize(Integer pageSize) {
     this.pageSize = pageSize;
   }
 

--- a/src/main/java/mil/dds/anet/beans/search/AuthorizationGroupSearchQuery.java
+++ b/src/main/java/mil/dds/anet/beans/search/AuthorizationGroupSearchQuery.java
@@ -36,12 +36,4 @@ public class AuthorizationGroupSearchQuery extends AbstractSearchQuery {
     this.sortBy = sortBy;
   }
 
-  public static AuthorizationGroupSearchQuery withText(String text, int pageNum, int pageSize) {
-    final AuthorizationGroupSearchQuery query = new AuthorizationGroupSearchQuery();
-    query.setText(text);
-    query.setPageNum(pageNum);
-    query.setPageSize(pageSize);
-    return query;
-  }
-
 }

--- a/src/main/java/mil/dds/anet/beans/search/AuthorizationGroupSearchQuery.java
+++ b/src/main/java/mil/dds/anet/beans/search/AuthorizationGroupSearchQuery.java
@@ -11,7 +11,6 @@ public class AuthorizationGroupSearchQuery extends AbstractSearchQuery {
   private AuthorizationGroupStatus status;
   private String positionUuid;
   private AuthorizationGroupSearchSortBy sortBy;
-  private SortOrder sortOrder;
 
   public AuthorizationGroupStatus getStatus() {
     return status;
@@ -35,14 +34,6 @@ public class AuthorizationGroupSearchQuery extends AbstractSearchQuery {
 
   public void setSortBy(AuthorizationGroupSearchSortBy sortBy) {
     this.sortBy = sortBy;
-  }
-
-  public SortOrder getSortOrder() {
-    return sortOrder;
-  }
-
-  public void setSortOrder(SortOrder sortOrder) {
-    this.sortOrder = sortOrder;
   }
 
   public static AuthorizationGroupSearchQuery withText(String text, int pageNum, int pageSize) {

--- a/src/main/java/mil/dds/anet/beans/search/ISearchQuery.java
+++ b/src/main/java/mil/dds/anet/beans/search/ISearchQuery.java
@@ -1,8 +1,6 @@
 package mil.dds.anet.beans.search;
 
 public interface ISearchQuery {
-  // marker interface
-
   public enum SortOrder {
     ASC, DESC
   }
@@ -18,4 +16,8 @@ public interface ISearchQuery {
   public int getPageSize();
 
   public void setPageSize(int pageSize);
+
+  public SortOrder getSortOrder();
+
+  public void setSortOrder(SortOrder sortOrder);
 }

--- a/src/main/java/mil/dds/anet/beans/search/ISearchQuery.java
+++ b/src/main/java/mil/dds/anet/beans/search/ISearchQuery.java
@@ -11,11 +11,11 @@ public interface ISearchQuery {
 
   public int getPageNum();
 
-  public void setPageNum(int pageNum);
+  public void setPageNum(Integer pageNum);
 
   public int getPageSize();
 
-  public void setPageSize(int pageSize);
+  public void setPageSize(Integer pageSize);
 
   public SortOrder getSortOrder();
 

--- a/src/main/java/mil/dds/anet/beans/search/LocationSearchQuery.java
+++ b/src/main/java/mil/dds/anet/beans/search/LocationSearchQuery.java
@@ -28,12 +28,4 @@ public class LocationSearchQuery extends AbstractSearchQuery {
     this.sortBy = sortBy;
   }
 
-  public static LocationSearchQuery withText(String text, int pageNum, int pageSize) {
-    LocationSearchQuery query = new LocationSearchQuery();
-    query.setText(text);
-    query.setPageNum(pageNum);
-    query.setPageSize(pageSize);
-    return query;
-  }
-
 }

--- a/src/main/java/mil/dds/anet/beans/search/LocationSearchQuery.java
+++ b/src/main/java/mil/dds/anet/beans/search/LocationSearchQuery.java
@@ -11,7 +11,6 @@ public class LocationSearchQuery extends AbstractSearchQuery {
   private LocationStatus status;
 
   private LocationSearchSortBy sortBy;
-  private SortOrder sortOrder;
 
   public LocationStatus getStatus() {
     return status;
@@ -27,14 +26,6 @@ public class LocationSearchQuery extends AbstractSearchQuery {
 
   public void setSortBy(LocationSearchSortBy sortBy) {
     this.sortBy = sortBy;
-  }
-
-  public SortOrder getSortOrder() {
-    return sortOrder;
-  }
-
-  public void setSortOrder(SortOrder sortOrder) {
-    this.sortOrder = sortOrder;
   }
 
   public static LocationSearchQuery withText(String text, int pageNum, int pageSize) {

--- a/src/main/java/mil/dds/anet/beans/search/OrganizationSearchQuery.java
+++ b/src/main/java/mil/dds/anet/beans/search/OrganizationSearchQuery.java
@@ -20,7 +20,6 @@ public class OrganizationSearchQuery extends AbstractSearchQuery {
   private Boolean parentOrgRecursively;
 
   private OrganizationSearchSortBy sortBy;
-  private SortOrder sortOrder;
 
   public OrganizationStatus getStatus() {
     return status;
@@ -60,14 +59,6 @@ public class OrganizationSearchQuery extends AbstractSearchQuery {
 
   public void setSortBy(OrganizationSearchSortBy sortBy) {
     this.sortBy = sortBy;
-  }
-
-  public SortOrder getSortOrder() {
-    return sortOrder;
-  }
-
-  public void setSortOrder(SortOrder sortOrder) {
-    this.sortOrder = sortOrder;
   }
 
   public static OrganizationSearchQuery withText(String text, int pageNum, int pageSize) {

--- a/src/main/java/mil/dds/anet/beans/search/OrganizationSearchQuery.java
+++ b/src/main/java/mil/dds/anet/beans/search/OrganizationSearchQuery.java
@@ -61,12 +61,4 @@ public class OrganizationSearchQuery extends AbstractSearchQuery {
     this.sortBy = sortBy;
   }
 
-  public static OrganizationSearchQuery withText(String text, int pageNum, int pageSize) {
-    OrganizationSearchQuery query = new OrganizationSearchQuery();
-    query.setText(text);
-    query.setPageNum(pageNum);
-    query.setPageSize(pageSize);
-    return query;
-  }
-
 }

--- a/src/main/java/mil/dds/anet/beans/search/PersonSearchQuery.java
+++ b/src/main/java/mil/dds/anet/beans/search/PersonSearchQuery.java
@@ -30,12 +30,11 @@ public class PersonSearchQuery extends AbstractSearchQuery {
   Boolean pendingVerification;
 
   private PersonSearchSortBy sortBy;
-  private SortOrder sortOrder;
 
   public PersonSearchQuery() {
     this.setPageSize(100);
-    this.sortOrder = SortOrder.ASC;
     this.sortBy = PersonSearchSortBy.NAME;
+    this.setSortOrder(SortOrder.ASC);
   }
 
   public String getOrgUuid() {
@@ -116,14 +115,6 @@ public class PersonSearchQuery extends AbstractSearchQuery {
 
   public void setSortBy(PersonSearchSortBy sortBy) {
     this.sortBy = sortBy;
-  }
-
-  public SortOrder getSortOrder() {
-    return sortOrder;
-  }
-
-  public void setSortOrder(SortOrder sortOrder) {
-    this.sortOrder = sortOrder;
   }
 
   public Instant getEndOfTourDateStart() {

--- a/src/main/java/mil/dds/anet/beans/search/PersonSearchQuery.java
+++ b/src/main/java/mil/dds/anet/beans/search/PersonSearchQuery.java
@@ -134,12 +134,4 @@ public class PersonSearchQuery extends AbstractSearchQuery {
     this.endOfTourDateEnd = endOfTourDateEnd;
   }
 
-  public static PersonSearchQuery withText(String text, int pageNum, int pageSize) {
-    PersonSearchQuery query = new PersonSearchQuery();
-    query.setText(text);
-    query.setPageNum(pageNum);
-    query.setPageSize(pageSize);
-    return query;
-  }
-
 }

--- a/src/main/java/mil/dds/anet/beans/search/PersonSearchQuery.java
+++ b/src/main/java/mil/dds/anet/beans/search/PersonSearchQuery.java
@@ -32,6 +32,7 @@ public class PersonSearchQuery extends AbstractSearchQuery {
   private PersonSearchSortBy sortBy;
 
   public PersonSearchQuery() {
+    super();
     this.setPageSize(100);
     this.sortBy = PersonSearchSortBy.NAME;
     this.setSortOrder(SortOrder.ASC);

--- a/src/main/java/mil/dds/anet/beans/search/PositionSearchQuery.java
+++ b/src/main/java/mil/dds/anet/beans/search/PositionSearchQuery.java
@@ -98,12 +98,4 @@ public class PositionSearchQuery extends AbstractSearchQuery {
     this.sortBy = sortBy;
   }
 
-  public static PositionSearchQuery withText(String text, int pageNum, int pageSize) {
-    PositionSearchQuery query = new PositionSearchQuery();
-    query.setText(text);
-    query.setPageNum(pageNum);
-    query.setPageSize(pageSize);
-    return query;
-  }
-
 }

--- a/src/main/java/mil/dds/anet/beans/search/PositionSearchQuery.java
+++ b/src/main/java/mil/dds/anet/beans/search/PositionSearchQuery.java
@@ -20,7 +20,6 @@ public class PositionSearchQuery extends AbstractSearchQuery {
   private String authorizationGroupUuid;
 
   private PositionSearchSortBy sortBy;
-  private SortOrder sortOrder;
 
   public PositionSearchQuery() {
     super();
@@ -97,14 +96,6 @@ public class PositionSearchQuery extends AbstractSearchQuery {
 
   public void setSortBy(PositionSearchSortBy sortBy) {
     this.sortBy = sortBy;
-  }
-
-  public SortOrder getSortOrder() {
-    return sortOrder;
-  }
-
-  public void setSortOrder(SortOrder sortOrder) {
-    this.sortOrder = sortOrder;
   }
 
   public static PositionSearchQuery withText(String text, int pageNum, int pageSize) {

--- a/src/main/java/mil/dds/anet/beans/search/ReportSearchQuery.java
+++ b/src/main/java/mil/dds/anet/beans/search/ReportSearchQuery.java
@@ -296,12 +296,4 @@ public class ReportSearchQuery extends AbstractSearchQuery {
     this.sortBy = sortBy;
   }
 
-  public static ReportSearchQuery withText(String text, int pageNum, int pageSize) {
-    ReportSearchQuery query = new ReportSearchQuery();
-    query.setText(text);
-    query.setPageNum(pageNum);
-    query.setPageSize(pageSize);
-    return query;
-  }
-
 }

--- a/src/main/java/mil/dds/anet/beans/search/ReportSearchQuery.java
+++ b/src/main/java/mil/dds/anet/beans/search/ReportSearchQuery.java
@@ -49,12 +49,11 @@ public class ReportSearchQuery extends AbstractSearchQuery {
   private Boolean sensitiveInfo;
 
   private ReportSearchSortBy sortBy;
-  private SortOrder sortOrder;
 
   public ReportSearchQuery() {
     super();
     this.sortBy = ReportSearchSortBy.CREATED_AT;
-    this.sortOrder = SortOrder.DESC;
+    this.setSortOrder(SortOrder.DESC);
   }
 
   public String getAuthorUuid() {
@@ -295,14 +294,6 @@ public class ReportSearchQuery extends AbstractSearchQuery {
 
   public void setSortBy(ReportSearchSortBy sortBy) {
     this.sortBy = sortBy;
-  }
-
-  public SortOrder getSortOrder() {
-    return sortOrder;
-  }
-
-  public void setSortOrder(SortOrder sortOrder) {
-    this.sortOrder = sortOrder;
   }
 
   public static ReportSearchQuery withText(String text, int pageNum, int pageSize) {

--- a/src/main/java/mil/dds/anet/beans/search/SavedSearch.java
+++ b/src/main/java/mil/dds/anet/beans/search/SavedSearch.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import mil.dds.anet.beans.ForeignObjectHolder;
 import mil.dds.anet.beans.Person;
+import mil.dds.anet.utils.BatchingUtils;
 import mil.dds.anet.views.AbstractAnetBean;
 import mil.dds.anet.views.UuidFetcher;
 
@@ -36,7 +37,8 @@ public class SavedSearch extends AbstractAnetBean {
     if (owner.hasForeignObject()) {
       return CompletableFuture.completedFuture(owner.getForeignObject());
     }
-    return new UuidFetcher<Person>().load(context, "people", owner.getForeignUuid())
+    return new UuidFetcher<Person>()
+        .load(context, BatchingUtils.DataLoaderKey.ID_PEOPLE, owner.getForeignUuid())
         .thenApply(o -> {
           owner.setForeignObject(o);
           return o;

--- a/src/main/java/mil/dds/anet/beans/search/TagSearchQuery.java
+++ b/src/main/java/mil/dds/anet/beans/search/TagSearchQuery.java
@@ -16,12 +16,4 @@ public class TagSearchQuery extends AbstractSearchQuery {
     this.sortBy = sortBy;
   }
 
-  public static TagSearchQuery withText(String text, int pageNum, int pageSize) {
-    final TagSearchQuery query = new TagSearchQuery();
-    query.setText(text);
-    query.setPageNum(pageNum);
-    query.setPageSize(pageSize);
-    return query;
-  }
-
 }

--- a/src/main/java/mil/dds/anet/beans/search/TagSearchQuery.java
+++ b/src/main/java/mil/dds/anet/beans/search/TagSearchQuery.java
@@ -7,7 +7,6 @@ public class TagSearchQuery extends AbstractSearchQuery {
   }
 
   private TagSearchSortBy sortBy;
-  private SortOrder sortOrder;
 
   public TagSearchSortBy getSortBy() {
     return sortBy;
@@ -15,14 +14,6 @@ public class TagSearchQuery extends AbstractSearchQuery {
 
   public void setSortBy(TagSearchSortBy sortBy) {
     this.sortBy = sortBy;
-  }
-
-  public SortOrder getSortOrder() {
-    return sortOrder;
-  }
-
-  public void setSortOrder(SortOrder sortOrder) {
-    this.sortOrder = sortOrder;
   }
 
   public static TagSearchQuery withText(String text, int pageNum, int pageSize) {

--- a/src/main/java/mil/dds/anet/beans/search/TaskSearchQuery.java
+++ b/src/main/java/mil/dds/anet/beans/search/TaskSearchQuery.java
@@ -28,7 +28,6 @@ public class TaskSearchQuery extends AbstractSearchQuery {
   private Boolean customFieldRef1Recursively;
 
   private TaskSearchSortBy sortBy;
-  private SortOrder sortOrder;
 
   public String getResponsibleOrgUuid() {
     return responsibleOrgUuid;
@@ -132,14 +131,6 @@ public class TaskSearchQuery extends AbstractSearchQuery {
 
   public void setSortBy(TaskSearchSortBy sortBy) {
     this.sortBy = sortBy;
-  }
-
-  public SortOrder getSortOrder() {
-    return sortOrder;
-  }
-
-  public void setSortOrder(SortOrder sortOrder) {
-    this.sortOrder = sortOrder;
   }
 
   public static TaskSearchQuery withText(String text, int pageNum, int pageSize) {

--- a/src/main/java/mil/dds/anet/beans/search/TaskSearchQuery.java
+++ b/src/main/java/mil/dds/anet/beans/search/TaskSearchQuery.java
@@ -133,12 +133,4 @@ public class TaskSearchQuery extends AbstractSearchQuery {
     this.sortBy = sortBy;
   }
 
-  public static TaskSearchQuery withText(String text, int pageNum, int pageSize) {
-    TaskSearchQuery query = new TaskSearchQuery();
-    query.setText(text);
-    query.setPageNum(pageNum);
-    query.setPageSize(pageSize);
-    return query;
-  }
-
 }

--- a/src/main/java/mil/dds/anet/database/ApprovalStepDao.java
+++ b/src/main/java/mil/dds/anet/database/ApprovalStepDao.java
@@ -11,6 +11,7 @@ import mil.dds.anet.beans.ApprovalStep;
 import mil.dds.anet.beans.Position;
 import mil.dds.anet.database.mappers.ApprovalStepMapper;
 import mil.dds.anet.database.mappers.PositionMapper;
+import mil.dds.anet.utils.BatchingUtils;
 import mil.dds.anet.views.ForeignKeyFetcher;
 import org.jdbi.v3.core.mapper.MapMapper;
 import ru.vyarus.guicey.jdbi3.tx.InTransaction;
@@ -24,8 +25,8 @@ public class ApprovalStepDao extends AnetBaseDao<ApprovalStep> {
 
   public CompletableFuture<List<ApprovalStep>> getByAdvisorOrganizationUuid(
       Map<String, Object> context, String aoUuid) {
-    return new ForeignKeyFetcher<ApprovalStep>().load(context, "organization.approvalSteps",
-        aoUuid);
+    return new ForeignKeyFetcher<ApprovalStep>().load(context,
+        BatchingUtils.DataLoaderKey.FK_ORGANIZATION_APPROVAL_STEPS, aoUuid);
   }
 
   @Override
@@ -197,8 +198,8 @@ public class ApprovalStepDao extends AnetBaseDao<ApprovalStep> {
    */
   public CompletableFuture<List<Position>> getApproversForStep(Map<String, Object> context,
       String approvalStepUuid) {
-    return new ForeignKeyFetcher<Position>().load(context, "approvalStep.approvers",
-        approvalStepUuid);
+    return new ForeignKeyFetcher<Position>().load(context,
+        BatchingUtils.DataLoaderKey.FK_APPROVAL_STEP_APPROVERS, approvalStepUuid);
   }
 
   public int addApprover(ApprovalStep step, String positionUuid) {

--- a/src/main/java/mil/dds/anet/database/AuthorizationGroupDao.java
+++ b/src/main/java/mil/dds/anet/database/AuthorizationGroupDao.java
@@ -15,6 +15,7 @@ import mil.dds.anet.beans.search.AuthorizationGroupSearchQuery;
 import mil.dds.anet.database.mappers.AuthorizationGroupMapper;
 import mil.dds.anet.database.mappers.PositionMapper;
 import mil.dds.anet.database.mappers.ReportMapper;
+import mil.dds.anet.utils.BatchingUtils;
 import mil.dds.anet.utils.DaoUtils;
 import mil.dds.anet.views.ForeignKeyFetcher;
 import org.jdbi.v3.sqlobject.customizer.Bind;
@@ -120,8 +121,8 @@ public class AuthorizationGroupDao extends AnetBaseDao<AuthorizationGroup> {
 
   public CompletableFuture<List<Position>> getPositionsForAuthorizationGroup(
       Map<String, Object> context, String authorizationGroupUuid) {
-    return new ForeignKeyFetcher<Position>().load(context, "authorizationGroup.positions",
-        authorizationGroupUuid);
+    return new ForeignKeyFetcher<Position>().load(context,
+        BatchingUtils.DataLoaderKey.FK_AUTHORIZATION_GROUP_POSITIONS, authorizationGroupUuid);
   }
 
   public AnetBeanList<AuthorizationGroup> search(AuthorizationGroupSearchQuery query) {

--- a/src/main/java/mil/dds/anet/database/NoteDao.java
+++ b/src/main/java/mil/dds/anet/database/NoteDao.java
@@ -10,6 +10,7 @@ import mil.dds.anet.beans.Note;
 import mil.dds.anet.beans.NoteRelatedObject;
 import mil.dds.anet.database.mappers.NoteMapper;
 import mil.dds.anet.database.mappers.NoteRelatedObjectMapper;
+import mil.dds.anet.utils.BatchingUtils;
 import mil.dds.anet.utils.DaoUtils;
 import mil.dds.anet.views.ForeignKeyFetcher;
 import ru.vyarus.guicey.jdbi3.tx.InTransaction;
@@ -73,8 +74,8 @@ public class NoteDao extends AnetBaseDao<Note> {
 
   public CompletableFuture<List<Note>> getNotesForRelatedObject(
       @GraphQLRootContext Map<String, Object> context, String relatedObjectUuid) {
-    return new ForeignKeyFetcher<Note>().load(context, "noteRelatedObject.notes",
-        relatedObjectUuid);
+    return new ForeignKeyFetcher<Note>().load(context,
+        BatchingUtils.DataLoaderKey.FK_NOTE_RELATED_OBJECT_NOTES, relatedObjectUuid);
   }
 
   static class NotesBatcher extends ForeignKeyBatcher<Note> {
@@ -113,8 +114,8 @@ public class NoteDao extends AnetBaseDao<Note> {
 
   public CompletableFuture<List<NoteRelatedObject>> getRelatedObjects(Map<String, Object> context,
       Note note) {
-    return new ForeignKeyFetcher<NoteRelatedObject>().load(context, "note.noteRelatedObjects",
-        note.getUuid());
+    return new ForeignKeyFetcher<NoteRelatedObject>().load(context,
+        BatchingUtils.DataLoaderKey.FK_NOTE_NOTE_RELATED_OBJECTS, note.getUuid());
   }
 
   private void insertNoteRelatedObjects(String uuid, List<NoteRelatedObject> noteRelatedObjects) {

--- a/src/main/java/mil/dds/anet/database/OrganizationDao.java
+++ b/src/main/java/mil/dds/anet/database/OrganizationDao.java
@@ -12,6 +12,7 @@ import mil.dds.anet.beans.Organization.OrganizationType;
 import mil.dds.anet.beans.lists.AnetBeanList;
 import mil.dds.anet.beans.search.OrganizationSearchQuery;
 import mil.dds.anet.database.mappers.OrganizationMapper;
+import mil.dds.anet.utils.BatchingUtils;
 import mil.dds.anet.utils.DaoUtils;
 import mil.dds.anet.utils.Utils;
 import mil.dds.anet.views.ForeignKeyFetcher;
@@ -71,7 +72,8 @@ public class OrganizationDao extends AnetBaseDao<Organization> {
 
   public CompletableFuture<List<Organization>> getOrganizationsForPerson(
       Map<String, Object> context, String personUuid) {
-    return new ForeignKeyFetcher<Organization>().load(context, "person.organizations", personUuid);
+    return new ForeignKeyFetcher<Organization>().load(context,
+        BatchingUtils.DataLoaderKey.FK_PERSON_ORGANIZATIONS, personUuid);
   }
 
   public List<Organization> getTopLevelOrgs(OrganizationType type) {

--- a/src/main/java/mil/dds/anet/database/PersonDao.java
+++ b/src/main/java/mil/dds/anet/database/PersonDao.java
@@ -12,6 +12,7 @@ import mil.dds.anet.beans.lists.AnetBeanList;
 import mil.dds.anet.beans.search.PersonSearchQuery;
 import mil.dds.anet.database.mappers.PersonMapper;
 import mil.dds.anet.database.mappers.PersonPositionHistoryMapper;
+import mil.dds.anet.utils.BatchingUtils;
 import mil.dds.anet.utils.DaoUtils;
 import mil.dds.anet.views.ForeignKeyFetcher;
 import ru.vyarus.guicey.jdbi3.tx.InTransaction;
@@ -222,7 +223,7 @@ public class PersonDao extends AnetBaseDao<Person> {
   public CompletableFuture<List<PersonPositionHistory>> getPositionHistory(
       Map<String, Object> context, String personUuid) {
     return new ForeignKeyFetcher<PersonPositionHistory>()
-        .load(context, "person.personPositionHistory", personUuid)
+        .load(context, BatchingUtils.DataLoaderKey.FK_PERSON_PERSON_POSITION_HISTORY, personUuid)
         .thenApply(l -> PersonPositionHistory.getDerivedHistory(l));
   }
 

--- a/src/main/java/mil/dds/anet/database/PositionDao.java
+++ b/src/main/java/mil/dds/anet/database/PositionDao.java
@@ -343,13 +343,6 @@ public class PositionDao extends AnetBaseDao<Position> {
         .bind("type", DaoUtils.getEnumId(type)).map(new PositionMapper()).list();
   }
 
-  public List<Position> getByOrganization(String organizationUuid) {
-    return getDbHandle()
-        .createQuery("/* getPositionByOrg */ SELECT " + POSITIONS_FIELDS + "FROM positions "
-            + "WHERE \"organizationUuid\" = :orgUuid")
-        .bind("orgUuid", organizationUuid).map(new PositionMapper()).list();
-  }
-
   public AnetBeanList<Position> search(PositionSearchQuery query) {
     return AnetObjectEngine.getInstance().getSearcher().getPositionSearcher().runSearch(query);
   }

--- a/src/main/java/mil/dds/anet/database/PositionDao.java
+++ b/src/main/java/mil/dds/anet/database/PositionDao.java
@@ -20,6 +20,7 @@ import mil.dds.anet.beans.search.PositionSearchQuery;
 import mil.dds.anet.database.mappers.PersonMapper;
 import mil.dds.anet.database.mappers.PersonPositionHistoryMapper;
 import mil.dds.anet.database.mappers.PositionMapper;
+import mil.dds.anet.utils.BatchingUtils;
 import mil.dds.anet.utils.DaoUtils;
 import mil.dds.anet.views.ForeignKeyFetcher;
 import org.jdbi.v3.core.mapper.MapMapper;
@@ -275,8 +276,8 @@ public class PositionDao extends AnetBaseDao<Position> {
 
   public CompletableFuture<List<Position>> getAssociatedPositions(Map<String, Object> context,
       String positionUuid) {
-    return new ForeignKeyFetcher<Position>().load(context, "position.associatedPositions",
-        positionUuid);
+    return new ForeignKeyFetcher<Position>().load(context,
+        BatchingUtils.DataLoaderKey.FK_POSITION_ASSOCIATED_POSITIONS, positionUuid);
   }
 
   static class AssociatedPositionsBatcher extends ForeignKeyBatcher<Position> {
@@ -349,15 +350,15 @@ public class PositionDao extends AnetBaseDao<Position> {
 
   public CompletableFuture<List<PersonPositionHistory>> getPositionHistory(
       Map<String, Object> context, String positionUuid) {
-    return new ForeignKeyFetcher<PersonPositionHistory>()
-        .load(context, "position.personPositionHistory", positionUuid)
+    return new ForeignKeyFetcher<PersonPositionHistory>().load(context,
+        BatchingUtils.DataLoaderKey.FK_POSITION_PERSON_POSITION_HISTORY, positionUuid)
         .thenApply(l -> PersonPositionHistory.getDerivedHistory(l));
   }
 
   public CompletableFuture<Position> getCurrentPositionForPerson(Map<String, Object> context,
       String personUuid) {
-    return new ForeignKeyFetcher<Position>()
-        .load(context, "position.currentPositionForPerson", personUuid)
+    return new ForeignKeyFetcher<Position>().load(context,
+        BatchingUtils.DataLoaderKey.FK_POSITION_CURRENT_POSITION_FOR_PERSON, personUuid)
         .thenApply(l -> l.isEmpty() ? null : l.get(0));
   }
 

--- a/src/main/java/mil/dds/anet/database/ReportActionDao.java
+++ b/src/main/java/mil/dds/anet/database/ReportActionDao.java
@@ -6,6 +6,7 @@ import java.util.concurrent.CompletableFuture;
 import mil.dds.anet.AnetObjectEngine;
 import mil.dds.anet.beans.ReportAction;
 import mil.dds.anet.database.mappers.ReportActionMapper;
+import mil.dds.anet.utils.BatchingUtils;
 import mil.dds.anet.utils.DaoUtils;
 import mil.dds.anet.views.ForeignKeyFetcher;
 import ru.vyarus.guicey.jdbi3.tx.InTransaction;
@@ -36,7 +37,8 @@ public class ReportActionDao extends AnetBaseDao<ReportAction> {
    */
   public CompletableFuture<List<ReportAction>> getActionsForReport(Map<String, Object> context,
       String reportUuid) {
-    return new ForeignKeyFetcher<ReportAction>().load(context, "report.reportActions", reportUuid);
+    return new ForeignKeyFetcher<ReportAction>().load(context,
+        BatchingUtils.DataLoaderKey.FK_REPORT_REPORT_ACTIONS, reportUuid);
   }
 
   public ReportAction getByUuid(String uuid) {

--- a/src/main/java/mil/dds/anet/database/ReportDao.java
+++ b/src/main/java/mil/dds/anet/database/ReportDao.java
@@ -435,7 +435,7 @@ public class ReportDao extends AnetBaseDao<Report> {
       OrganizationSearchQuery query = new OrganizationSearchQuery();
       query.setParentOrgUuid(parentOrgUuid);
       query.setParentOrgRecursively(true);
-      query.setPageSize(Integer.MAX_VALUE);
+      query.setPageSize(0);
       orgList = AnetObjectEngine.getInstance().getOrganizationDao().search(query).getList();
       Optional<Organization> parentOrg =
           orgList.stream().filter(o -> o.getUuid().equals(parentOrgUuid)).findFirst();

--- a/src/main/java/mil/dds/anet/database/ReportDao.java
+++ b/src/main/java/mil/dds/anet/database/ReportDao.java
@@ -40,6 +40,7 @@ import mil.dds.anet.database.mappers.TagMapper;
 import mil.dds.anet.database.mappers.TaskMapper;
 import mil.dds.anet.emails.ReportPublishedEmail;
 import mil.dds.anet.threads.AnetEmailWorker;
+import mil.dds.anet.utils.BatchingUtils;
 import mil.dds.anet.utils.DaoUtils;
 import mil.dds.anet.utils.Utils;
 import mil.dds.anet.views.ForeignKeyFetcher;
@@ -320,7 +321,8 @@ public class ReportDao extends AnetBaseDao<Report> {
 
   public CompletableFuture<List<ReportPerson>> getAttendeesForReport(
       @GraphQLRootContext Map<String, Object> context, String reportUuid) {
-    return new ForeignKeyFetcher<ReportPerson>().load(context, "report.attendees", reportUuid);
+    return new ForeignKeyFetcher<ReportPerson>().load(context,
+        BatchingUtils.DataLoaderKey.FK_REPORT_ATTENDEES, reportUuid);
   }
 
   public List<AuthorizationGroup> getAuthorizationGroupsForReport(String reportUuid) {
@@ -333,12 +335,14 @@ public class ReportDao extends AnetBaseDao<Report> {
 
   public CompletableFuture<List<Task>> getTasksForReport(
       @GraphQLRootContext Map<String, Object> context, String reportUuid) {
-    return new ForeignKeyFetcher<Task>().load(context, "report.tasks", reportUuid);
+    return new ForeignKeyFetcher<Task>().load(context, BatchingUtils.DataLoaderKey.FK_REPORT_TASKS,
+        reportUuid);
   }
 
   public CompletableFuture<List<Tag>> getTagsForReport(
       @GraphQLRootContext Map<String, Object> context, String reportUuid) {
-    return new ForeignKeyFetcher<Tag>().load(context, "report.tags", reportUuid);
+    return new ForeignKeyFetcher<Tag>().load(context, BatchingUtils.DataLoaderKey.FK_REPORT_TAGS,
+        reportUuid);
   }
 
   // Does an unauthenticated search. This will never return any DRAFT or REJECTED reports

--- a/src/main/java/mil/dds/anet/database/ReportSensitiveInformationDao.java
+++ b/src/main/java/mil/dds/anet/database/ReportSensitiveInformationDao.java
@@ -10,6 +10,7 @@ import mil.dds.anet.beans.Report;
 import mil.dds.anet.beans.ReportSensitiveInformation;
 import mil.dds.anet.database.mappers.ReportSensitiveInformationMapper;
 import mil.dds.anet.utils.AnetAuditLogger;
+import mil.dds.anet.utils.BatchingUtils;
 import mil.dds.anet.utils.DaoUtils;
 import mil.dds.anet.utils.Utils;
 import mil.dds.anet.views.ForeignKeyFetcher;
@@ -120,8 +121,9 @@ public class ReportSensitiveInformationDao extends AnetBaseDao<ReportSensitiveIn
     if (!isAuthorized(user, report)) {
       return CompletableFuture.completedFuture(null);
     }
-    return new ForeignKeyFetcher<ReportSensitiveInformation>()
-        .load(context, "report.reportSensitiveInformation", report.getUuid()).thenApply(l -> {
+    return new ForeignKeyFetcher<ReportSensitiveInformation>().load(context,
+        BatchingUtils.DataLoaderKey.FK_REPORT_REPORT_SENSITIVE_INFORMATION, report.getUuid())
+        .thenApply(l -> {
           ReportSensitiveInformation rsi = Utils.isEmptyOrNull(l) ? null : l.get(0);
           if (rsi != null) {
             AnetAuditLogger.log("ReportSensitiveInformation {} retrieved by {} ", rsi, user);

--- a/src/main/java/mil/dds/anet/database/TaskDao.java
+++ b/src/main/java/mil/dds/anet/database/TaskDao.java
@@ -169,11 +169,4 @@ public class TaskDao extends AnetBaseDao<Task> {
         .bind("maxResults", maxResults).bind("status", DaoUtils.getEnumId(TaskStatus.ACTIVE))
         .map(new TaskMapper()).list();
   }
-
-  public List<Task> getTasksByOrganizationUuid(String orgUuid) {
-    return getDbHandle()
-        .createQuery(
-            "/* getTasksByOrg */ SELECT * from tasks WHERE \"organizationUuid\" = :orgUuid")
-        .bind("orgUuid", orgUuid).map(new TaskMapper()).list();
-  }
 }

--- a/src/main/java/mil/dds/anet/database/TaskDao.java
+++ b/src/main/java/mil/dds/anet/database/TaskDao.java
@@ -14,6 +14,7 @@ import mil.dds.anet.beans.lists.AnetBeanList;
 import mil.dds.anet.beans.search.TaskSearchQuery;
 import mil.dds.anet.database.mappers.PositionMapper;
 import mil.dds.anet.database.mappers.TaskMapper;
+import mil.dds.anet.utils.BatchingUtils;
 import mil.dds.anet.utils.DaoUtils;
 import mil.dds.anet.views.ForeignKeyFetcher;
 import org.jdbi.v3.sqlobject.customizer.Bind;
@@ -127,7 +128,8 @@ public class TaskDao extends AnetBaseDao<Task> {
 
   public CompletableFuture<List<Position>> getResponsiblePositionsForTask(
       Map<String, Object> context, String taskUuid) {
-    return new ForeignKeyFetcher<Position>().load(context, "task.responsiblePositions", taskUuid);
+    return new ForeignKeyFetcher<Position>().load(context,
+        BatchingUtils.DataLoaderKey.FK_TASK_RESPONSIBLE_POSITIONS, taskUuid);
   }
 
   public int setResponsibleOrgForTask(String taskUuid, String organizationUuid) {

--- a/src/main/java/mil/dds/anet/emails/DailyRollupEmail.java
+++ b/src/main/java/mil/dds/anet/emails/DailyRollupEmail.java
@@ -63,7 +63,7 @@ public class DailyRollupEmail implements AnetEmailAction {
     Instant engagementDateStart =
         startDate.atZone(DaoUtils.getDefaultZoneId()).minusDays(maxReportAge).toInstant();
     ReportSearchQuery query = new ReportSearchQuery();
-    query.setPageSize(Integer.MAX_VALUE);
+    query.setPageSize(0);
     query.setReleasedAtStart(startDate);
     query.setReleasedAtEnd(endDate);
     query.setEngagementDateStart(engagementDateStart);

--- a/src/main/java/mil/dds/anet/resources/GraphQlResource.java
+++ b/src/main/java/mil/dds/anet/resources/GraphQlResource.java
@@ -260,8 +260,9 @@ public class GraphQlResource {
   }
 
   /**
-   * Create the sheet with the supplied name in the supplied workbook using the supplied data. TODO:
-   * This should end up in a converter type class, perhaps lookup by annotations.
+   * Create the sheet with the supplied name in the supplied workbook using the supplied data.
+   *
+   * TODO: This should end up in a converter type class, perhaps lookup by annotations.
    *
    * @param workbook the workbook
    * @param name the name for the sheet

--- a/src/main/java/mil/dds/anet/threads/AccountDeactivationWorker.java
+++ b/src/main/java/mil/dds/anet/threads/AccountDeactivationWorker.java
@@ -76,7 +76,7 @@ public class AccountDeactivationWorker implements Runnable {
   private void runInternal(int daysUntilEndOfTour, int daysTillNextWarning) {
     // Get a list of all people with a end of tour coming up
     PersonSearchQuery query = new PersonSearchQuery();
-    query.setPageSize(Integer.MAX_VALUE);
+    query.setPageSize(0);
     Instant now = Instant.now().atZone(DaoUtils.getDefaultZoneId()).toInstant();
     Instant warningDate = now.plus(daysUntilEndOfTour, ChronoUnit.DAYS);
     query.setEndOfTourDateEnd(warningDate);

--- a/src/main/java/mil/dds/anet/threads/FutureEngagementWorker.java
+++ b/src/main/java/mil/dds/anet/threads/FutureEngagementWorker.java
@@ -42,7 +42,7 @@ public class FutureEngagementWorker implements Runnable {
   private void runInternal() {
     // Get a list of all FUTURE and engagementDate < today reports, and their authors
     ReportSearchQuery query = new ReportSearchQuery();
-    query.setPageSize(Integer.MAX_VALUE);
+    query.setPageSize(0);
     query.setState(Collections.singletonList(ReportState.FUTURE));
     Instant endOfToday = Instant.now().atZone(DaoUtils.getDefaultZoneId()).withHour(23)
         .withMinute(59).withSecond(59).withNano(999999999).toInstant();

--- a/src/main/java/mil/dds/anet/threads/ReportPublicationWorker.java
+++ b/src/main/java/mil/dds/anet/threads/ReportPublicationWorker.java
@@ -48,7 +48,7 @@ public class ReportPublicationWorker implements Runnable {
         .minusHours(this.nbOfHoursQuarantineApproved).toInstant();
     // Get a list of all APPROVED reports
     final ReportSearchQuery query = new ReportSearchQuery();
-    query.setPageSize(Integer.MAX_VALUE);
+    query.setPageSize(0);
     query.setState(Collections.singletonList(ReportState.APPROVED));
     final List<Report> reports = dao.search(query, null, true).getList();
     final Map<String, Object> context = AnetObjectEngine.getInstance().getContext();

--- a/src/main/java/mil/dds/anet/utils/AuthUtils.java
+++ b/src/main/java/mil/dds/anet/utils/AuthUtils.java
@@ -12,6 +12,7 @@ import mil.dds.anet.beans.Organization.OrganizationType;
 import mil.dds.anet.beans.Person;
 import mil.dds.anet.beans.Position;
 import mil.dds.anet.beans.Position.PositionType;
+import mil.dds.anet.beans.search.OrganizationSearchQuery;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -69,7 +70,9 @@ public class AuthUtils {
     try {
       Organization posOrg =
           position.loadOrganization(AnetObjectEngine.getInstance().getContext()).get();
-      Optional<Organization> orgMatch = posOrg.loadAllDescendants().stream()
+      final OrganizationSearchQuery osQuery = new OrganizationSearchQuery();
+      osQuery.setPageSize(0);
+      Optional<Organization> orgMatch = posOrg.loadDescendantOrgs(osQuery).stream()
           .filter(o -> o.getUuid().equals(organizationUuid)).findFirst();
       return orgMatch.isPresent();
     } catch (InterruptedException | ExecutionException e) {

--- a/src/main/java/mil/dds/anet/utils/BatchingUtils.java
+++ b/src/main/java/mil/dds/anet/utils/BatchingUtils.java
@@ -32,6 +32,28 @@ import org.dataloader.stats.Statistics;
 
 public final class BatchingUtils {
 
+  public static enum DataLoaderKey {
+    // Foreign key batching data loaders
+    FK_APPROVAL_STEP_APPROVERS, // approvalStep.approvers
+    FK_AUTHORIZATION_GROUP_POSITIONS, // authorizationGroup.positions
+    FK_NOTE_NOTE_RELATED_OBJECTS, // note.noteRelatedObjects
+    FK_NOTE_RELATED_OBJECT_NOTES, // noteRelatedObject.notes
+    FK_ORGANIZATION_APPROVAL_STEPS, // organization.approvalSteps
+    FK_PERSON_ORGANIZATIONS, // person.organizations
+    FK_PERSON_PERSON_POSITION_HISTORY, // person.personPositionHistory
+    FK_POSITION_ASSOCIATED_POSITIONS, // position.associatedPositions
+    FK_POSITION_CURRENT_POSITION_FOR_PERSON, // position.currentPositionForPerson
+    FK_POSITION_PERSON_POSITION_HISTORY, // position.personPositionHistory
+    FK_REPORT_ATTENDEES, // report.attendees
+    FK_REPORT_REPORT_ACTIONS, // report.reportActions
+    FK_REPORT_REPORT_SENSITIVE_INFORMATION, // report.reportSensitiveInformation
+    FK_REPORT_TAGS, // report.tags
+    FK_REPORT_TASKS, // report.tasks
+    FK_TASK_RESPONSIBLE_POSITIONS, // task.responsiblePositions
+    // ID batching data loaders
+    ID_APPROVAL_STEPS, ID_AUTHORIZATION_GROUPS, ID_COMMENTS, ID_LOCATIONS, ID_ORGANIZATIONS, ID_PEOPLE, ID_POSITIONS, ID_REPORTS, ID_TAGS, ID_TASKS,
+  }
+
   private BatchingUtils() {}
 
   public static DataLoaderRegistry registerDataLoaders(AnetObjectEngine engine,
@@ -44,7 +66,7 @@ public final class BatchingUtils {
     // Give each registry its own thread pool
     final ExecutorService dispatcherService = Executors.newFixedThreadPool(3);
 
-    dataLoaderRegistry.register("approvalSteps",
+    dataLoaderRegistry.register(DataLoaderKey.ID_APPROVAL_STEPS.name(),
         new DataLoader<>(new BatchLoader<String, ApprovalStep>() {
           @Override
           public CompletionStage<List<ApprovalStep>> load(List<String> keys) {
@@ -52,7 +74,7 @@ public final class BatchingUtils {
                 dispatcherService);
           }
         }, dataLoaderOptions));
-    dataLoaderRegistry.register("approvalStep.approvers",
+    dataLoaderRegistry.register(DataLoaderKey.FK_APPROVAL_STEP_APPROVERS.name(),
         new DataLoader<>(new BatchLoader<String, List<Position>>() {
           @Override
           public CompletionStage<List<List<Position>>> load(List<String> foreignKeys) {
@@ -60,7 +82,7 @@ public final class BatchingUtils {
                 () -> engine.getApprovalStepDao().getApprovers(foreignKeys), dispatcherService);
           }
         }, dataLoaderOptions));
-    dataLoaderRegistry.register("authorizationGroups",
+    dataLoaderRegistry.register(DataLoaderKey.ID_AUTHORIZATION_GROUPS.name(),
         new DataLoader<>(new BatchLoader<String, AuthorizationGroup>() {
           @Override
           public CompletionStage<List<AuthorizationGroup>> load(List<String> keys) {
@@ -68,7 +90,7 @@ public final class BatchingUtils {
                 () -> engine.getAuthorizationGroupDao().getByIds(keys), dispatcherService);
           }
         }, dataLoaderOptions));
-    dataLoaderRegistry.register("authorizationGroup.positions",
+    dataLoaderRegistry.register(DataLoaderKey.FK_AUTHORIZATION_GROUP_POSITIONS.name(),
         new DataLoader<>(new BatchLoader<String, List<Position>>() {
           @Override
           public CompletionStage<List<List<Position>>> load(List<String> foreignKeys) {
@@ -77,21 +99,23 @@ public final class BatchingUtils {
                 dispatcherService);
           }
         }, dataLoaderOptions));
-    dataLoaderRegistry.register("comments", new DataLoader<>(new BatchLoader<String, Comment>() {
-      @Override
-      public CompletionStage<List<Comment>> load(List<String> keys) {
-        return CompletableFuture.supplyAsync(() -> engine.getCommentDao().getByIds(keys),
-            dispatcherService);
-      }
-    }, dataLoaderOptions));
-    dataLoaderRegistry.register("locations", new DataLoader<>(new BatchLoader<String, Location>() {
-      @Override
-      public CompletionStage<List<Location>> load(List<String> keys) {
-        return CompletableFuture.supplyAsync(() -> engine.getLocationDao().getByIds(keys),
-            dispatcherService);
-      }
-    }, dataLoaderOptions));
-    dataLoaderRegistry.register("note.noteRelatedObjects",
+    dataLoaderRegistry.register(DataLoaderKey.ID_COMMENTS.name(),
+        new DataLoader<>(new BatchLoader<String, Comment>() {
+          @Override
+          public CompletionStage<List<Comment>> load(List<String> keys) {
+            return CompletableFuture.supplyAsync(() -> engine.getCommentDao().getByIds(keys),
+                dispatcherService);
+          }
+        }, dataLoaderOptions));
+    dataLoaderRegistry.register(DataLoaderKey.ID_LOCATIONS.name(),
+        new DataLoader<>(new BatchLoader<String, Location>() {
+          @Override
+          public CompletionStage<List<Location>> load(List<String> keys) {
+            return CompletableFuture.supplyAsync(() -> engine.getLocationDao().getByIds(keys),
+                dispatcherService);
+          }
+        }, dataLoaderOptions));
+    dataLoaderRegistry.register(DataLoaderKey.FK_NOTE_NOTE_RELATED_OBJECTS.name(),
         new DataLoader<>(new BatchLoader<String, List<NoteRelatedObject>>() {
           @Override
           public CompletionStage<List<List<NoteRelatedObject>>> load(List<String> foreignKeys) {
@@ -99,7 +123,7 @@ public final class BatchingUtils {
                 () -> engine.getNoteDao().getNoteRelatedObjects(foreignKeys), dispatcherService);
           }
         }, dataLoaderOptions));
-    dataLoaderRegistry.register("noteRelatedObject.notes",
+    dataLoaderRegistry.register(DataLoaderKey.FK_NOTE_RELATED_OBJECT_NOTES.name(),
         new DataLoader<>(new BatchLoader<String, List<Note>>() {
           @Override
           public CompletionStage<List<List<Note>>> load(List<String> foreignKeys) {
@@ -107,7 +131,7 @@ public final class BatchingUtils {
                 dispatcherService);
           }
         }, dataLoaderOptions));
-    dataLoaderRegistry.register("organizations",
+    dataLoaderRegistry.register(DataLoaderKey.ID_ORGANIZATIONS.name(),
         new DataLoader<>(new BatchLoader<String, Organization>() {
           @Override
           public CompletionStage<List<Organization>> load(List<String> keys) {
@@ -115,7 +139,7 @@ public final class BatchingUtils {
                 dispatcherService);
           }
         }, dataLoaderOptions));
-    dataLoaderRegistry.register("organization.approvalSteps",
+    dataLoaderRegistry.register(DataLoaderKey.FK_ORGANIZATION_APPROVAL_STEPS.name(),
         new DataLoader<>(new BatchLoader<String, List<ApprovalStep>>() {
           @Override
           public CompletionStage<List<List<ApprovalStep>>> load(List<String> foreignKeys) {
@@ -123,14 +147,15 @@ public final class BatchingUtils {
                 () -> engine.getApprovalStepDao().getApprovalSteps(foreignKeys), dispatcherService);
           }
         }, dataLoaderOptions));
-    dataLoaderRegistry.register("people", new DataLoader<>(new BatchLoader<String, Person>() {
-      @Override
-      public CompletionStage<List<Person>> load(List<String> keys) {
-        return CompletableFuture.supplyAsync(() -> engine.getPersonDao().getByIds(keys),
-            dispatcherService);
-      }
-    }, dataLoaderOptions));
-    dataLoaderRegistry.register("person.organizations",
+    dataLoaderRegistry.register(DataLoaderKey.ID_PEOPLE.name(),
+        new DataLoader<>(new BatchLoader<String, Person>() {
+          @Override
+          public CompletionStage<List<Person>> load(List<String> keys) {
+            return CompletableFuture.supplyAsync(() -> engine.getPersonDao().getByIds(keys),
+                dispatcherService);
+          }
+        }, dataLoaderOptions));
+    dataLoaderRegistry.register(DataLoaderKey.FK_PERSON_ORGANIZATIONS.name(),
         new DataLoader<>(new BatchLoader<String, List<Organization>>() {
           @Override
           public CompletionStage<List<List<Organization>>> load(List<String> foreignKeys) {
@@ -138,7 +163,7 @@ public final class BatchingUtils {
                 () -> engine.getOrganizationDao().getOrganizations(foreignKeys), dispatcherService);
           }
         }, dataLoaderOptions));
-    dataLoaderRegistry.register("person.personPositionHistory",
+    dataLoaderRegistry.register(DataLoaderKey.FK_PERSON_PERSON_POSITION_HISTORY.name(),
         new DataLoader<>(new BatchLoader<String, List<PersonPositionHistory>>() {
           @Override
           public CompletionStage<List<List<PersonPositionHistory>>> load(List<String> foreignKeys) {
@@ -147,14 +172,15 @@ public final class BatchingUtils {
                 dispatcherService);
           }
         }, dataLoaderOptions));
-    dataLoaderRegistry.register("positions", new DataLoader<>(new BatchLoader<String, Position>() {
-      @Override
-      public CompletionStage<List<Position>> load(List<String> keys) {
-        return CompletableFuture.supplyAsync(() -> engine.getPositionDao().getByIds(keys),
-            dispatcherService);
-      }
-    }, dataLoaderOptions));
-    dataLoaderRegistry.register("position.associatedPositions",
+    dataLoaderRegistry.register(DataLoaderKey.ID_POSITIONS.name(),
+        new DataLoader<>(new BatchLoader<String, Position>() {
+          @Override
+          public CompletionStage<List<Position>> load(List<String> keys) {
+            return CompletableFuture.supplyAsync(() -> engine.getPositionDao().getByIds(keys),
+                dispatcherService);
+          }
+        }, dataLoaderOptions));
+    dataLoaderRegistry.register(DataLoaderKey.FK_POSITION_ASSOCIATED_POSITIONS.name(),
         new DataLoader<>(new BatchLoader<String, List<Position>>() {
           @Override
           public CompletionStage<List<List<Position>>> load(List<String> foreignKeys) {
@@ -163,7 +189,7 @@ public final class BatchingUtils {
                 dispatcherService);
           }
         }, dataLoaderOptions));
-    dataLoaderRegistry.register("position.currentPositionForPerson",
+    dataLoaderRegistry.register(DataLoaderKey.FK_POSITION_CURRENT_POSITION_FOR_PERSON.name(),
         new DataLoader<>(new BatchLoader<String, List<Position>>() {
           @Override
           public CompletionStage<List<List<Position>>> load(List<String> foreignKeys) {
@@ -172,7 +198,7 @@ public final class BatchingUtils {
                 dispatcherService);
           }
         }, dataLoaderOptions));
-    dataLoaderRegistry.register("position.personPositionHistory",
+    dataLoaderRegistry.register(DataLoaderKey.FK_POSITION_PERSON_POSITION_HISTORY.name(),
         new DataLoader<>(new BatchLoader<String, List<PersonPositionHistory>>() {
           @Override
           public CompletionStage<List<List<PersonPositionHistory>>> load(List<String> foreignKeys) {
@@ -181,14 +207,15 @@ public final class BatchingUtils {
                 dispatcherService);
           }
         }, dataLoaderOptions));
-    dataLoaderRegistry.register("reports", new DataLoader<>(new BatchLoader<String, Report>() {
-      @Override
-      public CompletionStage<List<Report>> load(List<String> keys) {
-        return CompletableFuture.supplyAsync(() -> engine.getReportDao().getByIds(keys),
-            dispatcherService);
-      }
-    }, dataLoaderOptions));
-    dataLoaderRegistry.register("report.reportActions",
+    dataLoaderRegistry.register(DataLoaderKey.ID_REPORTS.name(),
+        new DataLoader<>(new BatchLoader<String, Report>() {
+          @Override
+          public CompletionStage<List<Report>> load(List<String> keys) {
+            return CompletableFuture.supplyAsync(() -> engine.getReportDao().getByIds(keys),
+                dispatcherService);
+          }
+        }, dataLoaderOptions));
+    dataLoaderRegistry.register(DataLoaderKey.FK_REPORT_REPORT_ACTIONS.name(),
         new DataLoader<>(new BatchLoader<String, List<ReportAction>>() {
           @Override
           public CompletionStage<List<List<ReportAction>>> load(List<String> foreignKeys) {
@@ -196,7 +223,7 @@ public final class BatchingUtils {
                 () -> engine.getReportActionDao().getReportActions(foreignKeys), dispatcherService);
           }
         }, dataLoaderOptions));
-    dataLoaderRegistry.register("report.attendees",
+    dataLoaderRegistry.register(DataLoaderKey.FK_REPORT_ATTENDEES.name(),
         new DataLoader<>(new BatchLoader<String, List<ReportPerson>>() {
           @Override
           public CompletionStage<List<List<ReportPerson>>> load(List<String> foreignKeys) {
@@ -204,7 +231,7 @@ public final class BatchingUtils {
                 () -> engine.getReportDao().getAttendees(foreignKeys), dispatcherService);
           }
         }, dataLoaderOptions));
-    dataLoaderRegistry.register("report.reportSensitiveInformation",
+    dataLoaderRegistry.register(DataLoaderKey.FK_REPORT_REPORT_SENSITIVE_INFORMATION.name(),
         new DataLoader<>(new BatchLoader<String, List<ReportSensitiveInformation>>() {
           @Override
           public CompletionStage<List<List<ReportSensitiveInformation>>> load(
@@ -213,7 +240,7 @@ public final class BatchingUtils {
                 .getReportSensitiveInformation(foreignKeys), dispatcherService);
           }
         }, dataLoaderOptions));
-    dataLoaderRegistry.register("report.tags",
+    dataLoaderRegistry.register(DataLoaderKey.FK_REPORT_TAGS.name(),
         new DataLoader<>(new BatchLoader<String, List<Tag>>() {
           @Override
           public CompletionStage<List<List<Tag>>> load(List<String> foreignKeys) {
@@ -221,7 +248,7 @@ public final class BatchingUtils {
                 dispatcherService);
           }
         }, dataLoaderOptions));
-    dataLoaderRegistry.register("report.tasks",
+    dataLoaderRegistry.register(DataLoaderKey.FK_REPORT_TASKS.name(),
         new DataLoader<>(new BatchLoader<String, List<Task>>() {
           @Override
           public CompletionStage<List<List<Task>>> load(List<String> foreignKeys) {
@@ -229,21 +256,23 @@ public final class BatchingUtils {
                 dispatcherService);
           }
         }, dataLoaderOptions));
-    dataLoaderRegistry.register("tags", new DataLoader<>(new BatchLoader<String, Tag>() {
-      @Override
-      public CompletionStage<List<Tag>> load(List<String> keys) {
-        return CompletableFuture.supplyAsync(() -> engine.getTagDao().getByIds(keys),
-            dispatcherService);
-      }
-    }, dataLoaderOptions));
-    dataLoaderRegistry.register("tasks", new DataLoader<>(new BatchLoader<String, Task>() {
-      @Override
-      public CompletionStage<List<Task>> load(List<String> keys) {
-        return CompletableFuture.supplyAsync(() -> engine.getTaskDao().getByIds(keys),
-            dispatcherService);
-      }
-    }, dataLoaderOptions));
-    dataLoaderRegistry.register("task.responsiblePositions",
+    dataLoaderRegistry.register(DataLoaderKey.ID_TAGS.name(),
+        new DataLoader<>(new BatchLoader<String, Tag>() {
+          @Override
+          public CompletionStage<List<Tag>> load(List<String> keys) {
+            return CompletableFuture.supplyAsync(() -> engine.getTagDao().getByIds(keys),
+                dispatcherService);
+          }
+        }, dataLoaderOptions));
+    dataLoaderRegistry.register(DataLoaderKey.ID_TASKS.name(),
+        new DataLoader<>(new BatchLoader<String, Task>() {
+          @Override
+          public CompletionStage<List<Task>> load(List<String> keys) {
+            return CompletableFuture.supplyAsync(() -> engine.getTaskDao().getByIds(keys),
+                dispatcherService);
+          }
+        }, dataLoaderOptions));
+    dataLoaderRegistry.register(DataLoaderKey.FK_TASK_RESPONSIBLE_POSITIONS.name(),
         new DataLoader<>(new BatchLoader<String, List<Position>>() {
           @Override
           public CompletionStage<List<List<Position>>> load(List<String> foreignKeys) {

--- a/src/main/java/mil/dds/anet/views/ForeignKeyFetcher.java
+++ b/src/main/java/mil/dds/anet/views/ForeignKeyFetcher.java
@@ -4,14 +4,15 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import mil.dds.anet.utils.BatchingUtils;
 import org.dataloader.DataLoader;
 import org.dataloader.DataLoaderRegistry;
 
 public class ForeignKeyFetcher<T extends AbstractAnetBean> {
-  public CompletableFuture<List<T>> load(Map<String, Object> context, String dataLoader,
-      String foreignKey) {
+  public CompletableFuture<List<T>> load(Map<String, Object> context,
+      BatchingUtils.DataLoaderKey dataLoaderKey, String foreignKey) {
     final DataLoaderRegistry dlr = (DataLoaderRegistry) context.get("dataLoaderRegistry");
-    final DataLoader<String, List<T>> dl = dlr.getDataLoader(dataLoader);
+    final DataLoader<String, List<T>> dl = dlr.getDataLoader(dataLoaderKey.name());
     return (foreignKey == null) ? CompletableFuture.completedFuture(new ArrayList<T>())
         : dl.load(foreignKey);
   }

--- a/src/main/java/mil/dds/anet/views/UuidFetcher.java
+++ b/src/main/java/mil/dds/anet/views/UuidFetcher.java
@@ -2,13 +2,15 @@ package mil.dds.anet.views;
 
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import mil.dds.anet.utils.BatchingUtils;
 import org.dataloader.DataLoader;
 import org.dataloader.DataLoaderRegistry;
 
 public class UuidFetcher<T extends AbstractAnetBean> {
-  public CompletableFuture<T> load(Map<String, Object> context, String dataLoader, String uuid) {
+  public CompletableFuture<T> load(Map<String, Object> context,
+      BatchingUtils.DataLoaderKey dataLoaderKey, String uuid) {
     final DataLoaderRegistry dlr = (DataLoaderRegistry) context.get("dataLoaderRegistry");
-    final DataLoader<String, T> dl = dlr.getDataLoader(dataLoader);
+    final DataLoader<String, T> dl = dlr.getDataLoader(dataLoaderKey.name());
     return (uuid == null) ? CompletableFuture.completedFuture(null) : dl.load(uuid);
   }
 }

--- a/src/test/java/mil/dds/anet/test/resources/GraphQlResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/GraphQlResourceTest.java
@@ -17,6 +17,7 @@ import javax.ws.rs.client.Invocation.Builder;
 import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.MediaType;
 import mil.dds.anet.beans.Person;
+import mil.dds.anet.beans.search.ReportSearchQuery;
 import org.apache.commons.io.IOUtils;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -40,7 +41,9 @@ public class GraphQlResourceTest extends AbstractResourceTest {
     variables.put("positionUuid", steve.loadPosition().getUuid());
     variables.put("orgUuid", steve.getPosition().getOrganizationUuid());
     variables.put("searchQuery", "hospital");
-    variables.put("reportUuid", jack.loadAttendedReports(0, 1).getList().get(0).getUuid());
+    final ReportSearchQuery jaQuery = new ReportSearchQuery();
+    jaQuery.setPageSize(1);
+    variables.put("reportUuid", jack.loadAttendedReports(jaQuery).getList().get(0).getUuid());
     variables.put("pageNum", 0);
     variables.put("pageSize", 10);
     variables.put("maxResults", 6);

--- a/src/test/resources/graphQLTests/appQuery.gql
+++ b/src/test/resources/graphQLTests/appQuery.gql
@@ -2,7 +2,7 @@ me {
     uuid, name, role
     position {
         uuid, name, type,
-		organization { uuid, shortName, longName, descendantOrgs(query: {pageNum: 0, pageSize: 0}) { uuid }}
+		organization { uuid, shortName, longName, descendantOrgs(query: {pageSize: 0}) { uuid }}
     }
 }
 

--- a/src/test/resources/graphQLTests/appQuery.gql
+++ b/src/test/resources/graphQLTests/appQuery.gql
@@ -2,7 +2,7 @@ me {
     uuid, name, role
     position {
         uuid, name, type,
-		organization { uuid, shortName, longName, allDescendantOrgs { uuid }}
+		organization { uuid, shortName, longName, descendantOrgs(query: {pageNum: 0, pageSize: 0}) { uuid }}
     }
 }
 

--- a/src/test/resources/graphQLTests/intcore.gql
+++ b/src/test/resources/graphQLTests/intcore.gql
@@ -1,4 +1,4 @@
-reportList(query: {releasedAtStart: -259200000, pageSize: 3, pageNum: 0, sortBy: RELEASED_AT, sortOrder: DESC}) {
+reportList(query: {releasedAtStart: -259200000, pageSize: 3, sortBy: RELEASED_AT, sortOrder: DESC}) {
   pageNum
   totalCount
   list {

--- a/src/test/resources/graphQLTests/orgShow.gql
+++ b/src/test/resources/graphQLTests/orgShow.gql
@@ -2,7 +2,7 @@ organization(uuid:"${orgUuid}") {
 	uuid, shortName, longName, type
 	parentOrg { uuid, shortName, longName }
 	tasks { uuid, longName, shortName }
-	childrenOrgs { uuid, shortName, longName },
+	childrenOrgs(query: {pageNum: 0, pageSize: 0}) { uuid, shortName, longName },
 	positions {
 		uuid, name, code
 		person { uuid, name }

--- a/src/test/resources/graphQLTests/orgShow.gql
+++ b/src/test/resources/graphQLTests/orgShow.gql
@@ -2,7 +2,7 @@ organization(uuid:"${orgUuid}") {
 	uuid, shortName, longName, type
 	parentOrg { uuid, shortName, longName }
 	tasks { uuid, longName, shortName }
-	childrenOrgs(query: {pageNum: 0, pageSize: 0}) { uuid, shortName, longName },
+	childrenOrgs(query: {pageSize: 0}) { uuid, shortName, longName },
 	positions {
 		uuid, name, code
 		person { uuid, name }

--- a/src/test/resources/graphQLTests/orgShow.gql
+++ b/src/test/resources/graphQLTests/orgShow.gql
@@ -11,17 +11,6 @@ organization(uuid:"${orgUuid}") {
 			person { uuid, name }
 		}
 	},
-	reports(pageNum:0, pageSize:25) {
-		list { 
-			uuid, intent, engagementDate, duration, keyOutcomes, nextSteps
-			author { uuid, name },
-			primaryAdvisor { uuid, name } ,
-			primaryPrincipal { uuid, name },
-			advisorOrg { uuid, shortName, longName }
-			principalOrg { uuid, shortName, longName }
-			location { uuid, name, lat, lng }
-		}
-	},
 	approvalSteps {
 		uuid, name, approvers { uuid, name, person { uuid, name }}
 	},

--- a/src/test/resources/graphQLTests/person-all.gql
+++ b/src/test/resources/graphQLTests/person-all.gql
@@ -1,3 +1,3 @@
-personList(query:{pageNum:0, pageSize:0}) {
+personList(query:{pageSize:0}) {
 	list { uuid, name, rank, role, position { uuid, name, organization {uuid, shortName}} }
 }

--- a/src/test/resources/graphQLTests/person.gql
+++ b/src/test/resources/graphQLTests/person.gql
@@ -9,7 +9,7 @@ person(uuid:"${personUuid}") {
             shortName, longName
         }
     },
-    authoredReports(query: {pageNum: 0, pageSize: 10}) { list {
+    authoredReports(query: {pageSize: 10}) { list {
         uuid,
         engagementDate, duration,
         advisorOrg { uuid, shortName, longName }
@@ -19,7 +19,7 @@ person(uuid:"${personUuid}") {
             name
         }
     }},
-    attendedReports(query: {pageNum: 0, pageSize: 10}) { list {
+    attendedReports(query: {pageSize: 10}) { list {
         uuid,
         engagementDate, duration,
         advisorOrg { uuid, shortName, longName }

--- a/src/test/resources/graphQLTests/person.gql
+++ b/src/test/resources/graphQLTests/person.gql
@@ -9,7 +9,7 @@ person(uuid:"${personUuid}") {
             shortName, longName
         }
     },
-    authoredReports(pageNum:0,pageSize:10) { list { 
+    authoredReports(query: {pageNum: 0, pageSize: 10}) { list {
         uuid,
         engagementDate, duration,
         advisorOrg { uuid, shortName, longName }
@@ -19,7 +19,7 @@ person(uuid:"${personUuid}") {
             name
         }
     }},
-    attendedReports(pageNum:0, pageSize:10) { list { 
+    attendedReports(query: {pageNum: 0, pageSize: 10}) { list {
         uuid,
         engagementDate, duration,
         advisorOrg { uuid, shortName, longName }

--- a/src/test/resources/graphQLTests/reportsAll.gql
+++ b/src/test/resources/graphQLTests/reportsAll.gql
@@ -1,4 +1,4 @@
-reportList(query:{pageSize:100, pageNum:0}) {
+reportList(query:{pageSize:100}) {
 	totalCount, list { 
 	    uuid, intent, state
 	    author {

--- a/src/test/resources/graphQLTests/search.gql
+++ b/src/test/resources/graphQLTests/search.gql
@@ -1,4 +1,4 @@
-reportList (query:{text:"${searchQuery}",pageNum:0,pageSize:0}) {
+reportList (query:{text:"${searchQuery}",pageSize:0}) {
 	list { uuid, intent, engagementDate, duration, keyOutcomes, nextSteps
         primaryAdvisor { uuid, name, position { organization { uuid, shortName, longName}}},
         primaryPrincipal { uuid, name, position { organization { uuid, shortName, longName}}},
@@ -9,19 +9,19 @@ reportList (query:{text:"${searchQuery}",pageNum:0,pageSize:0}) {
 	}
 }
 
-personList (query:{text:"${searchQuery}",pageNum:0,pageSize:0}) {
+personList (query:{text:"${searchQuery}",pageSize:0}) {
 	totalCount, list { uuid, name, rank, emailAddress }
 }
-positionList (query:{text:"${searchQuery}",pageNum:0,pageSize:0}) {
+positionList (query:{text:"${searchQuery}",pageSize:0}) {
 	totalCount, list { uuid, name, type, organization{ uuid, shortName} , person { uuid, name}}
 }
-taskList (query:{text:"${searchQuery}",pageNum:0,pageSize:0}) {
+taskList (query:{text:"${searchQuery}",pageSize:0}) {
 	totalCount, list { uuid, shortName, longName}
 }
-locationList (query:{text:"${searchQuery}",pageNum:0,pageSize:0}) {
+locationList (query:{text:"${searchQuery}",pageSize:0}) {
 	totalCount, list { uuid, name, lat, lng}
 }
-organizationList (query:{text:"${searchQuery}",pageNum:0,pageSize:0}) {
+organizationList (query:{text:"${searchQuery}",pageSize:0}) {
 	totalCount, list { uuid, shortName, longName }
 }
 

--- a/src/test/resources/graphQLTests/tagsAll.gql
+++ b/src/test/resources/graphQLTests/tagsAll.gql
@@ -1,3 +1,3 @@
-tagList(query:{pageNum:0, pageSize:0}) {
+tagList(query:{pageSize:0}) {
 	totalCount, list { uuid, name, description }
 }


### PR DESCRIPTION
• Pull up sortOrder in search query class hierarchy
• Use query parameter instead of pageNum/pageSize parameters
• Use search query instead of specific SQL
• Rename allDescendantOrgs to the more appropriate descendantOrgs
• Change pageNum and pageSize from primitives to objects so they're optional
• Use pageSize=0 to get all results
• Set pageNum only when we (potentially) override the default of 0 
• Make dataloader registration/lookup strongly typed
• Remove unused code, including code only used in a test
• Add missing super() call
• Update TODO
• Format Javadoc/TODO for readability

Part of NCI-Agency/anet#1705