### PR TITLE
Remove synthetic Report::user field

### DIFF
--- a/src/main/java/mil/dds/anet/beans/Report.java
+++ b/src/main/java/mil/dds/anet/beans/Report.java
@@ -72,8 +72,6 @@ public class Report extends AbstractAnetBean {
   List<Comment> comments;
   private List<Tag> tags;
   private ReportSensitiveInformation reportSensitiveInformation;
-  // The user who instantiated this; needed to determine access to sensitive information
-  private Person user;
   private List<AuthorizationGroup> authorizationGroups;
   private List<ReportAction> workflow;
 
@@ -619,7 +617,7 @@ public class Report extends AbstractAnetBean {
       return CompletableFuture.completedFuture(reportSensitiveInformation);
     }
     return AnetObjectEngine.getInstance().getReportSensitiveInformationDao()
-        .getForReport(context, this, user).thenApply(o -> {
+        .getForReport(context, this, DaoUtils.getUserFromContext(context)).thenApply(o -> {
           reportSensitiveInformation = o;
           return o;
         });
@@ -632,18 +630,6 @@ public class Report extends AbstractAnetBean {
 
   public void setReportSensitiveInformation(ReportSensitiveInformation reportSensitiveInformation) {
     this.reportSensitiveInformation = reportSensitiveInformation;
-  }
-
-  @JsonIgnore
-  @GraphQLIgnore
-  public Person getUser() {
-    return user;
-  }
-
-  @JsonIgnore
-  @GraphQLIgnore
-  public void setUser(Person user) {
-    this.user = user;
   }
 
   // TODO: batch load? (used in reports/{Edit,Show}.js)

--- a/src/main/java/mil/dds/anet/database/ReportDao.java
+++ b/src/main/java/mil/dds/anet/database/ReportDao.java
@@ -188,15 +188,10 @@ public class ReportDao extends AnetBaseDao<Report, ReportSearchQuery> {
       keyField = "uuid";
       key = uuid;
     }
-    final Report result = getDbHandle()
+    return getDbHandle()
         .createQuery("/* " + queryDescriptor + " */ SELECT " + REPORT_FIELDS + "FROM reports "
             + "WHERE reports.\"" + keyField + "\" = :key")
         .bind("key", key).map(new ReportMapper()).findFirst().orElse(null);
-    if (result == null) {
-      return null;
-    }
-    result.setUser(user);
-    return result;
   }
 
   @InTransaction

--- a/src/main/java/mil/dds/anet/resources/ReportResource.java
+++ b/src/main/java/mil/dds/anet/resources/ReportResource.java
@@ -144,8 +144,6 @@ public class ReportResource {
     r.setReportText(
         Utils.isEmptyHtml(r.getReportText()) ? null : Utils.sanitizeHtml(r.getReportText()));
 
-    // Needed for sensitive information, e.g. when autoSaving a new report
-    r.setUser(author);
     r = dao.insert(r, author);
     AnetAuditLogger.log("Report {} created by author {} ", r, author);
     return r;
@@ -352,7 +350,6 @@ public class ReportResource {
 
     // Clear and re-load sensitive information; needed in case of autoSave by the client form, or
     // when sensitive info is 'empty' HTML
-    r.setUser(editor);
     try {
       r.setReportSensitiveInformation(null);
       r.loadReportSensitiveInformation(engine.getContext()).get();

--- a/src/main/java/mil/dds/anet/search/AbstractReportSearcher.java
+++ b/src/main/java/mil/dds/anet/search/AbstractReportSearcher.java
@@ -42,12 +42,7 @@ public abstract class AbstractReportSearcher extends AbstractSearcher<Report, Re
     outerQb.addSqlArgs(qb.getSqlArgs());
     outerQb.addListArgs(qb.getListArgs());
     addOrderByClauses(outerQb, query);
-    final AnetBeanList<Report> result =
-        outerQb.buildAndRun(getDbHandle(), query, new ReportMapper());
-    for (final Report report : result.getList()) {
-      report.setUser(query.getUser());
-    }
-    return result;
+    return outerQb.buildAndRun(getDbHandle(), query, new ReportMapper());
   }
 
   protected void buildQuery(ReportSearchQuery query) {

--- a/src/test/java/mil/dds/anet/test/resources/ReportsResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/ReportsResourceTest.java
@@ -1441,7 +1441,6 @@ public class ReportsResourceTest extends AbstractResourceTest {
     final Report returned2 = graphQLHelper.getObjectById(elizabeth, "report", rsiFields,
         returned.getUuid(), new TypeReference<GraphQlResponse<Report>>() {});
     // elizabeth should be allowed to see it
-    returned2.setUser(elizabeth);
     assertThat(returned2.getReportSensitiveInformation()).isNotNull();
     assertThat(returned2.getReportSensitiveInformation().getText())
         .isEqualTo(UtilsTest.getCombinedTestCase().getOutput());
@@ -1460,7 +1459,6 @@ public class ReportsResourceTest extends AbstractResourceTest {
     final Report returned3 = graphQLHelper.getObjectById(jack, "report", rsiFields,
         returned.getUuid(), new TypeReference<GraphQlResponse<Report>>() {});
     // jack should not be allowed to see it
-    returned3.setUser(jack);
     assertThat(returned3.getReportSensitiveInformation()).isNull();
   }
 
@@ -1490,7 +1488,6 @@ public class ReportsResourceTest extends AbstractResourceTest {
         .filter(r -> reportQuery.getText().equals(r.getKeyOutcomes())).findFirst();
     assertThat(reportResult).isNotEmpty();
     final Report report = reportResult.get();
-    report.setUser(erin);
     // erin is the author, so should be able to see the sensitive information
     assertThat(report.getReportSensitiveInformation()).isNotNull();
     assertThat(report.getReportSensitiveInformation().getText()).isEqualTo("Need to know only");
@@ -1515,7 +1512,6 @@ public class ReportsResourceTest extends AbstractResourceTest {
         .filter(r -> reportQuery.getText().equals(r.getKeyOutcomes())).findFirst();
     assertThat(reportResult2).isNotEmpty();
     final Report report2 = reportResult2.get();
-    report2.setUser(reina);
     // reina is in the authorization group, so should be able to see the sensitive information
     assertThat(report2.getReportSensitiveInformation()).isNotNull();
     assertThat(report2.getReportSensitiveInformation().getText()).isEqualTo("Need to know only");
@@ -1540,7 +1536,6 @@ public class ReportsResourceTest extends AbstractResourceTest {
         .filter(r -> reportQuery.getText().equals(r.getKeyOutcomes())).findFirst();
     assertThat(reportResult3).isNotEmpty();
     final Report report3 = reportResult3.get();
-    report3.setUser(elizabeth);
     // elizabeth is not in the authorization group, so should not be able to see the sensitive
     // information
     assertThat(report3.getReportSensitiveInformation()).isNull();


### PR DESCRIPTION
It is obsolete since we can get the user from the context.