### PR TITLE
Fix GraphQL media types

### DIFF
--- a/client/tests/sim/simutils.js
+++ b/client/tests/sim/simutils.js
@@ -5,7 +5,10 @@ async function runGQL(user, query) {
     `${process.env.SERVER_URL}/graphql?user=${user.name}&pass=${user.password}`,
     {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json"
+      },
       body: JSON.stringify(query)
     }
   )

--- a/src/main/java/mil/dds/anet/resources/GraphQlResource.java
+++ b/src/main/java/mil/dds/anet/resources/GraphQlResource.java
@@ -153,7 +153,7 @@ public class GraphQlResource {
 
   @POST
   @Timed
-  @Produces()
+  @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML, MEDIATYPE_XLSX})
   public Response graphqlPost(@Auth Person user, Map<String, Object> body) {
     String query = (String) body.get("query");
     String output = (String) body.get("output");


### PR DESCRIPTION
Put back media types produced by GraphQL POST, and explicitly state that the sim expects JSON.