### PR TITLE
NCI-Agency/anet#1886: Fix blank page when user tries to save report

### DIFF
--- a/client/src/pages/reports/Form.js
+++ b/client/src/pages/reports/Form.js
@@ -203,7 +203,8 @@ class BaseReportForm extends Component {
           values,
           touched,
           submitForm,
-          resetForm
+          resetForm,
+          setSubmitting
         }) => {
           const locationFilters = {
             activeLocations: {
@@ -327,7 +328,9 @@ class BaseReportForm extends Component {
               <Button
                 bsStyle="primary"
                 type="button"
-                onClick={() => this.onSubmit(values, { resetForm })}
+                onClick={() =>
+                  this.onSubmit(values, { resetForm, setSubmitting })
+                }
                 disabled={isSubmitting}
               >
                 {submitText}


### PR DESCRIPTION
When the save action of a report was resulting in a server side error (for instance a permission error about the user not being allowed to edit the report), the user was getting blank window. This has been fixed now.

Fixes #1886 

