### PR TITLE
Minor improvements to advanced search filters

### DIFF
--- a/client/src/components/AdvancedSearch.js
+++ b/client/src/components/AdvancedSearch.js
@@ -91,6 +91,10 @@ const AdvancedSearch = ({
     </Menu>
   )
 
+  const possibleFilterTypes = Object.keys(ALL_FILTERS).filter(type =>
+    searchObjectTypes.includes(type)
+  )
+
   return (
     <Formik>
       {() => (
@@ -102,18 +106,28 @@ const AdvancedSearch = ({
                   value={objectType}
                   onChange={changeObjectType}
                 >
-                  {Object.keys(ALL_FILTERS).map(
+                  {possibleFilterTypes.map(
                     type =>
-                      searchObjectTypes.indexOf(type) !== -1 && (
-                        <Button key={type} value={type}>
+                        <Button
+                          key={type}
+                          value={type}
+                          disabled={possibleFilterTypes.length < 2}
+                        >
                           {SEARCH_OBJECT_LABELS[type]}
                         </Button>
-                      )
                   )}
                 </ButtonToggleGroup>
               </Col>
               <Col xs={1}>
-                <Button bsStyle="link" onClick={clearObjectType}>
+                <Button
+                  bsStyle="link"
+                  onClick={clearObjectType}
+                  style={
+                    possibleFilterTypes.length > 1 && objectType
+                      ? {}
+                      : { visibility: "hidden" }
+                  }
+                >
                   <img src={REMOVE_ICON} height={14} alt="Clear type" />
                 </Button>
               </Col>
@@ -173,7 +187,7 @@ const AdvancedSearch = ({
                     }}
                   >
                     <Button bsStyle="link" id="addFilterDropdown">
-                      + Add another filter
+                      + Add {filters.length > 0 && "another"} filter
                     </Button>
                   </Popover>
                 )}

--- a/client/src/components/AdvancedSearch.js
+++ b/client/src/components/AdvancedSearch.js
@@ -23,8 +23,7 @@ import {
   Col,
   ControlLabel,
   FormControl,
-  FormGroup,
-  Row
+  FormGroup
 } from "react-bootstrap"
 import { connect } from "react-redux"
 import { useHistory } from "react-router-dom"
@@ -106,16 +105,15 @@ const AdvancedSearch = ({
                   value={objectType}
                   onChange={changeObjectType}
                 >
-                  {possibleFilterTypes.map(
-                    type =>
-                        <Button
-                          key={type}
-                          value={type}
-                          disabled={possibleFilterTypes.length < 2}
-                        >
-                          {SEARCH_OBJECT_LABELS[type]}
-                        </Button>
-                  )}
+                  {possibleFilterTypes.map(type => (
+                    <Button
+                      key={type}
+                      value={type}
+                      disabled={possibleFilterTypes.length < 2}
+                    >
+                      {SEARCH_OBJECT_LABELS[type]}
+                    </Button>
+                  ))}
                 </ButtonToggleGroup>
               </Col>
               <Col xs={1}>
@@ -324,23 +322,23 @@ const SearchFilter = ({ onRemove, filter, organizationFilter, element }) => {
 
   return (
     <FormGroup controlId={queryKey}>
-      <Row>
-        <Col xs={1} sm={2} style={{ textAlign: "right" }}>
-          <ControlLabel>{label}</ControlLabel>
-        </Col>
-        <Col xs={10} sm={9}>
+      <Col sm={3} lg={2} componentClass={ControlLabel}>
+        {label}
+      </Col>
+      <Col sm={8} lg={9}>
+        <div>
           <ChildComponent
             value={filter.value || ""}
             onChange={onChange}
             {...element.props}
           />
-        </Col>
-        <Col xs={1} sm={1}>
-          <Button bsStyle="link" onClick={() => onRemove(filter)}>
-            <img src={REMOVE_ICON} height={14} alt="Remove this filter" />
-          </Button>
-        </Col>
-      </Row>
+        </div>
+      </Col>
+      <Col sm={1} lg={1}>
+        <Button bsStyle="link" onClick={() => onRemove(filter)}>
+          <img src={REMOVE_ICON} height={14} alt="Remove this filter" />
+        </Button>
+      </Col>
     </FormGroup>
   )
 

--- a/client/src/components/AdvancedSearch.js
+++ b/client/src/components/AdvancedSearch.js
@@ -117,17 +117,11 @@ const AdvancedSearch = ({
                 </ButtonToggleGroup>
               </Col>
               <Col xs={1}>
-                <Button
-                  bsStyle="link"
-                  onClick={clearObjectType}
-                  style={
-                    possibleFilterTypes.length > 1 && objectType
-                      ? {}
-                      : { visibility: "hidden" }
-                  }
-                >
-                  <img src={REMOVE_ICON} height={14} alt="Clear type" />
-                </Button>
+                {possibleFilterTypes.length > 1 && objectType && (
+                  <Button bsStyle="link" onClick={clearObjectType}>
+                    <img src={REMOVE_ICON} height={14} alt="Clear type" />
+                  </Button>
+                )}
               </Col>
             </FormGroup>
 

--- a/client/src/components/AdvancedSearch.js
+++ b/client/src/components/AdvancedSearch.js
@@ -136,8 +136,22 @@ const AdvancedSearch = ({
               )}
             </div>
 
-            <Row style={{ borderTop: "1px solid #ddd", paddingTop: "15px" }}>
-              <Col md={6} mdOffset={2}>
+            <div
+              style={{
+                display: "flex",
+                flexDirection: "row",
+                justifyContent: "flex-end",
+                alignItems: "center",
+                borderTop: "1px solid #ddd",
+                paddingTop: "15px"
+              }}
+            >
+              <div
+                style={{
+                  display: "flex",
+                  flexGrow: 1
+                }}
+              >
                 {!objectType ? (
                   "To add filters, first pick a type above"
                 ) : !moreFiltersAvailable ? (
@@ -163,8 +177,14 @@ const AdvancedSearch = ({
                     </Button>
                   </Popover>
                 )}
-              </Col>
-              <Col md={4} style={{ whiteSpace: "nowrap", textAlign: "right" }}>
+              </div>
+              <div
+                style={{
+                  display: "flex",
+                  flexDirection: "row",
+                  justifyContent: "flex-end"
+                }}
+              >
                 <Button
                   className={Classes.POPOVER_DISMISS}
                   intent="danger"
@@ -183,8 +203,8 @@ const AdvancedSearch = ({
                 >
                   Search
                 </Button>
-              </Col>
-            </Row>
+              </div>
+            </div>
           </Form>
         </div>
       )}
@@ -290,21 +310,23 @@ const SearchFilter = ({ onRemove, filter, organizationFilter, element }) => {
 
   return (
     <FormGroup controlId={queryKey}>
-      <Col xs={1} sm={2}>
-        <ControlLabel>{label}</ControlLabel>
-      </Col>
-      <Col xs={10} sm={9}>
-        <ChildComponent
-          value={filter.value || ""}
-          onChange={onChange}
-          {...element.props}
-        />
-      </Col>
-      <Col xs={1} sm={1}>
-        <Button bsStyle="link" onClick={() => onRemove(filter)}>
-          <img src={REMOVE_ICON} height={14} alt="Remove this filter" />
-        </Button>
-      </Col>
+      <Row>
+        <Col xs={1} sm={2} style={{ textAlign: "right" }}>
+          <ControlLabel>{label}</ControlLabel>
+        </Col>
+        <Col xs={10} sm={9}>
+          <ChildComponent
+            value={filter.value || ""}
+            onChange={onChange}
+            {...element.props}
+          />
+        </Col>
+        <Col xs={1} sm={1}>
+          <Button bsStyle="link" onClick={() => onRemove(filter)}>
+            <img src={REMOVE_ICON} height={14} alt="Remove this filter" />
+          </Button>
+        </Col>
+      </Row>
     </FormGroup>
   )
 

--- a/client/src/components/advancedSearch/DateRangeSearch.js
+++ b/client/src/components/advancedSearch/DateRangeSearch.js
@@ -144,7 +144,8 @@ export default class DateRangeSearch extends Component {
         style={{
           display: "flex",
           flexDirection: "row",
-          alignItems: "center"
+          alignItems: "center",
+          flexWrap: "wrap"
         }}
       >
         {this.selectMenu(this.props.onlyBetween)}

--- a/client/src/components/advancedSearch/ReportStateSearch.js
+++ b/client/src/components/advancedSearch/ReportStateSearch.js
@@ -93,7 +93,12 @@ export default class ReportStateSearch extends Component {
     return !this.props.asFormField ? (
       stateDisplay
     ) : (
-      <div>
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "row"
+        }}
+      >
         <select
           id={this.props.queryKey}
           value={value.state}
@@ -107,7 +112,7 @@ export default class ReportStateSearch extends Component {
           ))}
         </select>
         {onlyCancelled && (
-          <span style={{ verticalAlign: "top", paddingLeft: "8px" }}>
+          <div style={{ verticalAlign: "top", paddingLeft: "8px" }}>
             due to{" "}
             <select
               id={`${this.props.queryKey}CancelledReason`}
@@ -121,7 +126,7 @@ export default class ReportStateSearch extends Component {
                 </option>
               ))}
             </select>
-          </span>
+          </div>
         )}
       </div>
     )

--- a/client/src/components/advancedSelectWidget/AdvancedSelect.css
+++ b/client/src/components/advancedSelectWidget/AdvancedSelect.css
@@ -41,3 +41,7 @@
 .advanced-select-popover table > tbody > tr > td {
   vertical-align: middle;
 }
+
+.advanced-select-popover > .bp3-overlay > .bp3-transition-container {
+  width: 100%;
+}

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -732,11 +732,12 @@ header.searchPagination {
 	height: 64px;
 }
 
-.advanced-search .col-xs-1 .btn {
+.advanced-search .col-xs-1 .btn, .advanced-search .col-sm-1 .btn {
 	padding-left: 0;
+	text-align: left;
 }
 
-.advanced-search .col-xs-1 .btn img {
+.advanced-search .col-xs-1 .btn img, .advanced-search .col-sm-1 .btn img {
 	vertical-align: baseline;
 }
 


### PR DESCRIPTION
several minor fixes in the layout

### User changes
- delete filter button is not visible when nothing to delete
- do not allow modification of type filter if only one type is possible (i.e. as in some of the insights)
- display "add _another_ filter" only when there is already one defined