### PR TITLE
Update customfields validation

### DIFF
--- a/anet.yml
+++ b/anet.yml
@@ -280,6 +280,7 @@ dictionary:
               label: "No"
         numberTrained:
           type: number
+          typeError: Number trained must be a number
           label: Number trained
           placeholder: Number of trainees
           validations:
@@ -349,6 +350,7 @@ dictionary:
               placeholder: Enter description of the asset
             quantity:
               type: number
+              typeError: Qty must be a number
               label: Qty
           visibleWhen: $[?(@.multipleButtons && (@.multipleButtons.indexOf('assist') != -1 || @.multipleButtons.indexOf('other') != -1))]
 
@@ -468,6 +470,7 @@ dictionary:
           visibleWhen: $[?(@.colourOptions === 'GREEN')]
         numberFieldName:
           type: number
+          typeError: Number field must be a number
           label: Number field
           placeholder: Placeholder text for number field
           helpText: Help text for number field

--- a/client/src/components/CustomFields.js
+++ b/client/src/components/CustomFields.js
@@ -382,6 +382,7 @@ const CustomField = ({
 }) => {
   const {
     type,
+    typeError,
     helpText,
     validations,
     visibleWhen,
@@ -534,6 +535,7 @@ export const ReadonlyCustomFields = ({
         const fieldConfig = fieldsConfig[key]
         const {
           type,
+          typeError,
           placeholder,
           helpText,
           validations,

--- a/client/src/components/Model.js
+++ b/client/src/components/Model.js
@@ -84,8 +84,11 @@ const CUSTOM_FIELD_TYPE_SCHEMA = {
 }
 
 const createFieldYupSchema = (fieldKey, fieldConfig, fieldPrefix) => {
-  const { label, validations, objectFields } = fieldConfig
+  const { label, validations, objectFields, typeError } = fieldConfig
   let fieldTypeYupSchema = CUSTOM_FIELD_TYPE_SCHEMA[fieldConfig.type]
+  if (typeError) {
+    fieldTypeYupSchema = fieldTypeYupSchema.typeError(typeError)
+  }
   if (!_isEmpty(objectFields)) {
     const objSchema = createYupObjectShape(objectFields, fieldPrefix)
     fieldTypeYupSchema = fieldTypeYupSchema.of(objSchema)

--- a/src/main/resources/anet-schema.yml
+++ b/src/main/resources/anet-schema.yml
@@ -75,6 +75,9 @@ definitions:
         title: value type field
         type: string
         enum: [text, number, date, datetime, enum, enumset, array_of_objects, special_field]
+      typeError:
+        title: custom value for type error
+        type: string
       label:
         type: string
       helpText:


### PR DESCRIPTION
This makes it possible to add custom validation error for field types.
It also makes sure that when a report would come from an external system (created through server side tests, or maybe later imported from an external source) and never went through the create/edit form, it would not validate the custom fields as they have never been filled.

### User changes
- The validation error for number type of custom fields can be more user friendly (if the system admin sets a custom one)

### System admin changes
- The validation error for number type of fields can be made more user friendly by adding the typeError setting to the custom field.

- [ ] anet.yml needs change
