### PR TITLE
Change the default view for showing report collections

### DIFF
--- a/client/src/components/CancelledEngagementReports.js
+++ b/client/src/components/CancelledEngagementReports.js
@@ -241,7 +241,7 @@ class CancelledEngagementReports extends ReportsVisualisation {
                 reports={context.allReports}
                 paginatedReports={context.reports}
                 goToPage={this.goToReportsPage}
-                viewFormats={[FORMAT_CALENDAR, FORMAT_TABLE, FORMAT_SUMMARY]}
+                viewFormats={[FORMAT_TABLE, FORMAT_SUMMARY, FORMAT_CALENDAR]}
               />
             </div>
           )

--- a/client/src/components/ReportCollection.js
+++ b/client/src/components/ReportCollection.js
@@ -69,7 +69,7 @@ export default class ReportCollection extends Component {
   }
 
   static defaultProps = {
-    viewFormats: [FORMAT_CALENDAR, FORMAT_SUMMARY, FORMAT_TABLE, FORMAT_MAP]
+    viewFormats: [FORMAT_SUMMARY, FORMAT_TABLE, FORMAT_CALENDAR, FORMAT_MAP]
   }
   static VIEW_FORMATS_WITH_PAGINATION = [FORMAT_SUMMARY, FORMAT_TABLE]
 
@@ -79,7 +79,7 @@ export default class ReportCollection extends Component {
     super(props)
 
     this.state = {
-      viewFormat: this.props.viewFormats[1]
+      viewFormat: this.props.viewFormats[0]
     }
   }
 
@@ -110,14 +110,14 @@ export default class ReportCollection extends Component {
                   onChange={this.changeViewFormat}
                   className="hide-for-print"
                 >
-                  {this.props.viewFormats.includes(FORMAT_CALENDAR) && (
-                    <Button value={FORMAT_CALENDAR}>Calendar</Button>
+                  {this.props.viewFormats.includes(FORMAT_TABLE) && (
+                    <Button value={FORMAT_TABLE}>Table</Button>
                   )}
                   {this.props.viewFormats.includes(FORMAT_SUMMARY) && (
                     <Button value={FORMAT_SUMMARY}>Summary</Button>
                   )}
-                  {this.props.viewFormats.includes(FORMAT_TABLE) && (
-                    <Button value={FORMAT_TABLE}>Table</Button>
+                  {this.props.viewFormats.includes(FORMAT_CALENDAR) && (
+                    <Button value={FORMAT_CALENDAR}>Calendar</Button>
                   )}
                   {this.props.viewFormats.includes(FORMAT_MAP) && (
                     <Button value={FORMAT_MAP}>Map</Button>

--- a/client/src/pages/locations/Show.js
+++ b/client/src/pages/locations/Show.js
@@ -19,6 +19,12 @@ import { Location, Person } from "models"
 import PropTypes from "prop-types"
 import React from "react"
 import { connect } from "react-redux"
+import {
+  FORMAT_MAP,
+  FORMAT_SUMMARY,
+  FORMAT_TABLE,
+  FORMAT_CALENDAR
+} from "components/ReportCollection"
 
 const Coordinate = ({ coord }) => {
   const parsedCoord =
@@ -133,6 +139,12 @@ class BaseLocationShow extends Page {
                   queryParams={{ locationUuid: this.props.match.params.uuid }}
                   paginationKey={`r_${this.props.match.params.uuid}`}
                   mapId="reports"
+                  viewFormats={[
+                    FORMAT_CALENDAR,
+                    FORMAT_SUMMARY,
+                    FORMAT_TABLE,
+                    FORMAT_MAP
+                  ]}
                 />
               </Fieldset>
             </div>

--- a/client/src/pages/organizations/Show.js
+++ b/client/src/pages/organizations/Show.js
@@ -24,6 +24,12 @@ import PropTypes from "prop-types"
 import React from "react"
 import { ListGroup, ListGroupItem, Nav, Button } from "react-bootstrap"
 import { connect } from "react-redux"
+import {
+  FORMAT_MAP,
+  FORMAT_SUMMARY,
+  FORMAT_TABLE,
+  FORMAT_CALENDAR
+} from "components/ReportCollection"
 import DictionaryField from "../../HOC/DictionaryField"
 import OrganizationApprovals from "./Approvals"
 import OrganizationLaydown from "./Laydown"
@@ -342,6 +348,12 @@ class BaseOrganizationShow extends Page {
                   <ReportCollectionContainer
                     queryParams={reportQueryParams}
                     paginationKey={`r_${this.props.match.params.uuid}`}
+                    viewFormats={[
+                      FORMAT_CALENDAR,
+                      FORMAT_SUMMARY,
+                      FORMAT_TABLE,
+                      FORMAT_MAP
+                    ]}
                     reportsFilter={
                       !isSuperUser ? null : (
                         <Button

--- a/client/src/pages/people/Show.js
+++ b/client/src/pages/people/Show.js
@@ -24,6 +24,12 @@ import PropTypes from "prop-types"
 import React from "react"
 import { Button, Col, ControlLabel, FormGroup, Table } from "react-bootstrap"
 import { connect } from "react-redux"
+import {
+  FORMAT_MAP,
+  FORMAT_SUMMARY,
+  FORMAT_TABLE,
+  FORMAT_CALENDAR
+} from "components/ReportCollection"
 
 class BasePersonShow extends Page {
   static propTypes = {
@@ -291,6 +297,12 @@ class BasePersonShow extends Page {
                       queryParams={{
                         authorUuid: this.props.match.params.uuid
                       }}
+                      viewFormats={[
+                        FORMAT_CALENDAR,
+                        FORMAT_SUMMARY,
+                        FORMAT_TABLE,
+                        FORMAT_MAP
+                      ]}
                       paginationKey={`r_authored_${this.props.match.params.uuid}`}
                       mapId="reports-authored"
                     />


### PR DESCRIPTION
### User changes
- People, Locations and Organizations have now Calendar enabled as default
- Order of view selection buttons is Table, Summary, Calendar, Map


