### PR TITLE
Fix NPE when saving avatar

### DIFF
--- a/src/main/java/mil/dds/anet/database/PersonDao.java
+++ b/src/main/java/mil/dds/anet/database/PersonDao.java
@@ -233,7 +233,7 @@ public class PersonDao extends AnetBaseDao<Person, PersonSearchQuery> {
 
   private static Blob convertImageToBlob(String image) {
     try {
-      return new SerialBlob(image.getBytes());
+      return image == null ? null : new SerialBlob(image.getBytes());
     } catch (Exception e) {
       logger.error("Failed to save avatar: ", e);
       return null;


### PR DESCRIPTION
Fixed an issue where saving an avatar using a 'null' image would result in a NPE.

Fixes #
Fiexes NPE when saving avatar without image
Expands unit tests

### User changes
None

### Super User changes
None

### Admin changes
None

### System admin changes
None

- [ ] anet.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
