### PR TITLE
Ignore coverage changes less than .1%

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,2 @@
+coverage:
+  precision: 1


### PR DESCRIPTION
Usually just meaningless rounding errors, not significant coverage changes.