### PR TITLE
Fix prevent create loop in tasks hierarchy

### DIFF
--- a/src/main/java/mil/dds/anet/search/AbstractTaskSearcher.java
+++ b/src/main/java/mil/dds/anet/search/AbstractTaskSearcher.java
@@ -76,9 +76,8 @@ public abstract class AbstractTaskSearcher extends AbstractSearcher<Task, TaskSe
 
   protected void addCustomFieldRef1UuidQuery(TaskSearchQuery query) {
     if (query.getCustomFieldRef1Recursively()) {
-      qb.addRecursiveClause(null, "tasks", "\"customFieldRef1Uuid\"", "parent_tasks",
-          "organizations", "\"parentOrgUuid\"", "customFieldRef1Uuid",
-          query.getCustomFieldRef1Uuid());
+      qb.addRecursiveClause(null, "tasks", "\"customFieldRef1Uuid\"", "parent_tasks", "tasks",
+          "\"customFieldRef1Uuid\"", "customFieldRef1Uuid", query.getCustomFieldRef1Uuid());
     } else {
       qb.addEqualsClause("customFieldRef1Uuid", "tasks.\"customFieldRef1Uuid\"",
           query.getCustomFieldRef1Uuid());


### PR DESCRIPTION
The code trying to do that was not working because of a wrong copy/paste action.

### User changes
- When the user is trying to save a task with a parent which would introduce a loop in the hierarchy of tasks, he/she will get the error message "Task can not be its own (grand…)parent"
