### PR TITLE
Explicitly set sorting by name (ascending) to reinstate pre-SOUNDEX search behaviour

### DIFF
--- a/src/main/java/mil/dds/anet/beans/search/PersonSearchQuery.java
+++ b/src/main/java/mil/dds/anet/beans/search/PersonSearchQuery.java
@@ -28,6 +28,8 @@ public class PersonSearchQuery extends AbstractSearchQuery<PersonSearchSortBy> {
   public PersonSearchQuery() {
     super(PersonSearchSortBy.NAME);
     this.setPageSize(100);
+    // FIXME: Explicitly set sorting by name (ascending) to reinstate pre-SOUNDEX search behaviour.
+    this.setSortBy(PersonSearchSortBy.NAME);
   }
 
   public String getOrgUuid() {


### PR DESCRIPTION
Fixes NCI-Agency/anet#1890