### PR TITLE
Only show active persons in advanced select widget

### DIFF
--- a/client/src/components/AssignPersonModal.js
+++ b/client/src/components/AssignPersonModal.js
@@ -52,7 +52,7 @@ export default class AssignPersonModal extends Component {
     let newPerson = this.state.person
 
     let personSearchQuery = {
-      status: [Person.STATUS.ACTIVE, Person.STATUS.NEW_USER]
+      status: [Person.STATUS.ACTIVE]
     }
     if (position.type === Position.TYPE.PRINCIPAL) {
       personSearchQuery.role = Person.ROLE.PRINCIPAL

--- a/client/src/pages/reports/Form.js
+++ b/client/src/pages/reports/Form.js
@@ -634,7 +634,7 @@ class BaseReportForm extends Component {
                     }
                     objectType={Person}
                     queryParams={{
-                      status: [Person.STATUS.ACTIVE, Person.STATUS.NEW_USER]
+                      status: [Person.STATUS.ACTIVE]
                     }}
                     fields={Person.autocompleteQuery}
                     addon={PEOPLE_ICON}


### PR DESCRIPTION
This makes sure that one can only add active persons as attendee to a
report or to a position.

Fixes #2036 

### User changes
- The attendee widget on the report form and the widget for assigning a person to a position no longer show people which are new users and didn't become active yet.