### PR TITLE
Fix update of advisor's assignment history

### DIFF
--- a/client/tests/e2e/position.js
+++ b/client/tests/e2e/position.js
@@ -1,7 +1,7 @@
 let test = require("../util/test")
 
 test("Move someone in and out of a position", async t => {
-  t.plan(9)
+  t.plan(11)
 
   let {
     $,
@@ -120,6 +120,27 @@ test("Move someone in and out of a position", async t => {
   )
 
   await assertElementText(t, await $(".position-name"), positionName)
+
+  // The change in position is also visible in the Previous positions
+  let $previousPositionsRows = await $$("#previous-positions table tbody tr")
+  let $lastRow = $previousPositionsRows.pop()
+  let [
+    /* eslint-disable no-unused-vars */ $positionCell1 /* eslint-enable no-unused-vars */,
+    $datesCell1
+  ] = await $lastRow.findElements(By.css("td"))
+  let datesCell1Text = await $datesCell1.getText()
+  t.regex(datesCell1Text, /[0-9a-f\s]+-[\s]?/i, "Last cell has no end date")
+  let $beforeLastRow = $previousPositionsRows.pop()
+  let [
+    /* eslint-disable no-unused-vars */ $positionCell2 /* eslint-enable no-unused-vars */,
+    $datesCell2
+  ] = await $beforeLastRow.findElements(By.css("td"))
+  let datesCell2Text = await $datesCell2.getText()
+  t.regex(
+    datesCell2Text,
+    /[0-9a-f\s]+-[0-9a-f\s]+/i,
+    "One before last cell has an end date"
+  )
 
   await t.context.pageHelpers.clickMyOrgLink()
 

--- a/src/main/java/mil/dds/anet/beans/PersonPositionHistory.java
+++ b/src/main/java/mil/dds/anet/beans/PersonPositionHistory.java
@@ -26,6 +26,17 @@ public class PersonPositionHistory extends AbstractAnetBean {
   private ForeignObjectHolder<Position> position = new ForeignObjectHolder<>();
   Instant startTime;
   Instant endTime;
+  protected Instant endedAt;
+
+  @JsonIgnore
+  @GraphQLIgnore
+  public Instant getEndedAt() {
+    return endedAt;
+  }
+
+  public void setEndedAt(Instant endedAt) {
+    this.endedAt = endedAt;
+  }
 
   @Override
   @JsonIgnore
@@ -119,14 +130,10 @@ public class PersonPositionHistory extends AbstractAnetBean {
   }
 
   public static List<PersonPositionHistory> getDerivedHistory(List<PersonPositionHistory> history) {
-    // Derive the start and end times; assumes list is in chronological order
-    PersonPositionHistory pphPrev = null;
+    // Set the start and end times; assumes list is in chronological order
     for (final PersonPositionHistory pph : history) {
       pph.setStartTime(pph.getCreatedAt());
-      if (pphPrev != null) {
-        pphPrev.setEndTime(pph.getStartTime());
-      }
-      pphPrev = pph;
+      pph.setEndTime(pph.getEndedAt());
     }
     // Remove all null entries
     return history.stream()

--- a/src/main/java/mil/dds/anet/beans/PersonPositionHistory.java
+++ b/src/main/java/mil/dds/anet/beans/PersonPositionHistory.java
@@ -26,17 +26,6 @@ public class PersonPositionHistory extends AbstractAnetBean {
   private ForeignObjectHolder<Position> position = new ForeignObjectHolder<>();
   Instant startTime;
   Instant endTime;
-  protected Instant endedAt;
-
-  @JsonIgnore
-  @GraphQLIgnore
-  public Instant getEndedAt() {
-    return endedAt;
-  }
-
-  public void setEndedAt(Instant endedAt) {
-    this.endedAt = endedAt;
-  }
 
   @Override
   @JsonIgnore
@@ -130,11 +119,6 @@ public class PersonPositionHistory extends AbstractAnetBean {
   }
 
   public static List<PersonPositionHistory> getDerivedHistory(List<PersonPositionHistory> history) {
-    // Set the start and end times; assumes list is in chronological order
-    for (final PersonPositionHistory pph : history) {
-      pph.setStartTime(pph.getCreatedAt());
-      pph.setEndTime(pph.getEndedAt());
-    }
     // Remove all null entries
     return history.stream()
         .filter(

--- a/src/main/java/mil/dds/anet/database/PositionDao.java
+++ b/src/main/java/mil/dds/anet/database/PositionDao.java
@@ -183,15 +183,19 @@ public class PositionDao extends AnetBaseDao<Position, PositionSearchQuery> {
     if (currPos != null) {
       String sql;
       if (DaoUtils.isMsSql()) {
-        sql = "/* positionSetPerson.end */ UPDATE t SET t.\"endedAt\" = :endedAt FROM ( "
-            + "          SELECT TOP(1) * FROM \"peoplePositions\" "
-            + "          WHERE \"personUuid\" = :personUuid AND \"positionUuid\" = :positionUuid "
-            + "          ORDER BY \"createdAt\" DESC ) t";
+        sql =
+            "/* positionSetPerson.end */ UPDATE \"peoplePositions\" SET \"endedAt\" = :endedAt FROM "
+                + "      (SELECT TOP(1) * FROM \"peoplePositions\" WHERE \"personUuid\" = :personUuid AND \"positionUuid\" = :positionUuid ORDER BY \"createdAt\" DESC) AS t "
+                + "      WHERE t.\"personUuid\" = \"peoplePositions\".\"personUuid\" AND "
+                + "            t.\"positionUuid\" = \"peoplePositions\".\"positionUuid\" AND "
+                + "            t.\"createdAt\" = \"peoplePositions\".\"createdAt\" ";
       } else {
-        sql = "/* positionSetPerson.end */ UPDATE t SET t.\"endedAt\" = :endedAt FROM ("
-            + "          SELECT TOP(1) * FROM \"peoplePositions\" "
-            + "          WHERE \"personUuid\" = :personUuid AND \"positionUuid\" = :positionUuid "
-            + "          ORDER BY \"createdAt\" DESC LIMIT 1) t";
+        sql =
+            "/* positionSetPerson.end */ UPDATE \"peoplePositions\" SET \"endedAt\" = :endedAt FROM "
+                + "      (SELECT * FROM \"peoplePositions\" WHERE \"personUuid\" = :personUuid AND \"positionUuid\" = :positionUuid ORDER BY \"createdAt\" DESC LIMIT 1) AS t "
+                + "      WHERE t.\"personUuid\" = \"peoplePositions\".\"personUuid\" AND "
+                + "            t.\"positionUuid\" = \"peoplePositions\".\"positionUuid\" AND "
+                + "            t.\"createdAt\" = \"peoplePositions\".\"createdAt\" ";
       }
       getDbHandle().createUpdate(sql).bind("personUuid", personUuid)
           .bind("positionUuid", currPos.getUuid()).bind("endedAt", DaoUtils.asLocalDateTime(now))
@@ -236,13 +240,19 @@ public class PositionDao extends AnetBaseDao<Position, PositionSearchQuery> {
 
     String updateSql;
     if (DaoUtils.isMsSql()) {
-      updateSql = "/* positionRemovePerson.end */ UPDATE t SET t.\"endedAt\" = :endedAt FROM "
-          + "(SELECT TOP(1) * FROM \"peoplePositions\" "
-          + "WHERE \"positionUuid\" = :positionUuid ORDER BY \"createdAt\" DESC) t";
+      updateSql =
+          "/* positionSetPerson.end */ UPDATE \"peoplePositions\" SET \"endedAt\" = :endedAt FROM "
+              + "      (SELECT TOP(1) * FROM \"peoplePositions\" WHERE \"positionUuid\" = :positionUuid ORDER BY \"createdAt\" DESC) AS t "
+              + "      WHERE t.\"personUuid\" = \"peoplePositions\".\"personUuid\" AND "
+              + "            t.\"positionUuid\" = \"peoplePositions\".\"positionUuid\" AND "
+              + "            t.\"createdAt\" = \"peoplePositions\".\"createdAt\" ";
     } else {
-      updateSql = "/* positionRemovePerson.end */ UPDATE t SET t.\"endedAt\" = :endedAt FROM "
-          + "(SELECT * FROM \"peoplePositions\" WHERE \"positionUuid\" = :positionUuid "
-          + "ORDER BY \"createdAt\" DESC LIMIT 1) t";
+      updateSql =
+          "/* positionSetPerson.end */ UPDATE \"peoplePositions\" SET \"endedAt\" = :endedAt FROM "
+              + "      (SELECT * FROM \"peoplePositions\" WHERE \"positionUuid\" = :positionUuid ORDER BY \"createdAt\" DESC LIMIT 1) AS t "
+              + "      WHERE t.\"personUuid\" = \"peoplePositions\".\"personUuid\" AND "
+              + "            t.\"positionUuid\" = \"peoplePositions\".\"positionUuid\" AND "
+              + "            t.\"createdAt\" = \"peoplePositions\".\"createdAt\" ";
     }
     getDbHandle().createUpdate(updateSql).bind("positionUuid", positionUuid)
         .bind("endedAt", DaoUtils.asLocalDateTime(now)).execute();

--- a/src/main/java/mil/dds/anet/database/PositionDao.java
+++ b/src/main/java/mil/dds/anet/database/PositionDao.java
@@ -11,13 +11,11 @@ import java.util.concurrent.CompletableFuture;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response.Status;
 import mil.dds.anet.AnetObjectEngine;
-import mil.dds.anet.beans.Person;
 import mil.dds.anet.beans.PersonPositionHistory;
 import mil.dds.anet.beans.Position;
 import mil.dds.anet.beans.Position.PositionType;
 import mil.dds.anet.beans.lists.AnetBeanList;
 import mil.dds.anet.beans.search.PositionSearchQuery;
-import mil.dds.anet.database.mappers.PersonMapper;
 import mil.dds.anet.database.mappers.PersonPositionHistoryMapper;
 import mil.dds.anet.database.mappers.PositionMapper;
 import mil.dds.anet.utils.DaoUtils;
@@ -278,60 +276,6 @@ public class PositionDao extends AnetBaseDao<Position, PositionSearchQuery> {
             + "VALUES (:positionUuid, null, :createdAt)")
         .bind("positionUuid", positionUuid).bind("createdAt", DaoUtils.asLocalDateTime(now))
         .execute();
-  }
-
-  public Person getPersonInPositionNow(String personUuid) {
-    if (personUuid == null) {
-      return null;
-    } // No person currently in position.
-    List<Person> people = getDbHandle()
-        .createQuery("/* positionFindCurrentPerson */ SELECT " + PersonDao.PERSON_FIELDS
-            + " FROM people WHERE uuid = :personUuid")
-        .bind("personUuid", personUuid).map(new PersonMapper()).list();
-    if (people.size() == 0) {
-      return null;
-    }
-    return people.get(0);
-  }
-
-  public Person getPersonInPosition(String positionUuid, Instant dtg) {
-    String sql;
-    if (DaoUtils.isMsSql()) {
-      sql = "/* positionFindPerson */ SELECT TOP(1) " + PersonDao.PERSON_FIELDS
-          + " FROM \"peoplePositions\" "
-          + "LEFT JOIN people ON people.uuid = \"peoplePositions\".\"personUuid\" "
-          + "WHERE \"peoplePositions\".\"positionUuid\" = :positionUuid "
-          + "AND \"peoplePositions\".\"createdAt\" < :dtg "
-          + "ORDER BY \"peoplePositions\".\"createdAt\" DESC";
-    } else {
-      sql = "/* positionFindPerson */ SELECT " + PersonDao.PERSON_FIELDS
-          + " FROM \"peoplePositions\" "
-          + "LEFT JOIN people ON people.uuid = \"peoplePositions\".\"personUuid\" "
-          + "WHERE \"peoplePositions\".\"positionUuid\" = :positionUuid "
-          + "AND \"peoplePositions\".\"createdAt\" < :dtg "
-          + "ORDER BY \"peoplePositions\".\"createdAt\" DESC LIMIT 1";
-    }
-    List<Person> results = getDbHandle().createQuery(sql).bind("positionUuid", positionUuid)
-        .bind("dtg", dtg).map(new PersonMapper()).list();
-    if (results.size() == 0) {
-      return null;
-    }
-    return results.get(0);
-  }
-
-  public List<Person> getPeoplePreviouslyInPosition(String positionUuid) {
-    List<Person> people = getDbHandle()
-        .createQuery("/* positionFindPreviousPeople */ SELECT " + PersonDao.PERSON_FIELDS
-            + "FROM \"peoplePositions\" "
-            + "LEFT JOIN people ON \"peoplePositions\".\"personUuid\" = people.uuid "
-            + "WHERE \"peoplePositions\".\"positionUuid\" = :positionUuid "
-            + "AND \"peoplePositions\".\"personUuid\" IS NOT NULL ORDER BY \"createdAt\" DESC")
-        .bind("positionUuid", positionUuid).map(new PersonMapper()).list();
-    // remove the last person, as that's the current position holder
-    if (people.size() > 0) {
-      people.remove(people.size() - 1);
-    }
-    return people;
   }
 
   public CompletableFuture<List<Position>> getAssociatedPositions(Map<String, Object> context,

--- a/src/main/java/mil/dds/anet/database/mappers/PersonPositionHistoryMapper.java
+++ b/src/main/java/mil/dds/anet/database/mappers/PersonPositionHistoryMapper.java
@@ -13,6 +13,7 @@ public class PersonPositionHistoryMapper implements RowMapper<PersonPositionHist
   public PersonPositionHistory map(ResultSet rs, StatementContext ctx) throws SQLException {
     final PersonPositionHistory pph = new PersonPositionHistory();
     pph.setCreatedAt(DaoUtils.getInstantAsLocalDateTime(rs, "createdAt"));
+    pph.setEndedAt(DaoUtils.getInstantAsLocalDateTime(rs, "endedAt"));
     pph.setPositionUuid(rs.getString("positionUuid"));
     pph.setPersonUuid(rs.getString("personUuid"));
     return pph;

--- a/src/main/java/mil/dds/anet/database/mappers/PersonPositionHistoryMapper.java
+++ b/src/main/java/mil/dds/anet/database/mappers/PersonPositionHistoryMapper.java
@@ -13,7 +13,8 @@ public class PersonPositionHistoryMapper implements RowMapper<PersonPositionHist
   public PersonPositionHistory map(ResultSet rs, StatementContext ctx) throws SQLException {
     final PersonPositionHistory pph = new PersonPositionHistory();
     pph.setCreatedAt(DaoUtils.getInstantAsLocalDateTime(rs, "createdAt"));
-    pph.setEndedAt(DaoUtils.getInstantAsLocalDateTime(rs, "endedAt"));
+    pph.setStartTime(DaoUtils.getInstantAsLocalDateTime(rs, "createdAt"));
+    pph.setEndTime(DaoUtils.getInstantAsLocalDateTime(rs, "endedAt"));
     pph.setPositionUuid(rs.getString("positionUuid"));
     pph.setPersonUuid(rs.getString("personUuid"));
     return pph;

--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -2633,4 +2633,35 @@
 		</addColumn>
 	</changeSet>
 
+	<changeSet id="add-endedAt-to-peoplePositions" author="mdragan">
+		<addColumn tableName="peoplePositions">
+			<column name="endedAt" type="datetime" />
+		</addColumn>
+		<sql dbms="mssql">
+			ALTER TABLE peoplePositions ALTER COLUMN endedAt datetime2;
+		</sql>
+	</changeSet>
+
+	<changeSet id="fill-endedAt-peoplePositions-column" author="mdragan">
+		<comment>Populate the new endedAt column of the peoplePositions table.</comment>
+		<sql dbms="mssql">
+			UPDATE "peoplePositions" SET "endedAt" = (
+				SELECT TOP(1) "createdAt" FROM "peoplePositions" next
+				WHERE next."positionUuid" = "peoplePositions"."positionUuid" AND next.createdAt > "peoplePositions"."createdAt"
+				ORDER BY next."createdAt"
+			);
+		</sql>
+		<sql dbms="postgresql">
+			UPDATE "peoplePositions" SET "endedAt" = (
+				SELECT "createdAt" FROM "peoplePositions" next
+				WHERE next."positionUuid" = "peoplePositions"."positionUuid" AND next.createdAt > "peoplePositions"."createdAt"
+				ORDER BY next."createdAt"
+				LIMIT 1
+			);
+		</sql>
+		<rollback>
+			UPDATE "peoplePositions" set "endedAt" = NULL;
+		</rollback>
+	</changeSet>
+
 </databaseChangeLog>

--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -2647,14 +2647,14 @@
 		<sql dbms="mssql">
 			UPDATE "peoplePositions" SET "endedAt" = (
 				SELECT TOP(1) "createdAt" FROM "peoplePositions" next
-				WHERE next."positionUuid" = "peoplePositions"."positionUuid" AND next.createdAt > "peoplePositions"."createdAt"
+				WHERE next."positionUuid" = "peoplePositions"."positionUuid" AND next."createdAt" > "peoplePositions"."createdAt"
 				ORDER BY next."createdAt"
 			);
 		</sql>
 		<sql dbms="postgresql">
 			UPDATE "peoplePositions" SET "endedAt" = (
 				SELECT "createdAt" FROM "peoplePositions" next
-				WHERE next."positionUuid" = "peoplePositions"."positionUuid" AND next.createdAt > "peoplePositions"."createdAt"
+				WHERE next."positionUuid" = "peoplePositions"."positionUuid" AND next."createdAt" > "peoplePositions"."createdAt"
 				ORDER BY next."createdAt"
 				LIMIT 1
 			);


### PR DESCRIPTION
This fixes the bug that when assigning an incoming advisor to an advisor position, the outgoing advisor's position history was not updated (no end date was being displayed).

Fixes #1917 

- [ ] db needs migration
