### PR TITLE
Allow report to have an engagementDate yet a NULL nextSteps

### DIFF
--- a/client/src/models/Report.js
+++ b/client/src/models/Report.js
@@ -216,6 +216,7 @@ export default class Report extends Model {
         .label(Settings.fields.report.reportText),
       nextSteps: yup
         .string()
+        .nullable()
         .when(["engagementDate"], (engagementDate, schema) =>
           !Report.isFuture(engagementDate)
             ? schema.required(


### PR DESCRIPTION
This condition can occur through the test data.