### PR TITLE
Add some extra fields to the Excel export for tasks/effort

### DIFF
--- a/client/src/exportUtils.js
+++ b/client/src/exportUtils.js
@@ -91,6 +91,16 @@ const GQL_GET_TASK_LIST = gql`
         uuid
         shortName
         longName
+        status
+        responsibleOrg {
+          uuid
+          shortName
+        }
+        customFieldEnum1
+        customFieldRef1 {
+          uuid
+          shortName
+        }
       }
     }
   }


### PR DESCRIPTION
Closes NCI-Agency/anet#2312

### User changes
- Excel exports of the search results for tasks/effort now also include the `status`, `responsibleOrg`, `customFieldEnum1` and `customFieldRef1` fields