### PR TITLE
Do not display organization related tiles on home for new users

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -252,6 +252,10 @@
       "standard"
     ],
     "rules": {
+      "eqeqeq": [
+        "error",
+        "always"
+      ],
       "import/order": [
         "warn",
         {

--- a/client/platform/web-dev/api.js
+++ b/client/platform/web-dev/api.js
@@ -9,7 +9,7 @@ function loadFileAjaxSync(filePath, mimeType) {
   if (authHeader) {
     xmlhttp.setRequestHeader(authHeader[0], authHeader[1])
   }
-  if (mimeType != null) {
+  if (mimeType !== null) {
     if (xmlhttp.overrideMimeType) {
       xmlhttp.overrideMimeType(mimeType)
     }

--- a/client/src/components/AdvisorReports/FilterableAdvisorReportsTable.js
+++ b/client/src/components/AdvisorReports/FilterableAdvisorReportsTable.js
@@ -86,7 +86,7 @@ const FilterableAdvisorReportsTable = props => {
     let result, csvGroupCols, csvCols, columnDelimiter, lineDelimiter, data
 
     data = args.data || null
-    if (data == null || !data.length) {
+    if (data === null || !data.length) {
       return null
     }
 
@@ -137,7 +137,7 @@ const FilterableAdvisorReportsTable = props => {
     let csv = convertArrayOfObjectsToCSV({
       data: args.data
     })
-    if (csv == null) return
+    if (csv === null) return
 
     filename = args.filename || "export-advisor-report.csv"
     var blob = new Blob([csv], { type: "text/csv;charset=utf-8;" })

--- a/client/src/components/AvatarComponent.js
+++ b/client/src/components/AvatarComponent.js
@@ -38,7 +38,7 @@ export default class AvatarComponent extends React.Component {
 
     let image =
       this.props.editCurrent &&
-      (this.props.src == null || this.props.src === ""
+      (this.props.src === null || this.props.src === ""
         ? DEFAULT_AVATAR
         : "data:image/jpeg;base64," + this.props.src)
 

--- a/client/src/components/AvatarDisplayComponent.js
+++ b/client/src/components/AvatarDisplayComponent.js
@@ -12,7 +12,7 @@ export default class AvatarDisplayComponent extends React.Component {
 
   render() {
     let image =
-      this.props.avatar == null || this.props.avatar === ""
+      this.props.avatar === null || this.props.avatar === ""
         ? DEFAULT_AVATAR
         : "data:image/jpeg;base64," + this.props.avatar
 

--- a/client/src/pages/Home.js
+++ b/client/src/pages/Home.js
@@ -124,9 +124,15 @@ const HomeTiles = props => {
   return (
     <Grid fluid>
       <Row>
-        {queries.map((query, index) => (
-          <HomeTile key={index} query={query} setSearchQuery={setSearchQuery} />
-        ))}
+        {queries
+          .filter(q => q.query != null)
+          .map((query, index) => (
+            <HomeTile
+              key={index}
+              query={query}
+              setSearchQuery={setSearchQuery}
+            />
+          ))}
       </Row>
     </Grid>
   )
@@ -226,7 +232,7 @@ const HomeTiles = props => {
 
   function myOrgRecent(currentUser) {
     if (!currentUser.position || !currentUser.position.organization) {
-      return { query: {} }
+      return { query: null }
     }
     return {
       title:
@@ -247,7 +253,7 @@ const HomeTiles = props => {
 
   function myOrgFuture(currentUser) {
     if (!currentUser.position || !currentUser.position.organization) {
-      return { query: {} }
+      return { query: null }
     }
     return {
       title:

--- a/client/src/pages/Home.js
+++ b/client/src/pages/Home.js
@@ -125,7 +125,7 @@ const HomeTiles = props => {
     <Grid fluid>
       <Row>
         {queries
-          .filter(q => q.query != null)
+          .filter(q => q.query !== null)
           .map((query, index) => (
             <HomeTile
               key={index}


### PR DESCRIPTION
This makes sure that we no longer display the organization related tiles on the homepage for users which are not related to an organization (like new users). These tiles were showing in this context the wrong information (the number of all reports) as there was no organization to filter on.

Fixes #2349 
