### PR TITLE
Add PostgreSQL full-text search

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -341,6 +341,7 @@ task dockerCreateDB(dependsOn: dockerPullDB, type: com.bmuschko.gradle.docker.ta
 	imageId = dockerPullDB.getImage()
 	containerName = dbContainerName
 	description = "Creates an ANET ${dbType} SQL DB container named " + dbContainerName + "."
+	hostConfig.shmSize = 1024*1024*1024L
 	hostConfig.binds = ["${projectDir}":"/hostdata"] + run.environment.get("DOCKER_MOUNTS", [:])
 	if (isMssql) {
 	  withEnvVar('ACCEPT_EULA', 'Y')

--- a/client/tests/e2e/report.js
+++ b/client/tests/e2e/report.js
@@ -35,7 +35,7 @@ test("Draft and submit a report", async t => {
 
   const $locationAdvancedSelect = await pageHelpers.chooseAdvancedSelectOption(
     "#location",
-    "general hospita"
+    "general hospit"
   )
 
   t.is(

--- a/prepare-psql.sql
+++ b/prepare-psql.sql
@@ -3,9 +3,6 @@ CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
 
 -- make sure the preconditions for full-text search are met
 CREATE EXTENSION IF NOT EXISTS unaccent;
-DROP TEXT SEARCH CONFIGURATION IF EXISTS anet;
-CREATE TEXT SEARCH CONFIGURATION anet ( COPY = pg_catalog.english );
-ALTER TEXT SEARCH CONFIGURATION anet ALTER MAPPING FOR hword, hword_part, word WITH unaccent, english_stem;
 
 CREATE OR REPLACE AGGREGATE tsvector_agg (tsvector) (
   SFUNC = tsvector_concat,

--- a/prepare-psql.sql
+++ b/prepare-psql.sql
@@ -7,5 +7,10 @@ DROP TEXT SEARCH CONFIGURATION IF EXISTS anet;
 CREATE TEXT SEARCH CONFIGURATION anet ( COPY = pg_catalog.english );
 ALTER TEXT SEARCH CONFIGURATION anet ALTER MAPPING FOR hword, hword_part, word WITH unaccent, english_stem;
 
+CREATE OR REPLACE AGGREGATE tsvector_agg (tsvector) (
+  SFUNC = tsvector_concat,
+  STYPE = tsvector
+);
+
 -- make sure the preconditions for UUID prefix search are met
 CREATE EXTENSION IF NOT EXISTS pg_trgm;

--- a/prepare-psql.sql
+++ b/prepare-psql.sql
@@ -1,2 +1,11 @@
 -- make sure the UUID extension exists
 CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
+-- make sure the preconditions for full-text search are met
+CREATE EXTENSION IF NOT EXISTS unaccent;
+DROP TEXT SEARCH CONFIGURATION IF EXISTS anet;
+CREATE TEXT SEARCH CONFIGURATION anet ( COPY = pg_catalog.english );
+ALTER TEXT SEARCH CONFIGURATION anet ALTER MAPPING FOR hword, hword_part, word WITH unaccent, english_stem;
+
+-- make sure the preconditions for UUID prefix search are met
+CREATE EXTENSION IF NOT EXISTS pg_trgm;

--- a/src/main/java/mil/dds/anet/AnetApplication.java
+++ b/src/main/java/mil/dds/anet/AnetApplication.java
@@ -237,12 +237,11 @@ public class AnetApplication extends Application<AnetConfiguration> {
     runAccountDeactivationWorker(configuration, scheduler, engine);
 
     if (DaoUtils.isPostgresql()) {
-      // Update PostgreSQL materialized views every 60 minutes.
-      // And run once 25 seconds after boot-up.
+      // Wait 60 seconds between updates of PostgreSQL materialized views,
+      // starting 30 seconds after boot-up.
       final MaterializedViewRefreshWorker materializedViewRefreshWorker =
           new MaterializedViewRefreshWorker(engine.getAdminDao());
-      scheduler.scheduleAtFixedRate(materializedViewRefreshWorker, 60, 60, TimeUnit.MINUTES);
-      scheduler.schedule(materializedViewRefreshWorker, 25, TimeUnit.SECONDS);
+      scheduler.scheduleWithFixedDelay(materializedViewRefreshWorker, 30, 60, TimeUnit.SECONDS);
     }
 
     // Create all of the HTTP Resources.

--- a/src/main/java/mil/dds/anet/AnetApplication.java
+++ b/src/main/java/mil/dds/anet/AnetApplication.java
@@ -57,7 +57,9 @@ import mil.dds.anet.resources.TaskResource;
 import mil.dds.anet.threads.AccountDeactivationWorker;
 import mil.dds.anet.threads.AnetEmailWorker;
 import mil.dds.anet.threads.FutureEngagementWorker;
+import mil.dds.anet.threads.MaterializedViewRefreshWorker;
 import mil.dds.anet.threads.ReportPublicationWorker;
+import mil.dds.anet.utils.DaoUtils;
 import mil.dds.anet.utils.HttpsRedirectFilter;
 import mil.dds.anet.views.ViewResponseFilter;
 import org.eclipse.jetty.server.session.SessionHandler;
@@ -233,6 +235,15 @@ public class AnetApplication extends Application<AnetConfiguration> {
     scheduler.schedule(futureWorker, 15, TimeUnit.SECONDS);
 
     runAccountDeactivationWorker(configuration, scheduler, engine);
+
+    if (DaoUtils.isPostgresql()) {
+      // Update PostgreSQL materialized views every 60 minutes.
+      // And run once 25 seconds after boot-up.
+      final MaterializedViewRefreshWorker materializedViewRefreshWorker =
+          new MaterializedViewRefreshWorker(engine.getAdminDao());
+      scheduler.scheduleAtFixedRate(materializedViewRefreshWorker, 60, 60, TimeUnit.MINUTES);
+      scheduler.schedule(materializedViewRefreshWorker, 25, TimeUnit.SECONDS);
+    }
 
     // Create all of the HTTP Resources.
     LoggingResource loggingResource = new LoggingResource();

--- a/src/main/java/mil/dds/anet/database/AdminDao.java
+++ b/src/main/java/mil/dds/anet/database/AdminDao.java
@@ -69,5 +69,10 @@ public class AdminDao {
         .bind("value", setting.getValue()).execute();
   }
 
-
+  @InTransaction
+  public void updateMaterializedView(String viewName) {
+    // Can't use a prepared statement with a parameter here, alas
+    getDbHandle()
+        .execute(String.format("REFRESH MATERIALIZED VIEW CONCURRENTLY \"%1$s\"", viewName));
+  }
 }

--- a/src/main/java/mil/dds/anet/database/AuthorizationGroupDao.java
+++ b/src/main/java/mil/dds/anet/database/AuthorizationGroupDao.java
@@ -9,12 +9,10 @@ import mil.dds.anet.beans.AuthorizationGroup;
 import mil.dds.anet.beans.AuthorizationGroup.AuthorizationGroupStatus;
 import mil.dds.anet.beans.Person;
 import mil.dds.anet.beans.Position;
-import mil.dds.anet.beans.Report;
 import mil.dds.anet.beans.lists.AnetBeanList;
 import mil.dds.anet.beans.search.AuthorizationGroupSearchQuery;
 import mil.dds.anet.database.mappers.AuthorizationGroupMapper;
 import mil.dds.anet.database.mappers.PositionMapper;
-import mil.dds.anet.database.mappers.ReportMapper;
 import mil.dds.anet.utils.DaoUtils;
 import mil.dds.anet.utils.FkDataLoaderKey;
 import mil.dds.anet.views.ForeignKeyFetcher;
@@ -160,15 +158,6 @@ public class AuthorizationGroupDao
         .bind("maxResults", maxResults)
         .bind("activeStatus", DaoUtils.getEnumId(AuthorizationGroupStatus.ACTIVE))
         .map(new AuthorizationGroupMapper()).list();
-  }
-
-  @InTransaction
-  public List<Report> getReportsForAuthorizationGroup(AuthorizationGroup a) {
-    return getDbHandle().createQuery("/* getReportsForAuthorizationGroup */ SELECT "
-        + ReportDao.REPORT_FIELDS + "FROM reports, \"reportAuthorizationGroups\" "
-        + "WHERE \"reportAuthorizationGroups\".\"authorizationGroupUuid\" = :authorizationGroupUuid "
-        + "AND \"reportAuthorizationGroups\".\"reportUuid\" = reports.uuid")
-        .bind("authorizationGroupUuid", a.getUuid()).map(new ReportMapper()).list();
   }
 
 }

--- a/src/main/java/mil/dds/anet/database/ReportDao.java
+++ b/src/main/java/mil/dds/anet/database/ReportDao.java
@@ -809,7 +809,8 @@ public class ReportDao extends AnetBaseDao<Report, ReportSearchQuery> {
     StringBuilder sql = new StringBuilder();
 
     sql.append("/* getFutureToPastReports */");
-    sql.append(" SELECT " + ReportDao.REPORT_FIELDS);
+    sql.append(
+        " SELECT reports.uuid AS reports_uuid, reports.\"authorUuid\" AS \"reports_authorUuid\"");
     sql.append(" FROM reports");
     // We are not interested in draft reports, as they will remain draft.
     // We are not interested in cancelled reports, as they will remain cancelled.

--- a/src/main/java/mil/dds/anet/database/ReportDao.java
+++ b/src/main/java/mil/dds/anet/database/ReportDao.java
@@ -1,5 +1,6 @@
 package mil.dds.anet.database;
 
+import com.google.common.collect.ObjectArrays;
 import io.leangen.graphql.annotations.GraphQLRootContext;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -8,6 +9,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
@@ -57,12 +59,18 @@ import ru.vyarus.guicey.jdbi3.tx.InTransaction;
 
 public class ReportDao extends AnetBaseDao<Report, ReportSearchQuery> {
 
-  private static final String[] fields = {"uuid", "state", "createdAt", "updatedAt",
-      "engagementDate", "duration", "locationUuid", "approvalStepUuid", "intent", "exsum",
-      "atmosphere", "cancelledReason", "advisorOrganizationUuid", "principalOrganizationUuid",
-      "releasedAt", "atmosphereDetails", "text", "keyOutcomes", "nextSteps", "authorUuid"};
+  // Must always retrieve these e.g. for ORDER BY
+  public static final String[] minimalFields =
+      {"uuid", "createdAt", "updatedAt", "engagementDate", "releasedAt"};
+  public static final String[] additionalFields =
+      {"state", "duration", "intent", "exsum", "locationUuid", "approvalStepUuid",
+          "advisorOrganizationUuid", "principalOrganizationUuid", "authorUuid", "atmosphere",
+          "cancelledReason", "atmosphereDetails", "text", "keyOutcomes", "nextSteps"};
+  public static final String[] allFields =
+      ObjectArrays.concat(minimalFields, additionalFields, String.class);
   public static final String TABLE_NAME = "reports";
-  public static final String REPORT_FIELDS = DaoUtils.buildFieldAliases(TABLE_NAME, fields, true);
+  public static final String REPORT_FIELDS =
+      DaoUtils.buildFieldAliases(TABLE_NAME, allFields, true);
 
   private String weekFormat;
 
@@ -352,7 +360,12 @@ public class ReportDao extends AnetBaseDao<Report, ReportSearchQuery> {
 
   @Override
   public AnetBeanList<Report> search(ReportSearchQuery query) {
-    return AnetObjectEngine.getInstance().getSearcher().getReportSearcher().runSearch(query);
+    return search(null, query);
+  }
+
+  public AnetBeanList<Report> search(Set<String> subFields, ReportSearchQuery query) {
+    return AnetObjectEngine.getInstance().getSearcher().getReportSearcher().runSearch(subFields,
+        query);
   }
 
   /*

--- a/src/main/java/mil/dds/anet/database/mappers/AnetEmailMapper.java
+++ b/src/main/java/mil/dds/anet/database/mappers/AnetEmailMapper.java
@@ -5,7 +5,6 @@ import java.lang.invoke.MethodHandles;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import mil.dds.anet.beans.AnetEmail;
-import mil.dds.anet.utils.DaoUtils;
 import org.jdbi.v3.core.mapper.RowMapper;
 import org.jdbi.v3.core.statement.StatementContext;
 import org.slf4j.Logger;
@@ -29,7 +28,7 @@ public class AnetEmailMapper implements RowMapper<AnetEmail> {
       AnetEmail email = mapper.readValue(jobSpec, AnetEmail.class);
 
       email.setId(rs.getInt("id"));
-      email.setCreatedAt(DaoUtils.getInstantAsLocalDateTime(rs, "createdAt"));
+      email.setCreatedAt(MapperUtils.getInstantAsLocalDateTime(rs, "createdAt"));
       return email;
     } catch (Exception e) {
       logger.error("Error mapping email", e);

--- a/src/main/java/mil/dds/anet/database/mappers/ApprovalStepMapper.java
+++ b/src/main/java/mil/dds/anet/database/mappers/ApprovalStepMapper.java
@@ -4,7 +4,6 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import mil.dds.anet.beans.ApprovalStep;
 import mil.dds.anet.beans.ApprovalStep.ApprovalStepType;
-import mil.dds.anet.utils.DaoUtils;
 import org.jdbi.v3.core.mapper.RowMapper;
 import org.jdbi.v3.core.statement.StatementContext;
 
@@ -13,7 +12,7 @@ public class ApprovalStepMapper implements RowMapper<ApprovalStep> {
   @Override
   public ApprovalStep map(ResultSet r, StatementContext ctx) throws SQLException {
     ApprovalStep step = new ApprovalStep();
-    DaoUtils.setCommonBeanFields(step, r, null);
+    MapperUtils.setCommonBeanFields(step, r, null);
     step.setNextStepUuid(r.getString("nextStepUuid"));
     step.setAdvisorOrganizationUuid(r.getString("advisorOrganizationUuid"));
     step.setName(r.getString("name"));

--- a/src/main/java/mil/dds/anet/database/mappers/AuthorizationGroupMapper.java
+++ b/src/main/java/mil/dds/anet/database/mappers/AuthorizationGroupMapper.java
@@ -4,7 +4,6 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import mil.dds.anet.beans.AuthorizationGroup;
 import mil.dds.anet.beans.AuthorizationGroup.AuthorizationGroupStatus;
-import mil.dds.anet.utils.DaoUtils;
 import org.jdbi.v3.core.mapper.RowMapper;
 import org.jdbi.v3.core.statement.StatementContext;
 
@@ -13,7 +12,7 @@ public class AuthorizationGroupMapper implements RowMapper<AuthorizationGroup> {
   @Override
   public AuthorizationGroup map(ResultSet rs, StatementContext ctx) throws SQLException {
     final AuthorizationGroup a = new AuthorizationGroup();
-    DaoUtils.setCommonBeanFields(a, rs, null);
+    MapperUtils.setCommonBeanFields(a, rs, null);
     a.setName(rs.getString("name"));
     a.setDescription(rs.getString("description"));
     a.setStatus(MapperUtils.getEnumIdx(rs, "status", AuthorizationGroupStatus.class));

--- a/src/main/java/mil/dds/anet/database/mappers/CommentMapper.java
+++ b/src/main/java/mil/dds/anet/database/mappers/CommentMapper.java
@@ -3,7 +3,6 @@ package mil.dds.anet.database.mappers;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import mil.dds.anet.beans.Comment;
-import mil.dds.anet.utils.DaoUtils;
 import org.jdbi.v3.core.mapper.RowMapper;
 import org.jdbi.v3.core.statement.StatementContext;
 
@@ -12,7 +11,7 @@ public class CommentMapper implements RowMapper<Comment> {
   @Override
   public Comment map(ResultSet r, StatementContext ctx) throws SQLException {
     final Comment c = new Comment();
-    DaoUtils.setCommonBeanFields(c, r, "comments");
+    MapperUtils.setCommonBeanFields(c, r, "comments");
     c.setReportUuid(r.getString("comments_reportUuid"));
     c.setAuthorUuid(r.getString("comments_authorUuid"));
     c.setText(r.getString("comments_text"));

--- a/src/main/java/mil/dds/anet/database/mappers/LocationMapper.java
+++ b/src/main/java/mil/dds/anet/database/mappers/LocationMapper.java
@@ -4,7 +4,6 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import mil.dds.anet.beans.Location;
 import mil.dds.anet.beans.Location.LocationStatus;
-import mil.dds.anet.utils.DaoUtils;
 import org.jdbi.v3.core.mapper.RowMapper;
 import org.jdbi.v3.core.statement.StatementContext;
 
@@ -13,12 +12,12 @@ public class LocationMapper implements RowMapper<Location> {
   @Override
   public Location map(ResultSet rs, StatementContext ctx) throws SQLException {
     Location l = new Location();
-    DaoUtils.setCommonBeanFields(l, rs, null);
+    MapperUtils.setCommonBeanFields(l, rs, null);
     l.setName(rs.getString("name"));
     l.setStatus(MapperUtils.getEnumIdx(rs, "status", LocationStatus.class));
     // preserve NULL values; when NULL there are no coordinates set:
-    l.setLat(DaoUtils.getOptionalDouble(rs, "lat"));
-    l.setLng(DaoUtils.getOptionalDouble(rs, "lng"));
+    l.setLat(MapperUtils.getOptionalDouble(rs, "lat"));
+    l.setLng(MapperUtils.getOptionalDouble(rs, "lng"));
 
     if (MapperUtils.containsColumnNamed(rs, "totalCount")) {
       ctx.define("totalCount", rs.getInt("totalCount"));

--- a/src/main/java/mil/dds/anet/database/mappers/MapperUtils.java
+++ b/src/main/java/mil/dds/anet/database/mappers/MapperUtils.java
@@ -5,9 +5,15 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import java.lang.invoke.MethodHandles;
+import java.sql.Blob;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import mil.dds.anet.utils.DaoUtils;
+import mil.dds.anet.utils.Utils;
+import mil.dds.anet.views.AbstractAnetBean;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -22,28 +28,67 @@ public class MapperUtils {
         .configure(DeserializationFeature.READ_DATE_TIMESTAMPS_AS_NANOSECONDS, false);
   }
 
-  /*
-   * Utility function to check for NULL values in the column Because .getInt returns 0 if the column
-   * is null. Boooo
-   */
-  public static Integer getInteger(ResultSet rs, String columnName) throws SQLException {
-    Object res = rs.getObject(columnName);
-    if (res == null) {
-      return null;
-    } else if (res instanceof Integer) {
-      return (Integer) res;
-    } else {
+  public static void setCommonBeanFields(AbstractAnetBean bean, ResultSet rs, String tableName)
+      throws SQLException {
+    // Should always be there
+    bean.setUuid(rs.getString(getQualifiedFieldName(tableName, "uuid")));
+
+    // Not all beans have createdAt and/or updatedAt
+    bean.setCreatedAt(getInstantAsLocalDateTime(rs, getQualifiedFieldName(tableName, "createdAt")));
+    bean.setUpdatedAt(getInstantAsLocalDateTime(rs, getQualifiedFieldName(tableName, "updatedAt")));
+
+    // Only present when batch searching
+    bean.setBatchUuid(getOptionalString(rs, "batchUuid"));
+  }
+
+  public static Integer getOptionalInt(final ResultSet rs, final String columnName)
+      throws SQLException {
+    if (!containsColumnNamed(rs, columnName)) {
       return null;
     }
+    final Integer value = rs.getInt(columnName);
+    return rs.wasNull() ? null : value;
+  }
+
+  public static Double getOptionalDouble(final ResultSet rs, final String columnName)
+      throws SQLException {
+    if (!containsColumnNamed(rs, columnName)) {
+      return null;
+    }
+    final Double value = rs.getDouble(columnName);
+    return rs.wasNull() ? null : value;
+  }
+
+  public static String getOptionalString(final ResultSet rs, final String columnName)
+      throws SQLException {
+    if (!containsColumnNamed(rs, columnName)) {
+      return null;
+    }
+    return rs.getString(columnName);
+  }
+
+  public static Boolean getOptionalBoolean(final ResultSet rs, final String columnName)
+      throws SQLException {
+    if (!containsColumnNamed(rs, columnName)) {
+      return null;
+    }
+    return rs.getBoolean(columnName);
+  }
+
+  public static Blob getOptionalBlob(final ResultSet rs, final String columnName)
+      throws SQLException {
+    if (!containsColumnNamed(rs, columnName)) {
+      return null;
+    }
+    return rs.getBlob(columnName);
   }
 
   public static <T extends Enum<T>> T getEnumIdx(ResultSet rs, String columnName, Class<T> clazz)
       throws SQLException {
-    Object res = rs.getObject(columnName);
-    if (res == null) {
+    final Integer idx = getOptionalInt(rs, columnName);
+    if (idx == null) {
       return null;
     }
-    int idx = rs.getInt(columnName);
 
     try {
       @SuppressWarnings("unchecked")
@@ -63,6 +108,31 @@ public class MapperUtils {
       }
     }
     return false;
+  }
+
+  private static String getQualifiedFieldName(String tableName, String fieldName) {
+    final StringBuilder result = new StringBuilder();
+    if (!Utils.isEmptyOrNull(tableName)) {
+      result.append(tableName);
+      result.append("_");
+    }
+    result.append(fieldName);
+    return result.toString();
+  }
+
+  public static Instant getInstantAsLocalDateTime(ResultSet rs, String columnName)
+      throws SQLException {
+    if (!containsColumnNamed(rs, columnName)) {
+      return null;
+    }
+    // We would like to do <code>rs.getObject(columnName, java.time.Instant.class)</code>
+    // but the MSSQL JDBC driver does not support that (yet).
+    // However, as of the 7.1.0 preview, at least java.time.LocalDateTime *is* supported.
+    final LocalDateTime result = rs.getObject(columnName, LocalDateTime.class);
+    if (result != null) {
+      return result.toInstant(DaoUtils.getDefaultZoneOffset());
+    }
+    return null;
   }
 
 }

--- a/src/main/java/mil/dds/anet/database/mappers/MapperUtils.java
+++ b/src/main/java/mil/dds/anet/database/mappers/MapperUtils.java
@@ -46,7 +46,7 @@ public class MapperUtils {
     if (!containsColumnNamed(rs, columnName)) {
       return null;
     }
-    final Integer value = rs.getInt(columnName);
+    final int value = rs.getInt(columnName);
     return rs.wasNull() ? null : value;
   }
 
@@ -55,7 +55,7 @@ public class MapperUtils {
     if (!containsColumnNamed(rs, columnName)) {
       return null;
     }
-    final Double value = rs.getDouble(columnName);
+    final double value = rs.getDouble(columnName);
     return rs.wasNull() ? null : value;
   }
 

--- a/src/main/java/mil/dds/anet/database/mappers/NoteMapper.java
+++ b/src/main/java/mil/dds/anet/database/mappers/NoteMapper.java
@@ -4,7 +4,6 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import mil.dds.anet.beans.Note;
 import mil.dds.anet.beans.Note.NoteType;
-import mil.dds.anet.utils.DaoUtils;
 import org.jdbi.v3.core.mapper.RowMapper;
 import org.jdbi.v3.core.statement.StatementContext;
 
@@ -13,7 +12,7 @@ public class NoteMapper implements RowMapper<Note> {
   @Override
   public Note map(ResultSet rs, StatementContext ctx) throws SQLException {
     final Note n = new Note();
-    DaoUtils.setCommonBeanFields(n, rs, null);
+    MapperUtils.setCommonBeanFields(n, rs, null);
     n.setType(MapperUtils.getEnumIdx(rs, "type", NoteType.class));
     n.setText(rs.getString("text"));
     n.setAuthorUuid(rs.getString("authorUuid"));

--- a/src/main/java/mil/dds/anet/database/mappers/OrganizationMapper.java
+++ b/src/main/java/mil/dds/anet/database/mappers/OrganizationMapper.java
@@ -5,7 +5,6 @@ import java.sql.SQLException;
 import mil.dds.anet.beans.Organization;
 import mil.dds.anet.beans.Organization.OrganizationStatus;
 import mil.dds.anet.beans.Organization.OrganizationType;
-import mil.dds.anet.utils.DaoUtils;
 import org.jdbi.v3.core.mapper.RowMapper;
 import org.jdbi.v3.core.statement.StatementContext;
 
@@ -14,7 +13,7 @@ public class OrganizationMapper implements RowMapper<Organization> {
   @Override
   public Organization map(ResultSet r, StatementContext ctx) throws SQLException {
     Organization org = new Organization();
-    DaoUtils.setCommonBeanFields(org, r, "organizations");
+    MapperUtils.setCommonBeanFields(org, r, "organizations");
     org.setShortName(r.getString("organizations_shortName"));
     org.setLongName(r.getString("organizations_longName"));
     org.setStatus(MapperUtils.getEnumIdx(r, "organizations_status", OrganizationStatus.class));

--- a/src/main/java/mil/dds/anet/database/mappers/PersonMapper.java
+++ b/src/main/java/mil/dds/anet/database/mappers/PersonMapper.java
@@ -7,7 +7,6 @@ import mil.dds.anet.beans.Person;
 import mil.dds.anet.beans.Person.PersonStatus;
 import mil.dds.anet.beans.Person.Role;
 import mil.dds.anet.beans.Position;
-import mil.dds.anet.utils.DaoUtils;
 import org.jdbi.v3.core.mapper.RowMapper;
 import org.jdbi.v3.core.statement.StatementContext;
 
@@ -27,27 +26,27 @@ public class PersonMapper implements RowMapper<Person> {
     return p;
   }
 
-  public static <T extends Person> T fillInFields(T a, ResultSet r) throws SQLException {
+  public static <T extends Person> T fillInFields(T a, ResultSet rs) throws SQLException {
     // This hits when we do a join but there's no Person record.
-    if (r.getObject("people_uuid") == null) {
+    if (rs.getObject("people_uuid") == null) {
       return null;
     }
-    DaoUtils.setCommonBeanFields(a, r, "people");
-    a.setName(r.getString("people_name"));
-    a.setStatus(MapperUtils.getEnumIdx(r, "people_status", PersonStatus.class));
-    a.setRole(MapperUtils.getEnumIdx(r, "people_role", Role.class));
-    a.setEmailAddress(r.getString("people_emailAddress"));
-    a.setPhoneNumber(r.getString("people_phoneNumber"));
-    a.setCountry(r.getString("people_country"));
-    a.setGender(r.getString("people_gender"));
-    a.setCode(r.getString("people_code"));
-    a.setEndOfTourDate(DaoUtils.getInstantAsLocalDateTime(r, "people_endOfTourDate"));
-    a.setRank(r.getString("people_rank"));
-    a.setBiography(r.getString("people_biography"));
-    a.setDomainUsername(r.getString("people_domainUsername"));
-    a.setPendingVerification(r.getBoolean("people_pendingVerification"));
-    Blob avatarBlob = r.getBlob("people_avatar");
-    String avatar =
+    MapperUtils.setCommonBeanFields(a, rs, "people");
+    a.setName(MapperUtils.getOptionalString(rs, "people_name"));
+    a.setStatus(MapperUtils.getEnumIdx(rs, "people_status", PersonStatus.class));
+    a.setRole(MapperUtils.getEnumIdx(rs, "people_role", Role.class));
+    a.setEmailAddress(MapperUtils.getOptionalString(rs, "people_emailAddress"));
+    a.setPhoneNumber(MapperUtils.getOptionalString(rs, "people_phoneNumber"));
+    a.setCountry(MapperUtils.getOptionalString(rs, "people_country"));
+    a.setGender(MapperUtils.getOptionalString(rs, "people_gender"));
+    a.setCode(MapperUtils.getOptionalString(rs, "people_code"));
+    a.setEndOfTourDate(MapperUtils.getInstantAsLocalDateTime(rs, "people_endOfTourDate"));
+    a.setRank(MapperUtils.getOptionalString(rs, "people_rank"));
+    a.setBiography(MapperUtils.getOptionalString(rs, "people_biography"));
+    a.setDomainUsername(MapperUtils.getOptionalString(rs, "people_domainUsername"));
+    a.setPendingVerification(MapperUtils.getOptionalBoolean(rs, "people_pendingVerification"));
+    final Blob avatarBlob = MapperUtils.getOptionalBlob(rs, "people_avatar");
+    final String avatar =
         avatarBlob == null ? null : new String(avatarBlob.getBytes(1L, (int) avatarBlob.length()));
     a.setAvatar(avatar);
 

--- a/src/main/java/mil/dds/anet/database/mappers/PersonPositionHistoryMapper.java
+++ b/src/main/java/mil/dds/anet/database/mappers/PersonPositionHistoryMapper.java
@@ -3,7 +3,6 @@ package mil.dds.anet.database.mappers;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import mil.dds.anet.beans.PersonPositionHistory;
-import mil.dds.anet.utils.DaoUtils;
 import org.jdbi.v3.core.mapper.RowMapper;
 import org.jdbi.v3.core.statement.StatementContext;
 
@@ -12,9 +11,9 @@ public class PersonPositionHistoryMapper implements RowMapper<PersonPositionHist
   @Override
   public PersonPositionHistory map(ResultSet rs, StatementContext ctx) throws SQLException {
     final PersonPositionHistory pph = new PersonPositionHistory();
-    pph.setCreatedAt(DaoUtils.getInstantAsLocalDateTime(rs, "createdAt"));
-    pph.setStartTime(DaoUtils.getInstantAsLocalDateTime(rs, "createdAt"));
-    pph.setEndTime(DaoUtils.getInstantAsLocalDateTime(rs, "endedAt"));
+    pph.setCreatedAt(MapperUtils.getInstantAsLocalDateTime(rs, "createdAt"));
+    pph.setStartTime(MapperUtils.getInstantAsLocalDateTime(rs, "createdAt"));
+    pph.setEndTime(MapperUtils.getInstantAsLocalDateTime(rs, "endedAt"));
     pph.setPositionUuid(rs.getString("positionUuid"));
     pph.setPersonUuid(rs.getString("personUuid"));
     return pph;

--- a/src/main/java/mil/dds/anet/database/mappers/PositionMapper.java
+++ b/src/main/java/mil/dds/anet/database/mappers/PositionMapper.java
@@ -5,7 +5,6 @@ import java.sql.SQLException;
 import mil.dds.anet.beans.Position;
 import mil.dds.anet.beans.Position.PositionStatus;
 import mil.dds.anet.beans.Position.PositionType;
-import mil.dds.anet.utils.DaoUtils;
 import org.jdbi.v3.core.mapper.RowMapper;
 import org.jdbi.v3.core.statement.StatementContext;
 
@@ -27,7 +26,7 @@ public class PositionMapper implements RowMapper<Position> {
   }
 
   public static Position fillInFields(Position p, ResultSet rs) throws SQLException {
-    DaoUtils.setCommonBeanFields(p, rs, "positions");
+    MapperUtils.setCommonBeanFields(p, rs, "positions");
     p.setName(rs.getString("positions_name"));
     p.setCode(rs.getString("positions_code"));
     p.setType(MapperUtils.getEnumIdx(rs, "positions_type", PositionType.class));

--- a/src/main/java/mil/dds/anet/database/mappers/ReportActionMapper.java
+++ b/src/main/java/mil/dds/anet/database/mappers/ReportActionMapper.java
@@ -4,7 +4,6 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import mil.dds.anet.beans.ReportAction;
 import mil.dds.anet.beans.ReportAction.ActionType;
-import mil.dds.anet.utils.DaoUtils;
 import org.jdbi.v3.core.mapper.RowMapper;
 import org.jdbi.v3.core.statement.StatementContext;
 
@@ -16,7 +15,7 @@ public class ReportActionMapper implements RowMapper<ReportAction> {
     aa.setPersonUuid(rs.getString("personUuid"));
     aa.setReportUuid(rs.getString("reportUuid"));
     aa.setStepUuid(rs.getString("approvalStepUuid"));
-    aa.setCreatedAt(DaoUtils.getInstantAsLocalDateTime(rs, "createdAt"));
+    aa.setCreatedAt(MapperUtils.getInstantAsLocalDateTime(rs, "createdAt"));
     aa.setType(MapperUtils.getEnumIdx(rs, "type", ActionType.class));
     return aa;
   }

--- a/src/main/java/mil/dds/anet/database/mappers/ReportMapper.java
+++ b/src/main/java/mil/dds/anet/database/mappers/ReportMapper.java
@@ -6,7 +6,6 @@ import mil.dds.anet.beans.Report;
 import mil.dds.anet.beans.Report.Atmosphere;
 import mil.dds.anet.beans.Report.ReportCancelledReason;
 import mil.dds.anet.beans.Report.ReportState;
-import mil.dds.anet.utils.DaoUtils;
 import org.jdbi.v3.core.mapper.RowMapper;
 import org.jdbi.v3.core.statement.StatementContext;
 
@@ -15,29 +14,29 @@ public class ReportMapper implements RowMapper<Report> {
   @Override
   public Report map(ResultSet rs, StatementContext ctx) throws SQLException {
     Report r = new Report();
-    DaoUtils.setCommonBeanFields(r, rs, "reports");
+    MapperUtils.setCommonBeanFields(r, rs, "reports");
 
     r.setState(MapperUtils.getEnumIdx(rs, "reports_state", ReportState.class));
-    r.setEngagementDate(DaoUtils.getInstantAsLocalDateTime(rs, "reports_engagementDate"));
-    r.setDuration(DaoUtils.getOptionalInt(rs, "reports_duration"));
-    r.setReleasedAt(DaoUtils.getInstantAsLocalDateTime(rs, "reports_releasedAt"));
-    r.setLocationUuid(rs.getString("reports_locationUuid"));
-    r.setApprovalStepUuid(rs.getString("reports_approvalStepUuid"));
+    r.setEngagementDate(MapperUtils.getInstantAsLocalDateTime(rs, "reports_engagementDate"));
+    r.setDuration(MapperUtils.getOptionalInt(rs, "reports_duration"));
+    r.setReleasedAt(MapperUtils.getInstantAsLocalDateTime(rs, "reports_releasedAt"));
+    r.setLocationUuid(MapperUtils.getOptionalString(rs, "reports_locationUuid"));
+    r.setApprovalStepUuid(MapperUtils.getOptionalString(rs, "reports_approvalStepUuid"));
 
-    r.setIntent(rs.getString("reports_intent"));
-    r.setExsum(rs.getString("reports_exsum"));
+    r.setIntent(MapperUtils.getOptionalString(rs, "reports_intent"));
+    r.setExsum(MapperUtils.getOptionalString(rs, "reports_exsum"));
     r.setAtmosphere(MapperUtils.getEnumIdx(rs, "reports_atmosphere", Atmosphere.class));
-    r.setAtmosphereDetails(rs.getString("reports_atmosphereDetails"));
+    r.setAtmosphereDetails(MapperUtils.getOptionalString(rs, "reports_atmosphereDetails"));
     r.setCancelledReason(
         MapperUtils.getEnumIdx(rs, "reports_cancelledReason", ReportCancelledReason.class));
 
-    r.setReportText(rs.getString("reports_text"));
-    r.setKeyOutcomes(rs.getString("reports_keyOutcomes"));
-    r.setNextSteps(rs.getString("reports_nextSteps"));
+    r.setReportText(MapperUtils.getOptionalString(rs, "reports_text"));
+    r.setKeyOutcomes(MapperUtils.getOptionalString(rs, "reports_keyOutcomes"));
+    r.setNextSteps(MapperUtils.getOptionalString(rs, "reports_nextSteps"));
 
-    r.setAuthorUuid(rs.getString("reports_authorUuid"));
-    r.setAdvisorOrgUuid(rs.getString("reports_advisorOrganizationUuid"));
-    r.setPrincipalOrgUuid(rs.getString("reports_principalOrganizationUuid"));
+    r.setAuthorUuid(MapperUtils.getOptionalString(rs, "reports_authorUuid"));
+    r.setAdvisorOrgUuid(MapperUtils.getOptionalString(rs, "reports_advisorOrganizationUuid"));
+    r.setPrincipalOrgUuid(MapperUtils.getOptionalString(rs, "reports_principalOrganizationUuid"));
 
     if (MapperUtils.containsColumnNamed(rs, "totalCount")) {
       ctx.define("totalCount", rs.getInt("totalCount"));

--- a/src/main/java/mil/dds/anet/database/mappers/ReportSensitiveInformationMapper.java
+++ b/src/main/java/mil/dds/anet/database/mappers/ReportSensitiveInformationMapper.java
@@ -3,7 +3,6 @@ package mil.dds.anet.database.mappers;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import mil.dds.anet.beans.ReportSensitiveInformation;
-import mil.dds.anet.utils.DaoUtils;
 import org.jdbi.v3.core.mapper.RowMapper;
 import org.jdbi.v3.core.statement.StatementContext;
 
@@ -12,7 +11,7 @@ public class ReportSensitiveInformationMapper implements RowMapper<ReportSensiti
   @Override
   public ReportSensitiveInformation map(ResultSet rs, StatementContext ctx) throws SQLException {
     final ReportSensitiveInformation rsi = new ReportSensitiveInformation();
-    DaoUtils.setCommonBeanFields(rsi, rs, "reportsSensitiveInformation");
+    MapperUtils.setCommonBeanFields(rsi, rs, "reportsSensitiveInformation");
     rsi.setText(rs.getString("reportsSensitiveInformation_text"));
     return rsi;
   }

--- a/src/main/java/mil/dds/anet/database/mappers/SavedSearchMapper.java
+++ b/src/main/java/mil/dds/anet/database/mappers/SavedSearchMapper.java
@@ -4,7 +4,6 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import mil.dds.anet.beans.search.SavedSearch;
 import mil.dds.anet.beans.search.SavedSearch.SearchObjectType;
-import mil.dds.anet.utils.DaoUtils;
 import org.jdbi.v3.core.mapper.RowMapper;
 import org.jdbi.v3.core.statement.StatementContext;
 
@@ -13,7 +12,7 @@ public class SavedSearchMapper implements RowMapper<SavedSearch> {
   @Override
   public SavedSearch map(ResultSet rs, StatementContext ctx) throws SQLException {
     SavedSearch ss = new SavedSearch();
-    DaoUtils.setCommonBeanFields(ss, rs, null);
+    MapperUtils.setCommonBeanFields(ss, rs, null);
     ss.setOwnerUuid(rs.getString("ownerUuid"));
     ss.setName(rs.getString("name"));
     ss.setObjectType(MapperUtils.getEnumIdx(rs, "objectType", SearchObjectType.class));

--- a/src/main/java/mil/dds/anet/database/mappers/TagMapper.java
+++ b/src/main/java/mil/dds/anet/database/mappers/TagMapper.java
@@ -3,7 +3,6 @@ package mil.dds.anet.database.mappers;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import mil.dds.anet.beans.Tag;
-import mil.dds.anet.utils.DaoUtils;
 import org.jdbi.v3.core.mapper.RowMapper;
 import org.jdbi.v3.core.statement.StatementContext;
 
@@ -12,7 +11,7 @@ public class TagMapper implements RowMapper<Tag> {
   @Override
   public Tag map(ResultSet rs, StatementContext ctx) throws SQLException {
     final Tag t = new Tag();
-    DaoUtils.setCommonBeanFields(t, rs, null);
+    MapperUtils.setCommonBeanFields(t, rs, null);
     t.setName(rs.getString("name"));
     t.setDescription(rs.getString("description"));
 

--- a/src/main/java/mil/dds/anet/database/mappers/TaskMapper.java
+++ b/src/main/java/mil/dds/anet/database/mappers/TaskMapper.java
@@ -4,7 +4,6 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import mil.dds.anet.beans.Task;
 import mil.dds.anet.beans.Task.TaskStatus;
-import mil.dds.anet.utils.DaoUtils;
 import org.jdbi.v3.core.mapper.RowMapper;
 import org.jdbi.v3.core.statement.StatementContext;
 
@@ -13,15 +12,15 @@ public class TaskMapper implements RowMapper<Task> {
   @Override
   public Task map(ResultSet r, StatementContext ctx) throws SQLException {
     Task p = new Task();
-    DaoUtils.setCommonBeanFields(p, r, null);
+    MapperUtils.setCommonBeanFields(p, r, null);
     p.setLongName(r.getString("longName"));
     p.setShortName(r.getString("shortName"));
     p.setCategory(r.getString("category"));
     p.setCustomField(r.getString("customField"));
     p.setCustomFieldEnum1(r.getString("customFieldEnum1"));
     p.setCustomFieldEnum2(r.getString("customFieldEnum2"));
-    p.setPlannedCompletion(DaoUtils.getInstantAsLocalDateTime(r, "plannedCompletion"));
-    p.setProjectedCompletion(DaoUtils.getInstantAsLocalDateTime(r, "projectedCompletion"));
+    p.setPlannedCompletion(MapperUtils.getInstantAsLocalDateTime(r, "plannedCompletion"));
+    p.setProjectedCompletion(MapperUtils.getInstantAsLocalDateTime(r, "projectedCompletion"));
     p.setStatus(MapperUtils.getEnumIdx(r, "status", TaskStatus.class));
     p.setCustomFieldRef1Uuid(r.getString("customFieldRef1Uuid"));
     p.setResponsibleOrgUuid(r.getString("organizationUuid"));

--- a/src/main/java/mil/dds/anet/resources/PersonResource.java
+++ b/src/main/java/mil/dds/anet/resources/PersonResource.java
@@ -1,11 +1,13 @@
 package mil.dds.anet.resources;
 
 import io.leangen.graphql.annotations.GraphQLArgument;
+import io.leangen.graphql.annotations.GraphQLEnvironment;
 import io.leangen.graphql.annotations.GraphQLMutation;
 import io.leangen.graphql.annotations.GraphQLQuery;
 import io.leangen.graphql.annotations.GraphQLRootContext;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response.Status;
@@ -187,8 +189,9 @@ public class PersonResource {
   }
 
   @GraphQLQuery(name = "personList")
-  public AnetBeanList<Person> search(@GraphQLArgument(name = "query") PersonSearchQuery query) {
-    return dao.search(query);
+  public AnetBeanList<Person> search(@GraphQLEnvironment Set<String> subFields,
+      @GraphQLArgument(name = "query") PersonSearchQuery query) {
+    return dao.search(subFields, query);
   }
 
   /**

--- a/src/main/java/mil/dds/anet/resources/ReportResource.java
+++ b/src/main/java/mil/dds/anet/resources/ReportResource.java
@@ -4,6 +4,7 @@ import freemarker.template.Configuration;
 import freemarker.template.DefaultObjectWrapperBuilder;
 import freemarker.template.Template;
 import io.leangen.graphql.annotations.GraphQLArgument;
+import io.leangen.graphql.annotations.GraphQLEnvironment;
 import io.leangen.graphql.annotations.GraphQLMutation;
 import io.leangen.graphql.annotations.GraphQLQuery;
 import io.leangen.graphql.annotations.GraphQLRootContext;
@@ -829,9 +830,10 @@ public class ReportResource {
 
   @GraphQLQuery(name = "reportList")
   public AnetBeanList<Report> search(@GraphQLRootContext Map<String, Object> context,
+      @GraphQLEnvironment Set<String> subFields,
       @GraphQLArgument(name = "query") ReportSearchQuery query) {
     query.setUser(DaoUtils.getUserFromContext(context));
-    return dao.search(query);
+    return dao.search(subFields, query);
   }
 
   /**

--- a/src/main/java/mil/dds/anet/search/AbstractPersonSearcher.java
+++ b/src/main/java/mil/dds/anet/search/AbstractPersonSearcher.java
@@ -1,5 +1,9 @@
 package mil.dds.anet.search;
 
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Sets;
+import java.util.Map;
+import java.util.Set;
 import mil.dds.anet.beans.Person;
 import mil.dds.anet.beans.lists.AnetBeanList;
 import mil.dds.anet.beans.search.ISearchQuery.SortOrder;
@@ -12,19 +16,33 @@ import ru.vyarus.guicey.jdbi3.tx.InTransaction;
 public abstract class AbstractPersonSearcher extends AbstractSearcher<Person, PersonSearchQuery>
     implements IPersonSearcher {
 
+  private static final Set<String> ALL_FIELDS = Sets.newHashSet(PersonDao.allFields);
+  private static final Set<String> MINIMAL_FIELDS = Sets.newHashSet(PersonDao.minimalFields);
+  private static final Map<String, String> FIELD_MAPPING = ImmutableMap.of();
+
   public AbstractPersonSearcher(AbstractSearchQueryBuilder<Person, PersonSearchQuery> qb) {
     super(qb);
   }
 
   @InTransaction
   @Override
-  public AnetBeanList<Person> runSearch(PersonSearchQuery query) {
-    buildQuery(query);
+  public AnetBeanList<Person> runSearch(Set<String> subFields, PersonSearchQuery query) {
+    buildQuery(subFields, query);
     return qb.buildAndRun(getDbHandle(), query, new PersonMapper());
   }
 
+  @Override
   protected void buildQuery(PersonSearchQuery query) {
-    qb.addSelectClause(PersonDao.PERSON_FIELDS);
+    throw new UnsupportedOperationException();
+  }
+
+  protected String getTableFields(Set<String> subFields) {
+    return getTableFields(PersonDao.TABLE_NAME, ALL_FIELDS, MINIMAL_FIELDS, FIELD_MAPPING,
+        subFields);
+  }
+
+  protected void buildQuery(Set<String> subFields, PersonSearchQuery query) {
+    qb.addSelectClause(getTableFields(subFields));
     qb.addTotalCount();
     qb.addFromClause("people");
 

--- a/src/main/java/mil/dds/anet/search/AbstractReportSearcher.java
+++ b/src/main/java/mil/dds/anet/search/AbstractReportSearcher.java
@@ -18,7 +18,6 @@ import mil.dds.anet.beans.search.ISearchQuery.SortOrder;
 import mil.dds.anet.beans.search.ReportSearchQuery;
 import mil.dds.anet.beans.search.ReportSearchQuery.EngagementStatus;
 import mil.dds.anet.database.PositionDao;
-import mil.dds.anet.database.ReportDao;
 import mil.dds.anet.database.mappers.ReportMapper;
 import mil.dds.anet.search.AbstractSearchQueryBuilder.Comparison;
 import mil.dds.anet.utils.DaoUtils;
@@ -46,10 +45,7 @@ public abstract class AbstractReportSearcher extends AbstractSearcher<Report, Re
   }
 
   protected void buildQuery(ReportSearchQuery query) {
-    qb.addSelectClause("DISTINCT " + ReportDao.REPORT_FIELDS);
-    qb.addFromClause("reports");
-    qb.addFromClause("LEFT JOIN \"reportTags\" ON \"reportTags\".\"reportUuid\" = reports.uuid");
-    qb.addFromClause("LEFT JOIN tags ON \"reportTags\".\"tagUuid\" = tags.uuid");
+    // Base select and from clauses are added by child classes
 
     if (query.isTextPresent()) {
       addTextQuery(query);

--- a/src/main/java/mil/dds/anet/search/AbstractSearchQueryBuilder.java
+++ b/src/main/java/mil/dds/anet/search/AbstractSearchQueryBuilder.java
@@ -121,6 +121,8 @@ public abstract class AbstractSearchQueryBuilder<B extends AbstractAnetBean, T e
     return stripWildcards(text) + "%";
   }
 
+  public abstract String getContainsQuery(String text);
+
   public abstract String getFullTextQuery(String text);
 
   /**

--- a/src/main/java/mil/dds/anet/search/AbstractSearcher.java
+++ b/src/main/java/mil/dds/anet/search/AbstractSearcher.java
@@ -1,5 +1,6 @@
 package mil.dds.anet.search;
 
+import com.google.common.base.Joiner;
 import java.util.ArrayList;
 import java.util.List;
 import javax.inject.Inject;
@@ -10,6 +11,8 @@ import mil.dds.anet.views.AbstractAnetBean;
 import org.jdbi.v3.core.Handle;
 
 public abstract class AbstractSearcher<B extends AbstractAnetBean, T extends AbstractSearchQuery<?>> {
+
+  private static final int MIN_UUID_PREFIX = 4;
 
   @Inject
   private Provider<Handle> handle;
@@ -25,6 +28,34 @@ public abstract class AbstractSearcher<B extends AbstractAnetBean, T extends Abs
   }
 
   protected abstract void buildQuery(T query);
+
+  protected void addFullTextSearch(String tableName, String text, boolean isSortByPresent) {
+    final List<String> whereClauses = new ArrayList<>();
+    final List<String> selectClauses = new ArrayList<>();
+
+    if (text.trim().length() >= MIN_UUID_PREFIX) {
+      whereClauses
+          .add(String.format("SELECT uuid FROM %1$s WHERE uuid ILIKE :likeQuery", tableName));
+      selectClauses
+          .add(String.format("CASE WHEN %1$s.uuid ILIKE :likeQuery THEN 1 ELSE 0 END", tableName));
+      qb.addSqlArg("likeQuery", qb.getLikeQuery(text));
+    }
+
+    final String tsQuery = "websearch_to_tsquery('anet', :fullTextQuery)";
+    whereClauses.add(
+        String.format("SELECT uuid FROM mv_fts_%1$s WHERE full_text @@ %2$s", tableName, tsQuery));
+    qb.addWhereClause(
+        String.format("%1$s.uuid IN (%2$s)", tableName, Joiner.on(" UNION ").join(whereClauses)));
+    qb.addSqlArg("fullTextQuery", qb.getFullTextQuery(text));
+
+    if (!isSortByPresent) {
+      selectClauses.add(String.format("ts_rank(full_text, %1$s)", tsQuery));
+      qb.addFromClause(
+          String.format("LEFT JOIN mv_fts_%1$s ON mv_fts_%1$s.uuid = %1$s.uuid", tableName));
+      qb.addSelectClause(
+          String.format("(%1$s) AS search_rank", Joiner.on(" + ").join(selectClauses)));
+    }
+  }
 
   protected List<String> getOrderBy(SortOrder sortOrder, String table, String... columns) {
     final List<String> clauses = new ArrayList<>();

--- a/src/main/java/mil/dds/anet/search/AbstractSearcher.java
+++ b/src/main/java/mil/dds/anet/search/AbstractSearcher.java
@@ -56,23 +56,23 @@ public abstract class AbstractSearcher<B extends AbstractAnetBean, T extends Abs
 
     if (text.trim().length() >= MIN_UUID_PREFIX) {
       whereClauses
-          .add(String.format("SELECT uuid FROM %1$s WHERE uuid ILIKE :likeQuery", tableName));
-      selectClauses
-          .add(String.format("CASE WHEN %1$s.uuid ILIKE :likeQuery THEN 1 ELSE 0 END", tableName));
+          .add(String.format("SELECT uuid FROM \"%1$s\" WHERE uuid ILIKE :likeQuery", tableName));
+      selectClauses.add(
+          String.format("CASE WHEN \"%1$s\".uuid ILIKE :likeQuery THEN 1 ELSE 0 END", tableName));
       qb.addSqlArg("likeQuery", qb.getLikeQuery(text));
     }
 
     final String tsQuery = "websearch_to_tsquery('anet', :fullTextQuery)";
-    whereClauses.add(
-        String.format("SELECT uuid FROM mv_fts_%1$s WHERE full_text @@ %2$s", tableName, tsQuery));
-    qb.addWhereClause(
-        String.format("%1$s.uuid IN (%2$s)", tableName, Joiner.on(" UNION ").join(whereClauses)));
+    whereClauses.add(String.format("SELECT uuid FROM \"mv_fts_%1$s\" WHERE full_text @@ %2$s",
+        tableName, tsQuery));
+    qb.addWhereClause(String.format("\"%1$s\".uuid IN (%2$s)", tableName,
+        Joiner.on(" UNION ").join(whereClauses)));
     qb.addSqlArg("fullTextQuery", qb.getFullTextQuery(text));
 
     if (!isSortByPresent) {
       selectClauses.add(String.format("ts_rank(full_text, %1$s)", tsQuery));
-      qb.addFromClause(
-          String.format("LEFT JOIN mv_fts_%1$s ON mv_fts_%1$s.uuid = %1$s.uuid", tableName));
+      qb.addFromClause(String
+          .format("LEFT JOIN \"mv_fts_%1$s\" ON \"mv_fts_%1$s\".uuid = \"%1$s\".uuid", tableName));
       qb.addSelectClause(
           String.format("(%1$s) AS search_rank", Joiner.on(" + ").join(selectClauses)));
     }

--- a/src/main/java/mil/dds/anet/search/IPersonSearcher.java
+++ b/src/main/java/mil/dds/anet/search/IPersonSearcher.java
@@ -1,11 +1,12 @@
 package mil.dds.anet.search;
 
+import java.util.Set;
 import mil.dds.anet.beans.Person;
 import mil.dds.anet.beans.lists.AnetBeanList;
 import mil.dds.anet.beans.search.PersonSearchQuery;
 
 public interface IPersonSearcher {
 
-  public AnetBeanList<Person> runSearch(PersonSearchQuery query);
+  public AnetBeanList<Person> runSearch(Set<String> subFields, PersonSearchQuery query);
 
 }

--- a/src/main/java/mil/dds/anet/search/IReportSearcher.java
+++ b/src/main/java/mil/dds/anet/search/IReportSearcher.java
@@ -1,11 +1,12 @@
 package mil.dds.anet.search;
 
+import java.util.Set;
 import mil.dds.anet.beans.Report;
 import mil.dds.anet.beans.lists.AnetBeanList;
 import mil.dds.anet.beans.search.ReportSearchQuery;
 
 public interface IReportSearcher {
 
-  public AnetBeanList<Report> runSearch(ReportSearchQuery query);
+  public AnetBeanList<Report> runSearch(Set<String> subFields, ReportSearchQuery query);
 
 }

--- a/src/main/java/mil/dds/anet/search/mssql/MssqlAuthorizationGroupSearcher.java
+++ b/src/main/java/mil/dds/anet/search/mssql/MssqlAuthorizationGroupSearcher.java
@@ -27,12 +27,12 @@ public class MssqlAuthorizationGroupSearcher extends AbstractAuthorizationGroupS
     qb.addFromClause(
         "LEFT JOIN CONTAINSTABLE (authorizationGroups, (name, description), :containsQuery) c_authorizationGroups"
             + " ON authorizationGroups.uuid = c_authorizationGroups.[Key]"
-            + " LEFT JOIN FREETEXTTABLE(authorizationGroups, (name, description), :freetextQuery) f_authorizationGroups"
+            + " LEFT JOIN FREETEXTTABLE(authorizationGroups, (name, description), :fullTextQuery) f_authorizationGroups"
             + " ON authorizationGroups.uuid = f_authorizationGroups.[Key]");
     qb.addWhereClause("c_authorizationGroups.rank IS NOT NULL");
     final String text = query.getText();
-    qb.addSqlArg("containsQuery", qb.getFullTextQuery(text));
-    qb.addSqlArg("freetextQuery", text);
+    qb.addSqlArg("containsQuery", qb.getContainsQuery(text));
+    qb.addSqlArg("fullTextQuery", qb.getFullTextQuery(text));
   }
 
   @Override

--- a/src/main/java/mil/dds/anet/search/mssql/MssqlLocationSearcher.java
+++ b/src/main/java/mil/dds/anet/search/mssql/MssqlLocationSearcher.java
@@ -23,7 +23,7 @@ public class MssqlLocationSearcher extends AbstractLocationSearcher {
         + " ON locations.uuid = c_locations.[Key]");
     qb.addWhereClause("c_locations.rank IS NOT NULL");
     final String text = query.getText();
-    qb.addSqlArg("containsQuery", qb.getFullTextQuery(text));
+    qb.addSqlArg("containsQuery", qb.getContainsQuery(text));
   }
 
   @Override

--- a/src/main/java/mil/dds/anet/search/mssql/MssqlOrganizationSearcher.java
+++ b/src/main/java/mil/dds/anet/search/mssql/MssqlOrganizationSearcher.java
@@ -31,7 +31,7 @@ public class MssqlOrganizationSearcher extends AbstractOrganizationSearcher {
         "(c_organizations.rank IS NOT NULL OR organizations.identificationCode LIKE :likeQuery"
             + " OR organizations.shortName LIKE :likeQuery)");
     final String text = query.getText();
-    qb.addSqlArg("containsQuery", qb.getFullTextQuery(text));
+    qb.addSqlArg("containsQuery", qb.getContainsQuery(text));
     qb.addSqlArg("likeQuery", qb.getLikeQuery(text));
   }
 

--- a/src/main/java/mil/dds/anet/search/mssql/MssqlPersonSearcher.java
+++ b/src/main/java/mil/dds/anet/search/mssql/MssqlPersonSearcher.java
@@ -43,8 +43,8 @@ public class MssqlPersonSearcher extends AbstractPersonSearcher {
     whereRank.append(")");
     qb.addWhereClause(whereRank.toString());
     final String text = query.getText();
-    qb.addSqlArg("containsQuery", qb.getFullTextQuery(text));
-    qb.addSqlArg("freetextQuery", text);
+    qb.addSqlArg("containsQuery", qb.getContainsQuery(text));
+    qb.addSqlArg("fullTextQuery", qb.getFullTextQuery(text));
     qb.addSqlArg("likeQuery", qb.getLikeQuery(text));
   }
 

--- a/src/main/java/mil/dds/anet/search/mssql/MssqlPersonSearcher.java
+++ b/src/main/java/mil/dds/anet/search/mssql/MssqlPersonSearcher.java
@@ -30,7 +30,7 @@ public class MssqlPersonSearcher extends AbstractPersonSearcher {
     qb.addFromClause(
         "LEFT JOIN CONTAINSTABLE (people, (name, emailAddress), :containsQuery) c_people"
             + " ON people.uuid = c_people.[Key]"
-            + " LEFT JOIN FREETEXTTABLE(people, (name), :freetextQuery) f_people"
+            + " LEFT JOIN FREETEXTTABLE(people, (name), :fullTextQuery) f_people"
             + " ON people.uuid = f_people.[Key]");
     final StringBuilder whereRank =
         new StringBuilder("(c_people.rank IS NOT NULL OR f_people.rank IS NOT NULL"

--- a/src/main/java/mil/dds/anet/search/mssql/MssqlPositionSearcher.java
+++ b/src/main/java/mil/dds/anet/search/mssql/MssqlPositionSearcher.java
@@ -35,7 +35,7 @@ public class MssqlPositionSearcher extends AbstractPositionSearcher {
     whereRank.append(")");
     qb.addWhereClause(whereRank.toString());
     final String text = query.getText();
-    qb.addSqlArg("containsQuery", qb.getFullTextQuery(text));
+    qb.addSqlArg("containsQuery", qb.getContainsQuery(text));
     qb.addSqlArg("likeQuery", qb.getLikeQuery(text));
   }
 

--- a/src/main/java/mil/dds/anet/search/mssql/MssqlReportSearcher.java
+++ b/src/main/java/mil/dds/anet/search/mssql/MssqlReportSearcher.java
@@ -34,17 +34,17 @@ public class MssqlReportSearcher extends AbstractReportSearcher {
     qb.addFromClause(
         "LEFT JOIN CONTAINSTABLE (reports, (text, intent, keyOutcomes, nextSteps), :containsQuery) c_reports"
             + " ON reports.uuid = c_reports.[Key]"
-            + " LEFT JOIN FREETEXTTABLE(reports, (text, intent, keyOutcomes, nextSteps), :freetextQuery) f_reports"
+            + " LEFT JOIN FREETEXTTABLE(reports, (text, intent, keyOutcomes, nextSteps), :fullTextQuery) f_reports"
             + " ON reports.uuid = f_reports.[Key]");
     qb.addFromClause("LEFT JOIN CONTAINSTABLE (tags, (name, description), :containsQuery) c_tags"
         + " ON tags.uuid = c_tags.[Key]"
-        + " LEFT JOIN FREETEXTTABLE(tags, (name, description), :freetextQuery) f_tags"
+        + " LEFT JOIN FREETEXTTABLE(tags, (name, description), :fullTextQuery) f_tags"
         + " ON tags.uuid = f_tags.[Key]");
     qb.addWhereClause("(c_reports.rank IS NOT NULL OR f_reports.rank IS NOT NULL"
         + " OR c_tags.rank IS NOT NULL OR f_tags.rank IS NOT NULL)");
     final String text = query.getText();
-    qb.addSqlArg("containsQuery", qb.getFullTextQuery(text));
-    qb.addSqlArg("freetextQuery", text);
+    qb.addSqlArg("containsQuery", qb.getContainsQuery(text));
+    qb.addSqlArg("fullTextQuery", qb.getFullTextQuery(text));
   }
 
   @Override

--- a/src/main/java/mil/dds/anet/search/mssql/MssqlReportSearcher.java
+++ b/src/main/java/mil/dds/anet/search/mssql/MssqlReportSearcher.java
@@ -4,6 +4,7 @@ import mil.dds.anet.beans.Report;
 import mil.dds.anet.beans.lists.AnetBeanList;
 import mil.dds.anet.beans.search.ISearchQuery.SortOrder;
 import mil.dds.anet.beans.search.ReportSearchQuery;
+import mil.dds.anet.database.ReportDao;
 import mil.dds.anet.search.AbstractReportSearcher;
 import mil.dds.anet.search.AbstractSearchQueryBuilder;
 
@@ -19,6 +20,15 @@ public class MssqlReportSearcher extends AbstractReportSearcher {
   @Override
   public AnetBeanList<Report> runSearch(ReportSearchQuery query) {
     return runSearch(outerQb, query);
+  }
+
+  @Override
+  protected void buildQuery(ReportSearchQuery query) {
+    qb.addSelectClause("DISTINCT " + ReportDao.REPORT_FIELDS);
+    qb.addFromClause("reports");
+    qb.addFromClause("LEFT JOIN \"reportTags\" ON \"reportTags\".\"reportUuid\" = reports.uuid");
+    qb.addFromClause("LEFT JOIN tags ON \"reportTags\".\"tagUuid\" = tags.uuid");
+    super.buildQuery(query);
   }
 
   @Override

--- a/src/main/java/mil/dds/anet/search/mssql/MssqlReportSearcher.java
+++ b/src/main/java/mil/dds/anet/search/mssql/MssqlReportSearcher.java
@@ -1,10 +1,10 @@
 package mil.dds.anet.search.mssql;
 
+import java.util.Set;
 import mil.dds.anet.beans.Report;
 import mil.dds.anet.beans.lists.AnetBeanList;
 import mil.dds.anet.beans.search.ISearchQuery.SortOrder;
 import mil.dds.anet.beans.search.ReportSearchQuery;
-import mil.dds.anet.database.ReportDao;
 import mil.dds.anet.search.AbstractReportSearcher;
 import mil.dds.anet.search.AbstractSearchQueryBuilder;
 
@@ -18,17 +18,17 @@ public class MssqlReportSearcher extends AbstractReportSearcher {
   }
 
   @Override
-  public AnetBeanList<Report> runSearch(ReportSearchQuery query) {
-    return runSearch(outerQb, query);
+  public AnetBeanList<Report> runSearch(Set<String> subFields, ReportSearchQuery query) {
+    return runSearch(outerQb, subFields, query);
   }
 
   @Override
-  protected void buildQuery(ReportSearchQuery query) {
-    qb.addSelectClause("DISTINCT " + ReportDao.REPORT_FIELDS);
+  protected void buildQuery(Set<String> subFields, ReportSearchQuery query) {
+    qb.addSelectClause("DISTINCT " + getTableFields(subFields));
     qb.addFromClause("reports");
     qb.addFromClause("LEFT JOIN \"reportTags\" ON \"reportTags\".\"reportUuid\" = reports.uuid");
     qb.addFromClause("LEFT JOIN tags ON \"reportTags\".\"tagUuid\" = tags.uuid");
-    super.buildQuery(query);
+    super.buildQuery(subFields, query);
   }
 
   @Override

--- a/src/main/java/mil/dds/anet/search/mssql/MssqlSearchQueryBuilder.java
+++ b/src/main/java/mil/dds/anet/search/mssql/MssqlSearchQueryBuilder.java
@@ -22,7 +22,7 @@ public class MssqlSearchQueryBuilder<B extends AbstractAnetBean, T extends Abstr
    * we do a prefix match on the string else we do an inflectional match.
    */
   @Override
-  public String getFullTextQuery(String text) {
+  public String getContainsQuery(String text) {
     String cleanText = stripWildcards(text);
     if (text.endsWith("*")) {
       cleanText = "\"" + cleanText + "*\"";
@@ -30,6 +30,11 @@ public class MssqlSearchQueryBuilder<B extends AbstractAnetBean, T extends Abstr
       cleanText = "FORMSOF(INFLECTIONAL, \"" + cleanText + "\")";
     }
     return cleanText;
+  }
+
+  @Override
+  public String getFullTextQuery(String text) {
+    return text;
   }
 
   @Override

--- a/src/main/java/mil/dds/anet/search/mssql/MssqlTagSearcher.java
+++ b/src/main/java/mil/dds/anet/search/mssql/MssqlTagSearcher.java
@@ -23,12 +23,12 @@ public class MssqlTagSearcher extends AbstractTagSearcher {
     }
     qb.addFromClause("LEFT JOIN CONTAINSTABLE (tags, (name, description), :containsQuery) c_tags"
         + " ON tags.uuid = c_tags.[Key]"
-        + " LEFT JOIN FREETEXTTABLE(tags, (name, description), :freetextQuery) f_tags"
+        + " LEFT JOIN FREETEXTTABLE(tags, (name, description), :fullTextQuery) f_tags"
         + " ON tags.uuid = f_tags.[Key]");
     qb.addWhereClause("c_tags.rank IS NOT NULL");
     final String text = query.getText();
-    qb.addSqlArg("containsQuery", qb.getFullTextQuery(text));
-    qb.addSqlArg("freetextQuery", text);
+    qb.addSqlArg("containsQuery", qb.getContainsQuery(text));
+    qb.addSqlArg("fullTextQuery", qb.getFullTextQuery(text));
   }
 
   @Override

--- a/src/main/java/mil/dds/anet/search/mssql/MssqlTaskSearcher.java
+++ b/src/main/java/mil/dds/anet/search/mssql/MssqlTaskSearcher.java
@@ -25,7 +25,7 @@ public class MssqlTaskSearcher extends AbstractTaskSearcher {
         + " ON tasks.uuid = c_tasks.[Key]");
     qb.addWhereClause("(c_tasks.rank IS NOT NULL OR tasks.shortName LIKE :likeQuery)");
     final String text = query.getText();
-    qb.addSqlArg("containsQuery", qb.getFullTextQuery(text));
+    qb.addSqlArg("containsQuery", qb.getContainsQuery(text));
     qb.addSqlArg("likeQuery", qb.getLikeQuery(text));
   }
 

--- a/src/main/java/mil/dds/anet/search/pg/PostgresqlAuthorizationGroupSearcher.java
+++ b/src/main/java/mil/dds/anet/search/pg/PostgresqlAuthorizationGroupSearcher.java
@@ -15,7 +15,7 @@ public class PostgresqlAuthorizationGroupSearcher extends AbstractAuthorizationG
 
   @Override
   protected void addTextQuery(AuthorizationGroupSearchQuery query) {
-    addFullTextSearch("\"authorizationGroups\"", query.getText(), query.isSortByPresent());
+    addFullTextSearch("authorizationGroups", query.getText(), query.isSortByPresent());
   }
 
   protected void addOrderByClauses(AbstractSearchQueryBuilder<?, ?> qb,

--- a/src/main/java/mil/dds/anet/search/pg/PostgresqlAuthorizationGroupSearcher.java
+++ b/src/main/java/mil/dds/anet/search/pg/PostgresqlAuthorizationGroupSearcher.java
@@ -13,7 +13,7 @@ public class PostgresqlAuthorizationGroupSearcher extends AbstractAuthorizationG
 
   @Override
   protected void addTextQuery(AuthorizationGroupSearchQuery query) {
-    final String text = qb.getFullTextQuery(query.getText());
+    final String text = qb.getContainsQuery(query.getText());
     qb.addLikeClauses("text",
         new String[] {"\"authorizationGroup\".name", "\"authorizationGroup\".description"}, text);
   }

--- a/src/main/java/mil/dds/anet/search/pg/PostgresqlLocationSearcher.java
+++ b/src/main/java/mil/dds/anet/search/pg/PostgresqlLocationSearcher.java
@@ -1,8 +1,10 @@
 package mil.dds.anet.search.pg;
 
 import mil.dds.anet.beans.Location;
+import mil.dds.anet.beans.search.ISearchQuery.SortOrder;
 import mil.dds.anet.beans.search.LocationSearchQuery;
 import mil.dds.anet.search.AbstractLocationSearcher;
+import mil.dds.anet.search.AbstractSearchQueryBuilder;
 
 public class PostgresqlLocationSearcher extends AbstractLocationSearcher {
 
@@ -13,8 +15,16 @@ public class PostgresqlLocationSearcher extends AbstractLocationSearcher {
 
   @Override
   protected void addTextQuery(LocationSearchQuery query) {
-    final String text = qb.getContainsQuery(query.getText());
-    qb.addLikeClause("text", "locations.name", text);
+    addFullTextSearch("locations", query.getText(), query.isSortByPresent());
+  }
+
+  protected void addOrderByClauses(AbstractSearchQueryBuilder<?, ?> qb, LocationSearchQuery query) {
+    if (query.isTextPresent() && !query.isSortByPresent()) {
+      // We're doing a full-text search without an explicit sort order,
+      // so sort first on the search pseudo-rank.
+      qb.addAllOrderByClauses(getOrderBy(SortOrder.DESC, null, "search_rank"));
+    }
+    super.addOrderByClauses(qb, query);
   }
 
 }

--- a/src/main/java/mil/dds/anet/search/pg/PostgresqlLocationSearcher.java
+++ b/src/main/java/mil/dds/anet/search/pg/PostgresqlLocationSearcher.java
@@ -13,7 +13,7 @@ public class PostgresqlLocationSearcher extends AbstractLocationSearcher {
 
   @Override
   protected void addTextQuery(LocationSearchQuery query) {
-    final String text = qb.getFullTextQuery(query.getText());
+    final String text = qb.getContainsQuery(query.getText());
     qb.addLikeClause("text", "locations.name", text);
   }
 

--- a/src/main/java/mil/dds/anet/search/pg/PostgresqlOrganizationSearcher.java
+++ b/src/main/java/mil/dds/anet/search/pg/PostgresqlOrganizationSearcher.java
@@ -1,8 +1,10 @@
 package mil.dds.anet.search.pg;
 
 import mil.dds.anet.beans.Organization;
+import mil.dds.anet.beans.search.ISearchQuery.SortOrder;
 import mil.dds.anet.beans.search.OrganizationSearchQuery;
 import mil.dds.anet.search.AbstractOrganizationSearcher;
+import mil.dds.anet.search.AbstractSearchQueryBuilder;
 
 public class PostgresqlOrganizationSearcher extends AbstractOrganizationSearcher {
 
@@ -13,9 +15,17 @@ public class PostgresqlOrganizationSearcher extends AbstractOrganizationSearcher
 
   @Override
   protected void addTextQuery(OrganizationSearchQuery query) {
-    final String text = qb.getContainsQuery(query.getText());
-    qb.addLikeClauses("text",
-        new String[] {"organizations.\"shortName\"", "organizations.\"longName\""}, text);
+    addFullTextSearch("organizations", query.getText(), query.isSortByPresent());
+  }
+
+  protected void addOrderByClauses(AbstractSearchQueryBuilder<?, ?> qb,
+      OrganizationSearchQuery query) {
+    if (query.isTextPresent() && !query.isSortByPresent()) {
+      // We're doing a full-text search without an explicit sort order,
+      // so sort first on the search pseudo-rank.
+      qb.addAllOrderByClauses(getOrderBy(SortOrder.DESC, null, "search_rank"));
+    }
+    super.addOrderByClauses(qb, query);
   }
 
 }

--- a/src/main/java/mil/dds/anet/search/pg/PostgresqlOrganizationSearcher.java
+++ b/src/main/java/mil/dds/anet/search/pg/PostgresqlOrganizationSearcher.java
@@ -13,7 +13,7 @@ public class PostgresqlOrganizationSearcher extends AbstractOrganizationSearcher
 
   @Override
   protected void addTextQuery(OrganizationSearchQuery query) {
-    final String text = qb.getFullTextQuery(query.getText());
+    final String text = qb.getContainsQuery(query.getText());
     qb.addLikeClauses("text",
         new String[] {"organizations.\"shortName\"", "organizations.\"longName\""}, text);
   }

--- a/src/main/java/mil/dds/anet/search/pg/PostgresqlReportSearcher.java
+++ b/src/main/java/mil/dds/anet/search/pg/PostgresqlReportSearcher.java
@@ -24,7 +24,7 @@ public class PostgresqlReportSearcher extends AbstractReportSearcher {
 
   @Override
   protected void addTextQuery(ReportSearchQuery query) {
-    final String text = qb.getFullTextQuery(query.getText());
+    final String text = qb.getContainsQuery(query.getText());
     qb.addLikeClauses("text", new String[] {"reports.text", "reports.intent",
         "reports.\"keyOutcomes\"", "reports.\"nextSteps\"", "tags.name", "tags.description"}, text);
   }

--- a/src/main/java/mil/dds/anet/search/pg/PostgresqlReportSearcher.java
+++ b/src/main/java/mil/dds/anet/search/pg/PostgresqlReportSearcher.java
@@ -16,7 +16,7 @@ public class PostgresqlReportSearcher extends AbstractReportSearcher {
 
   public PostgresqlReportSearcher() {
     super(new PostgresqlSearchQueryBuilder<Report, ReportSearchQuery>("PostgresqlReportSearch"));
-    this.isoDowFormat = "EXTRACT(ISODOW FROM %s)";
+    this.isoDowFormat = "EXTRACT(DOW FROM %s)+1"; // We need Sunday=1, Monday=2, etc.
   }
 
   @InTransaction

--- a/src/main/java/mil/dds/anet/search/pg/PostgresqlReportSearcher.java
+++ b/src/main/java/mil/dds/anet/search/pg/PostgresqlReportSearcher.java
@@ -1,10 +1,10 @@
 package mil.dds.anet.search.pg;
 
+import java.util.Set;
 import mil.dds.anet.beans.Report;
 import mil.dds.anet.beans.lists.AnetBeanList;
 import mil.dds.anet.beans.search.ISearchQuery.SortOrder;
 import mil.dds.anet.beans.search.ReportSearchQuery;
-import mil.dds.anet.database.ReportDao;
 import mil.dds.anet.database.mappers.ReportMapper;
 import mil.dds.anet.search.AbstractReportSearcher;
 import mil.dds.anet.search.AbstractSearchQueryBuilder;
@@ -21,17 +21,16 @@ public class PostgresqlReportSearcher extends AbstractReportSearcher {
 
   @InTransaction
   @Override
-  public AnetBeanList<Report> runSearch(ReportSearchQuery query) {
-    buildQuery(query);
+  public AnetBeanList<Report> runSearch(Set<String> subFields, ReportSearchQuery query) {
+    buildQuery(subFields, query);
     return qb.buildAndRun(getDbHandle(), query, new ReportMapper());
   }
 
-  @Override
-  protected void buildQuery(ReportSearchQuery query) {
-    qb.addSelectClause(ReportDao.REPORT_FIELDS);
+  protected void buildQuery(Set<String> subFields, ReportSearchQuery query) {
+    qb.addSelectClause(getTableFields(subFields));
     qb.addTotalCount();
     qb.addFromClause("reports");
-    super.buildQuery(query);
+    super.buildQuery(subFields, query);
   }
 
   @Override

--- a/src/main/java/mil/dds/anet/search/pg/PostgresqlSearchQueryBuilder.java
+++ b/src/main/java/mil/dds/anet/search/pg/PostgresqlSearchQueryBuilder.java
@@ -19,8 +19,17 @@ public class PostgresqlSearchQueryBuilder<B extends AbstractAnetBean, T extends 
   }
 
   @Override
-  public String getFullTextQuery(String text) {
+  public String getContainsQuery(String text) {
     return "%" + stripWildcards(text) + "%";
+  }
+
+  @Override
+  public String getFullTextQuery(String text) {
+    String cleanText = stripWildcards(text);
+    if (text.endsWith("*")) {
+      cleanText = cleanText + ":*";
+    }
+    return cleanText;
   }
 
   @Override

--- a/src/main/java/mil/dds/anet/search/pg/PostgresqlTagSearcher.java
+++ b/src/main/java/mil/dds/anet/search/pg/PostgresqlTagSearcher.java
@@ -1,7 +1,9 @@
 package mil.dds.anet.search.pg;
 
 import mil.dds.anet.beans.Tag;
+import mil.dds.anet.beans.search.ISearchQuery.SortOrder;
 import mil.dds.anet.beans.search.TagSearchQuery;
+import mil.dds.anet.search.AbstractSearchQueryBuilder;
 import mil.dds.anet.search.AbstractTagSearcher;
 
 public class PostgresqlTagSearcher extends AbstractTagSearcher {
@@ -12,8 +14,16 @@ public class PostgresqlTagSearcher extends AbstractTagSearcher {
 
   @Override
   protected void addTextQuery(TagSearchQuery query) {
-    final String text = qb.getContainsQuery(query.getText());
-    qb.addLikeClauses("text", new String[] {"tags.name", "tags.description"}, text);
+    addFullTextSearch("tags", query.getText(), query.isSortByPresent());
+  }
+
+  protected void addOrderByClauses(AbstractSearchQueryBuilder<?, ?> qb, TagSearchQuery query) {
+    if (query.isTextPresent() && !query.isSortByPresent()) {
+      // We're doing a full-text search without an explicit sort order,
+      // so sort first on the search pseudo-rank.
+      qb.addAllOrderByClauses(getOrderBy(SortOrder.DESC, null, "search_rank"));
+    }
+    super.addOrderByClauses(qb, query);
   }
 
 }

--- a/src/main/java/mil/dds/anet/search/pg/PostgresqlTagSearcher.java
+++ b/src/main/java/mil/dds/anet/search/pg/PostgresqlTagSearcher.java
@@ -12,7 +12,7 @@ public class PostgresqlTagSearcher extends AbstractTagSearcher {
 
   @Override
   protected void addTextQuery(TagSearchQuery query) {
-    final String text = qb.getFullTextQuery(query.getText());
+    final String text = qb.getContainsQuery(query.getText());
     qb.addLikeClauses("text", new String[] {"tags.name", "tags.description"}, text);
   }
 

--- a/src/main/java/mil/dds/anet/search/pg/PostgresqlTaskSearcher.java
+++ b/src/main/java/mil/dds/anet/search/pg/PostgresqlTaskSearcher.java
@@ -12,7 +12,7 @@ public class PostgresqlTaskSearcher extends AbstractTaskSearcher {
 
   @Override
   protected void addTextQuery(TaskSearchQuery query) {
-    final String text = qb.getFullTextQuery(query.getText());
+    final String text = qb.getContainsQuery(query.getText());
     qb.addLikeClauses("text", new String[] {"tasks.\"longName\"", "tasks.\"shortName\""}, text);
   }
 

--- a/src/main/java/mil/dds/anet/threads/MaterializedViewRefreshWorker.java
+++ b/src/main/java/mil/dds/anet/threads/MaterializedViewRefreshWorker.java
@@ -1,0 +1,36 @@
+package mil.dds.anet.threads;
+
+import java.lang.invoke.MethodHandles;
+import mil.dds.anet.database.AdminDao;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class MaterializedViewRefreshWorker implements Runnable {
+
+  private static final Logger logger =
+      LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+  private static final String[] materializedViews =
+      {"mv_fts_authorizationGroups", "mv_fts_locations", "mv_fts_organizations", "mv_fts_people",
+          "mv_fts_positions", "mv_fts_reports", "mv_fts_tags", "mv_fts_tasks"};
+
+  private final AdminDao dao;
+
+  public MaterializedViewRefreshWorker(AdminDao dao) {
+    this.dao = dao;
+  }
+
+  @Override
+  public void run() {
+    logger.debug("Refreshing materialized views");
+    for (final String materializedView : materializedViews) {
+      try {
+        dao.updateMaterializedView(materializedView);
+      } catch (Throwable e) {
+        // Cannot let this thread die, otherwise ANET will stop this worker.
+        logger.error("Exception in run()", e);
+      }
+    }
+  }
+
+}

--- a/src/main/java/mil/dds/anet/utils/AnetDbLogger.java
+++ b/src/main/java/mil/dds/anet/utils/AnetDbLogger.java
@@ -34,7 +34,8 @@ public class AnetDbLogger implements SqlLogger {
                 " <REPORTS_SENSITIVE_INFORMATION_FIELDS> ")
             .replace(CommentDao.COMMENT_FIELDS, " <COMMENT_FIELDS> ")
             .replaceAll("LEFT JOIN (CONTAINS|FREETEXT)TABLE[^=]*= (\\S+)\\.\\[Key\\]", "<$1_$2>")
-            .replaceFirst("(EXP|ISNULL|CASE).* AS (search_rank)", "<$1>");
+            .replaceFirst("LEFT JOIN (mv_fts_\\S+) ON \\S+\\s*=\\s*\\S+", "<$1>")
+            .replaceFirst("\\(?(EXP|ISNULL|CASE|ts_rank).* AS (search_rank)", "<$2>");
     logger.debug("{}\t{}", context.getElapsedTime(ChronoUnit.MILLIS), msg);
   }
 }

--- a/src/main/java/mil/dds/anet/utils/BatchingUtils.java
+++ b/src/main/java/mil/dds/anet/utils/BatchingUtils.java
@@ -42,13 +42,14 @@ public final class BatchingUtils {
   private final DataLoaderOptions dataLoaderOptions;
 
   public BatchingUtils(AnetObjectEngine engine, boolean batchingEnabled, boolean cachingEnabled) {
+    final int maxBatchSize = DaoUtils.isMsSql() ? 1000 : 25000;
     // Give each registry its own thread pool
     dispatcherService = Executors.newFixedThreadPool(3);
     dataLoaderRegistry = new DataLoaderRegistry();
     dataLoaderOptions =
         DataLoaderOptions.newOptions().setStatisticsCollector(() -> new SimpleStatisticsCollector())
             .setBatchingEnabled(batchingEnabled).setCachingEnabled(cachingEnabled)
-            .setMaxBatchSize(1000);
+            .setMaxBatchSize(maxBatchSize);
     registerDataLoaders(engine);
   }
 

--- a/src/main/java/mil/dds/anet/utils/DaoUtils.java
+++ b/src/main/java/mil/dds/anet/utils/DaoUtils.java
@@ -2,8 +2,6 @@ package mil.dds.anet.utils;
 
 import com.google.common.base.Joiner;
 import java.lang.invoke.MethodHandles;
-import java.sql.ResultSet;
-import java.sql.SQLException;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -14,7 +12,6 @@ import java.util.Map;
 import java.util.UUID;
 import mil.dds.anet.AnetObjectEngine;
 import mil.dds.anet.beans.Person;
-import mil.dds.anet.database.mappers.MapperUtils;
 import mil.dds.anet.views.AbstractAnetBean;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -94,37 +91,6 @@ public class DaoUtils {
     bean.setUpdatedAt(now);
   }
 
-  public static void setCommonBeanFields(AbstractAnetBean bean, ResultSet rs, String tableName)
-      throws SQLException {
-    // Should always be there
-    bean.setUuid(rs.getString(getQualifiedFieldName(tableName, "uuid")));
-
-    // Not all beans have createdAt and/or updatedAt
-    final String createdAtCol = getQualifiedFieldName(tableName, "createdAt");
-    if (MapperUtils.containsColumnNamed(rs, createdAtCol)) {
-      bean.setCreatedAt(getInstantAsLocalDateTime(rs, createdAtCol));
-    }
-    final String updatedAtCol = getQualifiedFieldName(tableName, "updatedAt");
-    if (MapperUtils.containsColumnNamed(rs, updatedAtCol)) {
-      bean.setUpdatedAt(getInstantAsLocalDateTime(rs, updatedAtCol));
-    }
-
-    // Only present when batch searching
-    if (MapperUtils.containsColumnNamed(rs, "batchUuid")) {
-      bean.setBatchUuid(rs.getString("batchUuid"));
-    }
-  }
-
-  private static String getQualifiedFieldName(String tableName, String fieldName) {
-    final StringBuilder result = new StringBuilder();
-    if (!Utils.isEmptyOrNull(tableName)) {
-      result.append(tableName);
-      result.append("_");
-    }
-    result.append(fieldName);
-    return result.toString();
-  }
-
   public static String buildFieldAliases(String tableName, String[] fields, boolean addAs) {
     final List<String> fieldAliases = new LinkedList<String>();
     for (String field : fields) {
@@ -135,18 +101,6 @@ public class DaoUtils {
       fieldAliases.add(sb.toString());
     }
     return " " + Joiner.on(", ").join(fieldAliases) + " ";
-  }
-
-  public static Double getOptionalDouble(final ResultSet rs, final String columnName)
-      throws SQLException {
-    final Double value = rs.getDouble(columnName);
-    return rs.wasNull() ? null : value;
-  }
-
-  public static Integer getOptionalInt(final ResultSet rs, final String columnName)
-      throws SQLException {
-    final Integer value = rs.getInt(columnName);
-    return rs.wasNull() ? null : value;
   }
 
   public static Person getUser(Map<String, Object> context, Person user) {
@@ -166,17 +120,6 @@ public class DaoUtils {
 
   public static ZoneOffset getDefaultZoneOffset() {
     return ZoneOffset.UTC;
-  }
-
-  public static Instant getInstantAsLocalDateTime(ResultSet rs, String field) throws SQLException {
-    // We would like to do <code>rs.getObject(field, java.time.Instant.class)</code>
-    // but the MSSQL JDBC driver does not support that (yet).
-    // However, as of the 7.1.0 preview, at least java.time.LocalDateTime *is* supported.
-    final LocalDateTime result = rs.getObject(field, LocalDateTime.class);
-    if (result != null) {
-      return result.toInstant(getDefaultZoneOffset());
-    }
-    return null;
   }
 
   public static void addInstantAsLocalDateTime(Map<String, Object> args, String parameterName,

--- a/src/main/java/mil/dds/anet/utils/DaoUtils.java
+++ b/src/main/java/mil/dds/anet/utils/DaoUtils.java
@@ -74,6 +74,10 @@ public class DaoUtils {
     return getDbType(AnetObjectEngine.getInstance().getDbUrl()) == DbType.MSSQL;
   }
 
+  public static boolean isPostgresql() {
+    return getDbType(AnetObjectEngine.getInstance().getDbUrl()) == DbType.POSTGRESQL;
+  }
+
   public static String getNewUuid() {
     return UUID.randomUUID().toString();
   }

--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -2735,6 +2735,7 @@
 	<changeSet id="add-postgresql-fulltext" author="gjvoosten" dbms="postgresql">
 		<sql>
 			<!-- Create text search configuration -->
+			DROP TEXT SEARCH CONFIGURATION IF EXISTS anet;
 			CREATE TEXT SEARCH CONFIGURATION anet ( COPY = pg_catalog.english );
 			ALTER TEXT SEARCH CONFIGURATION anet ALTER MAPPING FOR hword, hword_part, word WITH unaccent, english_stem;
 

--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -10,6 +10,7 @@
 	<property name="uuid_type" value="varchar(36)" />
 	<!-- Convenience functions to generate UUIDv4 on various databases -->
 	<property name="uuid_function" value="lower(newid())" dbms="mssql" />
+	<!-- Extension "uuid-ossp" should exist already, see `prepare-psql.sql`: -->
 	<property name="uuid_function" value="uuid_generate_v4()" dbms="postgresql" />
 	<!-- Not really a UUID but who cares? -->
 	<property name="uuid_function" value="lower(hex(randomblob(16)))" dbms="sqlite" />
@@ -21,6 +22,12 @@
 	<!-- Use a NONCLUSTERED index only for MSSQL -->
 	<property name="non_clustered" value="NONCLUSTERED" dbms="mssql" />
 	<property name="non_clustered" value="" dbms="postgresql,sqlite" />
+
+	<!-- Full-text search configuration 'anet' should exist already, see `prepare-psql.sql`: -->
+	<property name="fts_config" value="'anet'" dbms="postgresql" />
+	<!-- Full-text search weights -->
+	<property name="fts_high" value="'A'" dbms="postgresql" />
+	<property name="fts_low" value="'B'" dbms="postgresql" />
 
 	<changeSet id="1" author="hpitelka">
 		<createTable tableName="people">
@@ -2723,6 +2730,164 @@
 		<addColumn tableName="people">
 			<column name="code" type="nvarchar(100)" />
 		</addColumn>
+	</changeSet>
+
+	<changeSet id="add-postgresql-fulltext" author="gjvoosten" dbms="postgresql">
+		<sql>
+			<!-- Create full-text materialized views and indexes -->
+			CREATE MATERIALIZED VIEW IF NOT EXISTS "mv_fts_authorizationGroups"(uuid, full_text) AS
+				SELECT
+					"authorizationGroups".uuid,
+					setweight(to_tsvector(${fts_config}, coalesce("authorizationGroups".name, '')), ${fts_high})
+					|| setweight(to_tsvector(${fts_config}, coalesce("authorizationGroups".description, '')), ${fts_low})
+					|| setweight(to_tsvector(${fts_config}, coalesce(string_agg(notes.text, ' '), '')), ${fts_low})
+				FROM "authorizationGroups"
+				LEFT JOIN "noteRelatedObjects" ON "noteRelatedObjects"."relatedObjectType" = 'authorizationGroups'
+					AND "noteRelatedObjects"."relatedObjectUuid" = "authorizationGroups".uuid
+				LEFT JOIN notes ON notes.uuid = "noteRelatedObjects"."noteUuid"
+				GROUP BY "authorizationGroups".uuid
+				WITH DATA;
+			CREATE UNIQUE INDEX "UQ_mv_fts_authorizationGroups_uuid" ON "mv_fts_authorizationGroups"(uuid);
+			CREATE INDEX "FT_mv_fts_authorizationGroups" ON "mv_fts_authorizationGroups" USING gin(full_text);
+			CREATE INDEX "TR_authorizationGroups_uuid" ON "mv_fts_authorizationGroups" USING gin(uuid gin_trgm_ops);
+
+			CREATE MATERIALIZED VIEW IF NOT EXISTS mv_fts_locations(uuid, full_text) AS
+				SELECT
+					locations.uuid,
+					setweight(to_tsvector(${fts_config}, coalesce(locations.name, '')), ${fts_high})
+					|| setweight(to_tsvector(${fts_config}, coalesce(string_agg(notes.text, ' '), '')), ${fts_low})
+				FROM locations
+				LEFT JOIN "noteRelatedObjects" ON "noteRelatedObjects"."relatedObjectType" = 'locations'
+					AND "noteRelatedObjects"."relatedObjectUuid" = locations.uuid
+				LEFT JOIN notes ON notes.uuid = "noteRelatedObjects"."noteUuid"
+				GROUP BY locations.uuid
+				WITH DATA;
+			CREATE UNIQUE INDEX "UQ_mv_fts_locations_uuid" ON mv_fts_locations(uuid);
+			CREATE INDEX "FT_mv_fts_locations" ON mv_fts_locations USING gin(full_text);
+			CREATE INDEX "TR_locations_uuid" ON mv_fts_locations USING gin(uuid gin_trgm_ops);
+
+			CREATE MATERIALIZED VIEW IF NOT EXISTS mv_fts_organizations(uuid, full_text) AS
+				SELECT
+					organizations.uuid,
+					setweight(to_tsvector(${fts_config}, coalesce(organizations."shortName", '')), ${fts_high})
+					|| setweight(to_tsvector(${fts_config}, coalesce(organizations."longName", '')), ${fts_high})
+					|| setweight(to_tsvector(${fts_config}, coalesce(organizations."identificationCode", '')), ${fts_high})
+					|| setweight(to_tsvector(${fts_config}, coalesce(string_agg(notes.text, ' '), '')), ${fts_low})
+				FROM organizations
+				LEFT JOIN "noteRelatedObjects" ON "noteRelatedObjects"."relatedObjectType" = 'organizations'
+					AND "noteRelatedObjects"."relatedObjectUuid" = organizations.uuid
+				LEFT JOIN notes ON notes.uuid = "noteRelatedObjects"."noteUuid"
+				GROUP BY organizations.uuid
+				WITH DATA;
+			CREATE UNIQUE INDEX "UQ_mv_fts_organizations_uuid" ON mv_fts_organizations(uuid);
+			CREATE INDEX "FT_mv_fts_organizations" ON mv_fts_organizations USING gin(full_text);
+			CREATE INDEX "TR_organizations_uuid" ON mv_fts_organizations USING gin(uuid gin_trgm_ops);
+
+			CREATE MATERIALIZED VIEW IF NOT EXISTS mv_fts_people(uuid, full_text) AS
+				SELECT
+					people.uuid,
+					setweight(to_tsvector(${fts_config}, coalesce(people.name, '')), ${fts_high})
+					|| setweight(to_tsvector(${fts_config}, coalesce(people."domainUsername", '')), ${fts_high})
+					|| setweight(to_tsvector(${fts_config}, coalesce(people."emailAddress", '')), ${fts_high})
+					|| setweight(to_tsvector(${fts_config}, coalesce(people."phoneNumber", '')), ${fts_high})
+					|| setweight(to_tsvector(${fts_config}, coalesce(people.biography, '')), ${fts_low})
+					|| setweight(to_tsvector(${fts_config}, coalesce(string_agg(positions.name, ' '), '')), ${fts_high})
+					|| setweight(to_tsvector(${fts_config}, coalesce(string_agg(positions.code, ' '), '')), ${fts_high})
+					|| setweight(to_tsvector(${fts_config}, coalesce(string_agg(organizations."shortName", ' '), '')), ${fts_high})
+					|| setweight(to_tsvector(${fts_config}, coalesce(string_agg(organizations."identificationCode", ' '), '')), ${fts_high})
+					|| setweight(to_tsvector(${fts_config}, coalesce(string_agg(notes.text, ' '), '')), ${fts_low})
+				FROM people
+				LEFT JOIN positions ON positions."currentPersonUuid" = people.uuid
+				LEFT JOIN organizations ON organizations.uuid = positions."organizationUuid"
+				LEFT JOIN "noteRelatedObjects" ON "noteRelatedObjects"."relatedObjectType" = 'people'
+					AND "noteRelatedObjects"."relatedObjectUuid" = people.uuid
+				LEFT JOIN notes ON notes.uuid = "noteRelatedObjects"."noteUuid"
+				GROUP BY people.uuid
+				WITH DATA;
+			CREATE UNIQUE INDEX "UQ_mv_fts_people_uuid" ON mv_fts_people(uuid);
+			CREATE INDEX "FT_mv_fts_people" ON mv_fts_people USING gin(full_text);
+			CREATE INDEX "TR_people_uuid" ON mv_fts_people USING gin(uuid gin_trgm_ops);
+
+			CREATE MATERIALIZED VIEW IF NOT EXISTS mv_fts_positions(uuid, full_text) AS
+				SELECT
+					positions.uuid,
+					setweight(to_tsvector(${fts_config}, coalesce(positions.name, '')), ${fts_high})
+					|| setweight(to_tsvector(${fts_config}, coalesce(positions.code, '')), ${fts_high})
+					|| setweight(to_tsvector(${fts_config}, coalesce(string_agg(people.name, ' '), '')), ${fts_high})
+					|| setweight(to_tsvector(${fts_config}, coalesce(string_agg(organizations."shortName", ' '), '')), ${fts_high})
+					|| setweight(to_tsvector(${fts_config}, coalesce(string_agg(organizations."identificationCode", ' '), '')), ${fts_high})
+					|| setweight(to_tsvector(${fts_config}, coalesce(string_agg(notes.text, ' '), '')), ${fts_low})
+				FROM positions
+				LEFT JOIN people ON people.uuid = positions."currentPersonUuid"
+				LEFT JOIN organizations ON organizations.uuid = positions."organizationUuid"
+				LEFT JOIN "noteRelatedObjects" ON "noteRelatedObjects"."relatedObjectType" = 'positions'
+					AND "noteRelatedObjects"."relatedObjectUuid" = positions.uuid
+				LEFT JOIN notes ON notes.uuid = "noteRelatedObjects"."noteUuid"
+				GROUP BY positions.uuid
+				WITH DATA;
+			CREATE UNIQUE INDEX "UQ_mv_fts_positions" ON mv_fts_positions(uuid);
+			CREATE INDEX "FT_mv_fts_positions" ON mv_fts_positions USING gin(full_text);
+			CREATE INDEX "TR_positions_uuid" ON mv_fts_positions USING gin(uuid gin_trgm_ops);
+
+			CREATE MATERIALIZED VIEW IF NOT EXISTS mv_fts_reports(uuid, full_text) AS
+				SELECT
+					reports.uuid,
+					setweight(to_tsvector(${fts_config}, coalesce(reports.intent, '')), ${fts_high})
+					|| setweight(to_tsvector(${fts_config}, coalesce(reports."keyOutcomes", '')), ${fts_high})
+					|| setweight(to_tsvector(${fts_config}, coalesce(reports."nextSteps", '')), ${fts_high})
+					|| setweight(to_tsvector(${fts_config}, coalesce(reports.text, '')), ${fts_low})
+					|| setweight(to_tsvector(${fts_config}, coalesce(string_agg(notes.text, ' '), '')), ${fts_low})
+				FROM reports
+				LEFT JOIN "noteRelatedObjects" ON "noteRelatedObjects"."relatedObjectType" = 'reports'
+					AND "noteRelatedObjects"."relatedObjectUuid" = reports.uuid
+				LEFT JOIN notes ON notes.uuid = "noteRelatedObjects"."noteUuid"
+				GROUP BY reports.uuid
+				WITH DATA;
+			CREATE UNIQUE INDEX "UQ_mv_fts_reports_uuid" ON mv_fts_reports(uuid);
+			CREATE INDEX "FT_mv_fts_reports" ON mv_fts_reports USING gin(full_text);
+			CREATE INDEX "TR_reports_uuid" ON mv_fts_reports USING gin(uuid gin_trgm_ops);
+
+			CREATE MATERIALIZED VIEW IF NOT EXISTS mv_fts_tags(uuid, full_text) AS
+				SELECT
+					tags.uuid,
+					setweight(to_tsvector(${fts_config}, coalesce(tags.name, '')), ${fts_high})
+					|| setweight(to_tsvector(${fts_config}, coalesce(tags.description, '')), ${fts_low})
+				FROM tags
+				GROUP BY tags.uuid
+				WITH DATA;
+			CREATE UNIQUE INDEX "UQ_mv_fts_tags" ON mv_fts_tags(uuid);
+			CREATE INDEX "FT_mv_fts_tags" ON mv_fts_tags USING gin(full_text);
+			CREATE INDEX "TR_tags_uuid" ON mv_fts_tags USING gin(uuid gin_trgm_ops);
+
+			CREATE MATERIALIZED VIEW IF NOT EXISTS mv_fts_tasks(uuid, full_text) AS
+				SELECT
+					tasks.uuid,
+					setweight(to_tsvector(${fts_config}, coalesce(tasks."shortName", '')), ${fts_high})
+					|| setweight(to_tsvector(${fts_config}, coalesce(tasks."longName", '')), ${fts_high})
+					|| setweight(to_tsvector(${fts_config}, coalesce(string_agg(notes.text, ' '), '')), ${fts_low})
+				FROM tasks
+				LEFT JOIN "noteRelatedObjects" ON "noteRelatedObjects"."relatedObjectType" = 'tasks'
+					AND "noteRelatedObjects"."relatedObjectUuid" = tasks.uuid
+				LEFT JOIN notes ON notes.uuid = "noteRelatedObjects"."noteUuid"
+				GROUP BY tasks.uuid
+				WITH DATA;
+			CREATE UNIQUE INDEX "UQ_mv_fts_tasks" ON mv_fts_tasks(uuid);
+			CREATE INDEX "FT_mv_fts_tasks" ON mv_fts_tasks USING gin(full_text);
+			CREATE INDEX "TR_tasks_uuid" ON mv_fts_tasks USING gin(uuid gin_trgm_ops);
+		</sql>
+		<rollback>
+			<sql>
+				<!-- Drop full-text materialized views (incl. indexes) -->
+				DROP MATERIALIZED VIEW "mv_fts_authorizationGroups";
+				DROP MATERIALIZED VIEW mv_fts_locations;
+				DROP MATERIALIZED VIEW mv_fts_organizations;
+				DROP MATERIALIZED VIEW mv_fts_people;
+				DROP MATERIALIZED VIEW mv_fts_positions;
+				DROP MATERIALIZED VIEW mv_fts_reports;
+				DROP MATERIALIZED VIEW mv_fts_tags;
+				DROP MATERIALIZED VIEW mv_fts_tasks;
+			</sql>
+		</rollback>
 	</changeSet>
 
 </databaseChangeLog>

--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -2734,13 +2734,71 @@
 
 	<changeSet id="add-postgresql-fulltext" author="gjvoosten" dbms="postgresql">
 		<sql>
+			<!-- Add generated full-text columns -->
+			ALTER TABLE "authorizationGroups"
+				ADD COLUMN full_text tsvector GENERATED ALWAYS AS (
+					setweight(to_tsvector(${fts_config}, coalesce("authorizationGroups".name, '')), ${fts_high})
+					|| setweight(to_tsvector(${fts_config}, coalesce("authorizationGroups".description, '')), ${fts_low})
+				) STORED;
+
+			ALTER TABLE locations
+				ADD COLUMN full_text tsvector GENERATED ALWAYS AS (
+					setweight(to_tsvector(${fts_config}, coalesce(locations.name, '')), ${fts_high})
+				) STORED;
+
+			ALTER TABLE organizations
+				ADD COLUMN full_text tsvector GENERATED ALWAYS AS (
+					setweight(to_tsvector(${fts_config}, coalesce(organizations."identificationCode", '')), ${fts_high})
+					|| setweight(to_tsvector(${fts_config}, coalesce(organizations."shortName", '')), ${fts_high})
+					|| setweight(to_tsvector(${fts_config}, coalesce(organizations."longName", '')), ${fts_low})
+				) STORED;
+
+			ALTER TABLE notes
+				ADD COLUMN full_text tsvector GENERATED ALWAYS AS (
+					setweight(to_tsvector(${fts_config}, coalesce(notes.text, '')), ${fts_low})
+				) STORED;
+
+			ALTER TABLE people
+				ADD COLUMN full_text tsvector GENERATED ALWAYS AS (
+					setweight(to_tsvector(${fts_config}, coalesce(people.name, '')), ${fts_high})
+					|| setweight(to_tsvector(${fts_config}, coalesce(people."domainUsername", '')), ${fts_high})
+					|| setweight(to_tsvector(${fts_config}, coalesce(people."emailAddress", '')), ${fts_high})
+					|| setweight(to_tsvector(${fts_config}, coalesce(people."phoneNumber", '')), ${fts_high})
+					|| setweight(to_tsvector(${fts_config}, coalesce(people.biography, '')), ${fts_low})
+				) STORED;
+
+			ALTER TABLE positions
+				ADD COLUMN full_text tsvector GENERATED ALWAYS AS (
+					setweight(to_tsvector(${fts_config}, coalesce(positions.name, '')), ${fts_high})
+					|| setweight(to_tsvector(${fts_config}, coalesce(positions.code, '')), ${fts_high})
+				) STORED;
+
+			ALTER TABLE reports
+				ADD COLUMN full_text tsvector GENERATED ALWAYS AS (
+					setweight(to_tsvector(${fts_config}, coalesce(reports.intent, '')), ${fts_high})
+					|| setweight(to_tsvector(${fts_config}, coalesce(reports."keyOutcomes", '')), ${fts_high})
+					|| setweight(to_tsvector(${fts_config}, coalesce(reports."nextSteps", '')), ${fts_high})
+					|| setweight(to_tsvector(${fts_config}, coalesce(reports.text, '')), ${fts_low})
+				) STORED;
+
+			ALTER TABLE tags
+				ADD COLUMN full_text tsvector GENERATED ALWAYS AS (
+					setweight(to_tsvector(${fts_config}, coalesce(tags.name, '')), ${fts_high})
+					|| setweight(to_tsvector(${fts_config}, coalesce(tags.description, '')), ${fts_low})
+				) STORED;
+
+			ALTER TABLE tasks
+				ADD COLUMN full_text tsvector GENERATED ALWAYS AS (
+					setweight(to_tsvector(${fts_config}, coalesce(tasks."shortName", '')), ${fts_high})
+					|| setweight(to_tsvector(${fts_config}, coalesce(tasks."longName", '')), ${fts_high})
+				) STORED;
+
 			<!-- Create full-text materialized views and indexes -->
 			CREATE MATERIALIZED VIEW IF NOT EXISTS "mv_fts_authorizationGroups"(uuid, full_text) AS
 				SELECT
 					"authorizationGroups".uuid,
-					setweight(to_tsvector(${fts_config}, coalesce("authorizationGroups".name, '')), ${fts_high})
-					|| setweight(to_tsvector(${fts_config}, coalesce("authorizationGroups".description, '')), ${fts_low})
-					|| setweight(to_tsvector(${fts_config}, coalesce(string_agg(notes.text, ' '), '')), ${fts_low})
+					"authorizationGroups".full_text
+					|| coalesce(tsvector_agg(notes.full_text), ''::tsvector)
 				FROM "authorizationGroups"
 				LEFT JOIN "noteRelatedObjects" ON "noteRelatedObjects"."relatedObjectType" = 'authorizationGroups'
 					AND "noteRelatedObjects"."relatedObjectUuid" = "authorizationGroups".uuid
@@ -2754,8 +2812,8 @@
 			CREATE MATERIALIZED VIEW IF NOT EXISTS mv_fts_locations(uuid, full_text) AS
 				SELECT
 					locations.uuid,
-					setweight(to_tsvector(${fts_config}, coalesce(locations.name, '')), ${fts_high})
-					|| setweight(to_tsvector(${fts_config}, coalesce(string_agg(notes.text, ' '), '')), ${fts_low})
+					locations.full_text
+					|| coalesce(tsvector_agg(notes.full_text), ''::tsvector)
 				FROM locations
 				LEFT JOIN "noteRelatedObjects" ON "noteRelatedObjects"."relatedObjectType" = 'locations'
 					AND "noteRelatedObjects"."relatedObjectUuid" = locations.uuid
@@ -2769,10 +2827,8 @@
 			CREATE MATERIALIZED VIEW IF NOT EXISTS mv_fts_organizations(uuid, full_text) AS
 				SELECT
 					organizations.uuid,
-					setweight(to_tsvector(${fts_config}, coalesce(organizations."shortName", '')), ${fts_high})
-					|| setweight(to_tsvector(${fts_config}, coalesce(organizations."longName", '')), ${fts_high})
-					|| setweight(to_tsvector(${fts_config}, coalesce(organizations."identificationCode", '')), ${fts_high})
-					|| setweight(to_tsvector(${fts_config}, coalesce(string_agg(notes.text, ' '), '')), ${fts_low})
+					organizations.full_text
+					|| coalesce(tsvector_agg(notes.full_text), ''::tsvector)
 				FROM organizations
 				LEFT JOIN "noteRelatedObjects" ON "noteRelatedObjects"."relatedObjectType" = 'organizations'
 					AND "noteRelatedObjects"."relatedObjectUuid" = organizations.uuid
@@ -2786,16 +2842,10 @@
 			CREATE MATERIALIZED VIEW IF NOT EXISTS mv_fts_people(uuid, full_text) AS
 				SELECT
 					people.uuid,
-					setweight(to_tsvector(${fts_config}, coalesce(people.name, '')), ${fts_high})
-					|| setweight(to_tsvector(${fts_config}, coalesce(people."domainUsername", '')), ${fts_high})
-					|| setweight(to_tsvector(${fts_config}, coalesce(people."emailAddress", '')), ${fts_high})
-					|| setweight(to_tsvector(${fts_config}, coalesce(people."phoneNumber", '')), ${fts_high})
-					|| setweight(to_tsvector(${fts_config}, coalesce(people.biography, '')), ${fts_low})
-					|| setweight(to_tsvector(${fts_config}, coalesce(string_agg(positions.name, ' '), '')), ${fts_high})
-					|| setweight(to_tsvector(${fts_config}, coalesce(string_agg(positions.code, ' '), '')), ${fts_high})
-					|| setweight(to_tsvector(${fts_config}, coalesce(string_agg(organizations."shortName", ' '), '')), ${fts_high})
-					|| setweight(to_tsvector(${fts_config}, coalesce(string_agg(organizations."identificationCode", ' '), '')), ${fts_high})
-					|| setweight(to_tsvector(${fts_config}, coalesce(string_agg(notes.text, ' '), '')), ${fts_low})
+					people.full_text
+					|| coalesce(tsvector_agg(positions.full_text), ''::tsvector)
+					|| coalesce(tsvector_agg(organizations.full_text), ''::tsvector)
+					|| coalesce(tsvector_agg(notes.full_text), ''::tsvector)
 				FROM people
 				LEFT JOIN positions ON positions."currentPersonUuid" = people.uuid
 				LEFT JOIN organizations ON organizations.uuid = positions."organizationUuid"
@@ -2811,12 +2861,10 @@
 			CREATE MATERIALIZED VIEW IF NOT EXISTS mv_fts_positions(uuid, full_text) AS
 				SELECT
 					positions.uuid,
-					setweight(to_tsvector(${fts_config}, coalesce(positions.name, '')), ${fts_high})
-					|| setweight(to_tsvector(${fts_config}, coalesce(positions.code, '')), ${fts_high})
-					|| setweight(to_tsvector(${fts_config}, coalesce(string_agg(people.name, ' '), '')), ${fts_high})
-					|| setweight(to_tsvector(${fts_config}, coalesce(string_agg(organizations."shortName", ' '), '')), ${fts_high})
-					|| setweight(to_tsvector(${fts_config}, coalesce(string_agg(organizations."identificationCode", ' '), '')), ${fts_high})
-					|| setweight(to_tsvector(${fts_config}, coalesce(string_agg(notes.text, ' '), '')), ${fts_low})
+					positions.full_text
+					|| coalesce(tsvector_agg(people.full_text), ''::tsvector)
+					|| coalesce(tsvector_agg(organizations.full_text), ''::tsvector)
+					|| coalesce(tsvector_agg(notes.full_text), ''::tsvector)
 				FROM positions
 				LEFT JOIN people ON people.uuid = positions."currentPersonUuid"
 				LEFT JOIN organizations ON organizations.uuid = positions."organizationUuid"
@@ -2832,11 +2880,8 @@
 			CREATE MATERIALIZED VIEW IF NOT EXISTS mv_fts_reports(uuid, full_text) AS
 				SELECT
 					reports.uuid,
-					setweight(to_tsvector(${fts_config}, coalesce(reports.intent, '')), ${fts_high})
-					|| setweight(to_tsvector(${fts_config}, coalesce(reports."keyOutcomes", '')), ${fts_high})
-					|| setweight(to_tsvector(${fts_config}, coalesce(reports."nextSteps", '')), ${fts_high})
-					|| setweight(to_tsvector(${fts_config}, coalesce(reports.text, '')), ${fts_low})
-					|| setweight(to_tsvector(${fts_config}, coalesce(string_agg(notes.text, ' '), '')), ${fts_low})
+					reports.full_text
+					|| coalesce(tsvector_agg(notes.full_text), ''::tsvector)
 				FROM reports
 				LEFT JOIN "noteRelatedObjects" ON "noteRelatedObjects"."relatedObjectType" = 'reports'
 					AND "noteRelatedObjects"."relatedObjectUuid" = reports.uuid
@@ -2850,8 +2895,7 @@
 			CREATE MATERIALIZED VIEW IF NOT EXISTS mv_fts_tags(uuid, full_text) AS
 				SELECT
 					tags.uuid,
-					setweight(to_tsvector(${fts_config}, coalesce(tags.name, '')), ${fts_high})
-					|| setweight(to_tsvector(${fts_config}, coalesce(tags.description, '')), ${fts_low})
+					tags.full_text
 				FROM tags
 				GROUP BY tags.uuid
 				WITH DATA;
@@ -2862,9 +2906,8 @@
 			CREATE MATERIALIZED VIEW IF NOT EXISTS mv_fts_tasks(uuid, full_text) AS
 				SELECT
 					tasks.uuid,
-					setweight(to_tsvector(${fts_config}, coalesce(tasks."shortName", '')), ${fts_high})
-					|| setweight(to_tsvector(${fts_config}, coalesce(tasks."longName", '')), ${fts_high})
-					|| setweight(to_tsvector(${fts_config}, coalesce(string_agg(notes.text, ' '), '')), ${fts_low})
+					tasks.full_text
+					|| coalesce(tsvector_agg(notes.full_text), ''::tsvector)
 				FROM tasks
 				LEFT JOIN "noteRelatedObjects" ON "noteRelatedObjects"."relatedObjectType" = 'tasks'
 					AND "noteRelatedObjects"."relatedObjectUuid" = tasks.uuid
@@ -2886,6 +2929,17 @@
 				DROP MATERIALIZED VIEW mv_fts_reports;
 				DROP MATERIALIZED VIEW mv_fts_tags;
 				DROP MATERIALIZED VIEW mv_fts_tasks;
+
+				<!-- Drop generated full-text columns -->
+				ALTER TABLE "authorizationGroups" DROP COLUMN full_text;
+				ALTER TABLE locations DROP COLUMN full_text;
+				ALTER TABLE organizations DROP COLUMN full_text;
+				ALTER TABLE notes DROP COLUMN full_text;
+				ALTER TABLE people DROP COLUMN full_text;
+				ALTER TABLE positions DROP COLUMN full_text;
+				ALTER TABLE reports DROP COLUMN full_text;
+				ALTER TABLE tags DROP COLUMN full_text;
+				ALTER TABLE tasks DROP COLUMN full_text;
 			</sql>
 		</rollback>
 	</changeSet>

--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -23,8 +23,9 @@
 	<property name="non_clustered" value="NONCLUSTERED" dbms="mssql" />
 	<property name="non_clustered" value="" dbms="postgresql,sqlite" />
 
-	<!-- Full-text search configuration 'anet' should exist already, see `prepare-psql.sql`: -->
-	<property name="fts_config" value="'anet'" dbms="postgresql" />
+	<!-- Full-text search configuration used by PostgreSQL -->
+	<property name="fts_config_name" value="anet" dbms="postgresql" />
+	<property name="fts_config" value="'${fts_config_name}'" dbms="postgresql" />
 	<!-- Full-text search weights -->
 	<property name="fts_high" value="'A'" dbms="postgresql" />
 	<property name="fts_low" value="'B'" dbms="postgresql" />
@@ -2735,9 +2736,9 @@
 	<changeSet id="add-postgresql-fulltext" author="gjvoosten" dbms="postgresql">
 		<sql>
 			<!-- Create text search configuration -->
-			DROP TEXT SEARCH CONFIGURATION IF EXISTS anet;
-			CREATE TEXT SEARCH CONFIGURATION anet ( COPY = pg_catalog.english );
-			ALTER TEXT SEARCH CONFIGURATION anet ALTER MAPPING FOR hword, hword_part, word WITH unaccent, english_stem;
+			DROP TEXT SEARCH CONFIGURATION IF EXISTS ${fts_config_name};
+			CREATE TEXT SEARCH CONFIGURATION ${fts_config_name} ( COPY = pg_catalog.english );
+			ALTER TEXT SEARCH CONFIGURATION ${fts_config_name} ALTER MAPPING FOR hword, hword_part, word WITH unaccent, english_stem;
 
 			<!-- Add generated full-text columns -->
 			ALTER TABLE "authorizationGroups"
@@ -2947,7 +2948,7 @@
 				ALTER TABLE tasks DROP COLUMN full_text;
 
 				<!-- Drop text search configuration -->
-				DROP TEXT SEARCH CONFIGURATION anet;
+				DROP TEXT SEARCH CONFIGURATION ${fts_config_name};
 			</sql>
 		</rollback>
 	</changeSet>

--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -2734,6 +2734,10 @@
 
 	<changeSet id="add-postgresql-fulltext" author="gjvoosten" dbms="postgresql">
 		<sql>
+			<!-- Create text search configuration -->
+			CREATE TEXT SEARCH CONFIGURATION anet ( COPY = pg_catalog.english );
+			ALTER TEXT SEARCH CONFIGURATION anet ALTER MAPPING FOR hword, hword_part, word WITH unaccent, english_stem;
+
 			<!-- Add generated full-text columns -->
 			ALTER TABLE "authorizationGroups"
 				ADD COLUMN full_text tsvector GENERATED ALWAYS AS (
@@ -2940,6 +2944,9 @@
 				ALTER TABLE reports DROP COLUMN full_text;
 				ALTER TABLE tags DROP COLUMN full_text;
 				ALTER TABLE tasks DROP COLUMN full_text;
+
+				<!-- Drop text search configuration -->
+				DROP TEXT SEARCH CONFIGURATION anet;
 			</sql>
 		</rollback>
 	</changeSet>

--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -2767,6 +2767,7 @@
 			ALTER TABLE people
 				ADD COLUMN full_text tsvector GENERATED ALWAYS AS (
 					setweight(to_tsvector(${fts_config}, coalesce(people.name, '')), ${fts_high})
+					|| setweight(to_tsvector(${fts_config}, coalesce(people.code, '')), ${fts_high})
 					|| setweight(to_tsvector(${fts_config}, coalesce(people."domainUsername", '')), ${fts_high})
 					|| setweight(to_tsvector(${fts_config}, coalesce(people."emailAddress", '')), ${fts_high})
 					|| setweight(to_tsvector(${fts_config}, coalesce(people."phoneNumber", '')), ${fts_high})

--- a/src/test/java/mil/dds/anet/test/beans/PersonTest.java
+++ b/src/test/java/mil/dds/anet/test/beans/PersonTest.java
@@ -175,7 +175,6 @@ public class PersonTest extends BeanTester<Person> {
     ReportPerson rp = new ReportPerson();
     rp.setName(p.getName());
     rp.setUuid(p.getUuid());
-    rp.setUuid(p.getUuid());
     rp.setPhoneNumber(p.getPhoneNumber());
     rp.setEmailAddress(p.getEmailAddress());
     rp.setBiography(p.getBiography());

--- a/src/test/java/mil/dds/anet/test/resources/AbstractResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/AbstractResourceTest.java
@@ -1,6 +1,7 @@
 package mil.dds.anet.test.resources;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import io.dropwizard.client.JerseyClientBuilder;
@@ -18,10 +19,12 @@ import mil.dds.anet.beans.Person;
 import mil.dds.anet.beans.lists.AnetBeanList;
 import mil.dds.anet.beans.search.PersonSearchQuery;
 import mil.dds.anet.config.AnetConfiguration;
+import mil.dds.anet.database.AdminDao;
 import mil.dds.anet.test.beans.PersonTest;
 import mil.dds.anet.test.resources.utils.GraphQlHelper;
 import mil.dds.anet.test.resources.utils.GraphQlResponse;
 import mil.dds.anet.utils.BatchingUtils;
+import mil.dds.anet.utils.DaoUtils;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -58,12 +61,30 @@ public abstract class AbstractResourceTest {
 
   @BeforeClass
   public static void setUp() {
+    if (DaoUtils.isPostgresql()) {
+      // Update full-text index
+      refreshMaterializedViews();
+    }
     client = new JerseyClientBuilder(RULE.getEnvironment()).using(config).build("test client");
     graphQLHelper = new GraphQlHelper(client, RULE.getLocalPort());
     admin = findOrPutPersonInDb(PersonTest.getArthurDmin());
     context = new HashMap<>();
     batchingUtils = new BatchingUtils(AnetObjectEngine.getInstance(), false, false);
     context.put("dataLoaderRegistry", batchingUtils.getDataLoaderRegistry());
+  }
+
+  private static void refreshMaterializedViews() {
+    final String[] materializedViews =
+        {"mv_fts_authorizationGroups", "mv_fts_locations", "mv_fts_organizations", "mv_fts_people",
+            "mv_fts_positions", "mv_fts_reports", "mv_fts_tags", "mv_fts_tasks"};
+    final AdminDao adminDao = AnetObjectEngine.getInstance().getAdminDao();
+    for (final String materializedView : materializedViews) {
+      try {
+        adminDao.updateMaterializedView(materializedView);
+      } catch (Throwable e) {
+        fail("Exception in refreshMaterializedViews()", e);
+      }
+    }
   }
 
   @AfterClass

--- a/src/test/java/mil/dds/anet/test/resources/PersonResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/PersonResourceTest.java
@@ -211,7 +211,8 @@ public class PersonResourceTest extends AbstractResourceTest {
         .findFirst()).isNotEmpty();
 
     final OrganizationSearchQuery queryOrgs = new OrganizationSearchQuery();
-    queryOrgs.setText("EF 1");
+    // FIXME: decide what the search should do in both cases
+    queryOrgs.setText(DaoUtils.isPostgresql() ? "\"EF 1\" or \"EF 1.1\"" : "EF 1");
     queryOrgs.setType(OrganizationType.ADVISOR_ORG);
     final AnetBeanList<Organization> orgs = graphQLHelper.searchObjects(jack, "organizationList",
         "query", "OrganizationSearchQueryInput", "uuid shortName", queryOrgs,

--- a/src/test/java/mil/dds/anet/test/resources/PositionResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/PositionResourceTest.java
@@ -34,6 +34,7 @@ import mil.dds.anet.beans.search.PositionSearchSortBy;
 import mil.dds.anet.test.beans.OrganizationTest;
 import mil.dds.anet.test.beans.PositionTest;
 import mil.dds.anet.test.resources.utils.GraphQlResponse;
+import mil.dds.anet.utils.DaoUtils;
 import org.junit.Test;
 
 public class PositionResourceTest extends AbstractResourceTest {
@@ -396,7 +397,8 @@ public class PositionResourceTest extends AbstractResourceTest {
 
     // Search by organization
     final OrganizationSearchQuery queryOrgs = new OrganizationSearchQuery();
-    queryOrgs.setText("ef 1");
+    // FIXME: decide what the search should do in both cases
+    queryOrgs.setText(DaoUtils.isPostgresql() ? "\"ef 1\" or \"ef 1.1\"" : "ef 1");
     queryOrgs.setType(OrganizationType.ADVISOR_ORG);
     final AnetBeanList<Organization> orgs = graphQLHelper.searchObjects(jack, "organizationList",
         "query", "OrganizationSearchQueryInput", ORGANIZATION_FIELDS, queryOrgs,

--- a/src/test/java/mil/dds/anet/test/resources/ReportsResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/ReportsResourceTest.java
@@ -558,7 +558,8 @@ public class ReportsResourceTest extends AbstractResourceTest {
 
     // Put billet in EF1
     final OrganizationSearchQuery queryOrgs = new OrganizationSearchQuery();
-    queryOrgs.setText("EF 1");
+    // FIXME: decide what the search should do in both cases
+    queryOrgs.setText(DaoUtils.isPostgresql() ? "\"EF 1\" or \"EF 1.1\"" : "EF 1");
     queryOrgs.setType(OrganizationType.ADVISOR_ORG);
     final AnetBeanList<Organization> results = graphQLHelper.searchObjects(nick, "organizationList",
         "query", "OrganizationSearchQueryInput", ORGANIZATION_FIELDS, queryOrgs,
@@ -779,7 +780,8 @@ public class ReportsResourceTest extends AbstractResourceTest {
             queryTasks, new TypeReference<GraphQlResponse<AnetBeanList<Task>>>() {});
     assertThat(taskResults).isNotNull();
     assertThat(taskResults.getList()).isNotEmpty();
-    Task task = taskResults.getList().get(0);
+    Task task = taskResults.getList().stream().filter(t -> "1.1.A".equals(t.getShortName()))
+        .findFirst().get();
 
     // Search by Task
     query.setAttendeeUuid(null);
@@ -799,7 +801,8 @@ public class ReportsResourceTest extends AbstractResourceTest {
 
     // Search by direct organization
     OrganizationSearchQuery queryOrgs = new OrganizationSearchQuery();
-    queryOrgs.setText("EF 1");
+    // FIXME: decide what the search should do in both cases
+    queryOrgs.setText(DaoUtils.isPostgresql() ? "\"EF 1\" or \"EF 1.1\"" : "EF 1");
     queryOrgs.setType(OrganizationType.ADVISOR_ORG);
     AnetBeanList<Organization> orgs = graphQLHelper.searchObjects(jack, "organizationList", "query",
         "OrganizationSearchQueryInput", ORGANIZATION_FIELDS, queryOrgs,


### PR DESCRIPTION
Also improves performance of some queries (for PostgreSQL and Microsoft SQL Server) by only retrieving necessary fields (`getFutureToPastReports` query, person search, report search).

Partially addresses NCI-Agency/anet#1969 and NCI-Agency/anet#2351

- [x] db needs migration

