### PR TITLE
Use general task labels, or top-level or sub-level task labels when appropriate

### DIFF
--- a/anet.yml
+++ b/anet.yml
@@ -205,15 +205,38 @@ dictionary:
       shortLabel: Objective / Effort
       shortName:
         label: Objective / Effort number
-        placeholder: Enter an effort name, example....
-
+        placeholder: Enter an objective / effort name, example....
       longLabel: Objectives and Efforts
       longName:
-        label: Task description
-        placeholder: Enter an effort description, example ....
+        label: Objective / Effort description
+        placeholder: Enter an objective / effort description, example ....
         componentClass: textarea
         style:
           height: 400px
+      topLevel:
+         shortLabel: Objective
+         shortName:
+           label: Objective name
+           placeholder: Enter an objective name, example....
+         longLabel: Objectives
+         longName:
+           label: Objective description
+           placeholder: Enter an objective description, example ....
+           componentClass: textarea
+           style:
+             height: 400px
+      subLevel:
+         shortLabel: Effort
+         shortName:
+           label: Effort name
+           placeholder: Enter an effort name, example....
+         longLabel: Efforts
+         longName:
+           label: Effort description
+           placeholder: Enter an effort description, example ....
+           componentClass: textarea
+           style:
+             height: 400px
       customFieldRef1:
         label: Parent task
         placeholder: Start typing to search for a higher level task

--- a/client/src/components/ReportSummary.js
+++ b/client/src/components/ReportSummary.js
@@ -325,7 +325,9 @@ const ReportSummaryRow = ({ report }) => {
         <Col md={12}>
           {report.tasks.length > 0 && (
             <span>
-              <strong>{pluralize(Settings.fields.task.shortLabel)}:</strong>{" "}
+              <strong>
+                {pluralize(Settings.fields.task.subLevel.shortLabel)}:
+              </strong>{" "}
               {report.tasks.map(
                 (task, i) =>
                   task.shortName + (i < report.tasks.length - 1 ? ", " : "")

--- a/client/src/components/ReportsByTask.js
+++ b/client/src/components/ReportsByTask.js
@@ -52,7 +52,7 @@ const Chart = ({
     if (!data) {
       return []
     }
-    const noTaskMessage = `No ${Settings.fields.task.shortLabel}`
+    const noTaskMessage = `No ${Settings.fields.task.subLevel.shortLabel}`
     const noTask = {
       uuid: "-1",
       shortName: noTaskMessage,
@@ -170,7 +170,7 @@ Map.propTypes = {
 const ReportsByTask = ({ pageDispatchers, queryParams, style }) => {
   const [focusedSelection, setFocusedSelection] = useState(null)
 
-  const taskShortLabel = Settings.fields.task.shortLabel
+  const taskShortLabel = Settings.fields.task.subLevel.shortLabel
   const chartId = "reports_by_task"
   const selectedBarClass = "selected-bar"
   const VISUALIZATIONS = [

--- a/client/src/components/TaskTable.js
+++ b/client/src/components/TaskTable.js
@@ -15,7 +15,8 @@ const TaskTable = ({
   showOrganization,
   showDelete,
   showDescription,
-  onDelete
+  onDelete,
+  noTasksMessage
 }) => {
   const tasksExist = _get(tasks, "length", 0) > 0
 
@@ -92,7 +93,7 @@ const TaskTable = ({
           </tbody>
         </Table>
       ) : (
-        <em>No {Settings.fields.task.shortLabel} found</em>
+        <em>{noTasksMessage}</em>
       )}
     </div>
   )
@@ -105,12 +106,14 @@ TaskTable.propTypes = {
   showDelete: PropTypes.bool,
   onDelete: PropTypes.func,
   showOrganization: PropTypes.bool,
-  showDescription: PropTypes.bool
+  showDescription: PropTypes.bool,
+  noTasksMessage: PropTypes.string
 }
 
 TaskTable.defaultProps = {
   showDelete: false,
-  showOrganization: false
+  showOrganization: false,
+  noTasksMessage: `No ${Settings.fields.task.shortLabel} found`
 }
 
 export default TaskTable

--- a/client/src/components/TaskTable.js
+++ b/client/src/components/TaskTable.js
@@ -1,6 +1,7 @@
 import { Settings } from "api"
 import LinkTo from "components/LinkTo"
 import _get from "lodash/get"
+import _isEmpty from "lodash/isEmpty"
 import { Task } from "models"
 import PropTypes from "prop-types"
 import React from "react"
@@ -21,20 +22,25 @@ const TaskTable = ({
   return (
     <div id={id}>
       {tasksExist ? (
-        <div>
-          <Table striped condensed hover responsive className="tasks_table">
-            <thead>
-              <tr>
-                <th>Name</th>
-                {/* TODO: Implement conditional labels, until then, we need to be explicit here */}
-                {showParent && <th>Objective</th>}
-                {showOrganization && <th>Tasked organizations</th>}
-                {showDescription && <th>Description</th>}
-                <th />
-              </tr>
-            </thead>
-            <tbody>
-              {Task.map(tasks, task => (
+        <Table striped condensed hover responsive className="tasks_table">
+          <thead>
+            <tr>
+              <th>Name</th>
+              {showParent && (
+                <th>{Settings.fields.task.topLevel.shortLabel}</th>
+              )}
+              {showOrganization && <th>Tasked organizations</th>}
+              {showDescription && <th>Description</th>}
+              <th />
+            </tr>
+          </thead>
+          <tbody>
+            {Task.map(tasks, task => {
+              const isTopLevelTask = _isEmpty(task.customFieldRef1)
+              const fieldSettings = isTopLevelTask
+                ? Settings.fields.task.topLevel
+                : Settings.fields.task.subLevel
+              return (
                 <tr key={task.uuid}>
                   <td className="taskName">
                     <LinkTo modelType="Task" model={task}>
@@ -75,24 +81,18 @@ const TaskTable = ({
                         <img
                           src={REMOVE_ICON}
                           height={14}
-                          alt={`Remove ${Settings.fields.task.shortLabel}`}
+                          alt={`Remove ${fieldSettings.shortLabel}`}
                         />
                       </span>
                     </td>
                   )}
                 </tr>
-              ))}
-            </tbody>
-          </Table>
-
-          {tasks.length === 0 && (
-            <p style={{ textAlign: "center" }}>
-              <em>No {Settings.fields.task.shortLabel} selected.</em>
-            </p>
-          )}
-        </div>
+              )
+            })}
+          </tbody>
+        </Table>
       ) : (
-        <em>No effort found</em>
+        <em>No {Settings.fields.task.shortLabel} found</em>
       )}
     </div>
   )

--- a/client/src/models/Report.js
+++ b/client/src/models/Report.js
@@ -182,7 +182,7 @@ export default class Report extends Model {
           function(tasks) {
             return _isEmpty(tasks)
               ? this.createError({
-                message: `You must provide at least one ${Settings.fields.task.shortLabel}`
+                message: `You must provide at least one ${Settings.fields.task.subLevel.shortLabel}`
               })
               : true
           }

--- a/client/src/pages/HopscotchTour.js
+++ b/client/src/pages/HopscotchTour.js
@@ -4,6 +4,8 @@ import pluralize from "pluralize"
 
 const taskShortLabelSingular = Settings.fields.task.shortLabel
 const taskShortLabelPlural = pluralize(taskShortLabelSingular)
+const subLevelTaskShortLabelSingular = Settings.fields.task.subLevel.shortLabel
+const subLevelTaskShortLabelPlural = pluralize(subLevelTaskShortLabelSingular)
 const advisorSingular = Settings.fields.advisor.person.name
 const advisorPlural = pluralize(advisorSingular)
 const principalSingular = Settings.fields.principal.person.name
@@ -162,7 +164,7 @@ const reportTour = (currentUser, history) => {
       },
       {
         title: "Recents",
-        content: `If you've written reports in the past, your recent selections of attendees, ${taskShortLabelPlural}, and locations will display to the right in a section called "Recents". You can click on one of the shortcuts to quickly add it to your report.`,
+        content: `If you've written reports in the past, your recent selections of attendees, ${subLevelTaskShortLabelPlural}, and locations will display to the right in a section called "Recents". You can click on one of the shortcuts to quickly add it to your report.`,
         target: "#attendees",
         placement: "bottom"
       },
@@ -173,8 +175,8 @@ const reportTour = (currentUser, history) => {
         placement: "bottom"
       },
       {
-        title: taskShortLabelPlural,
-        content: `Search for the ${taskShortLabelPlural} that apply to this engagement. You can search for ${taskShortLabelPlural} in any organization, including your organization and its sub-organizations. ${taskShortLabelPlural} are not required.`,
+        title: subLevelTaskShortLabelPlural,
+        content: `Search for the ${subLevelTaskShortLabelPlural} that apply to this engagement. You can search for ${subLevelTaskShortLabelPlural} in any organization, including your organization and its sub-organizations. ${subLevelTaskShortLabelPlural} are required.`,
         target: "#tasks",
         placement: "right"
       },

--- a/client/src/pages/insights/Show.js
+++ b/client/src/pages/insights/Show.js
@@ -67,7 +67,7 @@ export const INSIGHT_DETAILS = {
   [REPORTS_BY_TASK]: {
     searchProps: _SEARCH_PROPS,
     component: ReportsByTask,
-    navTitle: "Reports by Task",
+    navTitle: `Reports by ${Settings.fields.task.subLevel.shortLabel}`,
     title: ""
   },
   [REPORTS_BY_DAY_OF_WEEK]: {

--- a/client/src/pages/organizations/Form.js
+++ b/client/src/pages/organizations/Form.js
@@ -118,7 +118,7 @@ const BaseOrganizationForm = ({ currentUser, edit, title, initialValues }) => {
         )
         const tasksFilters = {
           allTasks: {
-            label: "All tasks",
+            label: `All ${pluralize(Settings.fields.task.shortLabel)}`,
             queryVars: {}
           }
         }

--- a/client/src/pages/reports/Form.js
+++ b/client/src/pages/reports/Form.js
@@ -423,10 +423,10 @@ const BaseReportForm = ({
           }
         }
 
-        const tasksFiltersLevel = {}
+        const tasksFilters = {}
 
         if (currentOrg) {
-          tasksFiltersLevel.assignedToMyOrg = {
+          tasksFilters.assignedToMyOrg = {
             label: `Assigned to ${currentOrg.shortName}`,
             queryVars: {
               taskedOrgUuid: currentOrg.uuid,
@@ -445,7 +445,7 @@ const BaseReportForm = ({
           primaryAdvisor?.position?.organization &&
           primaryAdvisor.position.organization.uuid !== currentOrg?.uuid
         ) {
-          tasksFiltersLevel.assignedToReportOrg = {
+          tasksFilters.assignedToReportOrg = {
             label: `Assigned to ${primaryAdvisor.position.organization}`,
             queryVars: {
               taskedOrgUuid: primaryAdvisor.position.organization.uuid,
@@ -456,8 +456,8 @@ const BaseReportForm = ({
         }
 
         if (currentUser.isAdmin()) {
-          tasksFiltersLevel.allTasks = {
-            label: "All efforts", // TODO: Implement conditional labels, until then, we need to be explicit here
+          tasksFilters.allTasks = {
+            label: `All ${pluralize(Settings.fields.task.subLevel.shortLabel)}`,
             queryVars: { hasCustomFieldRef1: true }
           }
         }
@@ -799,12 +799,12 @@ const BaseReportForm = ({
               </Fieldset>
 
               <Fieldset
-                title="Efforts" // TODO: Implement conditional labels, until then, we need to be explicit here
+                title={Settings.fields.task.subLevel.longLabel}
                 className="tasks-selector"
               >
                 <Field
                   name="tasks"
-                  label="Efforts" // TODO: Implement conditional labels, until then, we need to be explicit here
+                  label={Settings.fields.task.subLevel.longLabel}
                   component={FieldHelper.SpecialField}
                   onChange={value => {
                     // validation will be done by setFieldValue
@@ -816,7 +816,7 @@ const BaseReportForm = ({
                     <AdvancedMultiSelect
                       fieldName="tasks"
                       placeholder={`Search for ${pluralize(
-                        Settings.fields.task.shortLabel
+                        Settings.fields.task.subLevel.shortLabel
                       )}...`}
                       value={values.tasks}
                       renderSelected={
@@ -829,11 +829,11 @@ const BaseReportForm = ({
                         />
                       }
                       overlayColumns={[
-                        "Effort", // TODO: Implement conditional labels, until then, we need to be explicit here
-                        "Objective"
+                        Settings.fields.task.subLevel.shortLabel,
+                        Settings.fields.task.topLevel.shortLabel
                       ]}
                       overlayRenderRow={TaskDetailedOverlayRow}
-                      filterDefs={tasksFiltersLevel}
+                      filterDefs={tasksFilters}
                       objectType={Task}
                       queryParams={{ status: Task.STATUS.ACTIVE }}
                       fields={Task.autocompleteQuery}
@@ -844,7 +844,7 @@ const BaseReportForm = ({
                     <>
                       <FieldHelper.FieldShortcuts
                         title={`Recent ${pluralize(
-                          Settings.fields.task.shortLabel
+                          Settings.fields.task.subLevel.shortLabel
                         )}`}
                         shortcuts={recents.tasks}
                         fieldName="tasks"

--- a/client/src/pages/reports/Form.js
+++ b/client/src/pages/reports/Form.js
@@ -256,6 +256,7 @@ const BaseReportForm = ({
   const submitText = currentUser.hasActivePosition()
     ? "Preview and submit"
     : "Save draft"
+  const tasksLabel = pluralize(Settings.fields.task.subLevel.shortLabel)
   const showAssignedPositionWarning = !currentUser.hasAssignedPosition()
   const showActivePositionWarning =
     currentUser.hasAssignedPosition() && !currentUser.hasActivePosition()
@@ -457,7 +458,7 @@ const BaseReportForm = ({
 
         if (currentUser.isAdmin()) {
           tasksFilters.allTasks = {
-            label: `All ${pluralize(Settings.fields.task.subLevel.shortLabel)}`,
+            label: `All ${tasksLabel}`,
             queryVars: { hasCustomFieldRef1: true }
           }
         }
@@ -815,9 +816,7 @@ const BaseReportForm = ({
                   widget={
                     <AdvancedMultiSelect
                       fieldName="tasks"
-                      placeholder={`Search for ${pluralize(
-                        Settings.fields.task.subLevel.shortLabel
-                      )}...`}
+                      placeholder={`Search for ${tasksLabel}...`}
                       value={values.tasks}
                       renderSelected={
                         <TaskTable
@@ -826,6 +825,7 @@ const BaseReportForm = ({
                           showParent
                           showDelete
                           showDescription
+                          noTasksMessage={`No ${tasksLabel} selected; click in the efforts box to view your organization's efforts`}
                         />
                       }
                       overlayColumns={[
@@ -843,9 +843,7 @@ const BaseReportForm = ({
                   extraColElem={
                     <>
                       <FieldHelper.FieldShortcuts
-                        title={`Recent ${pluralize(
-                          Settings.fields.task.subLevel.shortLabel
-                        )}`}
+                        title={`Recent ${tasksLabel}`}
                         shortcuts={recents.tasks}
                         fieldName="tasks"
                         objectType="Task"

--- a/client/src/pages/reports/Minimal.js
+++ b/client/src/pages/reports/Minimal.js
@@ -110,6 +110,10 @@ const GQL_GET_REPORT = gql`
         uuid
         shortName
         longName
+        customFieldRef1 {
+          uuid
+          shortName
+        }
         taskedOrganizations {
           uuid
           shortName
@@ -407,7 +411,7 @@ const ReportMinimal = ({ pageDispatchers }) => {
               <AttendeesTable attendees={report.attendees} disabled />
             </Fieldset>
 
-            <Fieldset title={Settings.fields.task.longLabel}>
+            <Fieldset title={Settings.fields.task.subLevel.longLabel}>
               <TaskTable tasks={report.tasks} showParent />
             </Fieldset>
 

--- a/client/src/pages/reports/Minimal.js
+++ b/client/src/pages/reports/Minimal.js
@@ -17,6 +17,7 @@ import { Field, Form, Formik } from "formik"
 import _isEmpty from "lodash/isEmpty"
 import { Report } from "models"
 import moment from "moment"
+import pluralize from "pluralize"
 import React from "react"
 import { Alert } from "react-bootstrap"
 import { connect } from "react-redux"
@@ -230,6 +231,7 @@ const ReportMinimal = ({ pageDispatchers }) => {
   }
 
   const reportType = report.isFuture() ? "planned engagement" : "report"
+  const tasksLabel = pluralize(Settings.fields.task.subLevel.shortLabel)
 
   return (
     <Formik enableReinitialize initialValues={report}>
@@ -412,7 +414,11 @@ const ReportMinimal = ({ pageDispatchers }) => {
             </Fieldset>
 
             <Fieldset title={Settings.fields.task.subLevel.longLabel}>
-              <TaskTable tasks={report.tasks} showParent />
+              <TaskTable
+                tasks={report.tasks}
+                showParent
+                noTasksMessage={`No ${tasksLabel} selected`}
+              />
             </Fieldset>
 
             {report.reportText && (

--- a/client/src/pages/reports/Show.js
+++ b/client/src/pages/reports/Show.js
@@ -614,8 +614,7 @@ const BaseReportShow = ({ currentUser, setSearchQuery, pageDispatchers }) => {
               <Fieldset title="Meeting attendees">
                 <AttendeesTable attendees={report.attendees} disabled />
               </Fieldset>
-              {/* TODO: Implement conditional labels, until then, we need to be explicit here */}
-              <Fieldset title="Efforts">
+              <Fieldset title={Settings.fields.task.subLevel.longLabel}>
                 <TaskTable tasks={report.tasks} showParent />
               </Fieldset>
               {report.reportText && (

--- a/client/src/pages/reports/Show.js
+++ b/client/src/pages/reports/Show.js
@@ -32,6 +32,7 @@ import _isEmpty from "lodash/isEmpty"
 import _upperFirst from "lodash/upperFirst"
 import { Comment, Person, Position, Report } from "models"
 import moment from "moment"
+import pluralize from "pluralize"
 import PropTypes from "prop-types"
 import React, { useState } from "react"
 import { Alert, Button, Col, HelpBlock, Modal } from "react-bootstrap"
@@ -316,6 +317,7 @@ const BaseReportShow = ({ currentUser, setSearchQuery, pageDispatchers }) => {
   const reportTypeUpperFirst = _upperFirst(reportType)
   const isAdmin = currentUser && currentUser.isAdmin()
   const isAuthor = Person.isEqual(currentUser, report.author)
+  const tasksLabel = pluralize(Settings.fields.task.subLevel.shortLabel)
 
   // User can approve if report is pending approval and user is one of the approvers in the current approval step
   const canApprove =
@@ -615,7 +617,11 @@ const BaseReportShow = ({ currentUser, setSearchQuery, pageDispatchers }) => {
                 <AttendeesTable attendees={report.attendees} disabled />
               </Fieldset>
               <Fieldset title={Settings.fields.task.subLevel.longLabel}>
-                <TaskTable tasks={report.tasks} showParent />
+                <TaskTable
+                  tasks={report.tasks}
+                  showParent
+                  noTasksMessage={`No ${tasksLabel} selected`}
+                />
               </Fieldset>
               {report.reportText && (
                 <Fieldset title={Settings.fields.report.reportText}>

--- a/client/src/pages/tasks/Form.js
+++ b/client/src/pages/tasks/Form.js
@@ -23,7 +23,8 @@ import { jumpToTop } from "components/Page"
 import PositionTable from "components/PositionTable"
 import OrganizationTable from "components/OrganizationTable"
 import RichTextEditor from "components/RichTextEditor"
-import { FastField, Form, Formik } from "formik"
+import { FastField, Field, Form, Formik } from "formik"
+import _isEmpty from "lodash/isEmpty"
 import { Organization, Person, Position, Task } from "models"
 import PropTypes from "prop-types"
 import React, { useState } from "react"
@@ -67,8 +68,8 @@ const BaseTaskForm = ({ currentUser, edit, title, initialValues }) => {
     }
   ]
 
-  const ShortNameField = DictionaryField(FastField)
-  const LongNameField = DictionaryField(FastField)
+  const ShortNameField = DictionaryField(Field)
+  const LongNameField = DictionaryField(Field)
   const TaskCustomFieldRef1 = DictionaryField(FastField)
   const TaskCustomField = DictionaryField(FastField)
   const PlannedCompletionField = DictionaryField(FastField)
@@ -92,7 +93,7 @@ const BaseTaskForm = ({ currentUser, edit, title, initialValues }) => {
 
   const tasksFilters = {
     allObjectives: {
-      label: "All objectives", // TODO: Implement conditional labels, until then, we need to be explicit here
+      label: `All ${Settings.fields.task.topLevel.longLabel}`,
       queryVars: { hasCustomFieldRef1: false }
     }
   }
@@ -154,6 +155,10 @@ const BaseTaskForm = ({ currentUser, edit, title, initialValues }) => {
       }) => {
         const isAdmin = currentUser && currentUser.isAdmin()
         const disabled = !isAdmin
+        const isTopLevelTask = _isEmpty(values.customFieldRef1)
+        const fieldSettings = isTopLevelTask
+          ? Settings.fields.task.topLevel
+          : Settings.fields.task.subLevel
         const action = (
           <div>
             <Button
@@ -163,7 +168,7 @@ const BaseTaskForm = ({ currentUser, edit, title, initialValues }) => {
               onClick={submitForm}
               disabled={isSubmitting}
             >
-              Save {Settings.fields.task.shortLabel}
+              Save {fieldSettings.shortLabel}
             </Button>
           </div>
         )
@@ -175,14 +180,14 @@ const BaseTaskForm = ({ currentUser, edit, title, initialValues }) => {
               <Fieldset title={title} action={action} />
               <Fieldset>
                 <ShortNameField
-                  dictProps={Settings.fields.task.shortName}
+                  dictProps={fieldSettings.shortName}
                   name="shortName"
                   component={FieldHelper.InputField}
                   disabled={disabled}
                 />
 
                 <LongNameField
-                  dictProps={Settings.fields.task.longName}
+                  dictProps={fieldSettings.longName}
                   name="longName"
                   component={FieldHelper.InputField}
                 />
@@ -395,7 +400,7 @@ const BaseTaskForm = ({ currentUser, edit, title, initialValues }) => {
 
               {Settings.fields.task.customFields && !disabled && (
                 <Fieldset
-                  title={`${Settings.fields.task.shortLabel} information`}
+                  title={`${fieldSettings.shortLabel} information`}
                   id="custom-fields"
                 >
                   <CustomFieldsContainer
@@ -442,7 +447,7 @@ const BaseTaskForm = ({ currentUser, edit, title, initialValues }) => {
                     onClick={submitForm}
                     disabled={isSubmitting}
                   >
-                    Save {Settings.fields.task.shortLabel}
+                    Save {fieldSettings.shortLabel}
                   </Button>
                 </div>
               </div>

--- a/client/src/pages/tasks/Show.js
+++ b/client/src/pages/tasks/Show.js
@@ -128,6 +128,10 @@ const BaseTaskShow = ({ pageDispatchers, currentUser }) => {
     data.task.formCustomFields = JSON.parse(data.task.customFields)
   }
   const task = new Task(data ? data.task : {})
+  const isTopLevelTask = _isEmpty(task.customFieldRef1)
+  const fieldSettings = isTopLevelTask
+    ? Settings.fields.task.topLevel
+    : Settings.fields.task.subLevel
   const ShortNameField = DictionaryField(Field)
   const LongNameField = DictionaryField(Field)
   const TaskCustomFieldRef1 = DictionaryField(Field)
@@ -172,19 +176,19 @@ const BaseTaskShow = ({ pageDispatchers, currentUser }) => {
             <Messages success={stateSuccess} error={stateError} />
             <Form className="form-horizontal" method="post">
               <Fieldset
-                title={`${Settings.fields.task.shortLabel} ${task.shortName}`}
+                title={`${fieldSettings.shortLabel} ${task.shortName}`}
                 action={action}
               />
               <Fieldset>
                 <ShortNameField
-                  dictProps={Settings.fields.task.shortName}
+                  dictProps={fieldSettings.shortName}
                   name="shortName"
                   component={FieldHelper.ReadonlyField}
                 />
 
                 {/* Override componentClass and style from dictProps */}
                 <LongNameField
-                  dictProps={Settings.fields.task.longName}
+                  dictProps={fieldSettings.longName}
                   componentClass="div"
                   style={{}}
                   name="longName"
@@ -292,7 +296,7 @@ const BaseTaskShow = ({ pageDispatchers, currentUser }) => {
               {currentUser.isAdmin() && // TODO: Only show task custom fields to admins until we implement visibility per role
                 Settings.fields.task.customFields && (
                   <Fieldset
-                    title={`${Settings.fields.task.shortLabel} information`}
+                    title={`${fieldSettings.shortLabel} information`}
                     id="custom-fields"
                   >
                     <ReadonlyCustomFields
@@ -311,9 +315,7 @@ const BaseTaskShow = ({ pageDispatchers, currentUser }) => {
 
             <Approvals relatedObject={task} />
 
-            <Fieldset
-              title={`Reports for this ${Settings.fields.task.shortLabel}`}
-            >
+            <Fieldset title={`Reports for this ${fieldSettings.shortLabel}`}>
               <ReportCollection
                 paginationKey={`r_${uuid}`}
                 queryParams={{

--- a/src/main/resources/anet-schema.yml
+++ b/src/main/resources/anet-schema.yml
@@ -302,7 +302,7 @@ properties:
       task:
         type: object
         additionalProperties: false
-        required: [shortLabel, shortName, longLabel, longName, taskedOrganizations, responsiblePositions]
+        required: [shortLabel, shortName, longLabel, longName, topLevel, subLevel, taskedOrganizations, responsiblePositions]
         properties:
           shortLabel:
             type: string
@@ -316,6 +316,21 @@ properties:
             description: Used in the UI where a long label for tasks is shown.
           longName:
             "$ref": "#/definitions/inputField"
+          topLevel:
+           type: object
+           additionalProperties: false
+           required: [shortLabel, shortName, longLabel, longName]
+           properties:
+             shortLabel:
+               "$ref": "#/properties/fields/properties/task/properties/shortLabel"
+             shortName:
+               "$ref": "#/properties/fields/properties/task/properties/shortName"
+             longLabel:
+               "$ref": "#/properties/fields/properties/task/properties/longLabel"
+             longName:
+               "$ref": "#/properties/fields/properties/task/properties/longName"
+          subLevel:
+            "$ref": "#/properties/fields/properties/task/properties/topLevel"
           projectedCompletion: 
             "$ref": "#/definitions/inputField"
           plannedCompletion:

--- a/src/main/resources/emails/approvalNeeded.ftlh
+++ b/src/main/resources/emails/approvalNeeded.ftlh
@@ -126,7 +126,7 @@ Dear ${approvalStepName},
 <div class="row">
   <div class="col-xs-12">
     <#-- <a href="${serverUrl}/tasks/${task.uuid}"> -->
-    <strong>Task:</strong> ${(task.longName)!}
+    <strong>${fields.task.subLevel.shortLabel}:</strong> ${(task.longName)!}
     <#-- </a> -->
   </div>
 </div>

--- a/src/main/resources/emails/emailReport.ftlh
+++ b/src/main/resources/emails/emailReport.ftlh
@@ -435,7 +435,7 @@ ${sender.name} sent you a report from ANET:
     <#assign tasks = report.getTasks()>
     <div>
       <h2 class="legend">
-        <span class="title-text">${fields.task.longLabel}</span>
+        <span class="title-text">${fields.task.subLevel.longLabel}</span>
       </h2>
       <fieldset>
         <table class="table">

--- a/src/main/resources/emails/rollup.ftlh
+++ b/src/main/resources/emails/rollup.ftlh
@@ -161,7 +161,7 @@ a {
         <div class="col-xs-12">
             <#-- <a href="${serverUrl}/tasks/${task.uuid}"> -->
 <!--                <img height="20" alt="Task" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABkAAAAXCAYAAAD+4+QTAAAABmJLR0QA/wDWABipT60nAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAB3RJTUUH4QERBQskHTWEPAAAABl0RVh0Q29tbWVudABDcmVhdGVkIHdpdGggR0lNUFeBDhcAAAGnSURBVEjHzZUxqsJAEIZnAtlgFYM22huJd9AriHYK2uoBFG+QRi+TSgtNoZUi2wUxsRMU21zgf5XyghoTUd5bGLbYnf3499+ZZQCgLw8lbcJ2u01PQYoxnU5RrVYxm83SpCGVEtd1abVakeu631GyXq9RKBRARCgWi9hsNp9X4jgOnc9nYmY6nU7kOM5nlRyPR+i6DiK6RTabxeVySaSEHz3h5XJJvu/TbrejIAhov9+T7/vEzATgNpumSeVymUqlElmWRaZpUq1Wi1di2zY0TUMmk4GmaRBCQFVVMHNEBRGBmcHMUFUVQohInm3bESV319Xr9aAoysOD44KZoSgK+v3+3XU99KTT6UAIkRjEzBBCoNvtPvTkqfGtVisR6Apot9tPjY99XfV6PRGk0Wi8XyfNZjNRGbzaFwuRUhIzv4RIKd+HeJ73EsLM5Hne+5DD4UC/a7VSqdBoNCLLsiL7giB4v61cW4lhGJhMJpG18XgMwzBARNB1Pdb4p5D5fI5cLofhcBh7wGAwQD6fx2KxSA+RUiIMw0QNMAxDSCnTNcg//+P/LeQHMm6FWr8JMB8AAAAASUVORK5CYII=" /> -->
-                <strong>${fields.task.shortLabel}:</strong> ${(task.shortName)!} ${(task.longName)!}
+                <strong>${fields.task.subLevel.shortLabel}:</strong> ${(task.shortName)!} ${(task.longName)!}
             <#-- </a> -->
         </div>
     </div>


### PR DESCRIPTION
Reports only use sub-level tasks (called 'Efforts').
Sub-level tasks have a top-level task as their parent (called 'Objectives').
Organizations can have both types of tasks, as can search etc.

On reports pages, show a more specific message when no tasks have been selected.

Closes NCI-Agency/anet#2817, NCI-Agency/anet#2915

### System admin changes
- Add something like this to `anet.yml`:
```
dictionary:
  fields:
    task:
      shortLabel: Objective / Effort
      shortName:
        label: Objective / Effort number
        placeholder: Enter an objective / effort name, example....
      longLabel: Objectives and Efforts
      longName:
        label: Objective / Effort description
        placeholder: Enter an objective / effort description, example ....
        componentClass: textarea
        style:
          height: 400px
      topLevel:
         shortLabel: Objective
         shortName:
           label: Objective name
           placeholder: Enter an objective name, example....
         longLabel: Objectives
         longName:
           label: Objective description
           placeholder: Enter an objective description, example ....
           componentClass: textarea
           style:
             height: 400px
      subLevel:
         shortLabel: Effort
         shortName:
           label: Effort name
           placeholder: Enter an effort name, example....
         longLabel: Efforts
         longName:
           label: Effort description
           placeholder: Enter an effort description, example ....
           componentClass: textarea
           style:
             height: 400px
```

- [x] anet.yml needs change
