### PR TITLE
Change super user permissions for position editing

### DIFF
--- a/client/src/components/PositionTable.js
+++ b/client/src/components/PositionTable.js
@@ -111,7 +111,14 @@ const BasePositionTable = props => {
             />
           )}
 
-          <Table striped condensed hover responsive className="positions_table">
+          <Table
+            striped
+            condensed
+            hover
+            responsive
+            className="positions_table"
+            id={props.id}
+          >
             <thead>
               <tr>
                 <th>Name</th>
@@ -172,6 +179,7 @@ const BasePositionTable = props => {
 }
 
 BasePositionTable.propTypes = {
+  id: PropTypes.string,
   positions: PropTypes.array, // list of positions, when no pagination wanted
   showDelete: PropTypes.bool,
   onDelete: PropTypes.func,

--- a/client/src/pages/Search.js
+++ b/client/src/pages/Search.js
@@ -437,7 +437,7 @@ const Positions = props => {
         goToPage={setPage}
       />
       <br />
-      <PositionTable positions={positions} />
+      <PositionTable positions={positions} id="positions-search-results" />
     </div>
   )
 

--- a/client/tests/e2e/permissions.js
+++ b/client/tests/e2e/permissions.js
@@ -2,9 +2,9 @@ let uuidv4 = require("uuid/v4")
 let test = require("../util/test")
 
 test("checking super user permissions", async t => {
-  t.plan(9)
+  t.plan(10)
 
-  let { pageHelpers } = t.context
+  let { pageHelpers, assertElementNotPresent, shortWaitMs } = t.context
 
   await t.context.get("/", "rebecca")
   await pageHelpers.clickMyOrgLink()
@@ -16,9 +16,9 @@ test("checking super user permissions", async t => {
 
   await validateUserCanEditUserForCurrentPage(t)
 
-  // User is super user, only admins may edit position of type super user
-  await editAndSavePositionFromCurrentUserPage(t, false)
-  // We are now still on the edit position page
+  // User is super user, he/she may edit position of type super user for
+  // his/her own organization
+  await editAndSavePositionFromCurrentUserPage(t, true)
 
   await t.context.get("/", "rebecca")
   await pageHelpers.clickMyOrgLink()
@@ -28,8 +28,28 @@ test("checking super user permissions", async t => {
 
   await validateUserCanEditUserForCurrentPage(t)
 
-  // User is super user, only admins may edit position of type super user
-  await editAndSavePositionFromCurrentUserPage(t, false)
+  // User is super user, he/she may edit position of type super user for
+  // his/her own organization
+  await editAndSavePositionFromCurrentUserPage(t, true)
+
+  // User is super user, he/she may edit positions only for his/her own organization
+  let $otherOrgPositionLink = await getFromSearchResults(
+    t,
+    "EF 1",
+    "EF 1 Manager",
+    "positions"
+  )
+  await $otherOrgPositionLink.click()
+  await t.context.driver.wait(
+    t.context.until.stalenessOf($otherOrgPositionLink)
+  )
+
+  await assertElementNotPresent(
+    t,
+    ".edit-position",
+    "super user should not be able to edit positions of another organization than his/her own",
+    shortWaitMs
+  )
 
   let $principalOrgLink = await getFromSearchResults(
     t,

--- a/src/main/java/mil/dds/anet/resources/PositionResource.java
+++ b/src/main/java/mil/dds/anet/resources/PositionResource.java
@@ -51,10 +51,18 @@ public class PositionResource {
       throw new WebApplicationException("A Position must belong to an organization",
           Status.BAD_REQUEST);
     }
+    // only admins can make super user positions
+    if (!AuthUtils.isAdmin(user) && (pos.getType() == PositionType.SUPER_USER)) {
+      final Position existingPos = dao.getByUuid(pos.getUuid());
+      if (existingPos.getType() != PositionType.SUPER_USER) {
+        throw new WebApplicationException(
+            "You are not allowed to change the position type to SUPER USER", Status.FORBIDDEN);
+      }
+    }
   }
 
   private void assertCanUpdatePosition(Person user, Position pos) {
-    if (pos.getType() == PositionType.ADMINISTRATOR || pos.getType() == PositionType.SUPER_USER) {
+    if (pos.getType() == PositionType.ADMINISTRATOR) {
       AuthUtils.assertAdministrator(user);
     }
     AuthUtils.assertSuperUserForOrg(user, pos.getOrganizationUuid(), true);


### PR DESCRIPTION
Closes #1571

### Super User changes
- Super users are now allowed to change a super user position as long as it is within their organization or in a subordinate organization. But super users are not allowed to upgrade a regular user's position to a super user position.