### PR TITLE
Honour Liskov substitution principle in equals()

### DIFF
--- a/src/main/java/mil/dds/anet/beans/ApprovalStep.java
+++ b/src/main/java/mil/dds/anet/beans/ApprovalStep.java
@@ -69,7 +69,7 @@ public class ApprovalStep extends AbstractAnetBean {
 
   @Override
   public boolean equals(Object o) {
-    if (o == null || o.getClass() != this.getClass()) {
+    if (!(o instanceof ApprovalStep)) {
       return false;
     }
     ApprovalStep as = (ApprovalStep) o;

--- a/src/main/java/mil/dds/anet/beans/AuthorizationGroup.java
+++ b/src/main/java/mil/dds/anet/beans/AuthorizationGroup.java
@@ -73,7 +73,7 @@ public class AuthorizationGroup extends AbstractAnetBean {
 
   @Override
   public boolean equals(Object o) {
-    if (o == null || o.getClass() != this.getClass()) {
+    if (!(o instanceof AuthorizationGroup)) {
       return false;
     }
     AuthorizationGroup a = (AuthorizationGroup) o;

--- a/src/main/java/mil/dds/anet/beans/Comment.java
+++ b/src/main/java/mil/dds/anet/beans/Comment.java
@@ -72,7 +72,7 @@ public class Comment extends AbstractAnetBean {
 
   @Override
   public boolean equals(Object o) {
-    if (o == null || o.getClass() != this.getClass()) {
+    if (!(o instanceof Comment)) {
       return false;
     }
     Comment c = (Comment) o;

--- a/src/main/java/mil/dds/anet/beans/Location.java
+++ b/src/main/java/mil/dds/anet/beans/Location.java
@@ -59,7 +59,7 @@ public class Location extends AbstractAnetBean {
 
   @Override
   public boolean equals(Object o) {
-    if (o == null || o.getClass() != this.getClass()) {
+    if (!(o instanceof Location)) {
       return false;
     }
     Location l = (Location) o;

--- a/src/main/java/mil/dds/anet/beans/Note.java
+++ b/src/main/java/mil/dds/anet/beans/Note.java
@@ -100,7 +100,7 @@ public class Note extends AbstractAnetBean {
 
   @Override
   public boolean equals(Object o) {
-    if (o == null || o.getClass() != this.getClass()) {
+    if (!(o instanceof Note)) {
       return false;
     }
     final Note n = (Note) o;

--- a/src/main/java/mil/dds/anet/beans/Organization.java
+++ b/src/main/java/mil/dds/anet/beans/Organization.java
@@ -205,7 +205,7 @@ public class Organization extends AbstractAnetBean {
 
   @Override
   public boolean equals(Object o) {
-    if (o == null || o.getClass() != this.getClass()) {
+    if (!(o instanceof Organization)) {
       return false;
     }
     Organization other = (Organization) o;

--- a/src/main/java/mil/dds/anet/beans/Person.java
+++ b/src/main/java/mil/dds/anet/beans/Person.java
@@ -231,7 +231,7 @@ public class Person extends AbstractAnetBean implements Principal {
 
   @Override
   public boolean equals(Object o) {
-    if (o == null || !(o instanceof Person)) {
+    if (!(o instanceof Person)) {
       return false;
     }
     Person other = (Person) o;

--- a/src/main/java/mil/dds/anet/beans/Position.java
+++ b/src/main/java/mil/dds/anet/beans/Position.java
@@ -227,7 +227,7 @@ public class Position extends AbstractAnetBean {
 
   @Override
   public boolean equals(Object o) {
-    if (o == null || o.getClass() != this.getClass()) {
+    if (!(o instanceof Position)) {
       return false;
     }
     Position other = (Position) o;

--- a/src/main/java/mil/dds/anet/beans/Report.java
+++ b/src/main/java/mil/dds/anet/beans/Report.java
@@ -636,11 +636,11 @@ public class Report extends AbstractAnetBean {
   }
 
   @Override
-  public boolean equals(Object other) {
-    if (other == null || other.getClass() != this.getClass()) {
+  public boolean equals(Object o) {
+    if (!(o instanceof Report)) {
       return false;
     }
-    Report r = (Report) other;
+    Report r = (Report) o;
     return Objects.equals(r.getUuid(), uuid) && Objects.equals(r.getState(), state)
         && Objects.equals(r.getApprovalStepUuid(), getApprovalStepUuid())
         && Objects.equals(r.getCreatedAt(), createdAt)

--- a/src/main/java/mil/dds/anet/beans/ReportAction.java
+++ b/src/main/java/mil/dds/anet/beans/ReportAction.java
@@ -131,7 +131,7 @@ public class ReportAction extends AbstractAnetBean {
 
   @Override
   public boolean equals(Object o) {
-    if (o == null || o.getClass() != this.getClass()) {
+    if (!(o instanceof ReportAction)) {
       return false;
     }
     ReportAction other = (ReportAction) o;

--- a/src/main/java/mil/dds/anet/beans/ReportPerson.java
+++ b/src/main/java/mil/dds/anet/beans/ReportPerson.java
@@ -22,7 +22,7 @@ public class ReportPerson extends Person {
 
   @Override
   public boolean equals(Object o) {
-    if (o == null || getClass() != o.getClass()) {
+    if (!(o instanceof ReportPerson)) {
       return false;
     }
     ReportPerson rp = (ReportPerson) o;

--- a/src/main/java/mil/dds/anet/beans/ReportSensitiveInformation.java
+++ b/src/main/java/mil/dds/anet/beans/ReportSensitiveInformation.java
@@ -19,7 +19,7 @@ public class ReportSensitiveInformation extends AbstractAnetBean {
 
   @Override
   public boolean equals(Object o) {
-    if (o == null || o.getClass() != this.getClass()) {
+    if (!(o instanceof ReportSensitiveInformation)) {
       return false;
     }
     final ReportSensitiveInformation rsi = (ReportSensitiveInformation) o;

--- a/src/main/java/mil/dds/anet/beans/Tag.java
+++ b/src/main/java/mil/dds/anet/beans/Tag.java
@@ -30,7 +30,7 @@ public class Tag extends AbstractAnetBean {
 
   @Override
   public boolean equals(Object o) {
-    if (o == null || o.getClass() != this.getClass()) {
+    if (!(o instanceof Tag)) {
       return false;
     }
     Tag t = (Tag) o;

--- a/src/main/java/mil/dds/anet/beans/Task.java
+++ b/src/main/java/mil/dds/anet/beans/Task.java
@@ -234,7 +234,7 @@ public class Task extends AbstractAnetBean {
 
   @Override
   public boolean equals(Object o) {
-    if (o == null || o.getClass() != this.getClass()) {
+    if (!(o instanceof Task)) {
       return false;
     }
     Task other = (Task) o;

--- a/src/main/java/mil/dds/anet/beans/search/SavedSearch.java
+++ b/src/main/java/mil/dds/anet/beans/search/SavedSearch.java
@@ -83,7 +83,7 @@ public class SavedSearch extends AbstractAnetBean {
 
   @Override
   public boolean equals(Object o) {
-    if (o == null || o instanceof SavedSearch == false) {
+    if (!(o instanceof SavedSearch)) {
       return false;
     }
     SavedSearch other = (SavedSearch) o;


### PR DESCRIPTION
Follow recommendations form Joshua Bloch's Effective Java.