### PR TITLE
Downgrade react-scroll to 1.7.14

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -143,7 +143,7 @@
     "react-redux-loading-bar": "^4.6.0",
     "react-router-bootstrap": "^0.25.0",
     "react-router-dom": "^5.1.2",
-    "react-scroll": "^1.7.15",
+    "react-scroll": "^1.7.14",
     "react-tag-input": "^6.4.2",
     "react-toastify": "^5.5.0",
     "react-tooltip": "^3.11.2",

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -14063,10 +14063,10 @@ react-router@5.1.2:
     tiny-invariant "^1.0.2"
     tiny-warning "^1.0.0"
 
-react-scroll@^1.7.15:
-  version "1.7.15"
-  resolved "https://registry.yarnpkg.com/react-scroll/-/react-scroll-1.7.15.tgz#90da4a1e953e620ae37be42747e0835b473158db"
-  integrity sha512-4AtQ/4GZmTW7CIQrVQhLvt3pMkITDvyXz6F3DZS3IOoux3fmccBRUR/x9wORupLbuKFlzOX1CoceDMpMgY7Tig==
+react-scroll@^1.7.14:
+  version "1.7.14"
+  resolved "https://registry.yarnpkg.com/react-scroll/-/react-scroll-1.7.14.tgz#cb7a19cc0f88e8608f6c3511bb5e03e76a2fbbe9"
+  integrity sha512-zQ2/8+TaEBctA9RSQspP5GWMffA6g7u+AB9gMWB42btZZTBcGEyomvxnm52UVVELjqXOpD9U1/tHhVTNXyntbQ==
   dependencies:
     lodash.throttle "^4.1.1"
     prop-types "^15.5.8"


### PR DESCRIPTION
1.7.15 introduces a new console error "TypeError: t.offsetParent is null" when clicking a scroll anchor from the left navigation.