### PR TITLE
Fix date range for date filters of type last day/week/month

### DIFF
--- a/client/src/dateUtils.js
+++ b/client/src/dateUtils.js
@@ -45,9 +45,10 @@ export function dateToQuery(queryKey, value) {
       [startKey]: moment(value.start).startOf("day")
     }
   } else {
-    // Time relative to now
+    // LAST_DAY, LAST_WEEK, LAST_MONTH => Time relative to now, up till now
     return {
-      [startKey]: parseInt(value.relative)
+      [startKey]: parseInt(value.relative),
+      [endKey]: moment()
     }
   }
 }


### PR DESCRIPTION
These filters used to only use a start timestamp for the date range, and therefore they were also returning items with a date in the future. We now also added the current timestamp as end timestamp for the date range.

Fixes #2056

### User changes
- When using a filter on the reports engagement date of the type last day/week/month, the search will no longer return future engagements 
