### PR TITLE
Remove ability of super users to edit existing location names

### DIFF
--- a/client/src/pages/Search.js
+++ b/client/src/pages/Search.js
@@ -437,7 +437,7 @@ class Search extends Page {
       <div>
         {this.paginationFor(SEARCH_OBJECT_TYPES.PEOPLE)}
         <br />
-        <Table responsive hover striped className="people-search-results">
+        <Table responsive hover striped id="people-search-results">
           <thead>
             <tr>
               <th>Name</th>
@@ -531,7 +531,7 @@ class Search extends Page {
       <div>
         {this.paginationFor(SEARCH_OBJECT_TYPES.LOCATIONS)}
         <br />
-        <Table responsive hover striped>
+        <Table responsive hover striped id="locations-search-results">
           <thead>
             <tr>
               <th>Name</th>
@@ -556,7 +556,7 @@ class Search extends Page {
       <div>
         {this.paginationFor(SEARCH_OBJECT_TYPES.TASKS)}
         <br />
-        <Table responsive hover striped>
+        <Table responsive hover striped id="tasks-search-results">
           <thead>
             <tr>
               <th>Name</th>

--- a/client/src/pages/locations/Show.js
+++ b/client/src/pages/locations/Show.js
@@ -98,7 +98,12 @@ class BaseLocationShow extends Page {
             })
           }
           const action = canEdit && (
-            <LinkTo anetLocation={location} edit button="primary">
+            <LinkTo
+              anetLocation={location}
+              edit
+              button="primary"
+              id="editButton"
+            >
               Edit
             </LinkTo>
           )


### PR DESCRIPTION
Was needed in order to make sure locations are not arbitrarily renamed.

Closes #1599 

### Super User changes
- Super users no longer have the ability to edit existing location names, 
