### PR TITLE
Fix emptying form fields containing an array

### DIFF
--- a/client/src/pages/organizations/Form.js
+++ b/client/src/pages/organizations/Form.js
@@ -80,8 +80,11 @@ const ApproverTable = props => {
 }
 
 ApproverTable.propTypes = {
-  approvers: PropTypes.array,
+  approvers: PropTypes.array.isRequired,
   onDelete: PropTypes.func
+}
+ApproverTable.defaultProps = {
+  approvers: []
 }
 
 const BaseOrganizationForm = props => {
@@ -381,7 +384,9 @@ const BaseOrganizationForm = props => {
                             </Modal.Footer>
                           </Modal>
 
-                          {values.planningApprovalSteps.map((step, index) =>
+                          {(
+                            values.planningApprovalSteps || []
+                          ).map((step, index) =>
                             renderApprovalStep(
                               "planningApprovalSteps",
                               arrayHelpers,
@@ -460,7 +465,7 @@ const BaseOrganizationForm = props => {
                             </Modal.Footer>
                           </Modal>
 
-                          {values.approvalSteps.map((step, index) =>
+                          {(values.approvalSteps || []).map((step, index) =>
                             renderApprovalStep(
                               "approvalSteps",
                               arrayHelpers,

--- a/client/src/pages/reports/Form.js
+++ b/client/src/pages/reports/Form.js
@@ -326,9 +326,10 @@ const BaseReportForm = props => {
           forSelectedObjectives: {
             label: "For selected objectives",
             queryVars: {
-              customFieldRef1Uuid: values.tasksLevel1.length
-                ? values.tasksLevel1.map(t => t.uuid)
-                : [""]
+              customFieldRef1Uuid:
+                values.tasksLevel1 && values.tasksLevel1.length
+                  ? values.tasksLevel1.map(t => t.uuid)
+                  : [""]
             }
           },
           allTasks: {
@@ -1063,7 +1064,7 @@ const BaseReportForm = props => {
       report.keyOutcomes = ""
     }
     // reportTags contains id's instead of uuid's (as that is what the ReactTags component expects)
-    report.tags = values.reportTags.map(tag => ({ uuid: tag.id }))
+    report.tags = (values.reportTags || []).map(tag => ({ uuid: tag.id }))
     // strip attendees fields not in data model
     report.attendees = (values.attendees || []).map(a =>
       Object.without(a, "firstName", "lastName", "position")


### PR DESCRIPTION
When emptying a field which used to contain an array (like report tagsor organization approval steps) this one gets the value undefined now. Consider this when using the map value on these
fields values, otherwise we get an error.
