### PR TITLE
Fix reset of search text when navigating

### DIFF
--- a/client/src/components/SearchBar.js
+++ b/client/src/components/SearchBar.js
@@ -1,8 +1,9 @@
 import { resetPagination, SEARCH_OBJECT_LABELS, setSearchQuery } from "actions"
 import AdvancedSearch from "components/AdvancedSearch"
 import { SearchDescription } from "components/SearchFilters"
+import _isEqual from "lodash/isEqual"
 import PropTypes from "prop-types"
-import React, { useRef, useState } from "react"
+import React, { useEffect, useRef, useState } from "react"
 import {
   Button,
   Form,
@@ -25,7 +26,17 @@ const SearchBar = props => {
   } = props
   const history = useHistory()
   const advancedSearchLink = useRef()
+  // (Re)set searchTerms if the query.text prop changes
+  const latestQueryText = useRef(query.text)
+  const queryTextUnchanged = _isEqual(latestQueryText.current, query.text)
   const [searchTerms, setSearchTerms] = useState(query.text)
+  useEffect(() => {
+    if (!queryTextUnchanged) {
+      latestQueryText.current = query.text
+      setSearchTerms(query.text)
+    }
+  }, [query, setSearchTerms, queryTextUnchanged])
+
   const [showAdvancedSearch, setShowAdvancedSearch] = useState(false)
   const placeholder = query.objectType
     ? "Filter " + SEARCH_OBJECT_LABELS[query.objectType]


### PR DESCRIPTION
This makes sure that when using the navigation menu or the ANET logo the
search terms in the search bar are being reset.

Fixes #2313