### PR TITLE
Report approval workflow for tasks

### DIFF
--- a/anet.yml
+++ b/anet.yml
@@ -195,6 +195,7 @@ dictionary:
 
   reportWorkflow:
     nbOfHoursQuarantineApproved: 24
+    nbOfHoursApprovalTimeout: 48
 
   maxTextFieldLength: 250
 

--- a/client/src/components/ApprovalDefinition.js
+++ b/client/src/components/ApprovalDefinition.js
@@ -1,0 +1,259 @@
+import API from "api"
+import { gql } from "apollo-boost"
+import AdvancedMultiSelect from "components/advancedSelectWidget/AdvancedMultiSelect"
+import { ApproverOverlayRow } from "components/advancedSelectWidget/AdvancedSelectOverlayRow"
+import * as FieldHelper from "components/FieldHelper"
+import Fieldset from "components/Fieldset"
+import LinkTo from "components/LinkTo"
+import { FastField, FieldArray } from "formik"
+import { Position } from "models"
+import PropTypes from "prop-types"
+import React, { useState } from "react"
+import { Button, Modal, Table } from "react-bootstrap"
+import REMOVE_ICON from "resources/delete.png"
+import POSITIONS_ICON from "resources/positions.png"
+
+const GQL_GET_APPROVAL_STEP_IN_USE = gql`
+  query($uuid: String!) {
+    approvalStepInUse(uuid: $uuid)
+  }
+`
+
+const ApproverTable = ({ approvers, onDelete }) => {
+  return (
+    <Table striped condensed hover responsive>
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Position</th>
+          <th />
+        </tr>
+      </thead>
+      <tbody>
+        {approvers.map((approver, approverIndex) => (
+          <tr key={approver.uuid}>
+            <td>
+              <LinkTo person={approver.person} target="_blank" />
+            </td>
+            <td>
+              <LinkTo position={approver} target="_blank" />
+            </td>
+            <td onClick={() => onDelete(approver)}>
+              <span style={{ cursor: "pointer" }}>
+                <img src={REMOVE_ICON} height={14} alt="Remove approver" />
+              </span>
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </Table>
+  )
+}
+ApproverTable.propTypes = {
+  approvers: PropTypes.array,
+  onDelete: PropTypes.func
+}
+
+const ApprovalDefinition = ({
+  fieldName,
+  values,
+  title,
+  addButtonLabel,
+  approversFilters,
+  setFieldTouched,
+  setFieldValue
+}) => {
+  const [showAddApprovalStepAlert, setShowAddApprovalStepAlert] = useState(
+    false
+  )
+  const [
+    showRemoveApprovalStepAlert,
+    setShowRemoveApprovalStepAlert
+  ] = useState(false)
+
+  return (
+    <div>
+      <Fieldset title={title}>
+        <FieldArray
+          name={fieldName}
+          render={arrayHelpers => (
+            <div>
+              <Button
+                className="pull-right"
+                onClick={() => addApprovalStep(arrayHelpers, values[fieldName])}
+                bsStyle="primary"
+                id={`add${fieldName}Button`}
+              >
+                {addButtonLabel}
+              </Button>
+              <Modal
+                show={showAddApprovalStepAlert}
+                onHide={hideAddApprovalStepAlert}
+              >
+                <Modal.Header closeButton>
+                  <Modal.Title>Step not added</Modal.Title>
+                </Modal.Header>
+                <Modal.Body>
+                  Please complete all approval steps; there already is an
+                  approval step that is not completely filled in.
+                </Modal.Body>
+                <Modal.Footer>
+                  <Button
+                    className="pull-right"
+                    onClick={hideAddApprovalStepAlert}
+                    bsStyle="primary"
+                  >
+                    OK
+                  </Button>
+                </Modal.Footer>
+              </Modal>
+              <Modal
+                show={showRemoveApprovalStepAlert}
+                onHide={hideRemoveApprovalStepAlert}
+              >
+                <Modal.Header closeButton>
+                  <Modal.Title>Step not removed</Modal.Title>
+                </Modal.Header>
+                <Modal.Body>
+                  You cannot remove this step; it is being used in a report.
+                </Modal.Body>
+                <Modal.Footer>
+                  <Button
+                    className="pull-right"
+                    onClick={hideRemoveApprovalStepAlert}
+                    bsStyle="primary"
+                  >
+                    OK
+                  </Button>
+                </Modal.Footer>
+              </Modal>
+
+              {values[fieldName].map((step, index) =>
+                renderApprovalStep(
+                  fieldName,
+                  arrayHelpers,
+                  setFieldValue,
+                  setFieldTouched,
+                  step,
+                  index,
+                  approversFilters
+                )
+              )}
+            </div>
+          )}
+        />
+      </Fieldset>
+    </div>
+  )
+
+  function renderApprovalStep(
+    fieldName,
+    arrayHelpers,
+    setFieldValue,
+    setFieldTouched,
+    step,
+    index,
+    approversFilters
+  ) {
+    const approvers = step.approvers
+
+    return (
+      <Fieldset title={`Step ${index + 1}`} key={index}>
+        <Button
+          className="pull-right"
+          title="Remove this step"
+          onClick={() => removeApprovalStep(arrayHelpers, index, step)}
+        >
+          <img src={REMOVE_ICON} height={14} alt="Remove this step" />
+        </Button>
+
+        <FastField
+          name={`${fieldName}.${index}.name`}
+          component={FieldHelper.InputField}
+          label="Step name"
+        />
+        <FastField
+          name={`${fieldName}.${index}.approvers`}
+          label="Add an approver"
+          component={FieldHelper.SpecialField}
+          onChange={value => {
+            // validation will be done by setFieldValue
+            setFieldTouched(`${fieldName}.${index}.approvers`, true, false) // onBlur doesn't work when selecting an option
+            setFieldValue(`${fieldName}.${index}.approvers`, value)
+          }}
+          widget={
+            <AdvancedMultiSelect
+              fieldName={`${fieldName}.${index}.approvers`}
+              placeholder="Search for the approver's position..."
+              value={approvers}
+              renderSelected={<ApproverTable approvers={approvers} />}
+              overlayColumns={["Name", "Position"]}
+              overlayRenderRow={ApproverOverlayRow}
+              filterDefs={approversFilters}
+              objectType={Position}
+              queryParams={{
+                status: Position.STATUS.ACTIVE,
+                type: [
+                  Position.TYPE.ADVISOR,
+                  Position.TYPE.SUPER_USER,
+                  Position.TYPE.ADMINISTRATOR
+                ],
+                matchPersonName: true
+              }}
+              fields="uuid, name, code, type, person { uuid, name, rank, role, avatar(size: 32) }"
+              addon={POSITIONS_ICON}
+            />
+          }
+        />
+      </Fieldset>
+    )
+  }
+
+  function hideAddApprovalStepAlert() {
+    setShowAddApprovalStepAlert(false)
+  }
+
+  function hideRemoveApprovalStepAlert() {
+    setShowRemoveApprovalStepAlert(false)
+  }
+
+  function addApprovalStep(arrayHelpers, values) {
+    const approvalSteps = values || []
+    for (let i = 0; i < approvalSteps.length; i++) {
+      const step = approvalSteps[i]
+      if (!step.name || !step.approvers || step.approvers.length === 0) {
+        setShowAddApprovalStepAlert(true)
+        return
+      }
+    }
+    arrayHelpers.push({ name: "", approvers: [] })
+  }
+
+  function removeApprovalStep(arrayHelpers, index, step) {
+    if (!step.uuid) {
+      // New, unsaved step
+      arrayHelpers.remove(index)
+      return
+    }
+    return API.query(GQL_GET_APPROVAL_STEP_IN_USE, { uuid: step.uuid }).then(
+      data => {
+        if (data.approvalStepInUse) {
+          setShowRemoveApprovalStepAlert(true)
+        } else {
+          arrayHelpers.remove(index)
+        }
+      }
+    )
+  }
+}
+ApprovalDefinition.propTypes = {
+  fieldName: PropTypes.string.isRequired,
+  title: PropTypes.string,
+  addButtonLabel: PropTypes.string,
+  values: PropTypes.array,
+  approversFilters: PropTypes.object,
+  setFieldTouched: PropTypes.func,
+  setFieldValue: PropTypes.func
+}
+
+export default ApprovalDefinition

--- a/client/src/components/ReportTable.js
+++ b/client/src/components/ReportTable.js
@@ -69,30 +69,6 @@ const GQL_GET_REPORT_LIST = gql`
           name
           description
         }
-        workflow {
-          type
-          createdAt
-          step {
-            uuid
-            name
-            approvers {
-              uuid
-              name
-              person {
-                uuid
-                name
-                rank
-                role
-              }
-            }
-          }
-          person {
-            uuid
-            name
-            rank
-            role
-          }
-        }
         updatedAt
       }
     }

--- a/client/src/components/ReportWorkflow.js
+++ b/client/src/components/ReportWorkflow.js
@@ -21,7 +21,13 @@ const ApprovalStepModalStatus = ({ action }) => {
     const cssClass = "label " + actionType.cssClass
     return (
       <span className={cssClass}>
-        {actionType.text} by <LinkTo person={action.person} isLink={false} /> on
+        {actionType.text} by{" "}
+        <LinkTo
+          person={action.person}
+          whenUnspecified="system"
+          isLink={false}
+        />{" "}
+        on
         <small>
           {" "}
           {moment(action.createdAt).format(
@@ -120,7 +126,7 @@ const ActionDetails = ({ action }) => {
     return (
       <div>
         <span>
-          By <LinkTo person={action.person} />
+          By <LinkTo person={action.person} whenUnspecified="system" />
         </span>
         <br />
         <small>

--- a/client/src/components/approvals/Approvals.js
+++ b/client/src/components/approvals/Approvals.js
@@ -1,13 +1,13 @@
 import Fieldset from "components/Fieldset"
 import LinkTo from "components/LinkTo"
-import { Organization } from "models"
+import { Organization, Task } from "models"
 import PropTypes from "prop-types"
 import React from "react"
 import { Table } from "react-bootstrap"
 
-const OrganizationApprovals = ({ organization }) => {
-  const approvalSteps = organization.approvalSteps
-  const planningApprovalSteps = organization.planningApprovalSteps
+const Approvals = ({ relatedObject }) => {
+  const approvalSteps = relatedObject.approvalSteps
+  const planningApprovalSteps = relatedObject.planningApprovalSteps
 
   return (
     <div>
@@ -50,8 +50,7 @@ const OrganizationApprovals = ({ organization }) => {
 
         {planningApprovalSteps.length === 0 && (
           <em>
-            This organization doesn't have any engagement planning approval
-            steps
+            This object doesn't have any engagement planning approval steps
           </em>
         )}
       </Fieldset>
@@ -91,7 +90,7 @@ const OrganizationApprovals = ({ organization }) => {
 
         {approvalSteps.length === 0 && (
           <em>
-            This organization doesn't have any report publication approval steps
+            This object doesn't have any report publication approval steps
           </em>
         )}
       </Fieldset>
@@ -99,8 +98,11 @@ const OrganizationApprovals = ({ organization }) => {
   )
 }
 
-OrganizationApprovals.propTypes = {
-  organization: PropTypes.instanceOf(Organization).isRequired
+Approvals.propTypes = {
+  relatedObject: PropTypes.oneOfType([
+    PropTypes.instanceOf(Organization),
+    PropTypes.instanceOf(Task)
+  ]).isRequired
 }
 
-export default OrganizationApprovals
+export default Approvals

--- a/client/src/components/approvals/ApprovalsDefinition.js
+++ b/client/src/components/approvals/ApprovalsDefinition.js
@@ -54,7 +54,7 @@ ApproverTable.propTypes = {
   onDelete: PropTypes.func
 }
 
-const ApprovalDefinition = ({
+const ApprovalsDefinition = ({
   fieldName,
   values,
   title,
@@ -246,14 +246,14 @@ const ApprovalDefinition = ({
     )
   }
 }
-ApprovalDefinition.propTypes = {
+ApprovalsDefinition.propTypes = {
   fieldName: PropTypes.string.isRequired,
   title: PropTypes.string,
   addButtonLabel: PropTypes.string,
-  values: PropTypes.array,
+  values: PropTypes.object,
   approversFilters: PropTypes.object,
   setFieldTouched: PropTypes.func,
   setFieldValue: PropTypes.func
 }
 
-export default ApprovalDefinition
+export default ApprovalsDefinition

--- a/client/src/models/Task.js
+++ b/client/src/models/Task.js
@@ -32,6 +32,11 @@ export default class Task extends Model {
     INACTIVE: "INACTIVE"
   }
 
+  static APPROVAL_STEP_TYPE = {
+    PLANNING_APPROVAL: "PLANNING_APPROVAL",
+    REPORT_APPROVAL: "REPORT_APPROVAL"
+  }
+
   // create yup schema for the customFields, based on the customFields config
   static customFieldsSchema = createYupObjectShape(
     Settings.fields.task.customFields
@@ -96,6 +101,47 @@ export default class Task extends Model {
         .nullable()
         .default([])
         .label(responsiblePositions && responsiblePositions.label),
+      // FIXME: resolve code duplication in yup schema for approval steps
+      planningApprovalSteps: yup
+        .array()
+        .of(
+          yup.object().shape({
+            name: yup
+              .string()
+              .required("You must provide the step name")
+              .default(""),
+            type: yup
+              .string()
+              .required()
+              .default(() => Task.APPROVAL_STEP_TYPE.PLANNING_APPROVAL),
+            approvers: yup
+              .array()
+              .required("You must select at least one approver")
+              .default([])
+          })
+        )
+        .nullable()
+        .default([]),
+      approvalSteps: yup
+        .array()
+        .of(
+          yup.object().shape({
+            name: yup
+              .string()
+              .required("You must provide the step name")
+              .default(""),
+            type: yup
+              .string()
+              .required()
+              .default(() => Task.APPROVAL_STEP_TYPE.REPORT_APPROVAL),
+            approvers: yup
+              .array()
+              .required("You must select at least one approver")
+              .default([])
+          })
+        )
+        .nullable()
+        .default([]),
       // not actually in the database, the database contains the JSON customFields
       formCustomFields: Task.customFieldsSchema.nullable()
     })

--- a/client/src/pages/organizations/Form.js
+++ b/client/src/pages/organizations/Form.js
@@ -7,7 +7,7 @@ import {
 } from "components/advancedSelectWidget/AdvancedSelectOverlayRow"
 import AdvancedSingleSelect from "components/advancedSelectWidget/AdvancedSingleSelect"
 import AppContext from "components/AppContext"
-import ApprovalDefinition from "components/ApprovalDefinition"
+import ApprovalsDefinition from "components/approvals/ApprovalsDefinition"
 import * as FieldHelper from "components/FieldHelper"
 import Fieldset from "components/Fieldset"
 import LinkTo from "components/LinkTo"
@@ -274,7 +274,7 @@ const BaseOrganizationForm = ({ currentUser, edit, title, initialValues }) => {
 
               {isAdvisorOrg && (
                 <div>
-                  <ApprovalDefinition
+                  <ApprovalsDefinition
                     fieldName="planningApprovalSteps"
                     values={values}
                     title="Engagement planning approval process"
@@ -288,7 +288,7 @@ const BaseOrganizationForm = ({ currentUser, edit, title, initialValues }) => {
 
               {isAdvisorOrg && (
                 <div>
-                  <ApprovalDefinition
+                  <ApprovalsDefinition
                     fieldName="approvalSteps"
                     values={values}
                     title="Report publication approval process"

--- a/client/src/pages/organizations/Show.js
+++ b/client/src/pages/organizations/Show.js
@@ -1,6 +1,7 @@
 import { DEFAULT_PAGE_PROPS, DEFAULT_SEARCH_PROPS } from "actions"
 import API, { Settings } from "api"
 import { gql } from "apollo-boost"
+import Approvals from "components/approvals/Approvals"
 import AppContext from "components/AppContext"
 import * as FieldHelper from "components/FieldHelper"
 import Fieldset from "components/Fieldset"
@@ -33,7 +34,6 @@ import { ListGroup, ListGroupItem, Nav, Button } from "react-bootstrap"
 import { connect } from "react-redux"
 import { useLocation, useParams } from "react-router-dom"
 import DictionaryField from "../../HOC/DictionaryField"
-import OrganizationApprovals from "./Approvals"
 import OrganizationLaydown from "./Laydown"
 import OrganizationTasks from "./OrganizationTasks"
 
@@ -347,9 +347,7 @@ const BaseOrganizationShow = ({ pageDispatchers, currentUser }) => {
               </Fieldset>
 
               <OrganizationLaydown organization={organization} />
-              {!isPrincipalOrg && (
-                <OrganizationApprovals organization={organization} />
-              )}
+              {!isPrincipalOrg && <Approvals relatedObject={organization} />}
               {organization.isTaskEnabled() && (
                 <OrganizationTasks
                   organization={organization}

--- a/client/src/pages/tasks/Edit.js
+++ b/client/src/pages/tasks/Edit.js
@@ -56,6 +56,36 @@ const GQL_GET_TASK = gql`
           avatar(size: 32)
         }
       }
+      planningApprovalSteps {
+        uuid
+        name
+        approvers {
+          uuid
+          name
+          person {
+            uuid
+            name
+            rank
+            role
+            avatar(size: 32)
+          }
+        }
+      }
+      approvalSteps {
+        uuid
+        name
+        approvers {
+          uuid
+          name
+          person {
+            uuid
+            name
+            rank
+            role
+            avatar(size: 32)
+          }
+        }
+      }
       customFields
       ${GRAPHQL_NOTES_FIELDS}
     }

--- a/client/src/pages/tasks/Form.js
+++ b/client/src/pages/tasks/Form.js
@@ -8,6 +8,7 @@ import {
 } from "components/advancedSelectWidget/AdvancedSelectOverlayRow"
 import AdvancedSingleSelect from "components/advancedSelectWidget/AdvancedSingleSelect"
 import AppContext from "components/AppContext"
+import ApprovalDefinition from "components/ApprovalDefinition"
 import CustomDateInput from "components/CustomDateInput"
 import {
   CustomFieldsContainer,
@@ -115,6 +116,29 @@ const BaseTaskForm = ({ currentUser, edit, title, initialValues }) => {
           Position.TYPE.ADMINISTRATOR
         ],
         matchPersonName: true
+      }
+    }
+  }
+
+  const approversFilters = {
+    allAdvisorPositions: {
+      label: "All advisor positions",
+      queryVars: {
+        type: [
+          Position.TYPE.ADVISOR,
+          Position.TYPE.SUPER_USER,
+          Position.TYPE.ADMINISTRATOR
+        ],
+        matchPersonName: true
+      }
+    }
+  }
+  if (currentUser.position) {
+    approversFilters.myColleagues = {
+      label: "My colleagues",
+      queryVars: {
+        matchPersonName: true,
+        organizationUuid: currentUser.position.organization.uuid
       }
     }
   }
@@ -394,6 +418,26 @@ const BaseTaskForm = ({ currentUser, edit, title, initialValues }) => {
                   />
                 </Fieldset>
               )}
+
+              <ApprovalDefinition
+                fieldName="planningApprovalSteps"
+                values={values}
+                title="Engagement planning approval process"
+                addButtonLabel="Add a Planning Approval Step"
+                setFieldTouched={setFieldTouched}
+                setFieldValue={setFieldValue}
+                approversFilters={approversFilters}
+              />
+
+              <ApprovalDefinition
+                fieldName="approvalSteps"
+                values={values}
+                title="Report publication approval process"
+                addButtonLabel="Add a Publication Approval Step"
+                setFieldTouched={setFieldTouched}
+                setFieldValue={setFieldValue}
+                approversFilters={approversFilters}
+              />
 
               <div className="submit-buttons">
                 <div>

--- a/client/src/pages/tasks/Form.js
+++ b/client/src/pages/tasks/Form.js
@@ -8,7 +8,7 @@ import {
 } from "components/advancedSelectWidget/AdvancedSelectOverlayRow"
 import AdvancedSingleSelect from "components/advancedSelectWidget/AdvancedSingleSelect"
 import AppContext from "components/AppContext"
-import ApprovalDefinition from "components/ApprovalDefinition"
+import ApprovalsDefinition from "components/approvals/ApprovalsDefinition"
 import CustomDateInput from "components/CustomDateInput"
 import {
   CustomFieldsContainer,
@@ -419,7 +419,7 @@ const BaseTaskForm = ({ currentUser, edit, title, initialValues }) => {
                 </Fieldset>
               )}
 
-              <ApprovalDefinition
+              <ApprovalsDefinition
                 fieldName="planningApprovalSteps"
                 values={values}
                 title="Engagement planning approval process"
@@ -429,7 +429,7 @@ const BaseTaskForm = ({ currentUser, edit, title, initialValues }) => {
                 approversFilters={approversFilters}
               />
 
-              <ApprovalDefinition
+              <ApprovalsDefinition
                 fieldName="approvalSteps"
                 values={values}
                 title="Report publication approval process"

--- a/client/src/pages/tasks/Show.js
+++ b/client/src/pages/tasks/Show.js
@@ -1,6 +1,7 @@
 import { DEFAULT_PAGE_PROPS, DEFAULT_SEARCH_PROPS } from "actions"
 import API, { Settings } from "api"
 import { gql } from "apollo-boost"
+import Approvals from "components/approvals/Approvals"
 import AppContext from "components/AppContext"
 import { ReadonlyCustomFields } from "components/CustomFields"
 import * as FieldHelper from "components/FieldHelper"
@@ -66,6 +67,36 @@ const GQL_GET_TASK = gql`
           rank
           role
           avatar(size: 32)
+        }
+      }
+      planningApprovalSteps {
+        uuid
+        name
+        approvers {
+          uuid
+          name
+          person {
+            uuid
+            name
+            rank
+            role
+            avatar(size: 32)
+          }
+        }
+      }
+      approvalSteps {
+        uuid
+        name
+        approvers {
+          uuid
+          name
+          person {
+            uuid
+            name
+            rank
+            role
+            avatar(size: 32)
+          }
         }
       }
       customFields
@@ -272,6 +303,8 @@ const BaseTaskShow = ({ pageDispatchers, currentUser }) => {
             <Fieldset title="Responsible positions">
               <PositionTable positions={task.responsiblePositions} />
             </Fieldset>
+
+            <Approvals relatedObject={task} />
 
             <Fieldset
               title={`Reports for this ${Settings.fields.task.shortLabel}`}

--- a/insertBaseData-mssql.sql
+++ b/insertBaseData-mssql.sql
@@ -8,6 +8,8 @@ SET QUOTED_IDENTIFIER ON
 --DROP TABLE reportTags;
 --DROP TABLE peoplePositions;
 --DROP TABLE savedSearches;
+--DROP TABLE taskTaskedOrganizations;
+--DROP TABLE taskResponsiblePositions;
 --DROP TABLE positions;
 --DROP TABLE tasks;
 --DROP TABLE comments;
@@ -40,6 +42,8 @@ TRUNCATE TABLE reportsSensitiveInformation;
 TRUNCATE TABLE authorizationGroupPositions;
 TRUNCATE TABLE reportAuthorizationGroups;
 TRUNCATE TABLE noteRelatedObjects;
+TRUNCATE TABLE taskTaskedOrganizations;
+TRUNCATE TABLE taskResponsiblePositions;
 DELETE FROM positions;
 DELETE FROM tasks WHERE customFieldRef1Uuid IS NOT NULL;
 DELETE FROM tasks WHERE customFieldRef1Uuid IS NULL;
@@ -145,7 +149,7 @@ INSERT INTO positions (uuid, name, type, status, currentPersonUuid, createdAt, u
 INSERT INTO positions (uuid, name, type, status, currentPersonUuid, createdAt, updatedAt)
 	VALUES (lower(newid()), 'EF 2.2 Final Reviewer', 2, 0, NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
 INSERT INTO positions (uuid, name, type, status, currentPersonUuid, createdAt, updatedAt)
-	VALUES (lower(newid()), 'EF 4.1 Advisor E', 0, 0, NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+	VALUES (lower(newid()), 'EF 4.1 Advisor A', 0, 0, NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
 INSERT INTO positions (uuid, name, type, status, currentPersonUuid, createdAt, updatedAt)
 	VALUES (lower(newid()), 'EF 4.1 Advisor for Coffee', 0, 0, NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
 INSERT INTO positions (uuid, name, type, status, currentPersonUuid, createdAt, updatedAt)
@@ -384,6 +388,38 @@ INSERT INTO taskTaskedOrganizations (taskUuid, organizationUuid)
 		((SELECT uuid from tasks where shortName = '4.b.5'), (SELECT uuid from organizations where shortName='EF 4')),
 		((SELECT uuid from tasks where shortName = '4.c'), (SELECT uuid from organizations where shortName='EF 4'));
 
+-- Create a task approval process for some tasks
+INSERT INTO taskResponsiblePositions (taskUuid, positionUuid)
+	VALUES
+		((SELECT uuid FROM tasks WHERE shortName = '1.1'), (SELECT uuid FROM positions WHERE name = 'EF 1.1 SuperUser')),
+		((SELECT uuid FROM tasks WHERE shortName = '1.1.A'), (SELECT uuid FROM positions WHERE name = 'EF 1 Manager')),
+		((SELECT uuid FROM tasks WHERE shortName = '1.1.A'), (SELECT uuid FROM positions WHERE name = 'EF 1.1 Advisor A')),
+		((SELECT uuid FROM tasks WHERE shortName = '1.1.B'), (SELECT uuid FROM positions WHERE name = 'EF 1.1 Advisor B')),
+		((SELECT uuid FROM tasks WHERE shortName = '1.1.B'), (SELECT uuid FROM positions WHERE name = 'EF 1.1 Advisor for Interagency Advising')),
+		((SELECT uuid FROM tasks WHERE shortName = '1.1.C'), (SELECT uuid FROM positions WHERE name = 'EF 1.1 Advisor C')),
+		((SELECT uuid FROM tasks WHERE shortName = '1.1.C'), (SELECT uuid FROM positions WHERE name = 'EF 1.1 Advisor for Mining')),
+		((SELECT uuid FROM tasks WHERE shortName = '2.A'), (SELECT uuid FROM positions WHERE name = 'EF 2.1 SuperUser')),
+		((SELECT uuid FROM tasks WHERE shortName = '2.B'), (SELECT uuid FROM positions WHERE name = 'EF 2.1 Advisor B')),
+		((SELECT uuid FROM tasks WHERE shortName = '2.C'), (SELECT uuid FROM positions WHERE name = 'EF 2.1 Advisor for Accounting')),
+		((SELECT uuid FROM tasks WHERE shortName = '2.D'), (SELECT uuid FROM positions WHERE name = 'EF 2.1 Advisor for Kites')),
+		((SELECT uuid FROM tasks WHERE shortName = '4.a'), (SELECT uuid FROM positions WHERE name = 'EF 4.1 Advisor A')),
+		((SELECT uuid FROM tasks WHERE shortName = '4.b'), (SELECT uuid FROM positions WHERE name = 'EF 4.1 Advisor for Coffee')),
+		((SELECT uuid FROM tasks WHERE shortName = '4.c'), (SELECT uuid FROM positions WHERE name = 'EF 4.1 Advisor on Software Engineering'));
+
+INSERT INTO approvalSteps (uuid, relatedObjectUuid, name, type)
+	SELECT lower(newid()), tasks.uuid, 'Task Owner approval', 1
+	FROM tasks
+	WHERE status = 0
+	AND customFieldRef1Uuid IS NOT NULL;
+
+INSERT INTO approvers (approvalStepUuid, positionUuid)
+	SELECT approvalSteps.uuid, taskResponsiblePositions.positionUuid
+	FROM taskResponsiblePositions
+	JOIN approvalSteps ON relatedObjectUuid = taskUuid
+	WHERE approvalSteps.name = 'Task Owner approval'
+	AND approvalSteps.type = 1;
+
+-- Create locations
 INSERT INTO locations (uuid, name, lat, lng, createdAt, updatedAt)
 	VALUES (N'cc49bb27-4d8f-47a8-a9ee-af2b68b992ac', 'St Johns Airport', 47.613442, -52.740936, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
 INSERT INTO locations (uuid, name, lat, lng, createdAt, updatedAt)

--- a/insertBaseData-mssql.sql
+++ b/insertBaseData-mssql.sql
@@ -283,7 +283,7 @@ UPDATE positions SET organizationUuid = (SELECT uuid FROM organizations WHERE sh
 UPDATE positions SET organizationUuid = (SELECT uuid FROM organizations WHERE shortName='ANET Administrators') where name = 'ANET Administrator';
 
 -- Create the EF 1.1 approval process
-INSERT INTO approvalSteps (uuid, advisorOrganizationUuid, name, type)
+INSERT INTO approvalSteps (uuid, relatedObjectUuid, name, type)
 	VALUES (lower(newid()), (SELECT uuid from organizations where shortName='EF 1.1'), 'EF 1.1 Approvers', 1);
 INSERT INTO approvers (approvalStepUuid, positionUuid)
 	VALUES ((SELECT uuid from approvalSteps WHERE name='EF 1.1 Approvers'), (SELECT uuid from positions where name = 'EF 1.1 SuperUser'));
@@ -291,9 +291,9 @@ INSERT INTO approvers (approvalStepUuid, positionUuid)
 -- Create the EF 2.2 approval process
 DECLARE @approvalStepUuid varchar(36);
 SET @approvalStepUuid = lower(newid());
-INSERT INTO approvalSteps (uuid, name, advisorOrganizationUuid, type)
+INSERT INTO approvalSteps (uuid, name, relatedObjectUuid, type)
 	VALUES (@approvalStepUuid, 'EF 2.2 Secondary Reviewers', (SELECT uuid from organizations where shortName='EF 2.2'), 1);
-INSERT INTO approvalSteps (uuid, name, advisorOrganizationUuid, nextStepUuid, type)
+INSERT INTO approvalSteps (uuid, name, relatedObjectUuid, nextStepUuid, type)
 	VALUES (lower(newid()), 'EF 2.2 Initial Approvers', (SELECT uuid from organizations where shortName='EF 2.2'), @approvalStepUuid, 1);
 
 INSERT INTO approvers (approvalStepUuid, positionUuid)
@@ -708,7 +708,7 @@ INSERT INTO reportTasks (taskUuid, reportUuid)
 UPDATE reports SET releasedAt = reports.createdAt WHERE state = 2 OR state = 4;
 
 --Create the default Approval Step
-INSERT INTO approvalSteps (uuid, name, advisorOrganizationUuid, type)
+INSERT INTO approvalSteps (uuid, name, relatedObjectUuid, type)
 	VALUES (lower(newid()), 'Default Approvers', (select uuid from organizations where shortName='ANET Administrators'), 1);
 INSERT INTO approvers (approvalStepUuid, positionUuid)
 	VALUES ((SELECT uuid from approvalSteps where name = 'Default Approvers'), (SELECT uuid from positions where name = 'ANET Administrator'));

--- a/src/integration-test/java/mil/dds/anet/integrationtest/utils/TestBeans.java
+++ b/src/integration-test/java/mil/dds/anet/integrationtest/utils/TestBeans.java
@@ -47,7 +47,7 @@ public class TestBeans {
 
   public static ApprovalStep getTestApprovalStep(Organization organization) {
     ApprovalStep as = new ApprovalStep();
-    as.setAdvisorOrganizationUuid(organization.getUuid());
+    as.setRelatedObjectUuid(organization.getUuid());
     as.setApprovers(ImmutableList.of());
     as.setType(ApprovalStepType.REPORT_APPROVAL);
     return as;

--- a/src/main/java/mil/dds/anet/AnetApplication.java
+++ b/src/main/java/mil/dds/anet/AnetApplication.java
@@ -48,6 +48,7 @@ import mil.dds.anet.beans.Person;
 import mil.dds.anet.config.AnetConfiguration;
 import mil.dds.anet.database.StatementLogger;
 import mil.dds.anet.resources.AdminResource;
+import mil.dds.anet.resources.ApprovalStepResource;
 import mil.dds.anet.resources.AuthorizationGroupResource;
 import mil.dds.anet.resources.GraphQlResource;
 import mil.dds.anet.resources.HomeResource;
@@ -264,6 +265,7 @@ public class AnetApplication extends Application<AnetConfiguration> {
     final AuthorizationGroupResource authorizationGroupResource =
         new AuthorizationGroupResource(engine);
     final NoteResource noteResource = new NoteResource(engine);
+    final ApprovalStepResource approvalStepResource = new ApprovalStepResource(engine);
 
     // Register all of the HTTP Resources
     environment.jersey().register(loggingResource);
@@ -274,7 +276,7 @@ public class AnetApplication extends Application<AnetConfiguration> {
         .register(new GraphQlResource(engine, configuration,
             ImmutableList.of(reportResource, personResource, positionResource, locationResource,
                 orgResource, taskResource, adminResource, savedSearchResource, tagResource,
-                authorizationGroupResource, noteResource),
+                authorizationGroupResource, noteResource, approvalStepResource),
             metricRegistry));
   }
 

--- a/src/main/java/mil/dds/anet/AnetApplication.java
+++ b/src/main/java/mil/dds/anet/AnetApplication.java
@@ -66,6 +66,7 @@ import mil.dds.anet.threads.AccountDeactivationWorker;
 import mil.dds.anet.threads.AnetEmailWorker;
 import mil.dds.anet.threads.FutureEngagementWorker;
 import mil.dds.anet.threads.MaterializedViewRefreshWorker;
+import mil.dds.anet.threads.ReportApprovalWorker;
 import mil.dds.anet.threads.ReportPublicationWorker;
 import mil.dds.anet.utils.DaoUtils;
 import mil.dds.anet.utils.HttpsRedirectFilter;
@@ -224,6 +225,8 @@ public class AnetApplication extends Application<AnetConfiguration> {
     FutureEngagementWorker futureWorker = new FutureEngagementWorker(engine.getReportDao());
     ReportPublicationWorker reportPublicationWorker =
         new ReportPublicationWorker(engine.getReportDao(), configuration);
+    final ReportApprovalWorker reportApprovalWorker =
+        new ReportApprovalWorker(engine.getReportDao(), configuration);
 
     // Check for any reports that need to be published every 5 minutes.
     // And run once in 5 seconds from boot-up. (give the server time to boot up).
@@ -239,6 +242,11 @@ public class AnetApplication extends Application<AnetConfiguration> {
     // And run once in 15 seconds from boot-up. (give the server time to boot up).
     scheduler.scheduleAtFixedRate(futureWorker, 0, 3, TimeUnit.HOURS);
     scheduler.schedule(futureWorker, 15, TimeUnit.SECONDS);
+
+    // Check for any reports that need to be approved every 5 minutes.
+    // And run once in 20 seconds from boot-up. (give the server time to boot up).
+    scheduler.scheduleAtFixedRate(reportApprovalWorker, 5, 5, TimeUnit.MINUTES);
+    scheduler.schedule(reportApprovalWorker, 5, TimeUnit.SECONDS);
 
     runAccountDeactivationWorker(configuration, scheduler, engine);
 

--- a/src/main/java/mil/dds/anet/AnetObjectEngine.java
+++ b/src/main/java/mil/dds/anet/AnetObjectEngine.java
@@ -9,7 +9,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 import mil.dds.anet.beans.ApprovalStep;
 import mil.dds.anet.beans.Organization;
 import mil.dds.anet.beans.Organization.OrganizationType;
@@ -213,12 +212,7 @@ public class AnetObjectEngine {
   public boolean canUserApproveStep(Map<String, Object> context, String userUuid,
       String approvalStepUuid) {
     ApprovalStep as = asDao.getByUuid(approvalStepUuid);
-    final List<Position> approvers;
-    try {
-      approvers = as.loadApprovers(context).get();
-    } catch (InterruptedException | ExecutionException e) {
-      return false;
-    }
+    final List<Position> approvers = as.loadApprovers(context).join();
     for (Position approverPosition : approvers) {
       // approverPosition.getPerson() has the currentPersonUuid already loaded, so this is safe.
       if (Objects.equals(userUuid, approverPosition.getPersonUuid())) {

--- a/src/main/java/mil/dds/anet/AnetObjectEngine.java
+++ b/src/main/java/mil/dds/anet/AnetObjectEngine.java
@@ -182,15 +182,15 @@ public class AnetObjectEngine {
         .thenApply(l -> l.isEmpty() ? null : l.get(0));
   }
 
-  public CompletableFuture<List<ApprovalStep>> getPlanningApprovalStepsForOrg(
+  public CompletableFuture<List<ApprovalStep>> getPlanningApprovalStepsForRelatedObject(
       Map<String, Object> context, String aoUuid) {
-    return asDao.getPlanningByAdvisorOrganizationUuid(context, aoUuid)
+    return asDao.getPlanningByRelatedObjectUuid(context, aoUuid)
         .thenApply(unordered -> orderSteps(unordered));
   }
 
-  public CompletableFuture<List<ApprovalStep>> getApprovalStepsForOrg(Map<String, Object> context,
-      String aoUuid) {
-    return asDao.getByAdvisorOrganizationUuid(context, aoUuid)
+  public CompletableFuture<List<ApprovalStep>> getApprovalStepsForRelatedObject(
+      Map<String, Object> context, String aoUuid) {
+    return asDao.getByRelatedObjectUuid(context, aoUuid)
         .thenApply(unordered -> orderSteps(unordered));
   }
 

--- a/src/main/java/mil/dds/anet/InitializationCommand.java
+++ b/src/main/java/mil/dds/anet/InitializationCommand.java
@@ -107,7 +107,7 @@ public class InitializationCommand extends EnvironmentCommand<AnetConfiguration>
     ApprovalStep defaultStep = new ApprovalStep();
     defaultStep.setName("Default Approver");
     defaultStep.setType(ApprovalStepType.REPORT_APPROVAL);
-    defaultStep.setAdvisorOrganizationUuid(adminOrg.getUuid());
+    defaultStep.setRelatedObjectUuid(adminOrg.getUuid());
     defaultStep.setApprovers(ImmutableList.of(adminPos));
     engine.getApprovalStepDao().insert(defaultStep);
     System.out.println("DONE!");

--- a/src/main/java/mil/dds/anet/beans/ApprovalStep.java
+++ b/src/main/java/mil/dds/anet/beans/ApprovalStep.java
@@ -27,7 +27,7 @@ public class ApprovalStep extends AbstractAnetBean {
   String nextStepUuid;
   @GraphQLQuery
   @GraphQLInputField
-  String advisorOrganizationUuid;
+  String relatedObjectUuid;
   @GraphQLQuery
   @GraphQLInputField
   String name;
@@ -62,12 +62,12 @@ public class ApprovalStep extends AbstractAnetBean {
     this.nextStepUuid = nextStepUuid;
   }
 
-  public String getAdvisorOrganizationUuid() {
-    return advisorOrganizationUuid;
+  public String getRelatedObjectUuid() {
+    return relatedObjectUuid;
   }
 
-  public void setAdvisorOrganizationUuid(String advisorOrganizationUuid) {
-    this.advisorOrganizationUuid = advisorOrganizationUuid;
+  public void setRelatedObjectUuid(String relatedObjectUuid) {
+    this.relatedObjectUuid = relatedObjectUuid;
   }
 
   public String getName() {
@@ -94,17 +94,17 @@ public class ApprovalStep extends AbstractAnetBean {
     ApprovalStep as = (ApprovalStep) o;
     return Objects.equals(uuid, as.getUuid()) && Objects.equals(name, as.getName())
         && Objects.equals(nextStepUuid, as.getNextStepUuid()) && Objects.equals(type, as.getType())
-        && Objects.equals(advisorOrganizationUuid, as.getAdvisorOrganizationUuid());
+        && Objects.equals(relatedObjectUuid, as.getRelatedObjectUuid());
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(uuid, approvers, name, nextStepUuid, advisorOrganizationUuid, type);
+    return Objects.hash(uuid, approvers, name, nextStepUuid, relatedObjectUuid, type);
   }
 
   @Override
   public String toString() {
-    return String.format("%s - %s, aoid: %s, nsid: %s", uuid, name, advisorOrganizationUuid,
+    return String.format("%s - %s, aoid: %s, nsid: %s", uuid, name, relatedObjectUuid,
         nextStepUuid);
   }
 

--- a/src/main/java/mil/dds/anet/beans/Organization.java
+++ b/src/main/java/mil/dds/anet/beans/Organization.java
@@ -152,7 +152,7 @@ public class Organization extends AbstractAnetBean {
     if (planningApprovalSteps != null) {
       return CompletableFuture.completedFuture(planningApprovalSteps);
     }
-    return AnetObjectEngine.getInstance().getPlanningApprovalStepsForOrg(context, uuid)
+    return AnetObjectEngine.getInstance().getPlanningApprovalStepsForRelatedObject(context, uuid)
         .thenApply(o -> {
           planningApprovalSteps = o;
           return o;
@@ -174,10 +174,11 @@ public class Organization extends AbstractAnetBean {
     if (approvalSteps != null) {
       return CompletableFuture.completedFuture(approvalSteps);
     }
-    return AnetObjectEngine.getInstance().getApprovalStepsForOrg(context, uuid).thenApply(o -> {
-      approvalSteps = o;
-      return o;
-    });
+    return AnetObjectEngine.getInstance().getApprovalStepsForRelatedObject(context, uuid)
+        .thenApply(o -> {
+          approvalSteps = o;
+          return o;
+        });
   }
 
   public List<ApprovalStep> getApprovalSteps() {

--- a/src/main/java/mil/dds/anet/beans/Report.java
+++ b/src/main/java/mil/dds/anet/beans/Report.java
@@ -571,7 +571,7 @@ public class Report extends AbstractCustomizableAnetBean {
       return CompletableFuture.completedFuture(new ArrayList<ApprovalStep>());
     }
 
-    return engine.getPlanningApprovalStepsForOrg(context, aoUuid);
+    return engine.getPlanningApprovalStepsForRelatedObject(context, aoUuid);
   }
 
   private CompletableFuture<List<ApprovalStep>> getWorkflowForOrg(Map<String, Object> context,
@@ -580,7 +580,7 @@ public class Report extends AbstractCustomizableAnetBean {
       return CompletableFuture.completedFuture(new ArrayList<ApprovalStep>());
     }
 
-    return engine.getApprovalStepsForOrg(context, aoUuid);
+    return engine.getApprovalStepsForRelatedObject(context, aoUuid);
   }
 
   private CompletableFuture<List<ApprovalStep>> getDefaultPlanningWorkflow(

--- a/src/main/java/mil/dds/anet/beans/Report.java
+++ b/src/main/java/mil/dds/anet/beans/Report.java
@@ -531,14 +531,25 @@ public class Report extends AbstractCustomizableAnetBean {
         return CompletableFuture.completedFuture(workflow);
       } else {
         return computeApprovalSteps(context, engine).thenCompose(steps -> {
-          final List<ReportAction> newApprovalStepsActions =
-              createApprovalStepsActions(actions, steps);
-          actions.addAll(newApprovalStepsActions);
-          workflow = actions;
+          final List<ReportAction> actionTail = getActionTail(actions);
+          actionTail.addAll(createApprovalStepsActions(actionTail, steps));
+          workflow = actionTail;
           return CompletableFuture.completedFuture(workflow);
         });
       }
     });
+  }
+
+  private List<ReportAction> getActionTail(List<ReportAction> actions) {
+    final List<ReportAction> actionTail = new ArrayList<>();
+    for (int i = actions.size() - 1; i >= 0; i--) {
+      final ReportAction action = actions.get(i);
+      actionTail.add(0, action);
+      if (ReportAction.ActionType.SUBMIT.equals(action.getType())) {
+        break;
+      }
+    }
+    return actionTail;
   }
 
   public List<ReportAction> getWorkflow() {

--- a/src/main/java/mil/dds/anet/beans/Task.java
+++ b/src/main/java/mil/dds/anet/beans/Task.java
@@ -61,6 +61,11 @@ public class Task extends AbstractCustomizableAnetBean {
   private List<Position> responsiblePositions;
   // annotated below
   private List<Organization> taskedOrganizations;
+  /* The following are all Lazy Loaded */
+  // annotated below
+  List<ApprovalStep> planningApprovalSteps; /* Planning approval process for this Task */
+  // annotated below
+  List<ApprovalStep> approvalSteps; /* Approval process for this Task */
 
   public void setPlannedCompletion(Instant plannedCompletion) {
     this.plannedCompletion = plannedCompletion;
@@ -221,6 +226,50 @@ public class Task extends AbstractCustomizableAnetBean {
   @GraphQLInputField(name = "taskedOrganizations")
   public void setTaskedOrganizations(List<Organization> organizations) {
     this.taskedOrganizations = organizations;
+  }
+
+  @GraphQLQuery(name = "planningApprovalSteps")
+  public CompletableFuture<List<ApprovalStep>> loadPlanningApprovalSteps(
+      @GraphQLRootContext Map<String, Object> context) {
+    if (planningApprovalSteps != null) {
+      return CompletableFuture.completedFuture(planningApprovalSteps);
+    }
+    return AnetObjectEngine.getInstance().getPlanningApprovalStepsForRelatedObject(context, uuid)
+        .thenApply(o -> {
+          planningApprovalSteps = o;
+          return o;
+        });
+  }
+
+  public List<ApprovalStep> getPlanningApprovalSteps() {
+    return planningApprovalSteps;
+  }
+
+  @GraphQLInputField(name = "planningApprovalSteps")
+  public void setPlanningApprovalSteps(List<ApprovalStep> steps) {
+    this.planningApprovalSteps = steps;
+  }
+
+  @GraphQLQuery(name = "approvalSteps")
+  public CompletableFuture<List<ApprovalStep>> loadApprovalSteps(
+      @GraphQLRootContext Map<String, Object> context) {
+    if (approvalSteps != null) {
+      return CompletableFuture.completedFuture(approvalSteps);
+    }
+    return AnetObjectEngine.getInstance().getApprovalStepsForRelatedObject(context, uuid)
+        .thenApply(o -> {
+          approvalSteps = o;
+          return o;
+        });
+  }
+
+  public List<ApprovalStep> getApprovalSteps() {
+    return approvalSteps;
+  }
+
+  @GraphQLInputField(name = "approvalSteps")
+  public void setApprovalSteps(List<ApprovalStep> steps) {
+    this.approvalSteps = steps;
   }
 
   @Override

--- a/src/main/java/mil/dds/anet/database/ApprovalStepDao.java
+++ b/src/main/java/mil/dds/anet/database/ApprovalStepDao.java
@@ -24,18 +24,17 @@ public class ApprovalStepDao extends AnetBaseDao<ApprovalStep, AbstractSearchQue
 
   public static final String TABLE_NAME = "approvalSteps";
 
-  public CompletableFuture<List<ApprovalStep>> getPlanningByAdvisorOrganizationUuid(
+  public CompletableFuture<List<ApprovalStep>> getPlanningByRelatedObjectUuid(
       Map<String, Object> context, String aoUuid) {
     return new ForeignKeyFetcher<ApprovalStep>().load(context,
-        FkDataLoaderKey.ORGANIZATION_PLANNING_APPROVAL_STEPS, aoUuid);
+        FkDataLoaderKey.RELATED_OBJECT_PLANNING_APPROVAL_STEPS, aoUuid);
   }
 
-  public CompletableFuture<List<ApprovalStep>> getByAdvisorOrganizationUuid(
-      Map<String, Object> context, String aoUuid) {
+  public CompletableFuture<List<ApprovalStep>> getByRelatedObjectUuid(Map<String, Object> context,
+      String aoUuid) {
     return new ForeignKeyFetcher<ApprovalStep>().load(context,
-        FkDataLoaderKey.ORGANIZATION_APPROVAL_STEPS, aoUuid);
+        FkDataLoaderKey.RELATED_OBJECT_APPROVAL_STEPS, aoUuid);
   }
-
 
   @Override
   public ApprovalStep getByUuid(String uuid) {
@@ -78,7 +77,7 @@ public class ApprovalStepDao extends AnetBaseDao<ApprovalStep, AbstractSearchQue
 
   static class PlanningApprovalStepsBatcher extends ForeignKeyBatcher<ApprovalStep> {
     private static final String sql =
-        "/* batch.getApprovalStepsByOrg */ SELECT * from \"approvalSteps\" WHERE \"advisorOrganizationUuid\" IN ( <foreignKeys> ) AND \"approvalSteps\".type = :type";
+        "/* batch.getApprovalStepsByOrg */ SELECT * from \"approvalSteps\" WHERE \"relatedObjectUuid\" IN ( <foreignKeys> ) AND \"approvalSteps\".type = :type";
     private static final Map<String, Object> additionalParams = new HashMap<>();
 
     static {
@@ -86,14 +85,13 @@ public class ApprovalStepDao extends AnetBaseDao<ApprovalStep, AbstractSearchQue
     }
 
     public PlanningApprovalStepsBatcher() {
-      super(sql, "foreignKeys", new ApprovalStepMapper(), "advisorOrganizationUuid",
-          additionalParams);
+      super(sql, "foreignKeys", new ApprovalStepMapper(), "relatedObjectUuid", additionalParams);
     }
   }
 
   static class ApprovalStepsBatcher extends ForeignKeyBatcher<ApprovalStep> {
     private static final String sql =
-        "/* batch.getApprovalStepsByOrg */ SELECT * from \"approvalSteps\" WHERE \"advisorOrganizationUuid\" IN ( <foreignKeys> ) AND \"approvalSteps\".type = :type";
+        "/* batch.getApprovalStepsByOrg */ SELECT * from \"approvalSteps\" WHERE \"relatedObjectUuid\" IN ( <foreignKeys> ) AND \"approvalSteps\".type = :type";
     private static final Map<String, Object> additionalParams = new HashMap<>();
 
     static {
@@ -101,8 +99,7 @@ public class ApprovalStepDao extends AnetBaseDao<ApprovalStep, AbstractSearchQue
     }
 
     public ApprovalStepsBatcher() {
-      super(sql, "foreignKeys", new ApprovalStepMapper(), "advisorOrganizationUuid",
-          additionalParams);
+      super(sql, "foreignKeys", new ApprovalStepMapper(), "relatedObjectUuid", additionalParams);
     }
   }
 
@@ -121,8 +118,8 @@ public class ApprovalStepDao extends AnetBaseDao<ApprovalStep, AbstractSearchQue
   @Override
   public ApprovalStep insertInternal(ApprovalStep as) {
     getDbHandle().createUpdate(
-        "/* insertApprovalStep */ INSERT into \"approvalSteps\" (uuid, name, \"nextStepUuid\", \"advisorOrganizationUuid\", type) "
-            + "VALUES (:uuid, :name, :nextStepUuid, :advisorOrganizationUuid, :type)")
+        "/* insertApprovalStep */ INSERT into \"approvalSteps\" (uuid, name, \"nextStepUuid\", \"relatedObjectUuid\", type) "
+            + "VALUES (:uuid, :name, :nextStepUuid, :relatedObjectUuid, :type)")
         .bindBean(as).bind("type", DaoUtils.getEnumId(as.getType())).execute();
 
     if (as.getApprovers() != null) {
@@ -150,7 +147,7 @@ public class ApprovalStepDao extends AnetBaseDao<ApprovalStep, AbstractSearchQue
     getDbHandle()
         .createUpdate(
             "/* insertApprovalAtEnd */ UPDATE \"approvalSteps\" SET \"nextStepUuid\" = :uuid "
-                + "WHERE \"advisorOrganizationUuid\" = :advisorOrganizationUuid "
+                + "WHERE \"relatedObjectUuid\" = :relatedObjectUuid "
                 + "AND type = :type AND \"nextStepUuid\" IS NULL AND uuid != :uuid")
         .bindBean(as).bind("type", DaoUtils.getEnumId(as.getType())).execute();
     return as;
@@ -164,7 +161,7 @@ public class ApprovalStepDao extends AnetBaseDao<ApprovalStep, AbstractSearchQue
   public int updateInternal(ApprovalStep as) {
     return getDbHandle()
         .createUpdate("/* updateApprovalStep */ UPDATE \"approvalSteps\" SET name = :name, "
-            + "\"nextStepUuid\" = :nextStepUuid, \"advisorOrganizationUuid\" = :advisorOrganizationUuid "
+            + "\"nextStepUuid\" = :nextStepUuid, \"relatedObjectUuid\" = :relatedObjectUuid "
             + "WHERE uuid = :uuid")
         .bindBean(as).execute();
   }

--- a/src/main/java/mil/dds/anet/database/ReportDao.java
+++ b/src/main/java/mil/dds/anet/database/ReportDao.java
@@ -744,7 +744,7 @@ public class ReportDao extends AnetBaseDao<Report, ReportSearchQuery> {
     private static final String sql =
         "/* batch.getTasksForReport */ SELECT * FROM tasks, \"reportTasks\" "
             + "WHERE \"reportTasks\".\"reportUuid\" IN ( <foreignKeys> ) "
-            + "AND \"reportTasks\".\"taskUuid\" = tasks.uuid";
+            + "AND \"reportTasks\".\"taskUuid\" = tasks.uuid ORDER BY uuid";
 
     public TasksBatcher() {
       super(sql, "foreignKeys", new TaskMapper(), "reportUuid");

--- a/src/main/java/mil/dds/anet/database/ReportDao.java
+++ b/src/main/java/mil/dds/anet/database/ReportDao.java
@@ -5,18 +5,20 @@ import io.leangen.graphql.annotations.GraphQLRootContext;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response.Status;
 import mil.dds.anet.AnetObjectEngine;
 import mil.dds.anet.beans.AnetEmail;
+import mil.dds.anet.beans.ApprovalStep;
 import mil.dds.anet.beans.ApprovalStep.ApprovalStepType;
 import mil.dds.anet.beans.AuthorizationGroup;
 import mil.dds.anet.beans.Organization;
@@ -41,6 +43,7 @@ import mil.dds.anet.database.mappers.ReportMapper;
 import mil.dds.anet.database.mappers.ReportPersonMapper;
 import mil.dds.anet.database.mappers.TagMapper;
 import mil.dds.anet.database.mappers.TaskMapper;
+import mil.dds.anet.emails.ApprovalNeededEmail;
 import mil.dds.anet.emails.ReportPublishedEmail;
 import mil.dds.anet.threads.AnetEmailWorker;
 import mil.dds.anet.utils.DaoUtils;
@@ -776,35 +779,98 @@ public class ReportDao extends AnetBaseDao<Report, ReportSearchQuery> {
         SqDataLoaderKey.REPORTS_SEARCH, new ImmutablePair<>(uuid, query));
   }
 
-  private void sendReportPublishedEmail(Report r) {
-    AnetEmail email = new AnetEmail();
-    ReportPublishedEmail action = new ReportPublishedEmail();
+  public void sendApprovalNeededEmail(Report r) {
+    final AnetObjectEngine engine = AnetObjectEngine.getInstance();
+    final ApprovalStep step = r.loadApprovalStep(engine.getContext()).join();
+    final List<Position> approvers = step.loadApprovers(engine.getContext()).join();
+    final AnetEmail approverEmail = new AnetEmail();
+    final ApprovalNeededEmail action = new ApprovalNeededEmail();
+    action.setReport(r);
+    approverEmail.setAction(action);
+    approverEmail.setToAddresses(approvers.stream()
+        .filter(a -> (a.getPersonUuid() != null) && !a.getPersonUuid().equals(r.getAuthorUuid()))
+        .map(a -> a.loadPerson(engine.getContext()).join().getEmailAddress())
+        .collect(Collectors.toList()));
+    AnetEmailWorker.sendEmailAsync(approverEmail);
+  }
+
+  public void sendReportPublishedEmail(Report r) {
+    final AnetEmail email = new AnetEmail();
+    final ReportPublishedEmail action = new ReportPublishedEmail();
     action.setReport(r);
     email.setAction(action);
-    try {
-      email.addToAddress(
-          r.loadAuthor(AnetObjectEngine.getInstance().getContext()).get().getEmailAddress());
-      AnetEmailWorker.sendEmailAsync(email);
-    } catch (InterruptedException | ExecutionException e) {
-      throw new WebApplicationException("failed to load Author", e);
+    email.addToAddress(
+        r.loadAuthor(AnetObjectEngine.getInstance().getContext()).join().getEmailAddress());
+    AnetEmailWorker.sendEmailAsync(email);
+  }
+
+  public int approve(Report r, Person user, ApprovalStep step) {
+    // Write the approval action
+    final ReportAction action = new ReportAction();
+    action.setReportUuid(r.getUuid());
+    action.setStepUuid(step.getUuid());
+    // User could be null when the publication action is being done automatically by a worker
+    action.setPersonUuid(DaoUtils.getUuid(user));
+    action.setType(ActionType.APPROVE);
+    AnetObjectEngine.getInstance().getReportActionDao().insert(action);
+
+    // Update the report
+    final String nextStepUuid = getNextStepUuid(r, step);
+    r.setApprovalStepUuid(nextStepUuid);
+    if (nextStepUuid == null) {
+      if (r.getCancelledReason() != null) {
+        // Done with cancel, move to CANCELLED and set releasedAt
+        r.setState(ReportState.CANCELLED);
+        r.setReleasedAt(Instant.now());
+      } else {
+        // Done with approvals, move to APPROVED
+        r.setState(ReportState.APPROVED);
+      }
     }
+    final int numRows = update(r, r.getAuthor());
+    if (numRows != 0 && nextStepUuid != null) {
+      sendApprovalNeededEmail(r);
+    }
+    return numRows;
+  }
+
+  private String getNextStepUuid(Report report, ApprovalStep step) {
+    final AnetObjectEngine engine = AnetObjectEngine.getInstance();
+    final String currentStepUuid = step.getUuid();
+    String nextStepUuid = step.getNextStepUuid();
+    if (nextStepUuid == null) {
+      // Find out if there's a next approval chain
+      final List<ApprovalStep> reportApprovalSteps =
+          report.computeApprovalSteps(engine.getContext(), engine).join();
+      final Iterator<ApprovalStep> iterator = reportApprovalSteps.iterator();
+      while (iterator.hasNext()) {
+        final ApprovalStep reportApprovalStep = iterator.next();
+        if (Objects.equals(DaoUtils.getUuid(reportApprovalStep), currentStepUuid)) {
+          // Found the current step, update the next step
+          if (iterator.hasNext()) {
+            final ApprovalStep reportApprovalStepNext = iterator.next();
+            nextStepUuid = DaoUtils.getUuid(reportApprovalStepNext);
+          }
+          break;
+        }
+      }
+    }
+    return nextStepUuid;
   }
 
   public int publish(Report r, Person user) {
     // Write the publication action
-    ReportAction action = new ReportAction();
+    final ReportAction action = new ReportAction();
     action.setReportUuid(r.getUuid());
-    if (user != null) {
-      // User is null when the publication action is being done automatically by a worker
-      action.setPersonUuid(user.getUuid());
-    }
+    // User could be null when the publication action is being done automatically by a worker
+    action.setPersonUuid(DaoUtils.getUuid(user));
     action.setType(ActionType.PUBLISH);
     AnetObjectEngine.getInstance().getReportActionDao().insert(action);
 
     // Move the report to PUBLISHED state
     r.setState(ReportState.PUBLISHED);
     r.setReleasedAt(Instant.now());
-    final int numRows = this.update(r, r.getAuthor());
+    final int numRows = update(r, r.getAuthor());
     if (numRows != 0) {
       sendReportPublishedEmail(r);
     }

--- a/src/main/java/mil/dds/anet/database/mappers/ApprovalStepMapper.java
+++ b/src/main/java/mil/dds/anet/database/mappers/ApprovalStepMapper.java
@@ -14,7 +14,7 @@ public class ApprovalStepMapper implements RowMapper<ApprovalStep> {
     ApprovalStep step = new ApprovalStep();
     MapperUtils.setCommonBeanFields(step, r, null);
     step.setNextStepUuid(r.getString("nextStepUuid"));
-    step.setAdvisorOrganizationUuid(r.getString("advisorOrganizationUuid"));
+    step.setRelatedObjectUuid(r.getString("relatedObjectUuid"));
     step.setName(r.getString("name"));
     step.setType(MapperUtils.getEnumIdx(r, "type", ApprovalStepType.class));
 

--- a/src/main/java/mil/dds/anet/emails/ApprovalNeededEmail.java
+++ b/src/main/java/mil/dds/anet/emails/ApprovalNeededEmail.java
@@ -1,19 +1,12 @@
 package mil.dds.anet.emails;
 
-import java.lang.invoke.MethodHandles;
 import java.util.Map;
-import java.util.concurrent.ExecutionException;
 import mil.dds.anet.AnetObjectEngine;
 import mil.dds.anet.beans.ApprovalStep;
 import mil.dds.anet.beans.Report;
 import org.apache.commons.lang3.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class ApprovalNeededEmail implements AnetEmailAction {
-
-  private static final Logger logger =
-      LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
   private Report report;
 
@@ -29,15 +22,9 @@ public class ApprovalNeededEmail implements AnetEmailAction {
 
   @Override
   public Map<String, Object> buildContext(Map<String, Object> context) {
-    Report r = AnetObjectEngine.getInstance().getReportDao().getByUuid(report.getUuid());
-    ApprovalStep step;
-    try {
-      step = r.loadApprovalStep(AnetObjectEngine.getInstance().getContext()).get();
-    } catch (InterruptedException | ExecutionException e) {
-      logger.error("failed to load ApprovalStep", e);
-      return context;
-    }
-
+    final Report r = AnetObjectEngine.getInstance().getReportDao().getByUuid(report.getUuid());
+    final ApprovalStep step =
+        r.loadApprovalStep(AnetObjectEngine.getInstance().getContext()).join();
     context.put("report", r);
     context.put("reportIntent", StringUtils.abbreviate(r.getIntent(), MAX_REPORT_INTENT_LENGTH));
     context.put("approvalStepName", (step != null) ? step.getName() : "");

--- a/src/main/java/mil/dds/anet/emails/DailyRollupEmail.java
+++ b/src/main/java/mil/dds/anet/emails/DailyRollupEmail.java
@@ -1,13 +1,11 @@
 package mil.dds.anet.emails;
 
-import java.lang.invoke.MethodHandles;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 import mil.dds.anet.AnetObjectEngine;
 import mil.dds.anet.beans.Organization;
@@ -19,13 +17,8 @@ import mil.dds.anet.beans.search.ReportSearchQuery;
 import mil.dds.anet.beans.search.ReportSearchSortBy;
 import mil.dds.anet.database.AdminDao.AdminSettingKeys;
 import mil.dds.anet.utils.DaoUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class DailyRollupEmail implements AnetEmailAction {
-
-  private static final Logger logger =
-      LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
   public static String SHOW_REPORT_TEXT_FLAG = "showReportText";
 
@@ -160,16 +153,11 @@ public class DailyRollupEmail implements AnetEmailAction {
       final Map<String, ReportGrouping> orgUuidToReports = new HashMap<>();
       for (Report r : reports) {
         final Map<String, Object> context = AnetObjectEngine.getInstance().getContext();
-        Organization reportOrg;
-        try {
-          reportOrg = (orgType == OrganizationType.ADVISOR_ORG) ? r.loadAdvisorOrg(context).get()
-              : r.loadPrincipalOrg(context).get();
-        } catch (InterruptedException | ExecutionException e) {
-          logger.error("failed to load AdvisorOrg/PrincipalOrg", e);
-          return null;
-        }
-        String topOrgUuid;
-        String topOrgName;
+        final Organization reportOrg =
+            (orgType == OrganizationType.ADVISOR_ORG) ? r.loadAdvisorOrg(context).join()
+                : r.loadPrincipalOrg(context).join();
+        final String topOrgUuid;
+        final String topOrgName;
         if (reportOrg == null) {
           topOrgUuid = Organization.DUMMY_ORG_UUID;
           topOrgName = "Other";

--- a/src/main/java/mil/dds/anet/resources/ApprovalStepResource.java
+++ b/src/main/java/mil/dds/anet/resources/ApprovalStepResource.java
@@ -1,0 +1,21 @@
+package mil.dds.anet.resources;
+
+import io.leangen.graphql.annotations.GraphQLArgument;
+import io.leangen.graphql.annotations.GraphQLQuery;
+import mil.dds.anet.AnetObjectEngine;
+import mil.dds.anet.database.ApprovalStepDao;
+
+public class ApprovalStepResource {
+
+  private final ApprovalStepDao dao;
+
+  public ApprovalStepResource(AnetObjectEngine engine) {
+    this.dao = engine.getApprovalStepDao();
+  }
+
+  @GraphQLQuery(name = "approvalStepInUse")
+  public boolean isApprovalStepInUse(@GraphQLArgument(name = "uuid") String uuid) {
+    return dao.isStepInUse(uuid);
+  }
+
+}

--- a/src/main/java/mil/dds/anet/resources/OrganizationResource.java
+++ b/src/main/java/mil/dds/anet/resources/OrganizationResource.java
@@ -7,7 +7,6 @@ import io.leangen.graphql.annotations.GraphQLRootContext;
 import java.lang.invoke.MethodHandles;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ExecutionException;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response.Status;
 import mil.dds.anet.AnetObjectEngine;
@@ -98,8 +97,7 @@ public class OrganizationResource {
 
   @GraphQLMutation(name = "updateOrganization")
   public Integer updateOrganization(@GraphQLRootContext Map<String, Object> context,
-      @GraphQLArgument(name = "organization") Organization org)
-      throws InterruptedException, ExecutionException, Exception {
+      @GraphQLArgument(name = "organization") Organization org) {
     final Person user = DaoUtils.getUserFromContext(context);
     // Verify correct Organization
     AuthUtils.assertSuperUserForOrg(user, DaoUtils.getUuid(org), false);

--- a/src/main/java/mil/dds/anet/resources/OrganizationResource.java
+++ b/src/main/java/mil/dds/anet/resources/OrganizationResource.java
@@ -181,8 +181,4 @@ public class OrganizationResource {
     return dao.search(query);
   }
 
-  @GraphQLQuery(name = "approvalStepInUse")
-  public boolean isApprovalStepInUse(@GraphQLArgument(name = "uuid") String uuid) {
-    return engine.getApprovalStepDao().isStepInUse(uuid);
-  }
 }

--- a/src/main/java/mil/dds/anet/resources/ReportResource.java
+++ b/src/main/java/mil/dds/anet/resources/ReportResource.java
@@ -460,9 +460,9 @@ public class ReportResource {
     List<ApprovalStep> steps = null;
     try {
       if (r.isFutureEngagement()) {
-        steps = engine.getPlanningApprovalStepsForOrg(engine.getContext(), orgUuid).get();
+        steps = engine.getPlanningApprovalStepsForRelatedObject(engine.getContext(), orgUuid).get();
       } else {
-        steps = engine.getApprovalStepsForOrg(engine.getContext(), orgUuid).get();
+        steps = engine.getApprovalStepsForRelatedObject(engine.getContext(), orgUuid).get();
         throwExceptionNoApprovalSteps(steps);
       }
     } catch (InterruptedException | ExecutionException e) {

--- a/src/main/java/mil/dds/anet/threads/FutureEngagementWorker.java
+++ b/src/main/java/mil/dds/anet/threads/FutureEngagementWorker.java
@@ -3,7 +3,6 @@ package mil.dds.anet.threads;
 import java.lang.invoke.MethodHandles;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ExecutionException;
 import mil.dds.anet.AnetObjectEngine;
 import mil.dds.anet.beans.AnetEmail;
 import mil.dds.anet.beans.Report;
@@ -55,13 +54,9 @@ public class FutureEngagementWorker implements Runnable {
         FutureEngagementUpdated action = new FutureEngagementUpdated();
         action.setReport(r);
         email.setAction(action);
-        try {
-          email.addToAddress(r.loadAuthor(context).get().getEmailAddress());
-          AnetEmailWorker.sendEmailAsync(email);
-          dao.updateToDraftState(r);
-        } catch (InterruptedException | ExecutionException e) {
-          logger.error("failed to load Author", e);
-        }
+        email.addToAddress(r.loadAuthor(context).join().getEmailAddress());
+        AnetEmailWorker.sendEmailAsync(email);
+        dao.updateToDraftState(r);
       } catch (Exception e) {
         logger.error("Exception when updating", e);
       }

--- a/src/main/java/mil/dds/anet/threads/ReportApprovalWorker.java
+++ b/src/main/java/mil/dds/anet/threads/ReportApprovalWorker.java
@@ -1,0 +1,93 @@
+package mil.dds.anet.threads;
+
+import java.lang.invoke.MethodHandles;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import mil.dds.anet.AnetObjectEngine;
+import mil.dds.anet.beans.ApprovalStep;
+import mil.dds.anet.beans.Report;
+import mil.dds.anet.beans.Report.ReportState;
+import mil.dds.anet.beans.ReportAction;
+import mil.dds.anet.beans.search.ReportSearchQuery;
+import mil.dds.anet.config.AnetConfiguration;
+import mil.dds.anet.database.ReportDao;
+import mil.dds.anet.utils.AnetAuditLogger;
+import mil.dds.anet.utils.DaoUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ReportApprovalWorker implements Runnable {
+
+  private static final Logger logger =
+      LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+  private final ReportDao dao;
+  private final Integer nbOfHoursApprovalTimeout;
+
+  public ReportApprovalWorker(ReportDao dao, AnetConfiguration config) {
+    this.dao = dao;
+    this.nbOfHoursApprovalTimeout =
+        (Integer) config.getDictionaryEntry("reportWorkflow.nbOfHoursApprovalTimeout");
+  }
+
+  @Override
+  public void run() {
+    logger.debug("Report Approval Worker waking up to check for reports to be approved");
+    try {
+      runInternal();
+    } catch (Throwable e) {
+      // Cannot let this thread die. Otherwise ANET will stop checking for reports which are to be
+      // automatically approved.
+      logger.error("Exception in run()", e);
+    }
+  }
+
+  private void runInternal() {
+    final Instant now = Instant.now().atZone(DaoUtils.getDefaultZoneId())
+        .minusHours(nbOfHoursApprovalTimeout).toInstant();
+    // Get a list of all PENDING_APPROVAL reports
+    final ReportSearchQuery query = new ReportSearchQuery();
+    query.setPageSize(0);
+    query.setState(Collections.singletonList(ReportState.PENDING_APPROVAL));
+    query.setSystemSearch(true);
+    final List<Report> reports = dao.search(query).getList();
+    final Map<String, Object> context = AnetObjectEngine.getInstance().getContext();
+    for (final Report r : reports) {
+      final List<ReportAction> workflow = r.loadWorkflow(context).join();
+      if (workflow.isEmpty()) {
+        logger.error("Couldn't process report approval for report {}, it has no workflow",
+            r.getUuid());
+      } else {
+        for (int i = workflow.size() - 1; i >= 0; i--) {
+          final ReportAction reportAction = workflow.get(i);
+          if (reportAction.getCreatedAt() == null && i > 1) {
+            // Check previous action
+            final ReportAction previousAction = workflow.get(i - 1);
+            if (previousAction.getCreatedAt() != null
+                && previousAction.getCreatedAt().isBefore(now)) {
+              // Approve the report
+              try {
+                final ApprovalStep approvalStep = reportAction.getStep();
+                final int numRows = dao.approve(r, null, approvalStep);
+                if (numRows == 0) {
+                  logger.error("Couldn't process report approval for report {} step {}",
+                      r.getUuid(), DaoUtils.getUuid(approvalStep));
+                } else {
+                  AnetAuditLogger.log(
+                      "report {} step {} automatically approved by the ReportApprovalWorker",
+                      r.getUuid(), DaoUtils.getUuid(approvalStep));
+                }
+              } catch (Exception e) {
+                logger.error("Exception when approving report", e);
+              }
+              break;
+            }
+          }
+        }
+      }
+    }
+  }
+
+}

--- a/src/main/java/mil/dds/anet/utils/BatchingUtils.java
+++ b/src/main/java/mil/dds/anet/utils/BatchingUtils.java
@@ -157,7 +157,7 @@ public final class BatchingUtils {
                 dispatcherService);
           }
         }, dataLoaderOptions));
-    dataLoaderRegistry.register(FkDataLoaderKey.ORGANIZATION_PLANNING_APPROVAL_STEPS.toString(),
+    dataLoaderRegistry.register(FkDataLoaderKey.RELATED_OBJECT_PLANNING_APPROVAL_STEPS.toString(),
         new DataLoader<>(new BatchLoader<String, List<ApprovalStep>>() {
           @Override
           public CompletionStage<List<List<ApprovalStep>>> load(List<String> foreignKeys) {
@@ -166,7 +166,7 @@ public final class BatchingUtils {
                 dispatcherService);
           }
         }, dataLoaderOptions));
-    dataLoaderRegistry.register(FkDataLoaderKey.ORGANIZATION_APPROVAL_STEPS.toString(),
+    dataLoaderRegistry.register(FkDataLoaderKey.RELATED_OBJECT_APPROVAL_STEPS.toString(),
         new DataLoader<>(new BatchLoader<String, List<ApprovalStep>>() {
           @Override
           public CompletionStage<List<List<ApprovalStep>>> load(List<String> foreignKeys) {

--- a/src/main/java/mil/dds/anet/utils/FkDataLoaderKey.java
+++ b/src/main/java/mil/dds/anet/utils/FkDataLoaderKey.java
@@ -6,13 +6,13 @@ public enum FkDataLoaderKey {
   AUTHORIZATION_GROUP_POSITIONS, // authorizationGroup.positions
   NOTE_NOTE_RELATED_OBJECTS, // note.noteRelatedObjects
   NOTE_RELATED_OBJECT_NOTES, // noteRelatedObject.notes
-  ORGANIZATION_PLANNING_APPROVAL_STEPS, // organization.planningApprovalSteps
-  ORGANIZATION_APPROVAL_STEPS, // organization.approvalSteps
   PERSON_ORGANIZATIONS, // person.organizations
   PERSON_PERSON_POSITION_HISTORY, // person.personPositionHistory
   POSITION_ASSOCIATED_POSITIONS, // position.associatedPositions
   POSITION_CURRENT_POSITION_FOR_PERSON, // position.currentPositionForPerson
   POSITION_PERSON_POSITION_HISTORY, // position.personPositionHistory
+  RELATED_OBJECT_APPROVAL_STEPS, // <relatedObject, e.g. organization or task>.approvalSteps
+  RELATED_OBJECT_PLANNING_APPROVAL_STEPS, // <relatedObject>.planningApprovalSteps
   REPORT_ATTENDEES, // report.attendees
   REPORT_REPORT_ACTIONS, // report.reportActions
   REPORT_REPORT_SENSITIVE_INFORMATION, // report.reportSensitiveInformation

--- a/src/main/java/mil/dds/anet/utils/Utils.java
+++ b/src/main/java/mil/dds/anet/utils/Utils.java
@@ -15,7 +15,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.concurrent.ExecutionException;
 import java.util.function.Consumer;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -515,14 +514,10 @@ public class Utils {
     }
 
     if (newStep.getApprovers() != null) {
-      try {
-        Utils.addRemoveElementsByUuid(oldStep.loadApprovers(engine.getContext()).get(),
-            newStep.getApprovers(),
-            newPosition -> approvalStepDao.addApprover(newStep, DaoUtils.getUuid(newPosition)),
-            oldPositionUuid -> approvalStepDao.removeApprover(newStep, oldPositionUuid));
-      } catch (InterruptedException | ExecutionException e) {
-        throw new WebApplicationException("failed to load Approvers", e);
-      }
+      Utils.addRemoveElementsByUuid(oldStep.loadApprovers(engine.getContext()).join(),
+          newStep.getApprovers(),
+          newPosition -> approvalStepDao.addApprover(newStep, DaoUtils.getUuid(newPosition)),
+          oldPositionUuid -> approvalStepDao.removeApprover(newStep, oldPositionUuid));
     }
   }
 

--- a/src/main/resources/anet-schema.yml
+++ b/src/main/resources/anet-schema.yml
@@ -287,7 +287,7 @@ properties:
   reportWorkflow:
     type: object
     additionalProperties: false
-    required: [nbOfHoursQuarantineApproved]
+    required: [nbOfHoursQuarantineApproved, nbOfHoursApprovalTimeout]
     properties:
       nbOfHoursQuarantineApproved:
         type: integer
@@ -295,6 +295,11 @@ properties:
         title: The number of hours between the approval of the report and the automatic publication
         description: Used in the UI of an approved report to show how many hours are left till publication.
         examples: [24]
+      nbOfHoursApprovalTimeout:
+        type: integer
+        minimum: 0
+        title: The number of hours between the last action on a report and the automatic approval of the next step in the workflow
+        description: Used to automatically advance a report to the next step in the workflow is manual action takes too long.
 
   maxTextFieldLength:
     type: integer

--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -3077,4 +3077,29 @@
 		</addColumn>
 	</changeSet>
 
+	<changeSet id="drop-FK_approvalSteps_organization" author="gjvoosten" dbms="mssql,postgresql">
+		<dropForeignKeyConstraint
+			baseTableName="approvalSteps" constraintName="FK_approvalSteps_organization" />
+	</changeSet>
+
+	<changeSet id="drop-IDX_approvalSteps_advisorOrganizationUuid" author="gjvoosten">
+		<dropIndex
+			tableName="approvalSteps" indexName="IDX_approvalSteps_advisorOrganizationUuid" />
+	</changeSet>
+
+	<changeSet id="rename-approvalSteps-advisorOrganizationUuid" author="gjvoosten">
+		 <renameColumn
+			 tableName="approvalSteps"
+			 oldColumnName="advisorOrganizationUuid"
+			 newColumnName="relatedObjectUuid"
+			 columnDataType="${uuid_type}" />
+	 </changeSet>
+
+	<changeSet id="add-IDX_approvalSteps_relatedObjectUuid" author="gjvoosten">
+		<createIndex
+			tableName="approvalSteps" indexName="IDX_approvalSteps_relatedObjectUuid">
+			<column name="relatedObjectUuid" />
+		</createIndex>
+	</changeSet>
+
 </databaseChangeLog>

--- a/src/test/java/mil/dds/anet/test/beans/ApprovalStepTest.java
+++ b/src/test/java/mil/dds/anet/test/beans/ApprovalStepTest.java
@@ -12,7 +12,7 @@ public class ApprovalStepTest extends BeanTester<ApprovalStep> {
   private static ApprovalStep getTestApprovalStep() {
     ApprovalStep as = new ApprovalStep();
     as.setUuid("42");
-    as.setAdvisorOrganizationUuid("22");
+    as.setRelatedObjectUuid("22");
     as.setApprovers(ImmutableList.of());
     as.setNextStepUuid("9292");
     as.setType(ApprovalStepType.REPORT_APPROVAL);

--- a/src/test/java/mil/dds/anet/test/beans/PersonTest.java
+++ b/src/test/java/mil/dds/anet/test/beans/PersonTest.java
@@ -165,6 +165,23 @@ public class PersonTest extends BeanTester<Person> {
     return p;
   }
 
+  public static Person getAndrewAnderson() {
+    Person p = new Person();
+    p.setName("ANDERSON, Andrew");
+    p.setEmailAddress("hunter+andrew@dds.mil");
+    p.setPhoneNumber("+1-412-7324");
+    p.setRank("CIV");
+    p.setStatus(PersonStatus.ACTIVE);
+    p.setRole(Role.ADVISOR);
+    p.setBiography("Andrew is the EF1 Manager");
+    p.setDomainUsername("andrew");
+    p.setGender("Male");
+    p.setCountry("United States of America");
+    p.setEndOfTourDate(
+        ZonedDateTime.of(2017, 2, 12, 0, 0, 0, 0, DaoUtils.getDefaultZoneId()).toInstant());
+    return p;
+  }
+
   public static ReportPerson personToPrimaryReportPerson(Person p) {
     ReportPerson rp = personToReportPerson(p);
     rp.setPrimary(true);

--- a/src/test/java/mil/dds/anet/test/resources/AbstractResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/AbstractResourceTest.java
@@ -172,6 +172,10 @@ public abstract class AbstractResourceTest {
     return findOrPutPersonInDb(PersonTest.getBobBobtown());
   }
 
+  public Person getAndrewAnderson() {
+    return findOrPutPersonInDb(PersonTest.getAndrewAnderson());
+  }
+
   public Organization createOrganizationWithUuid(String uuid) {
     final Organization ao = new Organization();
     ao.setUuid(uuid);

--- a/src/test/java/mil/dds/anet/test/resources/GraphQlResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/GraphQlResourceTest.java
@@ -12,7 +12,6 @@ import java.net.URLEncoder;
 import java.util.Base64;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.ExecutionException;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.client.Invocation.Builder;
 import javax.ws.rs.core.GenericType;
@@ -30,7 +29,7 @@ public class GraphQlResourceTest extends AbstractResourceTest {
       LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
   @Test
-  public void test() throws ExecutionException, InterruptedException {
+  public void test() {
     final Person jack = getJackJackson();
     final Person steve = getSteveSteveson();
     File testDir = new File("src/test/resources/graphQLTests/");

--- a/src/test/java/mil/dds/anet/test/resources/OrganizationResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/OrganizationResourceTest.java
@@ -8,7 +8,6 @@ import com.google.common.collect.ImmutableList;
 import java.io.UnsupportedEncodingException;
 import java.time.Instant;
 import java.util.List;
-import java.util.concurrent.ExecutionException;
 import javax.ws.rs.ClientErrorException;
 import javax.ws.rs.ForbiddenException;
 import mil.dds.anet.beans.ApprovalStep;
@@ -35,7 +34,7 @@ public class OrganizationResourceTest extends AbstractResourceTest {
       "uuid name code type status organization { uuid } location { uuid }";
 
   @Test
-  public void createAO() throws InterruptedException, ExecutionException {
+  public void createAO() {
     final Organization ao = OrganizationTest.getTestAO(true);
     final Person jack = getJackJackson();
 
@@ -116,9 +115,9 @@ public class OrganizationResourceTest extends AbstractResourceTest {
     // Verify approval step was saved.
     updated = graphQLHelper.getObjectById(jack, "organization", FIELDS, child.getUuid(),
         new TypeReference<GraphQlResponse<Organization>>() {});
-    List<ApprovalStep> returnedSteps = updated.loadApprovalSteps(context).get();
+    List<ApprovalStep> returnedSteps = updated.loadApprovalSteps(context).join();
     assertThat(returnedSteps.size()).isEqualTo(1);
-    assertThat(returnedSteps.get(0).loadApprovers(context).get()).contains(b1);
+    assertThat(returnedSteps.get(0).loadApprovers(context).join()).contains(b1);
 
     // Give this org a Task
     Task task = new Task();
@@ -141,7 +140,7 @@ public class OrganizationResourceTest extends AbstractResourceTest {
     // Verify task was saved.
     updated = graphQLHelper.getObjectById(jack, "organization", FIELDS, child.getUuid(),
         new TypeReference<GraphQlResponse<Organization>>() {});
-    final List<Task> tasks = updated.loadTasks(context).get();
+    final List<Task> tasks = updated.loadTasks(context).join();
     assertThat(tasks).isNotNull();
     assertThat(tasks.size()).isEqualTo(1);
     assertThat(tasks.get(0).getUuid()).isEqualTo(task.getUuid());
@@ -161,12 +160,12 @@ public class OrganizationResourceTest extends AbstractResourceTest {
     // Verify approval steps updated correct.
     updated = graphQLHelper.getObjectById(jack, "organization", FIELDS, child.getUuid(),
         new TypeReference<GraphQlResponse<Organization>>() {});
-    returnedSteps = updated.loadApprovalSteps(context).get();
+    returnedSteps = updated.loadApprovalSteps(context).join();
     assertThat(returnedSteps.size()).isEqualTo(2);
     assertThat(returnedSteps.get(0).getName()).isEqualTo(step1.getName());
-    assertThat(returnedSteps.get(0).loadApprovers(context).get())
+    assertThat(returnedSteps.get(0).loadApprovers(context).join())
         .containsExactly(admin.loadPosition());
-    assertThat(returnedSteps.get(1).loadApprovers(context).get()).containsExactly(b1);
+    assertThat(returnedSteps.get(1).loadApprovers(context).join()).containsExactly(b1);
 
   }
 

--- a/src/test/java/mil/dds/anet/test/resources/ReportsResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/ReportsResourceTest.java
@@ -342,12 +342,12 @@ public class ReportsResourceTest extends AbstractResourceTest {
 
     // Check on Report status for who needs to approve
     List<ReportAction> workflow = returned.getWorkflow();
-    assertThat(workflow.size()).isEqualTo(4);
-    ReportAction reportAction = workflow.get(2);
+    assertThat(workflow.size()).isEqualTo(3);
+    ReportAction reportAction = workflow.get(1);
     assertThat(reportAction.getPerson()).isNull(); // Because this hasn't been approved yet.
     assertThat(reportAction.getCreatedAt()).isNull();
     assertThat(reportAction.getStepUuid()).isEqualTo(steps.get(0).getUuid());
-    reportAction = workflow.get(3);
+    reportAction = workflow.get(2);
     assertThat(reportAction.getStepUuid()).isEqualTo(steps.get(1).getUuid());
 
     // Reject the report

--- a/src/test/java/mil/dds/anet/test/resources/ReportsResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/ReportsResourceTest.java
@@ -200,7 +200,7 @@ public class ReportsResourceTest extends AbstractResourceTest {
     final ApprovalStep approval = new ApprovalStep();
     approval.setName("Test Group for Approving");
     approval.setType(ApprovalStepType.REPORT_APPROVAL);
-    approval.setAdvisorOrganizationUuid(advisorOrg.getUuid());
+    approval.setRelatedObjectUuid(advisorOrg.getUuid());
     approval.setApprovers(ImmutableList.of(approver1Pos));
     approvalSteps.add(approval);
 
@@ -208,7 +208,7 @@ public class ReportsResourceTest extends AbstractResourceTest {
     final ApprovalStep releaseApproval = new ApprovalStep();
     releaseApproval.setName("Test Group of Releasers");
     releaseApproval.setType(ApprovalStepType.REPORT_APPROVAL);
-    releaseApproval.setAdvisorOrganizationUuid(advisorOrg.getUuid());
+    releaseApproval.setRelatedObjectUuid(advisorOrg.getUuid());
     releaseApproval.setApprovers(ImmutableList.of(approver2Pos));
     approvalSteps.add(releaseApproval);
     advisorOrg.setApprovalSteps(approvalSteps);
@@ -218,8 +218,8 @@ public class ReportsResourceTest extends AbstractResourceTest {
     assertThat(nrUpdated).isEqualTo(1);
     // Pull the approval workflow for this AO
     final Organization orgWithSteps = graphQLHelper.getObjectById(admin, "organization",
-        "uuid approvalSteps { uuid name nextStepUuid advisorOrganizationUuid }",
-        advisorOrg.getUuid(), new TypeReference<GraphQlResponse<Organization>>() {});
+        "uuid approvalSteps { uuid name nextStepUuid relatedObjectUuid }", advisorOrg.getUuid(),
+        new TypeReference<GraphQlResponse<Organization>>() {});
     final List<ApprovalStep> steps = orgWithSteps.loadApprovalSteps(context).get();
     assertThat(steps.size()).isEqualTo(2);
     assertThat(steps.get(0).getName()).isEqualTo(approval.getName());

--- a/src/test/resources/testJson/approvalSteps/testStep.json
+++ b/src/test/resources/testJson/approvalSteps/testStep.json
@@ -1,6 +1,6 @@
 {
 	"uuid" : "42",
-	"advisorOrganizationUuid" : "22",
+	"relatedObjectUuid" : "22",
 	"approvers" : [],
 	"nextStepUuid" : "9292",
 	"type": 1


### PR DESCRIPTION
From now on tasks also have approval chains, and when when a report is submitted, it will first go through the organization approval chain and then through its tasks approval chains.

In addition to the changes described below, a pending report can now also be automatically advanced to the next step in the approval workflow if no action has been taken for a configurable amount of time (e.g. 48 hours).

Closes NCI-Agency/anet#2682

### User changes
- When a report is pending approval, the whole chain of actions (pending or completed) since the last time the report was submitted for approval is shown (in short: only the chain of actions pertinent to the current approval workflow). For approved/published reports, the entire chain of actions is shown, including change requests etc.
- The approval workflow for the efforts/tasks is now appended to the approval workflow for the report's primary advisor's organization.

### Super User changes
- None.

### Admin changes
- For tasks it is now also possible to define engagement planning and report publication approval processes. These can be edited by admins and non-admin task owners.

### System admin changes
- Add a setting to `anet.yml` for how many hours since the last approval action must pass before the next step is approved automatically:
```
   reportWorkflow:
     nbOfHoursQuarantineApproved: 24
+    nbOfHoursApprovalTimeout: 48
```

- [x] anet.yml needs change
- [x] db needs migration
- [ ] documentation has changed