### PR TITLE
Introduce widget for hierarchical tasks selection

### DIFF
--- a/client/src/components/TaskTable.js
+++ b/client/src/components/TaskTable.js
@@ -12,7 +12,7 @@ const TaskTable = props => {
   const tasksExist = _get(tasks, "length", 0) > 0
 
   return (
-    <div>
+    <div id={props.id}>
       {tasksExist ? (
         <div>
           <Table striped condensed hover responsive className="tasks_table">
@@ -69,6 +69,7 @@ const TaskTable = props => {
 }
 
 TaskTable.propTypes = {
+  id: PropTypes.string,
   tasks: PropTypes.array,
   showDelete: PropTypes.bool,
   onDelete: PropTypes.func,

--- a/client/src/models/Report.js
+++ b/client/src/models/Report.js
@@ -166,6 +166,11 @@ export default class Report extends Model {
         .object()
         .nullable()
         .default({}),
+      // not actually in the database, but used for validation:
+      tasksLevel1: yup
+        .array()
+        .nullable()
+        .default([]),
       tasks: yup
         .array()
         .nullable()

--- a/client/src/pages/reports/Form.js
+++ b/client/src/pages/reports/Form.js
@@ -654,6 +654,7 @@ const BaseReportForm = props => {
                   value={values.tasksLevel1}
                   renderSelected={
                     <TaskTable
+                      id="tasks-objectives"
                       tasks={values.tasksLevel1}
                       showDelete
                       showOrganization
@@ -681,6 +682,7 @@ const BaseReportForm = props => {
                   value={values.tasks}
                   renderSelected={
                     <TaskTable
+                      id="tasks-tasks"
                       tasks={values.tasks}
                       showDelete
                       showOrganization

--- a/client/src/pages/reports/Form.js
+++ b/client/src/pages/reports/Form.js
@@ -670,11 +670,6 @@ const BaseReportForm = props => {
                   queryParams={{ status: Task.STATUS.ACTIVE }}
                   fields={Task.autocompleteQuery}
                   addon={TASKS_ICON}
-                  shortcutsTitle={`Recent ${pluralize(
-                    Settings.fields.task.shortLabel
-                  )}`}
-                  shortcuts={recents.tasks}
-                  renderExtraCol
                 />
 
                 <AdvancedMultiSelect

--- a/client/src/pages/reports/Form.js
+++ b/client/src/pages/reports/Form.js
@@ -316,17 +316,39 @@ const BaseReportForm = props => {
           }
         }
 
-        const tasksFilters = {
+        const tasksFiltersLevel1 = {
           allTasks: {
-            label: "All tasks",
-            queryVars: {}
+            label: "All objectives",
+            queryVars: { hasCustomFieldRef1: false }
+          }
+        }
+        const tasksFiltersLevel2 = {
+          allTasks: {
+            label: "All efforts",
+            queryVars: { hasCustomFieldRef1: true }
           }
         }
         if (currentOrgUuid) {
-          tasksFilters.assignedToMyOrg = {
+          tasksFiltersLevel1.assignedToMyOrg = {
             label: "Assigned to my organization",
             queryVars: {
-              responsibleOrgUuid: currentOrgUuid
+              responsibleOrgUuid: currentOrgUuid,
+              hasCustomFieldRef1: false
+            }
+          }
+          tasksFiltersLevel2.assignedToMyOrg = {
+            label: "Assigned to my organization",
+            queryVars: {
+              responsibleOrgUuid: currentOrgUuid,
+              hasCustomFieldRef1: true
+            }
+          }
+        }
+        if (values.tasksLevel1.length) {
+          tasksFiltersLevel2.forSelectedObjectives = {
+            label: "For selected objectives",
+            queryVars: {
+              customFieldRef1Uuid: values.tasksLevel1[0].uuid
             }
           }
         }
@@ -341,14 +363,21 @@ const BaseReportForm = props => {
           primaryAdvisor.position &&
           primaryAdvisor.position.organization
         ) {
-          tasksFilters.assignedToReportOrg = {
+          tasksFiltersLevel1.assignedToReportOrg = {
             label: "Assigned to organization of report",
             queryVars: {
-              responsibleOrgUuid: primaryAdvisor.position.organization.uuid
+              responsibleOrgUuid: primaryAdvisor.position.organization.uuid,
+              hasCustomFieldRef1: false
+            }
+          }
+          tasksFiltersLevel2.assignedToReportOrg = {
+            label: "Assigned to organization of report",
+            queryVars: {
+              responsibleOrgUuid: primaryAdvisor.position.organization.uuid,
+              hasCustomFieldRef1: true
             }
           }
         }
-
         const authorizationGroupsFilters = {
           allAuthorizationGroups: {
             label: "All authorization groups",
@@ -619,6 +648,36 @@ const BaseReportForm = props => {
                 className="tasks-selector"
               >
                 <AdvancedMultiSelect
+                  fieldName="tasksLevel1"
+                  fieldLabel="Objectives"
+                  placeholder="Search for objectives"
+                  value={values.tasksLevel1}
+                  renderSelected={
+                    <TaskTable
+                      tasks={values.tasksLevel1}
+                      showDelete
+                      showOrganization
+                    />
+                  }
+                  overlayColumns={["Name", "Organization"]}
+                  overlayRenderRow={TaskDetailedOverlayRow}
+                  filterDefs={tasksFiltersLevel1}
+                  onChange={value => {
+                    setFieldValue("tasksLevel1", value)
+                    setFieldTouched("tasksLevel1", true)
+                  }}
+                  objectType={Task}
+                  queryParams={{ status: Task.STATUS.ACTIVE }}
+                  fields={Task.autocompleteQuery}
+                  addon={TASKS_ICON}
+                  shortcutsTitle={`Recent ${pluralize(
+                    Settings.fields.task.shortLabel
+                  )}`}
+                  shortcuts={recents.tasks}
+                  renderExtraCol
+                />
+
+                <AdvancedMultiSelect
                   fieldName="tasks"
                   fieldLabel={Settings.fields.task.shortLabel}
                   placeholder={`Search for ${pluralize(
@@ -634,7 +693,7 @@ const BaseReportForm = props => {
                   }
                   overlayColumns={["Name", "Organization"]}
                   overlayRenderRow={TaskDetailedOverlayRow}
-                  filterDefs={tasksFilters}
+                  filterDefs={tasksFiltersLevel2}
                   onChange={value => {
                     setFieldValue("tasks", value)
                     setFieldTouched("tasks", true)
@@ -975,7 +1034,8 @@ const BaseReportForm = props => {
       "cancelled",
       "reportTags",
       "showSensitiveInfo",
-      "attendees"
+      "attendees",
+      "tasksLevel1"
     )
     if (Report.isFuture(values.engagementDate)) {
       // Empty fields which should not be set for future reports.

--- a/client/src/pages/reports/Form.js
+++ b/client/src/pages/reports/Form.js
@@ -323,6 +323,14 @@ const BaseReportForm = props => {
           }
         }
         const tasksFiltersLevel2 = {
+          forSelectedObjectives: {
+            label: "For selected objectives",
+            queryVars: {
+              customFieldRef1Uuid: values.tasksLevel1.length
+                ? values.tasksLevel1.map(t => t.uuid)
+                : [""]
+            }
+          },
           allTasks: {
             label: "All efforts",
             queryVars: { hasCustomFieldRef1: true }
@@ -341,14 +349,6 @@ const BaseReportForm = props => {
             queryVars: {
               responsibleOrgUuid: currentOrgUuid,
               hasCustomFieldRef1: true
-            }
-          }
-        }
-        if (values.tasksLevel1.length) {
-          tasksFiltersLevel2.forSelectedObjectives = {
-            label: "For selected objectives",
-            queryVars: {
-              customFieldRef1Uuid: values.tasksLevel1[0].uuid
             }
           }
         }

--- a/client/tests/e2e/report.js
+++ b/client/tests/e2e/report.js
@@ -6,7 +6,7 @@ let test = require("../util/test")
 var testReportURL = null
 
 test("Draft and submit a report", async t => {
-  t.plan(14)
+  t.plan(16)
 
   let {
     pageHelpers,
@@ -78,9 +78,28 @@ test("Draft and submit a report", async t => {
   )
   await assertElementText(t, $principalOrg, "MoD")
 
+  let $objectivesAdvancedSelect = await pageHelpers.chooseAdvancedSelectOption(
+    "#tasksLevel1",
+    "budget and planning"
+  )
+
+  let $tasksTitle = await t.context.driver.findElement(
+    By.xpath('//h2/span[text()="Tasks and Milestones"]')
+  )
+  await $tasksTitle.click()
+
+  t.is(
+    await $objectivesAdvancedSelect.getAttribute("value"),
+    "",
+    "Closing the objectives advanced multi select overlay empties the input field."
+  )
+
+  let $newObjectivesRow = await $("#tasks-objectives table tbody tr td")
+  await assertElementText(t, $newObjectivesRow, "EF 1 - Budget and Planning")
+
   let $tasksAdvancedSelect = await pageHelpers.chooseAdvancedSelectOption(
     "#tasks",
-    "1.1.B"
+    "1.1"
   )
 
   let $tasksShortcutTitle = await $("#tasks-shortcut-title")
@@ -92,12 +111,8 @@ test("Draft and submit a report", async t => {
     "Closing the tasks advanced multi select overlay empties the input field."
   )
 
-  let $newTaskRow = await $(".tasks-selector table tbody tr td")
-  await assertElementText(
-    t,
-    $newTaskRow,
-    "1.1.B - Milestone the Second in EF 1.1"
-  )
+  let $newTaskRow = await $("#tasks-tasks table tbody tr td")
+  await assertElementText(t, $newTaskRow, "1.1 - Budgeting in the MoD")
 
   await pageHelpers.writeInForm("#keyOutcomes", "key outcomes")
   await pageHelpers.writeInForm("#nextSteps", "next steps")

--- a/src/main/java/mil/dds/anet/AnetObjectEngine.java
+++ b/src/main/java/mil/dds/anet/AnetObjectEngine.java
@@ -2,6 +2,7 @@ package mil.dds.anet;
 
 import com.google.inject.Injector;
 import io.dropwizard.Application;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -275,7 +276,7 @@ public class AnetObjectEngine {
    */
   public Map<String, Task> buildTopLevelTaskHash(String parentTaskUuid) {
     final TaskSearchQuery query = new TaskSearchQuery();
-    query.setCustomFieldRef1Uuid(parentTaskUuid);
+    query.setCustomFieldRef1Uuid(Collections.singletonList(parentTaskUuid));
     query.setCustomFieldRef1Recursively(true);
     query.setPageSize(0);
     final List<Task> taskList = AnetObjectEngine.getInstance().getTaskDao().search(query).getList();

--- a/src/main/java/mil/dds/anet/beans/search/TaskSearchQuery.java
+++ b/src/main/java/mil/dds/anet/beans/search/TaskSearchQuery.java
@@ -1,6 +1,7 @@
 package mil.dds.anet.beans.search;
 
 import java.time.Instant;
+import java.util.List;
 import java.util.Objects;
 import mil.dds.anet.beans.Task.TaskStatus;
 
@@ -20,11 +21,11 @@ public class TaskSearchQuery extends AbstractSearchQuery<TaskSearchSortBy> {
   // Find tasks who (don't) have the customFieldRef1 filled in
   Boolean hasCustomFieldRef1;
 
-  // Search for tasks with a specific parent Task.
-  private String customFieldRef1Uuid;
-  // Include descendants recursively from the specified parent.
-  // If true will include all tasks in the tree of the parent Task
-  // Including the parent Task.
+  // Search for tasks with one of the given parent Task(s)
+  private List<String> customFieldRef1Uuid;
+  // Include descendants recursively from the specified parent(s).
+  // If true will include all tasks in the tree of the parent Task(s)
+  // Including the parent Task(s).
   private Boolean customFieldRef1Recursively;
 
   public TaskSearchQuery() {
@@ -119,11 +120,11 @@ public class TaskSearchQuery extends AbstractSearchQuery<TaskSearchSortBy> {
     this.hasCustomFieldRef1 = hasCustomFieldRef1;
   }
 
-  public String getCustomFieldRef1Uuid() {
+  public List<String> getCustomFieldRef1Uuid() {
     return customFieldRef1Uuid;
   }
 
-  public void setCustomFieldRef1Uuid(String customFieldRef1Uuid) {
+  public void setCustomFieldRef1Uuid(List<String> customFieldRef1Uuid) {
     this.customFieldRef1Uuid = customFieldRef1Uuid;
   }
 

--- a/src/main/java/mil/dds/anet/beans/search/TaskSearchQuery.java
+++ b/src/main/java/mil/dds/anet/beans/search/TaskSearchQuery.java
@@ -17,6 +17,9 @@ public class TaskSearchQuery extends AbstractSearchQuery<TaskSearchSortBy> {
   private String projectStatus;
   private String customField;
 
+  // Find tasks who (don't) have the customFieldRef1 filled in
+  Boolean hasCustomFieldRef1;
+
   // Search for tasks with a specific parent Task.
   private String customFieldRef1Uuid;
   // Include descendants recursively from the specified parent.
@@ -106,6 +109,14 @@ public class TaskSearchQuery extends AbstractSearchQuery<TaskSearchSortBy> {
 
   public void setCustomField(String customField) {
     this.customField = customField;
+  }
+
+  public Boolean getHasCustomFieldRef1() {
+    return hasCustomFieldRef1;
+  }
+
+  public void setHasCustomFieldRef1(Boolean hasCustomFieldRef1) {
+    this.hasCustomFieldRef1 = hasCustomFieldRef1;
   }
 
   public String getCustomFieldRef1Uuid() {

--- a/src/main/java/mil/dds/anet/search/AbstractTaskSearcher.java
+++ b/src/main/java/mil/dds/anet/search/AbstractTaskSearcher.java
@@ -87,7 +87,7 @@ public abstract class AbstractTaskSearcher extends AbstractSearcher<Task, TaskSe
       qb.addRecursiveClause(null, "tasks", "\"customFieldRef1Uuid\"", "parent_tasks", "tasks",
           "\"customFieldRef1Uuid\"", "customFieldRef1Uuid", query.getCustomFieldRef1Uuid());
     } else {
-      qb.addEqualsClause("customFieldRef1Uuid", "tasks.\"customFieldRef1Uuid\"",
+      qb.addInListClause("customFieldRef1Uuid", "tasks.\"customFieldRef1Uuid\"",
           query.getCustomFieldRef1Uuid());
     }
   }

--- a/src/main/java/mil/dds/anet/search/AbstractTaskSearcher.java
+++ b/src/main/java/mil/dds/anet/search/AbstractTaskSearcher.java
@@ -51,6 +51,14 @@ public abstract class AbstractTaskSearcher extends AbstractSearcher<Task, TaskSe
         "tasks.\"projectedCompletion\"", Comparison.BEFORE, query.getProjectedCompletionEnd());
     qb.addLikeClause("customField", "tasks.\"customField\"", query.getCustomField());
 
+    if (query.getHasCustomFieldRef1() != null) {
+      if (query.getHasCustomFieldRef1()) {
+        qb.addWhereClause("tasks.\"customFieldRef1Uuid\" IS NOT NULL");
+      } else {
+        qb.addWhereClause("tasks.\"customFieldRef1Uuid\" IS NULL");
+      }
+    }
+
     if (query.getCustomFieldRef1Uuid() != null) {
       addCustomFieldRef1UuidQuery(query);
     }


### PR DESCRIPTION
Tasks will have a 2 levels deep hierarchy (objectives => effort/tasks).
In order to make the selection of tasks easier for the users we have split the task selection in 2 fields: one to select one or more objectives, and one underneath to select effort/tasks.

Fixes #2601 

### User changes
- The reports form now contains two fields for effort/tasks selection: one to select one or more objectives, and one underneath to select one or more effort/tasks.
If the user has selected one or more objectives, the default list on the effort/tasks field would be the items related to the selected objectives.

The user can still select the "All efforts" filter option in order to be able to search through all efforts (note: in this list they would not see objectives).
