### PR TITLE
Fix text in editor being duplicated

### DIFF
--- a/client/src/components/RichTextEditor.js
+++ b/client/src/components/RichTextEditor.js
@@ -112,7 +112,6 @@ class RichTextEditor extends Component {
         blocksFromHTML.entityMap
       )
     }
-    return ""
   }
 
   _setEditorStateFromHTML(html) {


### PR DESCRIPTION
Fixes #1950

### User changes
This makes sure that when creating a new report and filling in one of
the following fields: Engagement Details, Sensitive Information and
Biography, the text is no longer being duplicated the first time we
click outside the field.
