### PR TITLE
Free batching resources

### DIFF
--- a/src/main/java/mil/dds/anet/AnetApplication.java
+++ b/src/main/java/mil/dds/anet/AnetApplication.java
@@ -271,7 +271,7 @@ public class AnetApplication extends Application<AnetConfiguration> {
             ImmutableList.of(reportResource, personResource, positionResource, locationResource,
                 orgResource, taskResource, adminResource, savedSearchResource, tagResource,
                 authorizationGroupResource, noteResource),
-            metricRegistry, configuration.isDevelopmentMode()));
+            metricRegistry));
   }
 
   protected static JSONObject getDictionary(AnetConfiguration configuration)

--- a/src/main/java/mil/dds/anet/AnetObjectEngine.java
+++ b/src/main/java/mil/dds/anet/AnetObjectEngine.java
@@ -294,7 +294,8 @@ public class AnetObjectEngine {
     if (context == null) {
       final Map<String, Object> ctx = new HashMap<>();
       // FIXME: create this per Jersey (non-GraphQL) request, and make it batch and cache?
-      ctx.put("dataLoaderRegistry", BatchingUtils.registerDataLoaders(this, false, false));
+      final BatchingUtils batchingUtils = new BatchingUtils(this, false, false);
+      ctx.put("dataLoaderRegistry", batchingUtils.getDataLoaderRegistry());
       context = ThreadLocal.withInitial(() -> ctx);
     }
     return context.get();

--- a/src/main/java/mil/dds/anet/resources/GraphQlResource.java
+++ b/src/main/java/mil/dds/anet/resources/GraphQlResource.java
@@ -201,8 +201,8 @@ public class GraphQlResource {
 
   private ExecutionResult dispatchRequest(Person user, String operationName, String query,
       Map<String, Object> variables) {
-    final DataLoaderRegistry dataLoaderRegistry =
-        BatchingUtils.registerDataLoaders(engine, true, true);
+    final BatchingUtils batchingUtils = new BatchingUtils(engine, true, true);
+    final DataLoaderRegistry dataLoaderRegistry = batchingUtils.getDataLoaderRegistry();
     final Map<String, Object> context = new HashMap<>();
     context.put("user", user);
     context.put("dataLoaderRegistry", dataLoaderRegistry);
@@ -242,7 +242,8 @@ public class GraphQlResource {
     } catch (InterruptedException | ExecutionException e) {
       throw new WebApplicationException("failed to complete graphql request", e);
     } finally {
-      BatchingUtils.updateStats(metricRegistry, dataLoaderRegistry);
+      batchingUtils.updateStats(metricRegistry, dataLoaderRegistry);
+      batchingUtils.shutdown();
     }
   }
 

--- a/src/main/java/mil/dds/anet/resources/GraphQlResource.java
+++ b/src/main/java/mil/dds/anet/resources/GraphQlResource.java
@@ -52,7 +52,6 @@ public class GraphQlResource {
 
   private final AnetObjectEngine engine;
   private final List<Object> resources;
-  private final boolean developmentMode;
   private final MetricRegistry metricRegistry;
 
   private GraphQLSchema graphqlSchema;
@@ -79,11 +78,10 @@ public class GraphQlResource {
       };
 
   public GraphQlResource(AnetObjectEngine engine, AnetConfiguration config, List<Object> resources,
-      MetricRegistry metricRegistry, boolean developmentMode) {
+      MetricRegistry metricRegistry) {
     this.engine = engine;
     this.resources = resources;
     this.metricRegistry = metricRegistry;
-    this.developmentMode = developmentMode;
 
     resourceTransformers.add(GraphQlResource.jsonTransformer);
     resourceTransformers.add(new ResourceTransformer("xml", MediaType.APPLICATION_XML) {
@@ -176,10 +174,6 @@ public class GraphQlResource {
 
   protected Response graphql(@Auth Person user, String operationName, String query,
       Map<String, Object> variables, String output) {
-    if (developmentMode) {
-      buildGraph();
-    }
-
     final ExecutionResult executionResult = dispatchRequest(user, operationName, query, variables);
     final Map<String, Object> result = executionResult.toSpecification();
     if (executionResult.getErrors().size() > 0) {

--- a/src/main/java/mil/dds/anet/utils/BatchingUtils.java
+++ b/src/main/java/mil/dds/anet/utils/BatchingUtils.java
@@ -37,18 +37,41 @@ import org.dataloader.stats.Statistics;
 
 public final class BatchingUtils {
 
-  private BatchingUtils() {}
+  private final ExecutorService dispatcherService;
+  private final DataLoaderRegistry dataLoaderRegistry;
+  private final DataLoaderOptions dataLoaderOptions;
 
-  public static DataLoaderRegistry registerDataLoaders(AnetObjectEngine engine,
-      boolean batchingEnabled, boolean cachingEnabled) {
-    final DataLoaderOptions dataLoaderOptions =
+  public BatchingUtils(AnetObjectEngine engine, boolean batchingEnabled, boolean cachingEnabled) {
+    // Give each registry its own thread pool
+    dispatcherService = Executors.newFixedThreadPool(3);
+    dataLoaderRegistry = new DataLoaderRegistry();
+    dataLoaderOptions =
         DataLoaderOptions.newOptions().setStatisticsCollector(() -> new SimpleStatisticsCollector())
             .setBatchingEnabled(batchingEnabled).setCachingEnabled(cachingEnabled)
             .setMaxBatchSize(1000);
-    final DataLoaderRegistry dataLoaderRegistry = new DataLoaderRegistry();
-    // Give each registry its own thread pool
-    final ExecutorService dispatcherService = Executors.newFixedThreadPool(3);
+    registerDataLoaders(engine);
+  }
 
+  public DataLoaderRegistry getDataLoaderRegistry() {
+    return dataLoaderRegistry;
+  }
+
+  /**
+   * Call this when you're done with this batcher; it shuts down the thread pool being used (which
+   * may free up some resources). If you don't call this yourself, eventually it will be done
+   * through {@link #finalize()}, but that might be delayed.
+   */
+  public void shutdown() {
+    dispatcherService.shutdown();
+  }
+
+  @Override
+  protected void finalize() throws Throwable {
+    shutdown();
+    super.finalize();
+  }
+
+  private void registerDataLoaders(AnetObjectEngine engine) {
     dataLoaderRegistry.register(IdDataLoaderKey.APPROVAL_STEPS.toString(),
         new DataLoader<>(new BatchLoader<String, ApprovalStep>() {
           @Override
@@ -309,11 +332,9 @@ public final class BatchingUtils {
                 () -> engine.getTaskDao().getResponsiblePositions(foreignKeys), dispatcherService);
           }
         }, dataLoaderOptions));
-    return dataLoaderRegistry;
   }
 
-  public static void updateStats(MetricRegistry metricRegistry,
-      DataLoaderRegistry dataLoaderRegistry) {
+  public void updateStats(MetricRegistry metricRegistry, DataLoaderRegistry dataLoaderRegistry) {
     // Combined stats for all data loaders
     updateStats(metricRegistry, "DataLoaderRegistry", dataLoaderRegistry.getStatistics());
     for (final String key : dataLoaderRegistry.getKeys()) {
@@ -322,8 +343,7 @@ public final class BatchingUtils {
     }
   }
 
-  private static void updateStats(MetricRegistry metricRegistry, String name,
-      Statistics statistics) {
+  private void updateStats(MetricRegistry metricRegistry, String name, Statistics statistics) {
     metricRegistry.counter(MetricRegistry.name(name, "BatchInvokeCount"))
         .inc(statistics.getBatchInvokeCount());
     metricRegistry.counter(MetricRegistry.name(name, "BatchLoadCount"))

--- a/src/test/java/mil/dds/anet/test/resources/AbstractResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/AbstractResourceTest.java
@@ -48,6 +48,7 @@ public abstract class AbstractResourceTest {
   protected static GraphQlHelper graphQLHelper;
   protected static Person admin;
   protected static Map<String, Object> context;
+  private static BatchingUtils batchingUtils;
 
   private static final String PERSON_FIELDS =
       "uuid name domainUsername role emailAddress rank status phoneNumber biography pendingVerification createdAt updatedAt"
@@ -60,13 +61,14 @@ public abstract class AbstractResourceTest {
     graphQLHelper = new GraphQlHelper(client, RULE.getLocalPort());
     admin = findOrPutPersonInDb(PersonTest.getArthurDmin());
     context = new HashMap<>();
-    context.put("dataLoaderRegistry",
-        BatchingUtils.registerDataLoaders(AnetObjectEngine.getInstance(), false, false));
+    batchingUtils = new BatchingUtils(AnetObjectEngine.getInstance(), false, false);
+    context.put("dataLoaderRegistry", batchingUtils.getDataLoaderRegistry());
   }
 
   @AfterClass
   public static void tearDown() {
     client.close();
+    batchingUtils.shutdown();
   }
 
   /*


### PR DESCRIPTION
- Explicitly free up batching resources when done.
- Do not rebuild the GraphQL schema each request in development mode.