### PR TITLE
Add several simulator improvements

### DIFF
--- a/client/tests/sim/Simulator.js
+++ b/client/tests/sim/Simulator.js
@@ -2,7 +2,7 @@ import Aigle from "aigle"
 import colors from "colors"
 import faker from "faker"
 import scenarioMapping from "./scenarios/scenarios"
-import { fuzzy, normalCDF, normalPPF } from "./simutils"
+import { fuzzy, normalCDF, normalPPF, sleep } from "./simutils"
 
 const DEFAULT_SCENARIO_NAME = "default"
 const DEFAULT_CYCLES = 3
@@ -95,6 +95,7 @@ async function runBuildup(scenario) {
       const user = await userType.userFunction()
       const grow = () => 100 // Probability = 100 (always execute)
 
+      await sleep(buildup.preDelay)
       for (var i = 0; i < buildup.number; i++) {
         await buildup.runnable(user, grow, buildup.arguments)
       }

--- a/client/tests/sim/scenarios/buildup/lotsOfData.js
+++ b/client/tests/sim/scenarios/buildup/lotsOfData.js
@@ -1,13 +1,24 @@
 import { Person, Organization, Report } from "models"
+import { createLocation } from "../../stories/LocationStories"
+import { createNote } from "../../stories/NoteStories"
 import { createHierarchy } from "../../stories/OrganizationStories"
 import { createPerson } from "../../stories/PersonStories"
 import { createReport } from "../../stories/ReportStories"
 
 const buildupLotsOfData = [
   {
+    name: "Create location",
+    number: 500,
+    runnable: createLocation,
+    preDelay: 0,
+    userTypes: ["existingAdmin"],
+    arguments: {}
+  },
+  {
     name: "Create active advisor",
     number: 2000,
     runnable: createPerson,
+    preDelay: 0,
     userTypes: ["existingAdmin"],
     arguments: { role: Person.ROLE.ADVISOR, status: Person.STATUS.ACTIVE }
   },
@@ -15,6 +26,7 @@ const buildupLotsOfData = [
     name: "Create inactive advisor",
     number: 10000,
     runnable: createPerson,
+    preDelay: 0,
     userTypes: ["existingAdmin"],
     arguments: { role: Person.ROLE.ADVISOR, status: Person.STATUS.INACTIVE }
   },
@@ -22,6 +34,7 @@ const buildupLotsOfData = [
     name: "Create active principal",
     number: 10000,
     runnable: createPerson,
+    preDelay: 0,
     userTypes: ["existingAdmin"],
     arguments: { role: Person.ROLE.PRINCIPAL, status: Person.STATUS.ACTIVE }
   },
@@ -29,6 +42,7 @@ const buildupLotsOfData = [
     name: "Create inactive principal",
     number: 10000,
     runnable: createPerson,
+    preDelay: 0,
     userTypes: ["existingAdmin"],
     arguments: { role: Person.ROLE.PRINCIPAL, status: Person.STATUS.INACTIVE }
   },
@@ -36,6 +50,7 @@ const buildupLotsOfData = [
     name: "Create advisor organization",
     number: 200,
     runnable: createHierarchy,
+    preDelay: 0,
     userTypes: ["existingAdmin"],
     arguments: {
       type: Organization.TYPE.ADVISOR_ORG,
@@ -47,6 +62,7 @@ const buildupLotsOfData = [
     name: "Create principal organization",
     number: 1000,
     runnable: createHierarchy,
+    preDelay: 0,
     userTypes: ["existingAdmin"],
     arguments: {
       type: Organization.TYPE.PRINCIPAL_ORG,
@@ -58,6 +74,7 @@ const buildupLotsOfData = [
     name: "Create published report #1",
     number: 25000,
     runnable: createReport,
+    preDelay: 120,
     userTypes: ["existingAdmin"],
     arguments: { state: Report.STATE.PUBLISHED }
   },
@@ -65,6 +82,7 @@ const buildupLotsOfData = [
     name: "Create published report #2",
     number: 25000,
     runnable: createReport,
+    preDelay: 120,
     userTypes: ["existingAdmin"],
     arguments: { state: Report.STATE.PUBLISHED }
   },
@@ -72,6 +90,7 @@ const buildupLotsOfData = [
     name: "Create published report #3",
     number: 25000,
     runnable: createReport,
+    preDelay: 120,
     userTypes: ["existingAdmin"],
     arguments: { state: Report.STATE.PUBLISHED }
   },
@@ -79,6 +98,7 @@ const buildupLotsOfData = [
     name: "Create published report #4",
     number: 25000,
     runnable: createReport,
+    preDelay: 120,
     userTypes: ["existingAdmin"],
     arguments: { state: Report.STATE.PUBLISHED }
   },
@@ -86,6 +106,7 @@ const buildupLotsOfData = [
     name: "Create published report #5",
     number: 25000,
     runnable: createReport,
+    preDelay: 120,
     userTypes: ["existingAdmin"],
     arguments: { state: Report.STATE.PUBLISHED }
   },
@@ -93,6 +114,7 @@ const buildupLotsOfData = [
     name: "Create published report #6",
     number: 25000,
     runnable: createReport,
+    preDelay: 120,
     userTypes: ["existingAdmin"],
     arguments: { state: Report.STATE.PUBLISHED }
   },
@@ -100,6 +122,7 @@ const buildupLotsOfData = [
     name: "Create published report #7",
     number: 25000,
     runnable: createReport,
+    preDelay: 120,
     userTypes: ["existingAdmin"],
     arguments: { state: Report.STATE.PUBLISHED }
   },
@@ -107,8 +130,121 @@ const buildupLotsOfData = [
     name: "Create published report #8",
     number: 25000,
     runnable: createReport,
+    preDelay: 120,
     userTypes: ["existingAdmin"],
     arguments: { state: Report.STATE.PUBLISHED }
+  },
+  {
+    name: "Create authorizationGroup note",
+    number: 25,
+    runnable: createNote,
+    preDelay: 60,
+    userTypes: ["existingAdmin"],
+    arguments: { relatedObjectType: "authorizationGroups" }
+  },
+  {
+    name: "Create location note",
+    number: 1000,
+    runnable: createNote,
+    preDelay: 60,
+    userTypes: ["existingAdmin"],
+    arguments: { relatedObjectType: "locations" }
+  },
+  {
+    name: "Create organization note",
+    number: 1500,
+    runnable: createNote,
+    preDelay: 60,
+    userTypes: ["existingAdmin"],
+    arguments: { relatedObjectType: "organizations" }
+  },
+  {
+    name: "Create person note",
+    number: 1000,
+    runnable: createNote,
+    preDelay: 60,
+    userTypes: ["existingAdmin"],
+    arguments: { relatedObjectType: "people" }
+  },
+  {
+    name: "Create position note",
+    number: 100,
+    runnable: createNote,
+    preDelay: 60,
+    userTypes: ["existingAdmin"],
+    arguments: { relatedObjectType: "positions" }
+  },
+  {
+    name: "Create task note",
+    number: 100,
+    runnable: createNote,
+    preDelay: 60,
+    userTypes: ["existingAdmin"],
+    arguments: { relatedObjectType: "tasks" }
+  },
+  {
+    name: "Create report note #1",
+    number: 1000,
+    runnable: createNote,
+    preDelay: 600,
+    userTypes: ["existingAdmin"],
+    arguments: { relatedObjectType: "reports" }
+  },
+  {
+    name: "Create report note #2",
+    number: 1000,
+    runnable: createNote,
+    preDelay: 600,
+    userTypes: ["existingAdmin"],
+    arguments: { relatedObjectType: "reports" }
+  },
+  {
+    name: "Create report note #3",
+    number: 1000,
+    runnable: createNote,
+    preDelay: 600,
+    userTypes: ["existingAdmin"],
+    arguments: { relatedObjectType: "reports" }
+  },
+  {
+    name: "Create report note #4",
+    number: 1000,
+    runnable: createNote,
+    preDelay: 600,
+    userTypes: ["existingAdmin"],
+    arguments: { relatedObjectType: "reports" }
+  },
+  {
+    name: "Create report note #5",
+    number: 1000,
+    runnable: createNote,
+    preDelay: 600,
+    userTypes: ["existingAdmin"],
+    arguments: { relatedObjectType: "reports" }
+  },
+  {
+    name: "Create report note #6",
+    number: 1000,
+    runnable: createNote,
+    preDelay: 600,
+    userTypes: ["existingAdmin"],
+    arguments: { relatedObjectType: "reports" }
+  },
+  {
+    name: "Create report note #7",
+    number: 1000,
+    runnable: createNote,
+    preDelay: 600,
+    userTypes: ["existingAdmin"],
+    arguments: { relatedObjectType: "reports" }
+  },
+  {
+    name: "Create report note #8",
+    number: 1000,
+    runnable: createNote,
+    preDelay: 600,
+    userTypes: ["existingAdmin"],
+    arguments: { relatedObjectType: "reports" }
   }
 ]
 

--- a/client/tests/sim/simutils.js
+++ b/client/tests/sim/simutils.js
@@ -1,5 +1,9 @@
 import fetch from "cross-fetch"
 
+export const sleep = seconds => {
+  return new Promise(resolve => setTimeout(resolve, (seconds || 0) * 1000))
+}
+
 async function runGQL(user, query) {
   const result = await fetch(
     `${process.env.SERVER_URL}/graphql?user=${user.name}&pass=${user.password}`,

--- a/client/tests/sim/stories/LocationStories.js
+++ b/client/tests/sim/stories/LocationStories.js
@@ -1,0 +1,39 @@
+import faker from "faker"
+import { Location } from "models"
+import { populate, runGQL } from "../simutils"
+
+async function populateLocation(location, user) {
+  const template = {
+    status: () => Location.STATUS.ACTIVE,
+    name: () => faker.address.city(),
+    lat: () => faker.address.latitude(38.4862816432, 29.318572496, 10),
+    lng: () => faker.address.longitude(75.1580277851, 60.5284298033, 10)
+  }
+  populate(location, template)
+    .status.always()
+    .name.always()
+    .lat.always()
+    .lng.always()
+  return location
+}
+
+const _createLocation = async function(user) {
+  const location = new Location()
+  if (await populateLocation(location, user)) {
+    console.debug(`Creating location ${location.name}`)
+
+    return (
+      await runGQL(user, {
+        query:
+          "mutation($location: LocationInput!) { createLocation(location: $location) { uuid } }",
+        variables: { location }
+      })
+    ).data.createLocation
+  }
+}
+
+const createLocation = async function(user, grow, args, delay) {
+  return _createLocation(user)
+}
+
+export { createLocation }

--- a/client/tests/sim/stories/NoteStories.js
+++ b/client/tests/sim/stories/NoteStories.js
@@ -1,0 +1,115 @@
+import { NOTE_TYPE } from "components/Model"
+import faker from "faker"
+import _isEmpty from "lodash/isEmpty"
+import { Person } from "models"
+import { populate, runGQL } from "../simutils"
+
+function getListEndpoint(type) {
+  switch (type) {
+    case "authorizationGroups":
+      return ["authorizationGroupList", "AuthorizationGroupSearchQueryInput"]
+    case "locations":
+      return ["locationList", "LocationSearchQueryInput"]
+    case "organizations":
+      return ["organizationList", "OrganizationSearchQueryInput"]
+    case "people":
+      return ["personList", "PersonSearchQueryInput"]
+    case "positions":
+      return ["positionList", "PositionSearchQueryInput"]
+    case "reports":
+      return ["reportList", "ReportSearchQueryInput"]
+    case "tasks":
+      return ["taskList", "TaskSearchQueryInput"]
+    default:
+      return null
+  }
+}
+
+async function getRandomObject(user, type, variables) {
+  const [listEndpoint, queryType] = getListEndpoint(type)
+  const objectQuery = Object.assign({}, variables, {
+    pageNum: 0,
+    pageSize: 1
+  })
+  const totalCount = (
+    await runGQL(user, {
+      query: `
+      query ($objectQuery: ${queryType}) {
+        ${listEndpoint}(query: $objectQuery) {
+          totalCount
+        }
+      }
+    `,
+      variables: {
+        objectQuery
+      }
+    })
+  ).data[listEndpoint].totalCount
+  if (totalCount === 0) {
+    return null
+  }
+  objectQuery.pageNum = faker.random.number({ max: totalCount - 1 })
+  const list = (
+    await runGQL(user, {
+      query: `
+      query ($objectQuery: ${queryType}) {
+        ${listEndpoint}(query: $objectQuery) {
+          list {
+            uuid
+          }
+        }
+      }
+    `,
+      variables: {
+        objectQuery
+      }
+    })
+  ).data[listEndpoint].list
+  return _isEmpty(list) ? null : list[0]
+}
+
+async function populateNote(note, user, relatedObjectType) {
+  const obj = await getRandomObject(user, relatedObjectType)
+  const relatedObject =
+    obj && obj.uuid ? { relatedObjectType, relatedObjectUuid: obj.uuid } : null
+  const author = await getRandomObject(user, "people", {
+    role: Person.ROLE.ADVISOR
+  })
+  const template = {
+    author: () => author,
+    type: () => NOTE_TYPE.FREE_TEXT,
+    noteRelatedObjects: () => [relatedObject],
+    text: () => faker.lorem.paragraphs()
+  }
+  populate(note, template)
+    .author.always()
+    .type.always()
+    .noteRelatedObjects.always()
+    .text.always()
+  return note
+}
+
+const _createNote = async function(user, relatedObjectType) {
+  const note = {}
+  if (await populateNote(note, user, relatedObjectType)) {
+    console.debug(
+      `Creating ${
+        NOTE_TYPE.FREE_TEXT.toLowerCase().green
+      } ${relatedObjectType} note`
+    )
+
+    return (
+      await runGQL(user, {
+        query:
+          "mutation($note: NoteInput!) { createNote(note: $note) { uuid } }",
+        variables: { note }
+      })
+    ).data.createNote
+  }
+}
+
+const createNote = async function(user, grow, args) {
+  return _createNote(user, args && args.relatedObjectType)
+}
+
+export { createNote }


### PR DESCRIPTION
- Add a buildup task to generate locations.
- Add a buildup task to generate notes.
- Add a `preDelay` so buildup tasks can start after other tasks have already been started (e.g. to only start generating report notes after at least several reports have been generated).
- Only require report primary attendees (advisor & principal) to have an active position; other attendees can be random people.