### PR TITLE
Add code field to people

### DIFF
--- a/anet.yml
+++ b/anet.yml
@@ -253,6 +253,7 @@ dictionary:
       emailAddress: Email
       phoneNumber: Phone
       country: Nationality
+      code: ID card number
       rank: Rank
       ranks:
         - value: CIV

--- a/client/src/models/Person.js
+++ b/client/src/models/Person.js
@@ -113,6 +113,10 @@ export default class Person extends Model {
         .nullable()
         .default("")
         .label(Settings.fields.person.phoneNumber),
+      code: yup
+        .string()
+        .nullable()
+        .default(""),
       endOfTourDate: yupDate
         .nullable()
         .when(["role", "status"], (role, status, schema) => {

--- a/client/src/pages/App.js
+++ b/client/src/pages/App.js
@@ -30,6 +30,7 @@ const GQL_GET_APP_DATA = gql`
       emailAddress
       status
       avatar(size: 32)
+      code
       position {
         uuid
         name

--- a/client/src/pages/onboarding/Edit.js
+++ b/client/src/pages/onboarding/Edit.js
@@ -30,6 +30,7 @@ const GQL_GET_PERSON = gql`
       endOfTourDate
       domainUsername
       avatar(size: 256)
+      code
       position {
         uuid
         name

--- a/client/src/pages/people/Edit.js
+++ b/client/src/pages/people/Edit.js
@@ -32,6 +32,7 @@ const GQL_GET_PERSON = gql`
       gender
       endOfTourDate
       avatar(size: 256)
+      code
       position {
         uuid
         name

--- a/client/src/pages/people/Form.js
+++ b/client/src/pages/people/Form.js
@@ -447,6 +447,12 @@ const BasePersonForm = props => {
                   }
                 />
                 <Field
+                  name="code"
+                  label={Settings.fields.person.code}
+                  component={FieldHelper.renderInputField}
+                  disabled={!isAdmin}
+                />
+                <Field
                   name="endOfTourDate"
                   label={Settings.fields.person.endOfTourDate}
                   component={FieldHelper.renderSpecialField}

--- a/client/src/pages/people/Show.js
+++ b/client/src/pages/people/Show.js
@@ -51,6 +51,7 @@ const GQL_GET_PERSON = gql`
       gender
       endOfTourDate
       avatar(size: 256)
+      code
       position {
         uuid
         name
@@ -234,6 +235,11 @@ const BasePersonShow = props => {
                 <Field
                   name="country"
                   label={Settings.fields.person.country}
+                  component={FieldHelper.renderReadonlyField}
+                />
+                <Field
+                  name="code"
+                  label={Settings.fields.person.code}
                   component={FieldHelper.renderReadonlyField}
                 />
                 <Field

--- a/src/main/java/mil/dds/anet/beans/Person.java
+++ b/src/main/java/mil/dds/anet/beans/Person.java
@@ -47,6 +47,7 @@ public class Person extends AbstractAnetBean implements Principal {
   private List<PersonPositionHistory> previousPositions;
 
   private String avatar;
+  private String code;
 
   public Person() {
     this.pendingVerification = false; // Defaults
@@ -248,6 +249,15 @@ public class Person extends AbstractAnetBean implements Principal {
     this.avatar = avatar;
   }
 
+  @GraphQLQuery(name = "code")
+  public String getCode() {
+    return code;
+  }
+
+  public void setCode(String code) {
+    this.code = code;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (!(o instanceof Person)) {
@@ -260,7 +270,8 @@ public class Person extends AbstractAnetBean implements Principal {
         && Objects.equals(other.getPhoneNumber(), phoneNumber)
         && Objects.equals(other.getRank(), rank) && Objects.equals(other.getBiography(), biography)
         && Objects.equals(other.getPendingVerification(), pendingVerification)
-        && Objects.equals(other.getAvatar(), avatar) && (createdAt != null)
+        && Objects.equals(other.getAvatar(), avatar) && Objects.equals(other.getCode(), code)
+        && (createdAt != null)
             ? (createdAt.equals(other.getCreatedAt()))
             : (other.getCreatedAt() == null) && (updatedAt != null)
                 ? (updatedAt.equals(other.getUpdatedAt()))
@@ -271,7 +282,7 @@ public class Person extends AbstractAnetBean implements Principal {
   @Override
   public int hashCode() {
     return Objects.hash(uuid, name, status, role, emailAddress, phoneNumber, rank, biography,
-        createdAt, updatedAt, pendingVerification);
+        pendingVerification, avatar, code, createdAt, updatedAt);
   }
 
   @Override

--- a/src/main/java/mil/dds/anet/beans/search/PersonSearchQuery.java
+++ b/src/main/java/mil/dds/anet/beans/search/PersonSearchQuery.java
@@ -31,8 +31,6 @@ public class PersonSearchQuery extends AbstractSearchQuery<PersonSearchSortBy> {
   public PersonSearchQuery() {
     super(PersonSearchSortBy.NAME);
     this.setPageSize(100);
-    // FIXME: Explicitly set sorting by name (ascending) to reinstate pre-SOUNDEX search behaviour.
-    this.setSortBy(PersonSearchSortBy.NAME);
   }
 
   public String getOrgUuid() {

--- a/src/main/java/mil/dds/anet/database/PersonDao.java
+++ b/src/main/java/mil/dds/anet/database/PersonDao.java
@@ -29,7 +29,7 @@ public class PersonDao extends AnetBaseDao<Person, PersonSearchQuery> {
 
   private static String[] fields = {"uuid", "name", "status", "role", "emailAddress", "phoneNumber",
       "rank", "biography", "country", "gender", "endOfTourDate", "domainUsername",
-      "pendingVerification", "createdAt", "updatedAt", "avatar"};
+      "pendingVerification", "avatar", "code", "createdAt", "updatedAt"};
   public static String TABLE_NAME = "people";
   public static String PERSON_FIELDS = DaoUtils.buildFieldAliases(TABLE_NAME, fields, true);
   public static String PERSON_FIELDS_NOAS = DaoUtils.buildFieldAliases(TABLE_NAME, fields, false);
@@ -78,9 +78,9 @@ public class PersonDao extends AnetBaseDao<Person, PersonSearchQuery> {
     StringBuilder sql = new StringBuilder();
     sql.append("/* personInsert */ INSERT INTO people "
         + "(uuid, name, status, role, \"emailAddress\", \"phoneNumber\", rank, \"pendingVerification\", "
-        + "gender, country, avatar, \"endOfTourDate\", biography, \"domainUsername\", \"createdAt\", \"updatedAt\") "
+        + "gender, country, avatar, code, \"endOfTourDate\", biography, \"domainUsername\", \"createdAt\", \"updatedAt\") "
         + "VALUES (:uuid, :name, :status, :role, :emailAddress, :phoneNumber, :rank, :pendingVerification, "
-        + ":gender, :country, :avatar, ");
+        + ":gender, :country, :avatar, :code, ");
     if (DaoUtils.isMsSql()) {
       // MsSql requires an explicit CAST when datetime2 might be NULL.
       sql.append("CAST(:endOfTourDate AS datetime2), ");
@@ -103,7 +103,7 @@ public class PersonDao extends AnetBaseDao<Person, PersonSearchQuery> {
     StringBuilder sql = new StringBuilder("/* personUpdate */ UPDATE people "
         + "SET name = :name, status = :status, role = :role, "
         + "gender = :gender, country = :country,  \"emailAddress\" = :emailAddress, "
-        + "\"avatar\" = :avatar,"
+        + "\"avatar\" = :avatar, code = :code, "
         + "\"phoneNumber\" = :phoneNumber, rank = :rank, biography = :biography, "
         + "\"pendingVerification\" = :pendingVerification, \"domainUsername\" = :domainUsername, "
         + "\"updatedAt\" = :updatedAt, ");

--- a/src/main/java/mil/dds/anet/database/mappers/PersonMapper.java
+++ b/src/main/java/mil/dds/anet/database/mappers/PersonMapper.java
@@ -40,6 +40,7 @@ public class PersonMapper implements RowMapper<Person> {
     a.setPhoneNumber(r.getString("people_phoneNumber"));
     a.setCountry(r.getString("people_country"));
     a.setGender(r.getString("people_gender"));
+    a.setCode(r.getString("people_code"));
     a.setEndOfTourDate(DaoUtils.getInstantAsLocalDateTime(r, "people_endOfTourDate"));
     a.setRank(r.getString("people_rank"));
     a.setBiography(r.getString("people_biography"));

--- a/src/main/java/mil/dds/anet/search/mssql/MssqlPersonSearcher.java
+++ b/src/main/java/mil/dds/anet/search/mssql/MssqlPersonSearcher.java
@@ -28,9 +28,9 @@ public class MssqlPersonSearcher extends AbstractPersonSearcher {
           + " AS search_rank");
     }
     qb.addFromClause(
-        "LEFT JOIN CONTAINSTABLE (people, (name, emailAddress, biography), :containsQuery) c_people"
+        "LEFT JOIN CONTAINSTABLE (people, (name, emailAddress), :containsQuery) c_people"
             + " ON people.uuid = c_people.[Key]"
-            + " LEFT JOIN FREETEXTTABLE(people, (name, biography), :freetextQuery) f_people"
+            + " LEFT JOIN FREETEXTTABLE(people, (name), :freetextQuery) f_people"
             + " ON people.uuid = f_people.[Key]");
     final StringBuilder whereRank =
         new StringBuilder("(c_people.rank IS NOT NULL OR f_people.rank IS NOT NULL"

--- a/src/main/java/mil/dds/anet/search/mssql/MssqlPersonSearcher.java
+++ b/src/main/java/mil/dds/anet/search/mssql/MssqlPersonSearcher.java
@@ -3,7 +3,6 @@ package mil.dds.anet.search.mssql;
 import mil.dds.anet.beans.Person;
 import mil.dds.anet.beans.search.ISearchQuery.SortOrder;
 import mil.dds.anet.beans.search.PersonSearchQuery;
-import mil.dds.anet.database.PersonDao;
 import mil.dds.anet.search.AbstractPersonSearcher;
 import mil.dds.anet.search.AbstractSearchQueryBuilder;
 
@@ -15,53 +14,38 @@ public class MssqlPersonSearcher extends AbstractPersonSearcher {
 
   @Override
   protected void addTextQuery(PersonSearchQuery query) {
-    final boolean doSoundex = !query.isSortByPresent();
-    final String text = query.getText();
-    if (doSoundex) {
-      if (!query.isSortByPresent()) {
-        // If we're doing a full-text search without an explicit sort order, add a pseudo-rank so we
-        // can sort on it.
-        qb.addSelectClause("EXP(SUM(LOG(1.0/(5-DIFFERENCE(name_token.value, search_token.value)))))"
-            + " AS search_rank");
-      }
-      qb.addFromClause("CROSS APPLY STRING_SPLIT(people.name, ' ') AS name_token"
-          + " CROSS APPLY STRING_SPLIT(:freetextQuery, ' ') AS search_token");
-      qb.addSqlArg("freetextQuery", text);
-      // Add grouping needed for soundex score
-      qb.addGroupByClause(PersonDao.PERSON_FIELDS_NOAS);
-    } else {
-      if (!query.isSortByPresent()) {
-        // If we're doing a full-text search without an explicit sort order, add a pseudo-rank (the
-        // sum of all search ranks) so we can sort on it (show the most relevant hits at the top).
-        // Note that summing up independent ranks is not ideal, but it's the best we can do now. See
-        // https://docs.microsoft.com/en-us/sql/relational-databases/search/limit-search-results-with-rank
-        qb.addSelectClause("ISNULL(c_people.rank, 0) + ISNULL(f_people.rank, 0)"
-            + " + CASE WHEN people.code LIKE :likeQuery THEN 1000 ELSE 0 END"
-            + (query.getMatchPositionName()
-                ? " + ISNULL(c_positions.rank, 0)"
-                    + " + CASE WHEN positions.code LIKE :likeQuery THEN 1000 ELSE 0 END"
-                : "")
-            + " AS search_rank");
-      }
-      qb.addFromClause(
-          "LEFT JOIN CONTAINSTABLE (people, (name, emailAddress, biography), :containsQuery) c_people"
-              + " ON people.uuid = c_people.[Key]"
-              + " LEFT JOIN FREETEXTTABLE(people, (name, biography), :freetextQuery) f_people"
-              + " ON people.uuid = f_people.[Key]");
-      final StringBuilder whereRank =
-          new StringBuilder("(c_people.rank IS NOT NULL OR f_people.rank IS NOT NULL"
-              + " OR people.code LIKE :likeQuery");
-      if (query.getMatchPositionName()) {
-        qb.addFromClause("LEFT JOIN CONTAINSTABLE(positions, (name), :containsQuery) c_positions"
-            + " ON positions.uuid = c_positions.[Key]");
-        whereRank.append(" OR c_positions.rank IS NOT NULL OR positions.code LIKE :likeQuery");
-      }
-      whereRank.append(")");
-      qb.addWhereClause(whereRank.toString());
-      qb.addSqlArg("containsQuery", qb.getFullTextQuery(text));
-      qb.addSqlArg("freetextQuery", text);
-      qb.addSqlArg("likeQuery", qb.getLikeQuery(text));
+    if (!query.isSortByPresent()) {
+      // If we're doing a full-text search without an explicit sort order, add a pseudo-rank (the
+      // sum of all search ranks) so we can sort on it (show the most relevant hits at the top).
+      // Note that summing up independent ranks is not ideal, but it's the best we can do now. See
+      // https://docs.microsoft.com/en-us/sql/relational-databases/search/limit-search-results-with-rank
+      qb.addSelectClause("ISNULL(c_people.rank, 0) + ISNULL(f_people.rank, 0)"
+          + " + CASE WHEN people.code LIKE :likeQuery THEN 1000 ELSE 0 END"
+          + (query.getMatchPositionName()
+              ? " + ISNULL(c_positions.rank, 0)"
+                  + " + CASE WHEN positions.code LIKE :likeQuery THEN 1000 ELSE 0 END"
+              : "")
+          + " AS search_rank");
     }
+    qb.addFromClause(
+        "LEFT JOIN CONTAINSTABLE (people, (name, emailAddress, biography), :containsQuery) c_people"
+            + " ON people.uuid = c_people.[Key]"
+            + " LEFT JOIN FREETEXTTABLE(people, (name, biography), :freetextQuery) f_people"
+            + " ON people.uuid = f_people.[Key]");
+    final StringBuilder whereRank =
+        new StringBuilder("(c_people.rank IS NOT NULL OR f_people.rank IS NOT NULL"
+            + " OR people.code LIKE :likeQuery");
+    if (query.getMatchPositionName()) {
+      qb.addFromClause("LEFT JOIN CONTAINSTABLE(positions, (name), :containsQuery) c_positions"
+          + " ON positions.uuid = c_positions.[Key]");
+      whereRank.append(" OR c_positions.rank IS NOT NULL OR positions.code LIKE :likeQuery");
+    }
+    whereRank.append(")");
+    qb.addWhereClause(whereRank.toString());
+    final String text = query.getText();
+    qb.addSqlArg("containsQuery", qb.getFullTextQuery(text));
+    qb.addSqlArg("freetextQuery", text);
+    qb.addSqlArg("likeQuery", qb.getLikeQuery(text));
   }
 
   protected void addOrderByClauses(AbstractSearchQueryBuilder<?, ?> qb, PersonSearchQuery query) {

--- a/src/main/java/mil/dds/anet/search/mssql/MssqlPositionSearcher.java
+++ b/src/main/java/mil/dds/anet/search/mssql/MssqlPositionSearcher.java
@@ -20,6 +20,7 @@ public class MssqlPositionSearcher extends AbstractPositionSearcher {
       // Note that summing up independent ranks is not ideal, but it's the best we can do now. See
       // https://docs.microsoft.com/en-us/sql/relational-databases/search/limit-search-results-with-rank
       qb.addSelectClause("ISNULL(c_positions.rank, 0)"
+          + " + CASE WHEN positions.code LIKE :likeQuery THEN 1000 ELSE 0 END"
           + (query.getMatchPersonName() ? " + ISNULL(c_people.rank, 0)" : "") + " AS search_rank");
     }
     qb.addFromClause("LEFT JOIN CONTAINSTABLE (positions, (name), :containsQuery) c_positions"

--- a/src/main/java/mil/dds/anet/search/pg/PostgresqlPersonSearcher.java
+++ b/src/main/java/mil/dds/anet/search/pg/PostgresqlPersonSearcher.java
@@ -14,11 +14,11 @@ public class PostgresqlPersonSearcher extends AbstractPersonSearcher {
   protected void addTextQuery(PersonSearchQuery query) {
     final String text = qb.getFullTextQuery(query.getText());
     if (query.getMatchPositionName()) {
-      qb.addLikeClauses("text", new String[] {"people.name", "people.\"emailAddress\"",
-          "people.biography", "positions.name", "positions.code"}, text);
+      qb.addLikeClauses("text", new String[] {"people.name", "people.code",
+          "people.\"emailAddress\"", "people.biography", "positions.name", "positions.code"}, text);
     } else {
-      qb.addLikeClauses("text",
-          new String[] {"people.name", "people.\"emailAddress\"", "people.biography"}, text);
+      qb.addLikeClauses("text", new String[] {"people.name", "people.code",
+          "people.\"emailAddress\"", "people.biography"}, text);
     }
   }
 

--- a/src/main/java/mil/dds/anet/search/pg/PostgresqlPersonSearcher.java
+++ b/src/main/java/mil/dds/anet/search/pg/PostgresqlPersonSearcher.java
@@ -15,10 +15,10 @@ public class PostgresqlPersonSearcher extends AbstractPersonSearcher {
     final String text = qb.getFullTextQuery(query.getText());
     if (query.getMatchPositionName()) {
       qb.addLikeClauses("text", new String[] {"people.name", "people.code",
-          "people.\"emailAddress\"", "people.biography", "positions.name", "positions.code"}, text);
+          "people.\"emailAddress\"", "positions.name", "positions.code"}, text);
     } else {
-      qb.addLikeClauses("text", new String[] {"people.name", "people.code",
-          "people.\"emailAddress\"", "people.biography"}, text);
+      qb.addLikeClauses("text",
+          new String[] {"people.name", "people.code", "people.\"emailAddress\""}, text);
     }
   }
 

--- a/src/main/resources/anet-schema.yml
+++ b/src/main/resources/anet-schema.yml
@@ -297,6 +297,10 @@ properties:
             type: string
             title: The label for a person's country
             description: Used in the UI where a person's country is shown.
+          code:
+            type: string
+            title: The label for a person's code
+            description: Used in the UI where a person's code is shown.
           rank:
             type: string
             title: The label for a person's rank

--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -2719,4 +2719,10 @@
 		<!-- Rolling back is not useful -->
 	</changeSet>
 
+	<changeSet id="add-people-code" author="gjvoosten">
+		<addColumn tableName="people">
+			<column name="code" type="nvarchar(100)" />
+		</addColumn>
+	</changeSet>
+
 </databaseChangeLog>

--- a/src/test/java/mil/dds/anet/test/resources/PersonResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/PersonResourceTest.java
@@ -260,12 +260,6 @@ public class PersonResourceTest extends AbstractResourceTest {
     assertThat(searchResults.getList()).isNotEmpty();
 
     query.setOrgUuid(null);
-    query.setText("advisor"); // Search against biographies
-    searchResults =
-        graphQLHelper.searchObjects(jack, "personList", "query", "PersonSearchQueryInput", FIELDS,
-            query, new TypeReference<GraphQlResponse<AnetBeanList<Person>>>() {});
-    assertThat(searchResults.getList().size()).isGreaterThan(1);
-
     query.setText(null);
     query.setRole(Role.ADVISOR);
     searchResults =

--- a/src/test/java/mil/dds/anet/test/resources/PersonResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/PersonResourceTest.java
@@ -44,7 +44,7 @@ public class PersonResourceTest extends AbstractResourceTest {
 
   private static final String POSITION_FIELDS = "uuid name code type status";
   private static final String PERSON_FIELDS =
-      "uuid name status role emailAddress phoneNumber rank biography country avatar"
+      "uuid name status role emailAddress phoneNumber rank biography country avatar code"
           + " gender endOfTourDate domainUsername pendingVerification createdAt updatedAt";
   private static final String FIELDS = PERSON_FIELDS + " position { " + POSITION_FIELDS + " }";
   private static final String DEFAULT_AVATAR_PATH = "src/test/resources/assets/default_avatar.png";
@@ -66,6 +66,7 @@ public class PersonResourceTest extends AbstractResourceTest {
     newPerson.setBiography(UtilsTest.getCombinedTestCase().getInput());
     newPerson.setGender("Female");
     newPerson.setCountry("Canada");
+    newPerson.setCode("123456");
     newPerson.setEndOfTourDate(
         ZonedDateTime.of(2020, 4, 1, 0, 0, 0, 0, DaoUtils.getDefaultZoneId()).toInstant());
     String newPersonUuid = graphQLHelper.createObject(admin, "createPerson", "person",
@@ -80,6 +81,7 @@ public class PersonResourceTest extends AbstractResourceTest {
 
     newPerson.setName("testCreatePerson updated name");
     newPerson.setCountry("The Commonwealth of Canada");
+    newPerson.setCode("A123456");
 
     // update avatar
     byte[] fileContent = Files.readAllBytes(new File(DEFAULT_AVATAR_PATH).toPath());
@@ -96,6 +98,7 @@ public class PersonResourceTest extends AbstractResourceTest {
     retPerson = graphQLHelper.getObjectById(jack, "person", FIELDS, newPerson.getUuid(),
         new TypeReference<GraphQlResponse<Person>>() {});
     assertThat(retPerson.getName()).isEqualTo(newPerson.getName());
+    assertThat(retPerson.getCode()).isEqualTo(newPerson.getCode());
     assertThat(retPerson.getAvatar()).isNotNull();
     // check that HTML of biography is sanitized after update
     assertThat(retPerson.getBiography()).isEqualTo(UtilsTest.getCombinedTestCase().getOutput());


### PR DESCRIPTION
Add a new code field to people (labeled "ID card number").

### User changes
- People now have a new (read-only) code field.
- Text searches for people try a prefix match of the code field.
- Text searches for people no longer look in the biography.
- Selecting report attendees shows the matching people by order of relevance (matches with the same relevance ranking are sub-ordered by name).

### Super User changes
In addition to the User changes:
- Selecting positions (for tasks or authorization groups) gives prefix-matching position codes a higher relevance ranking.

### Admin changes
- People have a new editable code field.

### System admin changes
- The suggested label in `anet.yml` for the new person code field is "ID card number"; change this as needed.

- [x] anet.yml needs change
- [x] db needs migration