### PR TITLE
Fix search with date filter of type LAST

### DIFF
--- a/client/src/dateUtils.js
+++ b/client/src/dateUtils.js
@@ -48,7 +48,7 @@ export function dateToQuery(queryKey, value) {
     // LAST_DAY, LAST_WEEK, LAST_MONTH => Time relative to now, up till now
     return {
       [startKey]: parseInt(value.relative),
-      [endKey]: moment()
+      [endKey]: moment().endOf("day")
     }
   }
 }


### PR DESCRIPTION
The report search using a date filter of type LAST DAY, LAST WEEK or LAST MONTH  was resulting in an endless loop.