### PR TITLE
Require gender when saving a principal

### DIFF
--- a/client/src/models/Person.js
+++ b/client/src/models/Person.js
@@ -105,13 +105,7 @@ export default class Person extends Model {
       gender: yup
         .string()
         .nullable()
-        .when("role", (role, schema) =>
-          Person.isAdvisor({ role })
-            ? schema.required(
-              `You must provide the ${Settings.fields.person.gender}`
-            )
-            : schema.nullable()
-        )
+        .required(`You must provide the ${Settings.fields.person.gender}`)
         .default("")
         .label(Settings.fields.person.gender),
       phoneNumber: yup

--- a/client/tests/webdriver/specs/createNewPerson.spec.js
+++ b/client/tests/webdriver/specs/createNewPerson.spec.js
@@ -13,7 +13,33 @@ const VALID_PERSON_ADVISOR = {
 
 describe("Create new Person form page", () => {
   describe("When creating a Principle user", () => {
-    it("Should not save a principle with only a last name", () => {
+    it("Should not save a principle without gender being filled in", () => {
+      CreatePerson.openAsSuperUser()
+      CreatePerson.form.waitForExist()
+      CreatePerson.form.waitForDisplayed()
+      CreatePerson.lastName.waitForDisplayed()
+      CreatePerson.lastName.setValue(VALID_PERSON_PRINCIPAL.lastName)
+      CreatePerson.gender.click()
+      CreatePerson.lastName.click()
+      const errorMessage = browser.$('select[name="gender"] + span.help-block')
+      errorMessage.waitForExist()
+      errorMessage.waitForDisplayed()
+      expect(errorMessage.getText()).to.equal("You must provide the Gender")
+
+      CreatePerson.gender.selectByAttribute(
+        "value",
+        CreatePerson.getRandomOption(CreatePerson.gender)
+      )
+      CreatePerson.rank.selectByAttribute(
+        "value",
+        CreatePerson.getRandomOption(CreatePerson.rank)
+      )
+      CreatePerson.submitForm()
+      CreatePerson.waitForAlertSuccessToLoad()
+      const alertMessage = CreatePerson.alertSuccess.getText()
+      expect(alertMessage).to.equal("Person saved")
+    })
+    it("Should save a principle without first name", () => {
       CreatePerson.openAsSuperUser()
       CreatePerson.form.waitForExist()
       CreatePerson.form.waitForDisplayed()
@@ -22,6 +48,10 @@ describe("Create new Person form page", () => {
       CreatePerson.rank.selectByAttribute(
         "value",
         CreatePerson.getRandomOption(CreatePerson.rank)
+      )
+      CreatePerson.gender.selectByAttribute(
+        "value",
+        CreatePerson.getRandomOption(CreatePerson.gender)
       )
       CreatePerson.submitForm()
       CreatePerson.waitForAlertSuccessToLoad()
@@ -37,6 +67,10 @@ describe("Create new Person form page", () => {
       CreatePerson.rank.selectByAttribute(
         "value",
         CreatePerson.getRandomOption(CreatePerson.rank)
+      )
+      CreatePerson.gender.selectByAttribute(
+        "value",
+        CreatePerson.getRandomOption(CreatePerson.gender)
       )
       CreatePerson.emailAddress.setValue("notValidEmail@")
       CreatePerson.lastName.click()


### PR DESCRIPTION
When creating a new principal or editing an existing principal, we now require a gender to be chosen before the principal's profile can be saved.

Closes #1703 

### Super User changes
- When creating or editing a principal, the gender is now a required field.

### Admin changes
- See super user changes.