### PR TITLE
Fix intermittent "yarn run test-jest" failures

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -160,10 +160,10 @@
     "test-all": "yarn run test-jest && yarn run test-wdio && yarn run test-e2e",
     "test-e2e": "export SERVER_URL=${SERVER_URL:-'http://localhost:8180'} ; NODE_ENV=test node $(npm bin)/ava tests/e2e/*.js --serial --fail-fast --verbose",
     "test-wdio": "export SERVER_URL=${SERVER_URL:-'http://localhost:8180'} ; wdio --baseUrl ${SERVER_URL} ./config/wdio.config.js",
-    "test-jest": "jest ../anet.yml --testPathPattern='tests/(actions|reducers)'",
+    "test-jest": "export ANET_CONFIG=../anet.yml ; jest --testPathPattern='tests/(actions|reducers)'",
     "storybook": "start-storybook -p 9001 -c .storybook",
     "graphql": "graphql",
-    "sim": "export SERVER_URL=${SERVER_URL:-'http://localhost:8080'} ; NODE_ENV=development webpack --mode development --config config/webpack.sim.dev.js && node build/anet.sim.dev.js ../anet.yml"
+    "sim": "export ANET_CONFIG=../anet.yml SERVER_URL=${SERVER_URL:-'http://localhost:8080'} ; NODE_ENV=development webpack --mode development --config config/webpack.sim.dev.js && node build/anet.sim.dev.js"
   },
   "jest": {
     "moduleDirectories": [

--- a/client/platform/node/api.js
+++ b/client/platform/node/api.js
@@ -2,8 +2,10 @@ import fs from "fs"
 import BaseAPI from "baseAPI"
 import jsyaml from "js-yaml"
 
-console.log("Using configuration file " + process.argv[2])
-const anetConfig = jsyaml.safeLoad(fs.readFileSync(process.argv[2], "utf8"))
+console.log("Using configuration file " + process.env.ANET_CONFIG)
+const anetConfig = jsyaml.safeLoad(
+  fs.readFileSync(process.env.ANET_CONFIG, "utf8")
+)
 const Settings = anetConfig.dictionary
 const API = BaseAPI
 


### PR DESCRIPTION
No longer pass an unsupported argument to jest, but use the ANET_CONFIG environment variable to pass anet.yml.
Do the same for the sim.