### PR TITLE
Try to avoid deadlocks when checking authorization

### DIFF
--- a/src/main/java/mil/dds/anet/database/ReportSensitiveInformationDao.java
+++ b/src/main/java/mil/dds/anet/database/ReportSensitiveInformationDao.java
@@ -3,6 +3,8 @@ package mil.dds.anet.database;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import mil.dds.anet.AnetObjectEngine;
 import mil.dds.anet.beans.Person;
@@ -143,16 +145,21 @@ public class ReportSensitiveInformationDao
       // No user or no report
       return false;
     }
+    if (Objects.equals(userUuid, report.getAuthorUuid())) {
+      // Author is always authorized
+      return true;
+    }
 
-    // Check authorization in a single query
-    final Query query = getDbHandle().createQuery("/* checkReportAuthorization */ SELECT r.uuid"
-        + " FROM reports r"
-        + " LEFT JOIN \"reportAuthorizationGroups\" rag ON rag.\"reportUuid\" = r.uuid"
-        + " LEFT JOIN \"authorizationGroupPositions\" agp ON agp.\"authorizationGroupUuid\" = rag.\"authorizationGroupUuid\" "
-        + " LEFT JOIN positions p ON p.uuid = agp.\"positionUuid\" WHERE r.uuid = :reportUuid"
-        + " AND ( (r.\"authorUuid\" = :userUuid) OR (p.\"currentPersonUuid\" = :userUuid) )")
+    // Check authorization groups
+    final Query query = getDbHandle()
+        .createQuery("/* checkReportAuthorization */ SELECT COUNT(*) AS count"
+            + " FROM \"reportAuthorizationGroups\" rag"
+            + " LEFT JOIN \"authorizationGroupPositions\" agp ON agp.\"authorizationGroupUuid\" = rag.\"authorizationGroupUuid\" "
+            + " LEFT JOIN positions p ON p.uuid = agp.\"positionUuid\" WHERE rag.\"reportUuid\" = :reportUuid"
+            + " AND p.\"currentPersonUuid\" = :userUuid")
         .bind("reportUuid", reportUuid).bind("userUuid", userUuid);
-    return (query.map(new MapMapper(false)).list().size() > 0);
+    final Optional<Map<String, Object>> result = query.map(new MapMapper(false)).findFirst();
+    return result.isPresent() && ((Number) result.get().get("count")).intValue() > 0;
   }
 
 }


### PR DESCRIPTION
While running parallel simulator scenarios, we would sometimes get:
```
  com.microsoft.sqlserver.jdbc.SQLServerException: Transaction (Process ID #) was deadlocked on lock resources with another process and has been chosen as the deadlock victim. Rerun the transaction.
```
and the exception would always be in the `checkReportAuthorization` query.
Probable cause is that that query tried to access the reports table while it was still locked (because of report insertion/update).
Avoid using the reports table altogether, by just checking the author from the report object.