### PR TITLE
Add authorization checks inside GraphQL methods

### DIFF
--- a/src/main/java/mil/dds/anet/resources/AdminResource.java
+++ b/src/main/java/mil/dds/anet/resources/AdminResource.java
@@ -44,7 +44,7 @@ public class AdminResource {
       @GraphQLArgument(name = "settings") List<AdminSetting> settings) {
     int numRows = 0;
     for (AdminSetting setting : settings) {
-      numRows = dao.saveSetting(setting);
+      numRows += dao.saveSetting(setting);
     }
     AnetAuditLogger.log("Admin settings updated by {}", DaoUtils.getUserFromContext(context));
     return numRows;

--- a/src/main/java/mil/dds/anet/resources/AdminResource.java
+++ b/src/main/java/mil/dds/anet/resources/AdminResource.java
@@ -7,22 +7,20 @@ import io.leangen.graphql.annotations.GraphQLQuery;
 import io.leangen.graphql.annotations.GraphQLRootContext;
 import java.util.List;
 import java.util.Map;
-import javax.annotation.security.PermitAll;
-import javax.annotation.security.RolesAllowed;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import mil.dds.anet.AnetObjectEngine;
 import mil.dds.anet.beans.AdminSetting;
+import mil.dds.anet.beans.Person;
 import mil.dds.anet.config.AnetConfiguration;
 import mil.dds.anet.database.AdminDao;
 import mil.dds.anet.utils.AnetAuditLogger;
+import mil.dds.anet.utils.AuthUtils;
 import mil.dds.anet.utils.DaoUtils;
 
 @Path("/api/admin")
-@Produces(MediaType.APPLICATION_JSON)
-@PermitAll
 public class AdminResource {
 
   private final AdminDao dao;
@@ -39,20 +37,22 @@ public class AdminResource {
   }
 
   @GraphQLMutation(name = "saveAdminSettings")
-  @RolesAllowed("ADMINISTRATOR")
   public Integer saveAdminSettings(@GraphQLRootContext Map<String, Object> context,
       @GraphQLArgument(name = "settings") List<AdminSetting> settings) {
+    final Person user = DaoUtils.getUserFromContext(context);
+    AuthUtils.assertAdministrator(user);
     int numRows = 0;
     for (AdminSetting setting : settings) {
       numRows += dao.saveSetting(setting);
     }
-    AnetAuditLogger.log("Admin settings updated by {}", DaoUtils.getUserFromContext(context));
+    AnetAuditLogger.log("Admin settings updated by {}", user);
     return numRows;
   }
 
   @GET
   @Timed
   @Path("/dictionary")
+  @Produces(MediaType.APPLICATION_JSON)
   public Map<String, Object> getDictionary() {
     return config.getDictionary();
   }

--- a/src/main/java/mil/dds/anet/resources/GraphQlResource.java
+++ b/src/main/java/mil/dds/anet/resources/GraphQlResource.java
@@ -19,7 +19,6 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Function;
-import javax.annotation.security.PermitAll;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -44,8 +43,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @Path("/graphql")
-@Produces(MediaType.APPLICATION_JSON)
-@PermitAll
 public class GraphQlResource {
 
   private static final Logger logger =
@@ -153,7 +150,7 @@ public class GraphQlResource {
 
   @POST
   @Timed
-  @Produces()
+  @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML, MEDIATYPE_XLSX})
   public Response graphqlPost(@Auth Person user, Map<String, Object> body) {
     String query = (String) body.get("query");
     String output = (String) body.get("output");

--- a/src/main/java/mil/dds/anet/resources/HomeResource.java
+++ b/src/main/java/mil/dds/anet/resources/HomeResource.java
@@ -2,7 +2,6 @@ package mil.dds.anet.resources;
 
 import com.codahale.metrics.annotation.Timed;
 import io.dropwizard.auth.Auth;
-import javax.annotation.security.PermitAll;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
@@ -14,7 +13,6 @@ import mil.dds.anet.database.AdminDao.AdminSettingKeys;
 import mil.dds.anet.views.IndexView;
 
 @Path("")
-@PermitAll
 public class HomeResource {
 
   private final AnetConfiguration config;

--- a/src/main/java/mil/dds/anet/resources/LocationResource.java
+++ b/src/main/java/mil/dds/anet/resources/LocationResource.java
@@ -5,19 +5,18 @@ import io.leangen.graphql.annotations.GraphQLMutation;
 import io.leangen.graphql.annotations.GraphQLQuery;
 import io.leangen.graphql.annotations.GraphQLRootContext;
 import java.util.Map;
-import javax.annotation.security.PermitAll;
-import javax.annotation.security.RolesAllowed;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response.Status;
 import mil.dds.anet.AnetObjectEngine;
 import mil.dds.anet.beans.Location;
+import mil.dds.anet.beans.Person;
 import mil.dds.anet.beans.lists.AnetBeanList;
 import mil.dds.anet.beans.search.LocationSearchQuery;
 import mil.dds.anet.database.LocationDao;
 import mil.dds.anet.utils.AnetAuditLogger;
+import mil.dds.anet.utils.AuthUtils;
 import mil.dds.anet.utils.DaoUtils;
 
-@PermitAll
 public class LocationResource {
 
   private final LocationDao dao;
@@ -41,26 +40,28 @@ public class LocationResource {
   }
 
   @GraphQLMutation(name = "createLocation")
-  @RolesAllowed("SUPER_USER")
   public Location createLocation(@GraphQLRootContext Map<String, Object> context,
       @GraphQLArgument(name = "location") Location l) {
+    final Person user = DaoUtils.getUserFromContext(context);
+    AuthUtils.assertSuperUser(user);
     if (l.getName() == null || l.getName().trim().length() == 0) {
       throw new WebApplicationException("Location name must not be empty", Status.BAD_REQUEST);
     }
     l = dao.insert(l);
-    AnetAuditLogger.log("Location {} created by {}", l, DaoUtils.getUserFromContext(context));
+    AnetAuditLogger.log("Location {} created by {}", l, user);
     return l;
   }
 
   @GraphQLMutation(name = "updateLocation")
-  @RolesAllowed("SUPER_USER")
   public Integer updateLocation(@GraphQLRootContext Map<String, Object> context,
       @GraphQLArgument(name = "location") Location l) {
+    final Person user = DaoUtils.getUserFromContext(context);
+    AuthUtils.assertSuperUser(user);
     final int numRows = dao.update(l);
     if (numRows == 0) {
       throw new WebApplicationException("Couldn't process location update", Status.NOT_FOUND);
     }
-    AnetAuditLogger.log("Location {} updated by {}", l, DaoUtils.getUserFromContext(context));
+    AnetAuditLogger.log("Location {} updated by {}", l, user);
     // GraphQL mutations *have* to return something, so we return the number of updated rows
     return numRows;
   }

--- a/src/main/java/mil/dds/anet/resources/LoggingResource.java
+++ b/src/main/java/mil/dds/anet/resources/LoggingResource.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.dropwizard.auth.Auth;
 import java.lang.invoke.MethodHandles;
 import java.util.List;
-import javax.annotation.security.PermitAll;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.POST;
@@ -17,8 +16,6 @@ import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 
 @Path("/api/logging")
-@Consumes(MediaType.APPLICATION_JSON)
-@PermitAll
 public class LoggingResource {
 
   private static final Logger logger = Logger.getLogger(MethodHandles.lookup().lookupClass());
@@ -48,7 +45,7 @@ public class LoggingResource {
   @POST
   @Timed
   @Path("/log")
-  @PermitAll
+  @Consumes(MediaType.APPLICATION_JSON)
   public void logMessage(final @Context HttpServletRequest requestContext, final @Auth Person user,
       final List<LogEntry> logEntries) {
     for (final LogEntry logEntry : logEntries) {

--- a/src/main/java/mil/dds/anet/resources/NoteResource.java
+++ b/src/main/java/mil/dds/anet/resources/NoteResource.java
@@ -4,7 +4,6 @@ import io.leangen.graphql.annotations.GraphQLArgument;
 import io.leangen.graphql.annotations.GraphQLMutation;
 import io.leangen.graphql.annotations.GraphQLRootContext;
 import java.util.Map;
-import javax.annotation.security.PermitAll;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response.Status;
 import mil.dds.anet.AnetObjectEngine;
@@ -16,7 +15,6 @@ import mil.dds.anet.utils.AuthUtils;
 import mil.dds.anet.utils.DaoUtils;
 import mil.dds.anet.utils.Utils;
 
-@PermitAll
 public class NoteResource {
 
   private final NoteDao dao;

--- a/src/main/java/mil/dds/anet/resources/OrganizationResource.java
+++ b/src/main/java/mil/dds/anet/resources/OrganizationResource.java
@@ -9,8 +9,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ExecutionException;
-import javax.annotation.security.PermitAll;
-import javax.annotation.security.RolesAllowed;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response.Status;
 import mil.dds.anet.AnetObjectEngine;
@@ -32,7 +30,6 @@ import org.jdbi.v3.core.statement.UnableToExecuteStatementException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@PermitAll
 public class OrganizationResource {
 
   private static final Logger logger =
@@ -62,10 +59,9 @@ public class OrganizationResource {
   }
 
   @GraphQLMutation(name = "createOrganization")
-  @RolesAllowed("ADMINISTRATOR")
   public Organization createOrganization(@GraphQLRootContext Map<String, Object> context,
       @GraphQLArgument(name = "organization") Organization org) {
-    Person user = DaoUtils.getUserFromContext(context);
+    final Person user = DaoUtils.getUserFromContext(context);
     AuthUtils.assertAdministrator(user);
     final Organization created;
     try {
@@ -117,11 +113,10 @@ public class OrganizationResource {
   }
 
   @GraphQLMutation(name = "updateOrganization")
-  @RolesAllowed("SUPER_USER")
   public Integer updateOrganization(@GraphQLRootContext Map<String, Object> context,
       @GraphQLArgument(name = "organization") Organization org)
       throws InterruptedException, ExecutionException, Exception {
-    Person user = DaoUtils.getUserFromContext(context);
+    final Person user = DaoUtils.getUserFromContext(context);
     // Verify correct Organization
     AuthUtils.assertSuperUserForOrg(user, DaoUtils.getUuid(org), false);
 

--- a/src/main/java/mil/dds/anet/resources/PersonResource.java
+++ b/src/main/java/mil/dds/anet/resources/PersonResource.java
@@ -7,8 +7,6 @@ import io.leangen.graphql.annotations.GraphQLRootContext;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import javax.annotation.security.PermitAll;
-import javax.annotation.security.RolesAllowed;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response.Status;
 import mil.dds.anet.AnetObjectEngine;
@@ -26,7 +24,6 @@ import mil.dds.anet.utils.AuthUtils;
 import mil.dds.anet.utils.DaoUtils;
 import mil.dds.anet.utils.Utils;
 
-@PermitAll
 public class PersonResource {
 
   private final PersonDao dao;
@@ -50,24 +47,23 @@ public class PersonResource {
   }
 
   @GraphQLMutation(name = "createPerson")
-  @RolesAllowed("SUPER_USER")
   public Person createPerson(@GraphQLRootContext Map<String, Object> context,
       @GraphQLArgument(name = "person") Person p) {
-    Person user = DaoUtils.getUserFromContext(context);
-    if (p.getRole().equals(Role.ADVISOR) && !Utils.isEmptyOrNull(p.getEmailAddress())) {
-      validateEmail(p.getEmailAddress());
+    final Person user = DaoUtils.getUserFromContext(context);
+    if (!canCreateOrUpdatePerson(user, p, true)) {
+      throw new WebApplicationException("You do not have permissions to create this person",
+          Status.FORBIDDEN);
     }
 
-    if (p.getPosition() != null && p.getPosition().getUuid() != null) {
-      Position position =
-          AnetObjectEngine.getInstance().getPositionDao().getByUuid(p.getPosition().getUuid());
-      if (position == null) {
-        throw new WebApplicationException("Position " + p.getPosition() + " does not exist",
-            Status.BAD_REQUEST);
-      }
-      if (position.getType() == PositionType.ADMINISTRATOR) {
-        AuthUtils.assertAdministrator(user);
-      }
+    final String positionUuid = DaoUtils.getUuid(p.getPosition());
+    if (positionUuid != null
+        && AnetObjectEngine.getInstance().getPositionDao().getByUuid(positionUuid) == null) {
+      throw new WebApplicationException("Position " + p.getPosition() + " does not exist",
+          Status.BAD_REQUEST);
+    }
+
+    if (p.getRole().equals(Role.ADVISOR) && !Utils.isEmptyOrNull(p.getEmailAddress())) {
+      validateEmail(p.getEmailAddress());
     }
 
     p.setBiography(Utils.sanitizeHtml(p.getBiography()));
@@ -82,11 +78,11 @@ public class PersonResource {
     return created;
   }
 
-  private boolean canUpdatePerson(Person editor, Person subject) {
+  private boolean canCreateOrUpdatePerson(Person editor, Person subject, boolean create) {
     if (editor.getUuid().equals(subject.getUuid())) {
       return true;
     }
-    Position editorPos = editor.getPosition();
+    final Position editorPos = editor.getPosition();
     if (editorPos == null) {
       return false;
     }
@@ -99,7 +95,11 @@ public class PersonResource {
         return true;
       }
       // Ensure that the editor is the Super User for the subject's organization.
-      Position subjectPos = subject.loadPosition();
+      final Position subjectPos =
+          create
+              ? AnetObjectEngine.getInstance().getPositionDao()
+                  .getByUuid(DaoUtils.getUuid(subject.getPosition()))
+              : subject.loadPosition();
       if (subjectPos == null) {
         // Super Users can edit position-less people.
         return true;
@@ -112,9 +112,9 @@ public class PersonResource {
   @GraphQLMutation(name = "updatePerson")
   public Integer updatePerson(@GraphQLRootContext Map<String, Object> context,
       @GraphQLArgument(name = "person") Person p) {
-    Person user = DaoUtils.getUserFromContext(context);
-    Person existing = dao.getByUuid(p.getUuid());
-    if (canUpdatePerson(user, existing) == false) {
+    final Person user = DaoUtils.getUserFromContext(context);
+    final Person existing = dao.getByUuid(p.getUuid());
+    if (!canCreateOrUpdatePerson(user, existing, false)) {
       throw new WebApplicationException("You do not have permissions to edit this person",
           Status.FORBIDDEN);
     }
@@ -210,12 +210,12 @@ public class PersonResource {
   }
 
   @GraphQLMutation(name = "mergePeople")
-  @RolesAllowed("ADMINISTRATOR")
   public Integer mergePeople(@GraphQLRootContext Map<String, Object> context,
       @GraphQLArgument(name = "winnerUuid") String winnerUuid,
       @GraphQLArgument(name = "loserUuid") String loserUuid,
       @GraphQLArgument(name = "copyPosition", defaultValue = "false") boolean copyPosition) {
     final Person user = DaoUtils.getUserFromContext(context);
+    AuthUtils.assertAdministrator(user);
     if (loserUuid.equals(winnerUuid)) {
       throw new WebApplicationException("You selected the same person twice",
           Status.NOT_ACCEPTABLE);

--- a/src/main/java/mil/dds/anet/resources/PositionResource.java
+++ b/src/main/java/mil/dds/anet/resources/PositionResource.java
@@ -6,8 +6,6 @@ import io.leangen.graphql.annotations.GraphQLQuery;
 import io.leangen.graphql.annotations.GraphQLRootContext;
 import java.util.Map;
 import java.util.Objects;
-import javax.annotation.security.PermitAll;
-import javax.annotation.security.RolesAllowed;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response.Status;
 import mil.dds.anet.AnetObjectEngine;
@@ -23,7 +21,6 @@ import mil.dds.anet.utils.AuthUtils;
 import mil.dds.anet.utils.DaoUtils;
 import mil.dds.anet.utils.Utils;
 
-@PermitAll
 public class PositionResource {
 
   private final PositionDao dao;
@@ -64,14 +61,13 @@ public class PositionResource {
   }
 
   @GraphQLMutation(name = "createPosition")
-  @RolesAllowed("SUPER_USER")
   public Position createPosition(@GraphQLRootContext Map<String, Object> context,
       @GraphQLArgument(name = "position") Position pos) {
-    Person user = DaoUtils.getUserFromContext(context);
+    final Person user = DaoUtils.getUserFromContext(context);
     assertCanUpdatePosition(user, pos);
     validatePosition(user, pos);
 
-    Position position = dao.insert(pos);
+    final Position position = dao.insert(pos);
 
     if (pos.getPersonUuid() != null) {
       dao.setPersonInPosition(pos.getPersonUuid(), position.getUuid());
@@ -82,10 +78,9 @@ public class PositionResource {
   }
 
   @GraphQLMutation(name = "updateAssociatedPosition")
-  @RolesAllowed("SUPER_USER")
   public Integer updateAssociatedPosition(@GraphQLRootContext Map<String, Object> context,
       @GraphQLArgument(name = "position") Position pos) {
-    Person user = DaoUtils.getUserFromContext(context);
+    final Person user = DaoUtils.getUserFromContext(context);
     AuthUtils.assertSuperUserForOrg(user, pos.getOrganizationUuid(), true);
 
     final Position current = dao.getByUuid(pos.getUuid());
@@ -110,10 +105,9 @@ public class PositionResource {
   }
 
   @GraphQLMutation(name = "updatePosition")
-  @RolesAllowed("SUPER_USER")
   public Integer updatePosition(@GraphQLRootContext Map<String, Object> context,
       @GraphQLArgument(name = "position") Position pos) {
-    Person user = DaoUtils.getUserFromContext(context);
+    final Person user = DaoUtils.getUserFromContext(context);
     assertCanUpdatePosition(user, pos);
     validatePosition(user, pos);
 
@@ -158,11 +152,10 @@ public class PositionResource {
   }
 
   @GraphQLMutation(name = "putPersonInPosition")
-  @RolesAllowed("SUPER_USER")
   public Integer putPersonInPosition(@GraphQLRootContext Map<String, Object> context,
       @GraphQLArgument(name = "uuid") String positionUuid,
       @GraphQLArgument(name = "person") Person person) {
-    Person user = DaoUtils.getUserFromContext(context);
+    final Person user = DaoUtils.getUserFromContext(context);
     final Position pos = dao.getByUuid(positionUuid);
     if (pos == null) {
       throw new WebApplicationException("Position not found", Status.NOT_FOUND);
@@ -177,8 +170,8 @@ public class PositionResource {
   @GraphQLMutation(name = "deletePersonFromPosition")
   public Integer deletePersonFromPosition(@GraphQLRootContext Map<String, Object> context,
       @GraphQLArgument(name = "uuid") String positionUuid) {
-    Person user = DaoUtils.getUserFromContext(context);
-    Position pos = dao.getByUuid(positionUuid);
+    final Person user = DaoUtils.getUserFromContext(context);
+    final Position pos = dao.getByUuid(positionUuid);
     if (pos == null) {
       throw new WebApplicationException("Position not found", Status.NOT_FOUND);
     }

--- a/src/main/java/mil/dds/anet/resources/ReportResource.java
+++ b/src/main/java/mil/dds/anet/resources/ReportResource.java
@@ -25,8 +25,6 @@ import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import javax.annotation.security.PermitAll;
-import javax.annotation.security.RolesAllowed;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response.Status;
 import mil.dds.anet.AnetObjectEngine;
@@ -68,7 +66,6 @@ import mil.dds.anet.utils.Utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@PermitAll
 public class ReportResource {
 
   private static final Logger logger =
@@ -961,14 +958,15 @@ public class ReportResource {
    * advisor in a given organization.
    * 
    * @param weeksAgo Weeks ago integer for the amount of weeks before the current week
-   *
    */
   @GraphQLQuery(name = "advisorReportInsights")
-  @RolesAllowed("SUPER_USER")
   public List<AdvisorReportsEntry> getAdvisorReportInsights(
+      @GraphQLRootContext Map<String, Object> context,
       @GraphQLArgument(name = "weeksAgo", defaultValue = "3") int weeksAgo,
       @GraphQLArgument(name = "orgUuid",
           defaultValue = Organization.DUMMY_ORG_UUID) String orgUuid) {
+    final Person user = DaoUtils.getUserFromContext(context);
+    AuthUtils.assertSuperUser(user);
 
     Instant now = Instant.now();
     Instant weekStart = now.atZone(DaoUtils.getDefaultZoneId()).with(DayOfWeek.MONDAY).withHour(0)

--- a/src/main/java/mil/dds/anet/resources/SavedSearchResource.java
+++ b/src/main/java/mil/dds/anet/resources/SavedSearchResource.java
@@ -7,7 +7,6 @@ import io.leangen.graphql.annotations.GraphQLRootContext;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import javax.annotation.security.PermitAll;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response.Status;
 import mil.dds.anet.AnetObjectEngine;
@@ -19,7 +18,6 @@ import mil.dds.anet.utils.DaoUtils;
 import mil.dds.anet.utils.ResponseUtils;
 import org.jdbi.v3.core.statement.UnableToExecuteStatementException;
 
-@PermitAll
 public class SavedSearchResource {
 
   private final SavedSearchDao dao;

--- a/src/main/java/mil/dds/anet/resources/TagResource.java
+++ b/src/main/java/mil/dds/anet/resources/TagResource.java
@@ -5,19 +5,18 @@ import io.leangen.graphql.annotations.GraphQLMutation;
 import io.leangen.graphql.annotations.GraphQLQuery;
 import io.leangen.graphql.annotations.GraphQLRootContext;
 import java.util.Map;
-import javax.annotation.security.PermitAll;
-import javax.annotation.security.RolesAllowed;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response.Status;
 import mil.dds.anet.AnetObjectEngine;
+import mil.dds.anet.beans.Person;
 import mil.dds.anet.beans.Tag;
 import mil.dds.anet.beans.lists.AnetBeanList;
 import mil.dds.anet.beans.search.TagSearchQuery;
 import mil.dds.anet.database.TagDao;
 import mil.dds.anet.utils.AnetAuditLogger;
+import mil.dds.anet.utils.AuthUtils;
 import mil.dds.anet.utils.DaoUtils;
 
-@PermitAll
 public class TagResource {
 
   private final TagDao dao;
@@ -41,9 +40,10 @@ public class TagResource {
   }
 
   @GraphQLMutation(name = "createTag")
-  @RolesAllowed("SUPER_USER")
   public Tag createTag(@GraphQLRootContext Map<String, Object> context,
       @GraphQLArgument(name = "tag") Tag t) {
+    final Person user = DaoUtils.getUserFromContext(context);
+    AuthUtils.assertSuperUser(user);
     if (t.getName() == null || t.getName().trim().length() == 0) {
       throw new WebApplicationException("Tag name must not be empty", Status.BAD_REQUEST);
     }
@@ -53,9 +53,10 @@ public class TagResource {
   }
 
   @GraphQLMutation(name = "updateTag")
-  @RolesAllowed("SUPER_USER")
   public Integer updateTag(@GraphQLRootContext Map<String, Object> context,
       @GraphQLArgument(name = "tag") Tag t) {
+    final Person user = DaoUtils.getUserFromContext(context);
+    AuthUtils.assertSuperUser(user);
     final int numRows = dao.update(t);
     if (numRows == 0) {
       throw new WebApplicationException("Couldn't process tag update", Status.NOT_FOUND);

--- a/src/main/java/mil/dds/anet/resources/TaskResource.java
+++ b/src/main/java/mil/dds/anet/resources/TaskResource.java
@@ -8,8 +8,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
-import javax.annotation.security.PermitAll;
-import javax.annotation.security.RolesAllowed;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response.Status;
 import mil.dds.anet.AnetObjectEngine;
@@ -26,7 +24,6 @@ import mil.dds.anet.utils.DaoUtils;
 import mil.dds.anet.utils.ResponseUtils;
 import org.jdbi.v3.core.statement.UnableToExecuteStatementException;
 
-@PermitAll
 public class TaskResource {
 
   private final AnetObjectEngine engine;
@@ -50,11 +47,10 @@ public class TaskResource {
   }
 
   @GraphQLMutation(name = "createTask")
-  @RolesAllowed("ADMIN")
   public Task createTask(@GraphQLRootContext Map<String, Object> context,
       @GraphQLArgument(name = "task") Task p) {
-    Person user = DaoUtils.getUserFromContext(context);
-    if (AuthUtils.isAdmin(user) == false) {
+    final Person user = DaoUtils.getUserFromContext(context);
+    if (!AuthUtils.isAdmin(user)) {
       if (p.getResponsibleOrgUuid() == null) {
         throw new WebApplicationException("You must select a responsible organization",
             Status.FORBIDDEN);

--- a/src/test/java/mil/dds/anet/test/resources/AbstractResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/AbstractResourceTest.java
@@ -1,5 +1,6 @@
 package mil.dds.anet.test.resources;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import com.fasterxml.jackson.core.type.TypeReference;
 import io.dropwizard.client.JerseyClientBuilder;
 import io.dropwizard.client.JerseyClientConfiguration;
@@ -48,6 +49,11 @@ public abstract class AbstractResourceTest {
   protected static Person admin;
   protected static Map<String, Object> context;
 
+  private static final String PERSON_FIELDS =
+      "uuid name domainUsername role emailAddress rank status phoneNumber biography pendingVerification createdAt updatedAt"
+          + " position { uuid name type status "
+          + "   organization { uuid shortName parentOrg { uuid shortName } } }";
+
   @BeforeClass
   public static void setUp() {
     client = new JerseyClientBuilder(RULE.getEnvironment()).using(config).build("test client");
@@ -67,26 +73,17 @@ public abstract class AbstractResourceTest {
    * Finds the specified person in the database. If missing, creates them.
    */
   public static Person findOrPutPersonInDb(Person stub) {
-    final String fields =
-        "uuid name domainUsername role emailAddress rank status phoneNumber biography pendingVerification createdAt updatedAt"
-            + " position { uuid name type status "
-            + "   organization { uuid shortName parentOrg { uuid shortName } } }";
     if (stub.getDomainUsername() != null) {
-      try {
-        final Person user = graphQLHelper.getObject(stub, "me", fields,
-            new TypeReference<GraphQlResponse<Person>>() {});
-        if (user != null) {
-          return user;
-        }
-      } catch (Exception e) {
-        logger.error("error getting user", e);
+      final Person user = findPerson(stub);
+      if (user != null) {
+        return user;
       }
     } else {
       PersonSearchQuery query = new PersonSearchQuery();
       query.setText(stub.getName());
       final AnetBeanList<Person> searchObjects = graphQLHelper.searchObjects(
-          PersonTest.getJackJacksonStub(), "personList", "query", "PersonSearchQueryInput", fields,
-          query, new TypeReference<GraphQlResponse<AnetBeanList<Person>>>() {});
+          PersonTest.getJackJacksonStub(), "personList", "query", "PersonSearchQueryInput",
+          PERSON_FIELDS, query, new TypeReference<GraphQlResponse<AnetBeanList<Person>>>() {});
       for (Person p : searchObjects.getList()) {
         if (p.getEmailAddress().equals(stub.getEmailAddress())) {
           return p;
@@ -97,8 +94,34 @@ public abstract class AbstractResourceTest {
     // Create insert into DB
     final String newPersonUuid = graphQLHelper.createObject(admin, "createPerson", "person",
         "PersonInput", stub, new TypeReference<GraphQlResponse<Person>>() {});
-    return graphQLHelper.getObjectById(admin, "person", fields, newPersonUuid,
+    return graphQLHelper.getObjectById(admin, "person", PERSON_FIELDS, newPersonUuid,
         new TypeReference<GraphQlResponse<Person>>() {});
+  }
+
+  public static Person findPerson(Person stub) {
+    try {
+      return graphQLHelper.getObject(stub, "me", PERSON_FIELDS,
+          new TypeReference<GraphQlResponse<Person>>() {});
+    } catch (Exception e) {
+      logger.error("error getting user", e);
+      return null;
+    }
+  }
+
+  public static Person getSuperUser() {
+    final Person rebeccaStub = new Person();
+    rebeccaStub.setDomainUsername("rebecca"); // super-user from the demo data
+    final Person rebecca = findPerson(rebeccaStub);
+    assertThat(rebecca).isNotNull();
+    return rebecca;
+  }
+
+  public static Person getRegularUser() {
+    final Person erinStub = new Person();
+    erinStub.setDomainUsername("erin"); // regular user from the demo data
+    final Person erin = findPerson(erinStub);
+    assertThat(erin).isNotNull();
+    return erin;
   }
 
   public Person getJackJackson() {

--- a/src/test/java/mil/dds/anet/test/resources/AdminResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/AdminResourceTest.java
@@ -1,0 +1,60 @@
+package mil.dds.anet.test.resources;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+import com.fasterxml.jackson.core.type.TypeReference;
+import java.io.UnsupportedEncodingException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.ws.rs.ForbiddenException;
+import mil.dds.anet.beans.AdminSetting;
+import mil.dds.anet.beans.Person;
+import mil.dds.anet.beans.Position;
+import mil.dds.anet.beans.Position.PositionType;
+import mil.dds.anet.test.resources.utils.GraphQlResponse;
+import org.junit.Test;
+
+public class AdminResourceTest extends AbstractResourceTest {
+
+  @Test
+  public void saveAdminPermissionTest() throws UnsupportedEncodingException {
+    saveSettings(admin);
+  }
+
+  @Test
+  public void saveSuperUserPermissionTest() throws UnsupportedEncodingException {
+    saveSettings(getSuperUser());
+  }
+
+  @Test
+  public void saveRegularUserPermissionTest() throws UnsupportedEncodingException {
+    saveSettings(getRegularUser());
+  }
+
+  private void saveSettings(Person user) {
+    final Position position = user.getPosition();
+    final boolean isAdmin = position.getType() == PositionType.ADMINISTRATOR;
+
+    final List<AdminSetting> settings = graphQLHelper.getObjectList(user, "adminSettings",
+        "key value", new TypeReference<GraphQlResponse<List<AdminSetting>>>() {});
+    final Map<String, Object> variables = new HashMap<>();
+    variables.put("settings", settings);
+
+    try {
+      final Integer nrUpdated = graphQLHelper.updateObject(user,
+          "mutation ($settings: [AdminSettingInput]) { payload: saveAdminSettings (settings: $settings) }",
+          variables);
+      if (isAdmin) {
+        assertThat(nrUpdated).isEqualTo(settings.size());
+      } else {
+        fail("Expected ForbiddenException");
+      }
+    } catch (ForbiddenException expectedException) {
+      if (isAdmin) {
+        fail("Unexpected ForbiddenException");
+      }
+    }
+  }
+
+}

--- a/src/test/java/mil/dds/anet/test/resources/LocationResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/LocationResourceTest.java
@@ -1,9 +1,15 @@
 package mil.dds.anet.test.resources;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 import com.fasterxml.jackson.core.type.TypeReference;
+import java.io.UnsupportedEncodingException;
 import java.lang.reflect.InvocationTargetException;
+import javax.ws.rs.ForbiddenException;
 import mil.dds.anet.beans.Location;
+import mil.dds.anet.beans.Person;
+import mil.dds.anet.beans.Position;
+import mil.dds.anet.beans.Position.PositionType;
 import mil.dds.anet.beans.lists.AnetBeanList;
 import mil.dds.anet.beans.search.LocationSearchQuery;
 import mil.dds.anet.test.TestData;
@@ -33,9 +39,9 @@ public class LocationResourceTest extends AbstractResourceTest {
     // so we search for a record in the base data set.
     final LocationSearchQuery query = new LocationSearchQuery();
     query.setText("Police");
-    final AnetBeanList<Location> searchObjects = graphQLHelper.searchObjects(admin, "locationList",
-        "query", "LocationSearchQueryInput", "uuid name lat lng", query,
-        new TypeReference<GraphQlResponse<AnetBeanList<Location>>>() {});
+    final AnetBeanList<Location> searchObjects =
+        graphQLHelper.searchObjects(admin, "locationList", "query", "LocationSearchQueryInput",
+            FIELDS, query, new TypeReference<GraphQlResponse<AnetBeanList<Location>>>() {});
     assertThat(searchObjects).isNotNull();
     assertThat(searchObjects.getList()).isNotEmpty();
 
@@ -47,6 +53,72 @@ public class LocationResourceTest extends AbstractResourceTest {
     final Location updated = graphQLHelper.getObjectById(admin, "location", FIELDS, lUuid,
         new TypeReference<GraphQlResponse<Location>>() {});
     assertThat(updated).isEqualTo(created);
+  }
+
+  @Test
+  public void locationCreateSuperUserPermissionTest() throws UnsupportedEncodingException {
+    createLocation(getSuperUser());
+  }
+
+  @Test
+  public void locationCreateRegularUserPermissionTest() throws UnsupportedEncodingException {
+    createLocation(getRegularUser());
+  }
+
+  private void createLocation(Person user) {
+    final Position position = user.getPosition();
+    final boolean isSuperUser = position.getType() == PositionType.SUPER_USER;
+    final Location l2 = TestData.createLocation("The Boat Dock2", 43.21, -87.65);
+    try {
+      final String lUuid = graphQLHelper.createObject(user, "createLocation", "location",
+          "LocationInput", l2, new TypeReference<GraphQlResponse<Location>>() {});
+      if (isSuperUser) {
+        assertThat(lUuid).isNotNull();
+      } else {
+        fail("Expected ForbiddenException");
+      }
+    } catch (ForbiddenException expectedException) {
+      if (isSuperUser) {
+        fail("Unexpected ForbiddenException");
+      }
+    }
+  }
+
+  @Test
+  public void locationUpdateSuperUserPermissionTest() throws UnsupportedEncodingException {
+    updateLocation(getSuperUser());
+  }
+
+  @Test
+  public void locationUpdateRegularUserPermissionTest() throws UnsupportedEncodingException {
+    updateLocation(getRegularUser());
+  }
+
+  private void updateLocation(Person user) {
+    final Position position = user.getPosition();
+    final boolean isSuperUser = position.getType() == PositionType.SUPER_USER;
+    final LocationSearchQuery query = new LocationSearchQuery();
+    query.setText("Police");
+    final AnetBeanList<Location> searchObjects =
+        graphQLHelper.searchObjects(admin, "locationList", "query", "LocationSearchQueryInput",
+            FIELDS, query, new TypeReference<GraphQlResponse<AnetBeanList<Location>>>() {});
+    assertThat(searchObjects).isNotNull();
+    assertThat(searchObjects.getList()).isNotEmpty();
+    final Location l = searchObjects.getList().get(0);
+
+    try {
+      final Integer nrUpdated =
+          graphQLHelper.updateObject(user, "updateLocation", "location", "LocationInput", l);
+      if (isSuperUser) {
+        assertThat(nrUpdated).isEqualTo(1);
+      } else {
+        fail("Expected ForbiddenException");
+      }
+    } catch (ForbiddenException expectedException) {
+      if (isSuperUser) {
+        fail("Unexpected ForbiddenException");
+      }
+    }
   }
 
 }

--- a/src/test/java/mil/dds/anet/test/resources/TagResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/TagResourceTest.java
@@ -5,7 +5,9 @@ import static org.assertj.core.api.Assertions.fail;
 import com.fasterxml.jackson.core.type.TypeReference;
 import java.io.UnsupportedEncodingException;
 import javax.ws.rs.BadRequestException;
+import javax.ws.rs.ForbiddenException;
 import javax.ws.rs.NotFoundException;
+import mil.dds.anet.beans.Person;
 import mil.dds.anet.beans.Tag;
 import mil.dds.anet.beans.lists.AnetBeanList;
 import mil.dds.anet.beans.search.TagSearchQuery;
@@ -17,16 +19,23 @@ public class TagResourceTest extends AbstractResourceTest {
   private static final String FIELDS = "uuid name description createdAt";
 
   @Test
-  public void tagCreateTest() throws UnsupportedEncodingException {
+  public void tagCreateUpdateAdminSuperUserTest() throws UnsupportedEncodingException {
+    // Check admin
+    createTag(admin, "name", "desc");
+    // Check super-user
+    createTag(getSuperUser(), "name2", "desc2");
+  }
+
+  private void createTag(Person user, String name, String description) {
     final Tag t = new Tag();
-    t.setName("name");
-    t.setDescription("desc");
+    t.setName(name);
+    t.setDescription(description);
 
     // Create
-    final String tUuid = graphQLHelper.createObject(admin, "createTag", "tag", "TagInput", t,
+    final String tUuid = graphQLHelper.createObject(user, "createTag", "tag", "TagInput", t,
         new TypeReference<GraphQlResponse<Tag>>() {});
     assertThat(tUuid).isNotNull();
-    final Tag created = graphQLHelper.getObjectById(admin, "tag", FIELDS, tUuid,
+    final Tag created = graphQLHelper.getObjectById(user, "tag", FIELDS, tUuid,
         new TypeReference<GraphQlResponse<Tag>>() {});
     assertThat(created.getName()).isEqualTo(t.getName());
     assertThat(created.getDescription()).isEqualTo(t.getDescription());
@@ -36,11 +45,11 @@ public class TagResourceTest extends AbstractResourceTest {
     // Update
     created.setName("eman");
     final Integer nrUpdated =
-        graphQLHelper.updateObject(admin, "updateTag", "tag", "TagInput", created);
+        graphQLHelper.updateObject(user, "updateTag", "tag", "TagInput", created);
     assertThat(nrUpdated).isEqualTo(1);
 
     // Get
-    final Tag updated = graphQLHelper.getObjectById(admin, "tag", FIELDS, tUuid,
+    final Tag updated = graphQLHelper.getObjectById(user, "tag", FIELDS, tUuid,
         new TypeReference<GraphQlResponse<Tag>>() {});
     assertThat(updated).isEqualTo(created);
   }
@@ -74,6 +83,40 @@ public class TagResourceTest extends AbstractResourceTest {
             new TypeReference<GraphQlResponse<AnetBeanList<Tag>>>() {});
     assertThat(searchObjects).isNotNull();
     assertThat(searchObjects.getList()).isNotEmpty();
+  }
+
+  @Test
+  public void tagCreateRegularUserPermissionTest() throws UnsupportedEncodingException {
+    final Tag t = new Tag();
+    t.setName("name3");
+    t.setDescription("desc3");
+
+    try {
+      graphQLHelper.createObject(getRegularUser(), "createTag", "tag", "TagInput", t,
+          new TypeReference<GraphQlResponse<Tag>>() {});
+      fail("Expected ForbiddenException");
+    } catch (ForbiddenException expectedException) {
+    }
+  }
+
+  @Test
+  public void tagUpdateRegularUserPermissionTest() throws UnsupportedEncodingException {
+    // Search for a tag from the initial data
+    final TagSearchQuery query = new TagSearchQuery();
+    query.setText("bribery");
+    final AnetBeanList<Tag> searchObjects =
+        graphQLHelper.searchObjects(admin, "tagList", "query", "TagSearchQueryInput", FIELDS, query,
+            new TypeReference<GraphQlResponse<AnetBeanList<Tag>>>() {});
+    assertThat(searchObjects).isNotNull();
+    assertThat(searchObjects.getList()).isNotEmpty();
+    final Tag t = searchObjects.getList().get(0);
+    t.setName(t.getName() + "_update");
+
+    try {
+      graphQLHelper.updateObject(getRegularUser(), "updateTag", "tag", "TagInput", t);
+      fail("Expected ForbiddenException");
+    } catch (ForbiddenException expectedException) {
+    }
   }
 
 }


### PR DESCRIPTION
Replace obsolete REST API annotations with formal authorization checks inside GraphQL methods.

### Super User changes
This formalises when a super user can create a new Person:
- when the new Person's role is _PRINCIPAL_
- when the new Person's role is _ADVISOR_ and the new Person is not linked to a Position
- when the new Person's role is _ADVISOR_, the new Person is linked to a Position, and you are a super user for the Position's Organization