### PR TITLE
Make recents a regular search

### DIFF
--- a/client/src/pages/reports/Form.js
+++ b/client/src/pages/reports/Form.js
@@ -55,13 +55,29 @@ import AuthorizationGroupTable from "./AuthorizationGroupTable"
 
 const GQL_GET_RECENTS = gql`
   query {
-    locationRecents(maxResults: 6) {
+    locationList(
+      query: {
+        pageSize: 6
+        status: ACTIVE
+        inMyReports: true
+        sortBy: RECENT
+        sortOrder: DESC
+      }
+    ) {
       list {
         uuid
         name
       }
     }
-    personRecents(maxResults: 6) {
+    personList(
+      query: {
+        pageSize: 6
+        status: ACTIVE
+        inMyReports: true
+        sortBy: RECENT
+        sortOrder: DESC
+      }
+    ) {
       list {
         uuid
         name
@@ -86,7 +102,15 @@ const GQL_GET_RECENTS = gql`
         }
       }
     }
-    taskRecents(maxResults: 6) {
+    taskList(
+      query: {
+        pageSize: 6
+        status: ACTIVE
+        inMyReports: true
+        sortBy: RECENT
+        sortOrder: DESC
+      }
+    ) {
       list {
         uuid
         shortName
@@ -98,7 +122,15 @@ const GQL_GET_RECENTS = gql`
         customFields
       }
     }
-    authorizationGroupRecents(maxResults: 6) {
+    authorizationGroupList(
+      query: {
+        pageSize: 6
+        status: ACTIVE
+        inMyReports: true
+        sortBy: RECENT
+        sortOrder: DESC
+      }
+    ) {
       list {
         uuid
         name
@@ -257,10 +289,10 @@ const BaseReportForm = ({
   let tagSuggestions = []
   if (data) {
     recents = {
-      locations: data.locationRecents.list,
-      persons: data.personRecents.list,
-      tasks: data.taskRecents.list,
-      authorizationGroups: data.authorizationGroupRecents.list
+      locations: data.locationList.list,
+      persons: data.personList.list,
+      tasks: data.taskList.list,
+      authorizationGroups: data.authorizationGroupList.list
     }
     // ReactTags expects id and text properties
     tagSuggestions = data.tagList.list.map(tag => ({

--- a/src/main/java/mil/dds/anet/beans/search/AbstractSearchQuery.java
+++ b/src/main/java/mil/dds/anet/beans/search/AbstractSearchQuery.java
@@ -7,6 +7,7 @@ import io.leangen.graphql.annotations.GraphQLQuery;
 import java.util.Objects;
 import java.util.Optional;
 import javax.annotation.Nonnull;
+import mil.dds.anet.beans.Person;
 
 @JsonIgnoreProperties({"user", "pass"})
 public abstract class AbstractSearchQuery<T extends ISortBy> implements ISearchQuery<T>, Cloneable {
@@ -23,6 +24,11 @@ public abstract class AbstractSearchQuery<T extends ISortBy> implements ISearchQ
   private Optional<SortOrder> sortOrder = Optional.empty();
   private Optional<T> sortBy = Optional.empty();
   private Optional<AbstractBatchParams<?, ?>> batchParams = Optional.empty();
+  @GraphQLQuery
+  @GraphQLInputField
+  private Boolean inMyReports;
+  // internal search parameter:
+  private Person user;
 
   public AbstractSearchQuery(T defaultSortBy) {
     this.defaultSortBy = defaultSortBy;
@@ -127,9 +133,17 @@ public abstract class AbstractSearchQuery<T extends ISortBy> implements ISearchQ
     this.batchParams = Optional.ofNullable(batchParams);
   }
 
+  public Boolean isInMyReports() {
+    return inMyReports;
+  }
+
+  public void setInMyReports(Boolean inMyReports) {
+    this.inMyReports = inMyReports;
+  }
+
   @Override
   public int hashCode() {
-    return Objects.hash(text, pageNum, pageSize, sortOrder, sortBy, batchParams);
+    return Objects.hash(text, pageNum, pageSize, sortOrder, sortBy, inMyReports, batchParams, user);
   }
 
   @Override
@@ -144,7 +158,9 @@ public abstract class AbstractSearchQuery<T extends ISortBy> implements ISearchQ
         && Objects.equals(getPageSize(), other.getPageSize())
         && Objects.equals(getSortOrder(), other.getSortOrder())
         && Objects.equals(getSortBy(), other.getSortBy())
-        && Objects.equals(getBatchParams(), other.getBatchParams());
+        && Objects.equals(isInMyReports(), other.isInMyReports())
+        && Objects.equals(getBatchParams(), other.getBatchParams())
+        && Objects.equals(getUser(), other.getUser());
   }
 
   @Override
@@ -155,6 +171,16 @@ public abstract class AbstractSearchQuery<T extends ISortBy> implements ISearchQ
       clone.setBatchParams((AbstractBatchParams<?, ?>) getBatchParams().clone());
     }
     return clone;
+  }
+
+  @JsonIgnore
+  public Person getUser() {
+    return user;
+  }
+
+  @JsonIgnore
+  public void setUser(Person user) {
+    this.user = user;
   }
 
 }

--- a/src/main/java/mil/dds/anet/beans/search/AuthorizationGroupSearchSortBy.java
+++ b/src/main/java/mil/dds/anet/beans/search/AuthorizationGroupSearchSortBy.java
@@ -1,5 +1,5 @@
 package mil.dds.anet.beans.search;
 
 public enum AuthorizationGroupSearchSortBy implements ISortBy {
-  CREATED_AT, NAME
+  CREATED_AT, NAME, RECENT
 }

--- a/src/main/java/mil/dds/anet/beans/search/LocationSearchSortBy.java
+++ b/src/main/java/mil/dds/anet/beans/search/LocationSearchSortBy.java
@@ -1,5 +1,5 @@
 package mil.dds.anet.beans.search;
 
 public enum LocationSearchSortBy implements ISortBy {
-  CREATED_AT, NAME
+  CREATED_AT, NAME, RECENT
 }

--- a/src/main/java/mil/dds/anet/beans/search/PersonSearchSortBy.java
+++ b/src/main/java/mil/dds/anet/beans/search/PersonSearchSortBy.java
@@ -1,5 +1,5 @@
 package mil.dds.anet.beans.search;
 
 public enum PersonSearchSortBy implements ISortBy {
-  CREATED_AT, NAME, RANK
+  CREATED_AT, NAME, RANK, RECENT
 }

--- a/src/main/java/mil/dds/anet/beans/search/ReportSearchQuery.java
+++ b/src/main/java/mil/dds/anet/beans/search/ReportSearchQuery.java
@@ -7,7 +7,6 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import mil.dds.anet.beans.Person;
 import mil.dds.anet.beans.Report.Atmosphere;
 import mil.dds.anet.beans.Report.ReportCancelledReason;
 import mil.dds.anet.beans.Report.ReportState;
@@ -114,8 +113,7 @@ public class ReportSearchQuery extends AbstractSearchQuery<ReportSearchSortBy> {
   @GraphQLQuery
   @GraphQLInputField
   private Boolean sensitiveInfo;
-  // internal search parameters:
-  private Person user;
+  // internal search parameter:
   private boolean systemSearch;
 
   public ReportSearchQuery() {
@@ -364,16 +362,6 @@ public class ReportSearchQuery extends AbstractSearchQuery<ReportSearchSortBy> {
   }
 
   @JsonIgnore
-  public Person getUser() {
-    return user;
-  }
-
-  @JsonIgnore
-  public void setUser(Person user) {
-    this.user = user;
-  }
-
-  @JsonIgnore
   public boolean isSystemSearch() {
     return systemSearch;
   }
@@ -391,7 +379,7 @@ public class ReportSearchQuery extends AbstractSearchQuery<ReportSearchSortBy> {
         advisorOrgUuid, includeAdvisorOrgChildren, principalOrgUuid, includePrincipalOrgChildren,
         orgUuid, orgRecurseStrategy, locationUuid, taskUuid, pendingApprovalOf, state,
         engagementStatus, cancelledReason, tagUuid, authorPositionUuid, attendeePositionUuid,
-        authorizationGroupUuid, sensitiveInfo, user, systemSearch);
+        authorizationGroupUuid, sensitiveInfo, systemSearch);
   }
 
   @Override

--- a/src/main/java/mil/dds/anet/beans/search/TaskSearchSortBy.java
+++ b/src/main/java/mil/dds/anet/beans/search/TaskSearchSortBy.java
@@ -1,5 +1,5 @@
 package mil.dds.anet.beans.search;
 
 public enum TaskSearchSortBy implements ISortBy {
-  CREATED_AT, NAME, CATEGORY
+  CREATED_AT, NAME, CATEGORY, RECENT
 }

--- a/src/main/java/mil/dds/anet/database/LocationDao.java
+++ b/src/main/java/mil/dds/anet/database/LocationDao.java
@@ -4,12 +4,10 @@ import java.util.Arrays;
 import java.util.List;
 import mil.dds.anet.AnetObjectEngine;
 import mil.dds.anet.beans.Location;
-import mil.dds.anet.beans.Person;
 import mil.dds.anet.beans.lists.AnetBeanList;
 import mil.dds.anet.beans.search.LocationSearchQuery;
 import mil.dds.anet.database.mappers.LocationMapper;
 import mil.dds.anet.utils.DaoUtils;
-import ru.vyarus.guicey.jdbi3.tx.InTransaction;
 
 public class LocationDao extends AnetBaseDao<Location, LocationSearchQuery> {
 
@@ -53,24 +51,6 @@ public class LocationDao extends AnetBaseDao<Location, LocationSearchQuery> {
         + "SET name = :name, status = :status, lat = :lat, lng = :lng, \"updatedAt\" = :updatedAt WHERE uuid = :uuid")
         .bindBean(l).bind("updatedAt", DaoUtils.asLocalDateTime(l.getUpdatedAt()))
         .bind("status", DaoUtils.getEnumId(l.getStatus())).execute();
-  }
-
-  @InTransaction
-  public List<Location> getRecentLocations(Person author, int maxResults) {
-    String sql;
-    if (DaoUtils.isMsSql()) {
-      sql = "/* recentLocations */ SELECT locations.* FROM locations WHERE uuid IN ( "
-          + "SELECT TOP(:maxResults) reports.\"locationUuid\" FROM reports "
-          + "WHERE authorUuid = :authorUuid GROUP BY \"locationUuid\" "
-          + "ORDER BY MAX(reports.\"createdAt\") DESC)";
-    } else {
-      sql = "/* recentLocations */ SELECT locations.* FROM locations WHERE uuid IN ( "
-          + "SELECT reports.\"locationUuid\" FROM reports "
-          + "WHERE \"authorUuid\" = :authorUuid GROUP BY \"locationUuid\" "
-          + "ORDER BY MAX(reports.\"createdAt\") DESC LIMIT :maxResults)";
-    }
-    return getDbHandle().createQuery(sql).bind("authorUuid", author.getUuid())
-        .bind("maxResults", maxResults).map(new LocationMapper()).list();
   }
 
   @Override

--- a/src/main/java/mil/dds/anet/database/PersonDao.java
+++ b/src/main/java/mil/dds/anet/database/PersonDao.java
@@ -156,28 +156,6 @@ public class PersonDao extends AnetBaseDao<Person, PersonSearchQuery> {
   }
 
   @InTransaction
-  public List<Person> getRecentPeople(Person author, int maxResults) {
-    String sql;
-    if (DaoUtils.isMsSql()) {
-      sql = "/* getRecentPeople */ SELECT " + PersonDao.PERSON_FIELDS
-          + "FROM people WHERE people.uuid IN ( "
-          + "SELECT top(:maxResults) \"reportPeople\".\"personUuid\" "
-          + "FROM reports JOIN \"reportPeople\" ON reports.uuid = \"reportPeople\".\"reportUuid\" "
-          + "WHERE \"authorUuid\" = :authorUuid AND \"personUuid\" != :authorUuid "
-          + "GROUP BY \"personUuid\" ORDER BY MAX(reports.\"createdAt\") DESC)";
-    } else {
-      sql = "/* getRecentPeople */ SELECT " + PersonDao.PERSON_FIELDS
-          + "FROM people WHERE people.uuid IN ( SELECT \"reportPeople\".\"personUuid\" "
-          + "FROM reports JOIN \"reportPeople\" ON reports.uuid = \"reportPeople\".\"reportUuid\" "
-          + "WHERE \"authorUuid\" = :authorUuid AND \"personUuid\" != :authorUuid "
-          + "GROUP BY \"personUuid\" ORDER BY MAX(reports.\"createdAt\") DESC "
-          + "LIMIT :maxResults)";
-    }
-    return getDbHandle().createQuery(sql).bind("authorUuid", author.getUuid())
-        .bind("maxResults", maxResults).map(new PersonMapper()).list();
-  }
-
-  @InTransaction
   public int mergePeople(Person winner, Person loser) {
     // delete duplicates where other is primary, or where neither is primary
     getDbHandle().createUpdate("DELETE FROM \"reportPeople\" WHERE ("

--- a/src/main/java/mil/dds/anet/resources/AuthorizationGroupResource.java
+++ b/src/main/java/mil/dds/anet/resources/AuthorizationGroupResource.java
@@ -40,8 +40,9 @@ public class AuthorizationGroupResource {
   }
 
   @GraphQLQuery(name = "authorizationGroupList")
-  public AnetBeanList<AuthorizationGroup> search(
+  public AnetBeanList<AuthorizationGroup> search(@GraphQLRootContext Map<String, Object> context,
       @GraphQLArgument(name = "query") AuthorizationGroupSearchQuery query) {
+    query.setUser(DaoUtils.getUserFromContext(context));
     return dao.search(query);
   }
 
@@ -90,18 +91,6 @@ public class AuthorizationGroupResource {
     AnetAuditLogger.log("AuthorizationGroup {} updated by {}", t, user);
     // GraphQL mutations *have* to return something, so we return the number of updated rows
     return numRows;
-  }
-
-  /**
-   * Returns the most recent authorization groups that this user used in reports.
-   * 
-   * @param maxResults maximum number of results to return, defaults to 3
-   */
-  @GraphQLQuery(name = "authorizationGroupRecents")
-  public AnetBeanList<AuthorizationGroup> recents(@GraphQLRootContext Map<String, Object> context,
-      @GraphQLArgument(name = "maxResults", defaultValue = "3") int maxResults) {
-    return new AnetBeanList<AuthorizationGroup>(
-        dao.getRecentAuthorizationGroups(DaoUtils.getUserFromContext(context), maxResults));
   }
 
 }

--- a/src/main/java/mil/dds/anet/resources/LocationResource.java
+++ b/src/main/java/mil/dds/anet/resources/LocationResource.java
@@ -35,7 +35,9 @@ public class LocationResource {
   }
 
   @GraphQLQuery(name = "locationList")
-  public AnetBeanList<Location> search(@GraphQLArgument(name = "query") LocationSearchQuery query) {
+  public AnetBeanList<Location> search(@GraphQLRootContext Map<String, Object> context,
+      @GraphQLArgument(name = "query") LocationSearchQuery query) {
+    query.setUser(DaoUtils.getUserFromContext(context));
     return dao.search(query);
   }
 
@@ -64,18 +66,6 @@ public class LocationResource {
     AnetAuditLogger.log("Location {} updated by {}", l, user);
     // GraphQL mutations *have* to return something, so we return the number of updated rows
     return numRows;
-  }
-
-  /**
-   * Returns the most recent locations that this user listed in reports.
-   * 
-   * @param maxResults maximum number of results to return, defaults to 3
-   */
-  @GraphQLQuery(name = "locationRecents")
-  public AnetBeanList<Location> recents(@GraphQLRootContext Map<String, Object> context,
-      @GraphQLArgument(name = "maxResults", defaultValue = "3") int maxResults) {
-    return new AnetBeanList<Location>(
-        dao.getRecentLocations(DaoUtils.getUserFromContext(context), maxResults));
   }
 
 }

--- a/src/main/java/mil/dds/anet/resources/PersonResource.java
+++ b/src/main/java/mil/dds/anet/resources/PersonResource.java
@@ -189,21 +189,11 @@ public class PersonResource {
   }
 
   @GraphQLQuery(name = "personList")
-  public AnetBeanList<Person> search(@GraphQLEnvironment Set<String> subFields,
+  public AnetBeanList<Person> search(@GraphQLRootContext Map<String, Object> context,
+      @GraphQLEnvironment Set<String> subFields,
       @GraphQLArgument(name = "query") PersonSearchQuery query) {
+    query.setUser(DaoUtils.getUserFromContext(context));
     return dao.search(subFields, query);
-  }
-
-  /**
-   * Returns the most recent people that this user listed as attendees in reports.
-   * 
-   * @param maxResults maximum number of results to return, defaults to 3
-   */
-  @GraphQLQuery(name = "personRecents")
-  public AnetBeanList<Person> recents(@GraphQLRootContext Map<String, Object> context,
-      @GraphQLArgument(name = "maxResults", defaultValue = "3") int maxResults) {
-    return new AnetBeanList<Person>(
-        dao.getRecentPeople(DaoUtils.getUserFromContext(context), maxResults));
   }
 
   /**

--- a/src/main/java/mil/dds/anet/resources/TaskResource.java
+++ b/src/main/java/mil/dds/anet/resources/TaskResource.java
@@ -159,19 +159,9 @@ public class TaskResource {
   }
 
   @GraphQLQuery(name = "taskList")
-  public AnetBeanList<Task> search(@GraphQLArgument(name = "query") TaskSearchQuery query) {
+  public AnetBeanList<Task> search(@GraphQLRootContext Map<String, Object> context,
+      @GraphQLArgument(name = "query") TaskSearchQuery query) {
+    query.setUser(DaoUtils.getUserFromContext(context));
     return dao.search(query);
-  }
-
-  /**
-   * Returns the most recent Tasks that this user listed in reports.
-   * 
-   * @param maxResults maximum number of results to return, defaults to 3
-   */
-  @GraphQLQuery(name = "taskRecents")
-  public AnetBeanList<Task> recents(@GraphQLRootContext Map<String, Object> context,
-      @GraphQLArgument(name = "maxResults", defaultValue = "3") int maxResults) {
-    return new AnetBeanList<Task>(
-        dao.getRecentTasks(DaoUtils.getUserFromContext(context), maxResults));
   }
 }

--- a/src/main/java/mil/dds/anet/search/AbstractPersonSearcher.java
+++ b/src/main/java/mil/dds/anet/search/AbstractPersonSearcher.java
@@ -12,6 +12,7 @@ import mil.dds.anet.beans.search.PersonSearchQuery;
 import mil.dds.anet.database.PersonDao;
 import mil.dds.anet.database.mappers.PersonMapper;
 import mil.dds.anet.search.AbstractSearchQueryBuilder.Comparison;
+import mil.dds.anet.utils.DaoUtils;
 import ru.vyarus.guicey.jdbi3.tx.InTransaction;
 
 public abstract class AbstractPersonSearcher extends AbstractSearcher<Person, PersonSearchQuery>
@@ -87,6 +88,17 @@ public abstract class AbstractPersonSearcher extends AbstractSearcher<Person, Pe
       }
     }
 
+    if (Boolean.TRUE.equals(query.isInMyReports())) {
+      qb.addFromClause("JOIN ("
+          + "  SELECT \"reportPeople\".\"personUuid\" AS uuid, MAX(reports.\"createdAt\") AS max"
+          + "  FROM reports"
+          + "  JOIN \"reportPeople\" ON reports.uuid = \"reportPeople\".\"reportUuid\""
+          + "  WHERE reports.\"authorUuid\" = :userUuid AND \"reportPeople\".\"personUuid\" != :userUuid"
+          + "  GROUP BY \"reportPeople\".\"personUuid\""
+          + ") \"inMyReports\" ON people.uuid = \"inMyReports\".uuid");
+      qb.addSqlArg("userUuid", DaoUtils.getUuid(query.getUser()));
+    }
+
     addOrderByClauses(qb, query);
   }
 
@@ -99,6 +111,12 @@ public abstract class AbstractPersonSearcher extends AbstractSearcher<Person, Pe
         break;
       case RANK:
         qb.addAllOrderByClauses(getOrderBy(query.getSortOrder(), "people", "rank"));
+        break;
+      case RECENT:
+        if (Boolean.TRUE.equals(query.isInMyReports())) {
+          // Otherwise the JOIN won't exist
+          qb.addAllOrderByClauses(getOrderBy(query.getSortOrder(), "\"inMyReports\"", "max"));
+        }
         break;
       case NAME:
       default:

--- a/src/main/java/mil/dds/anet/search/AbstractTaskSearcher.java
+++ b/src/main/java/mil/dds/anet/search/AbstractTaskSearcher.java
@@ -8,6 +8,7 @@ import mil.dds.anet.beans.search.ISearchQuery.SortOrder;
 import mil.dds.anet.beans.search.TaskSearchQuery;
 import mil.dds.anet.database.mappers.TaskMapper;
 import mil.dds.anet.search.AbstractSearchQueryBuilder.Comparison;
+import mil.dds.anet.utils.DaoUtils;
 import ru.vyarus.guicey.jdbi3.tx.InTransaction;
 
 public abstract class AbstractTaskSearcher extends AbstractSearcher<Task, TaskSearchQuery>
@@ -65,6 +66,16 @@ public abstract class AbstractTaskSearcher extends AbstractSearcher<Task, TaskSe
       addCustomFieldRef1UuidQuery(query);
     }
 
+    if (Boolean.TRUE.equals(query.isInMyReports())) {
+      qb.addFromClause("JOIN ("
+          + "  SELECT \"reportTasks\".\"taskUuid\" AS uuid, MAX(reports.\"createdAt\") AS max"
+          + "  FROM reports"
+          + "  JOIN \"reportTasks\" ON reports.uuid = \"reportTasks\".\"reportUuid\""
+          + "  WHERE reports.\"authorUuid\" = :userUuid GROUP BY \"reportTasks\".\"taskUuid\""
+          + ") \"inMyReports\" ON tasks.uuid = \"inMyReports\".uuid");
+      qb.addSqlArg("userUuid", DaoUtils.getUuid(query.getUser()));
+    }
+
     addOrderByClauses(qb, query);
   }
 
@@ -76,7 +87,6 @@ public abstract class AbstractTaskSearcher extends AbstractSearcher<Task, TaskSe
   }
 
   protected void addTaskedOrgUuidQuery(TaskSearchQuery query) {
-
     qb.addFromClause(
         "LEFT JOIN \"taskTaskedOrganizations\" ON tasks.uuid = \"taskTaskedOrganizations\".\"taskUuid\"");
 
@@ -108,6 +118,12 @@ public abstract class AbstractTaskSearcher extends AbstractSearcher<Task, TaskSe
         break;
       case CATEGORY:
         qb.addAllOrderByClauses(getOrderBy(query.getSortOrder(), "tasks", "category"));
+        break;
+      case RECENT:
+        if (Boolean.TRUE.equals(query.isInMyReports())) {
+          // Otherwise the JOIN won't exist
+          qb.addAllOrderByClauses(getOrderBy(query.getSortOrder(), "\"inMyReports\"", "max"));
+        }
         break;
       case NAME:
       default:

--- a/src/test/java/mil/dds/anet/test/resources/ReportsResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/ReportsResourceTest.java
@@ -28,6 +28,7 @@ import mil.dds.anet.beans.ApprovalStep;
 import mil.dds.anet.beans.ApprovalStep.ApprovalStepType;
 import mil.dds.anet.beans.Comment;
 import mil.dds.anet.beans.Location;
+import mil.dds.anet.beans.Location.LocationStatus;
 import mil.dds.anet.beans.Organization;
 import mil.dds.anet.beans.Organization.OrganizationType;
 import mil.dds.anet.beans.Person;
@@ -50,11 +51,14 @@ import mil.dds.anet.beans.Task.TaskStatus;
 import mil.dds.anet.beans.lists.AnetBeanList;
 import mil.dds.anet.beans.search.ISearchQuery.SortOrder;
 import mil.dds.anet.beans.search.LocationSearchQuery;
+import mil.dds.anet.beans.search.LocationSearchSortBy;
 import mil.dds.anet.beans.search.OrganizationSearchQuery;
 import mil.dds.anet.beans.search.PersonSearchQuery;
+import mil.dds.anet.beans.search.PersonSearchSortBy;
 import mil.dds.anet.beans.search.ReportSearchQuery;
 import mil.dds.anet.beans.search.ReportSearchSortBy;
 import mil.dds.anet.beans.search.TaskSearchQuery;
+import mil.dds.anet.beans.search.TaskSearchSortBy;
 import mil.dds.anet.test.TestData;
 import mil.dds.anet.test.beans.OrganizationTest;
 import mil.dds.anet.test.beans.PersonTest;
@@ -457,16 +461,34 @@ public class ReportsResourceTest extends AbstractResourceTest {
 
     // Pull recent People, Tasks, and Locations and verify that the records from the last report are
     // there.
-    AnetBeanList<Person> recentPeople = graphQLHelper.getAllObjects(author, "personRecents",
-        PERSON_FIELDS, new TypeReference<GraphQlResponse<AnetBeanList<Person>>>() {});
+    final PersonSearchQuery queryPeople = new PersonSearchQuery();
+    queryPeople.setStatus(Collections.singletonList(PersonStatus.ACTIVE));
+    queryPeople.setInMyReports(true);
+    queryPeople.setSortBy(PersonSearchSortBy.RECENT);
+    queryPeople.setSortOrder(SortOrder.DESC);
+    final AnetBeanList<Person> recentPeople = graphQLHelper.searchObjects(author, "personList",
+        "query", "PersonSearchQueryInput", PERSON_FIELDS, queryPeople,
+        new TypeReference<GraphQlResponse<AnetBeanList<Person>>>() {});
     assertThat(recentPeople.getList()).contains(principalPerson);
 
-    AnetBeanList<Task> recentTasks = graphQLHelper.getAllObjects(author, "taskRecents", TASK_FIELDS,
-        new TypeReference<GraphQlResponse<AnetBeanList<Task>>>() {});
+    final TaskSearchQuery queryTasks = new TaskSearchQuery();
+    queryTasks.setStatus(TaskStatus.ACTIVE);
+    queryTasks.setInMyReports(true);
+    queryTasks.setSortBy(TaskSearchSortBy.RECENT);
+    queryTasks.setSortOrder(SortOrder.DESC);
+    final AnetBeanList<Task> recentTasks =
+        graphQLHelper.searchObjects(author, "taskList", "query", "TaskSearchQueryInput",
+            TASK_FIELDS, queryTasks, new TypeReference<GraphQlResponse<AnetBeanList<Task>>>() {});
     assertThat(recentTasks.getList()).contains(action);
 
-    AnetBeanList<Location> recentLocations = graphQLHelper.getAllObjects(author, "locationRecents",
-        LOCATION_FIELDS, new TypeReference<GraphQlResponse<AnetBeanList<Location>>>() {});
+    final LocationSearchQuery queryLocations = new LocationSearchQuery();
+    queryLocations.setStatus(LocationStatus.ACTIVE);
+    queryLocations.setInMyReports(true);
+    queryLocations.setSortBy(LocationSearchSortBy.RECENT);
+    queryLocations.setSortOrder(SortOrder.DESC);
+    final AnetBeanList<Location> recentLocations = graphQLHelper.searchObjects(author,
+        "locationList", "query", "LocationSearchQueryInput", LOCATION_FIELDS, queryLocations,
+        new TypeReference<GraphQlResponse<AnetBeanList<Location>>>() {});;
     assertThat(recentLocations.getList()).contains(loc);
 
     // Go and delete the entire approval chain!

--- a/src/test/resources/graphQLTests/location-recents-maxResults.gql
+++ b/src/test/resources/graphQLTests/location-recents-maxResults.gql
@@ -1,4 +1,4 @@
-locationRecents(maxResults:${maxResults}) {
+locationList(query: {pageSize: ${maxResults}, status: ACTIVE, inMyReports: true, sortBy: RECENT, sortOrder: DESC}) {
   list {
     uuid
     name

--- a/src/test/resources/graphQLTests/location-recents.gql
+++ b/src/test/resources/graphQLTests/location-recents.gql
@@ -1,4 +1,4 @@
-locationRecents {
+locationList(query: {status: ACTIVE, inMyReports: true, sortBy: RECENT, sortOrder: DESC}) {
   list {
     uuid
     name

--- a/src/test/resources/graphQLTests/person-recents-maxResults.gql
+++ b/src/test/resources/graphQLTests/person-recents-maxResults.gql
@@ -1,4 +1,4 @@
-personRecents(maxResults:${maxResults}) {
+personList(query: {pageSize: ${maxResults}, status: ACTIVE, inMyReports: true, sortBy: RECENT, sortOrder: DESC}) {
   list {
     uuid
     name

--- a/src/test/resources/graphQLTests/person-recents.gql
+++ b/src/test/resources/graphQLTests/person-recents.gql
@@ -1,4 +1,4 @@
-personRecents {
+personList(query: {status: ACTIVE, inMyReports: true, sortBy: RECENT, sortOrder: DESC}) {
   list {
     uuid
     name

--- a/src/test/resources/graphQLTests/report-all-recents.gql
+++ b/src/test/resources/graphQLTests/report-all-recents.gql
@@ -1,10 +1,10 @@
-locationRecents(maxResults: 6) {
+locationList(query: {pageSize: 6, status: ACTIVE, inMyReports: true, sortBy: RECENT, sortOrder: DESC}) {
   list {
     uuid
     name
   }
 }
-personRecents(maxResults: 6) {
+personList(query: {pageSize: 6, status: ACTIVE, inMyReports: true, sortBy: RECENT, sortOrder: DESC}) {
   list {
     uuid
     name
@@ -29,18 +29,19 @@ personRecents(maxResults: 6) {
     }
   }
 }
-taskRecents(maxResults: 6) {
+taskList(query: {pageSize: 6, status: ACTIVE, inMyReports: true, sortBy: RECENT, sortOrder: DESC}) {
   list {
     uuid
     shortName
     longName
-      taskedOrganizations {
-        uuid
-        shortName
-      }
+    taskedOrganizations {
+      uuid
+      shortName
+    }
+    customFields
   }
 }
-authorizationGroupRecents(maxResults: 6) {
+authorizationGroupList(query: {pageSize: 6, status: ACTIVE, inMyReports: true, sortBy: RECENT, sortOrder: DESC}) {
   list {
     uuid
     name

--- a/src/test/resources/graphQLTests/task-recents-maxResults.gql
+++ b/src/test/resources/graphQLTests/task-recents-maxResults.gql
@@ -1,4 +1,4 @@
-taskRecents(maxResults:${maxResults}) {
+taskList(query: {pageSize: ${maxResults}, status: ACTIVE, inMyReports: true, sortBy: RECENT, sortOrder: DESC}) {
   list {
     uuid
     shortName
@@ -7,5 +7,6 @@ taskRecents(maxResults:${maxResults}) {
       uuid
       shortName
     }
+    customFields
   }
 }

--- a/src/test/resources/graphQLTests/task-recents.gql
+++ b/src/test/resources/graphQLTests/task-recents.gql
@@ -1,4 +1,4 @@
-taskRecents {
+taskList(query: {status: ACTIVE, inMyReports: true, sortBy: RECENT, sortOrder: DESC}) {
   list {
     uuid
     shortName
@@ -7,5 +7,6 @@ taskRecents {
       uuid
       shortName
     }
+    customFields
   }
 }


### PR DESCRIPTION
For authorizationGroups, locations, people and tasks, the list of recent objects is now no longer a dedicated GraphQL endpoint, but can be retrieved through the regular search.

Closes NCI-Agency/anet#1952