### PR TITLE
Reset total count while search is running

### DIFF
--- a/client/src/components/ReportCalendar.js
+++ b/client/src/components/ReportCalendar.js
@@ -71,6 +71,10 @@ const ReportCalendar = props => {
       return apiPromise.current
     }
     prevReportQuery.current = reportQuery
+    if (setTotalCount) {
+      // Reset the total count
+      setTotalCount(null)
+    }
     // Store API promise to use in optimised case
     apiPromise.current = API.query(GQL_GET_REPORT_LIST, {
       reportQuery

--- a/client/src/components/ReportMap.js
+++ b/client/src/components/ReportMap.js
@@ -67,6 +67,10 @@ const ReportMap = props => {
     return markerArray
   }, [data])
   if (done) {
+    if (setTotalCount) {
+      // Reset the total count
+      setTotalCount(null)
+    }
     return result
   }
 

--- a/client/src/components/ReportSummary.js
+++ b/client/src/components/ReportSummary.js
@@ -143,6 +143,10 @@ const ReportSummary = props => {
     ...props
   })
   if (done) {
+    if (setTotalCount) {
+      // Reset the total count
+      setTotalCount(null)
+    }
     return result
   }
 

--- a/client/src/components/ReportTable.js
+++ b/client/src/components/ReportTable.js
@@ -140,6 +140,10 @@ const ReportTable = props => {
     ...props
   })
   if (done) {
+    if (setTotalCount) {
+      // Reset the total count
+      setTotalCount(null)
+    }
     return result
   }
 

--- a/client/src/pages/Search.js
+++ b/client/src/pages/Search.js
@@ -206,6 +206,8 @@ const Organizations = props => {
     ...props
   })
   if (done) {
+    // Reset the total count
+    setTotalCount(null)
     return result
   }
 
@@ -303,6 +305,8 @@ const People = props => {
     ...props
   })
   if (done) {
+    // Reset the total count
+    setTotalCount(null)
     return result
   }
 
@@ -413,6 +417,8 @@ const Positions = props => {
     ...props
   })
   if (done) {
+    // Reset the total count
+    setTotalCount(null)
     return result
   }
 
@@ -478,6 +484,8 @@ const Tasks = props => {
     ...props
   })
   if (done) {
+    // Reset the total count
+    setTotalCount(null)
     return result
   }
 
@@ -570,6 +578,8 @@ const Locations = props => {
     ...props
   })
   if (done) {
+    // Reset the total count
+    setTotalCount(null)
     return result
   }
 


### PR DESCRIPTION
### User changes
- Regular users will see search result count being reset while search results are pending.