### PR TITLE
Store the avatar as binary data in the database

### DIFF
--- a/client/src/components/AvatarDisplayComponent.js
+++ b/client/src/components/AvatarDisplayComponent.js
@@ -2,9 +2,11 @@ import React from "react"
 import DEFAULT_AVATAR from "resources/default_avatar.svg"
 import PropTypes from "prop-types"
 
+export const AVATAR_IMAGE_DATA_PREFIX = "data:image/png;base64,"
+
 const AvatarDisplayComponent = ({ avatar, height, width, style }) => (
   <img
-    src={avatar ? `data:image/jpeg;base64,${avatar}` : DEFAULT_AVATAR}
+    src={avatar ? `${AVATAR_IMAGE_DATA_PREFIX}${avatar}` : DEFAULT_AVATAR}
     height={height}
     width={width}
     alt="Avatar"

--- a/client/src/components/AvatarEditModal.js
+++ b/client/src/components/AvatarEditModal.js
@@ -1,4 +1,5 @@
 import AvatarComponent from "components/AvatarComponent"
+import { AVATAR_IMAGE_DATA_PREFIX } from "components/AvatarDisplayComponent"
 import PropTypes from "prop-types"
 import React, { useState } from "react"
 import { Button, Modal } from "react-bootstrap"
@@ -36,7 +37,7 @@ const AvatarEditModal = ({ title, onAvatarUpdate }) => {
 
   function save() {
     const updatedAvatar = currentPreview.substring(
-      "data:image/jpeg;base64,".length - 1
+      AVATAR_IMAGE_DATA_PREFIX.length - 1
     )
     onAvatarUpdate(updatedAvatar)
     close()

--- a/client/src/components/graphs/OrganizationalChart.js
+++ b/client/src/components/graphs/OrganizationalChart.js
@@ -1,5 +1,6 @@
 import API, { Settings } from "api"
 import { gql } from "apollo-boost"
+import { AVATAR_IMAGE_DATA_PREFIX } from "components/AvatarDisplayComponent"
 import SVGCanvas from "components/graphs/SVGCanvas"
 import {
   PageDispatchersPropType,
@@ -314,7 +315,7 @@ const OrganizationalChart = ({
         d =>
           d.person &&
           (d.person.avatar
-            ? "data:image/jpeg;base64," + d.person.avatar
+            ? `${AVATAR_IMAGE_DATA_PREFIX}${d.person.avatar}`
             : DEFAULT_AVATAR)
       )
 
@@ -371,7 +372,7 @@ const OrganizationalChart = ({
         d =>
           d.person &&
           (d.person.avatar
-            ? "data:image/jpeg;base64," + d.person.avatar
+            ? `${AVATAR_IMAGE_DATA_PREFIX}${d.person.avatar}`
             : DEFAULT_AVATAR)
       )
 

--- a/src/main/java/mil/dds/anet/beans/Person.java
+++ b/src/main/java/mil/dds/anet/beans/Person.java
@@ -6,6 +6,7 @@ import io.leangen.graphql.annotations.GraphQLQuery;
 import io.leangen.graphql.annotations.GraphQLRootContext;
 import java.security.Principal;
 import java.time.Instant;
+import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -68,7 +69,7 @@ public class Person extends AbstractCustomizableAnetBean implements Principal {
   // annotated below
   private List<PersonPositionHistory> previousPositions;
   // annotated below
-  private String avatar;
+  private byte[] avatar;
   @GraphQLQuery
   @GraphQLInputField
   private String code;
@@ -248,19 +249,23 @@ public class Person extends AbstractCustomizableAnetBean implements Principal {
   @GraphQLQuery(name = "avatar")
   public String getAvatar(@GraphQLArgument(name = "size", defaultValue = "256") int size) {
     try {
-      return Utils.resizeImageBase64(this.avatar, size, size, "png");
+      return Base64.getEncoder().encodeToString(Utils.resizeImage(avatar, size, size, "png"));
     } catch (Exception e) {
       return null;
     }
   }
 
-  public String getAvatar() {
-    return this.avatar;
+  public byte[] getAvatar() {
+    return avatar;
+  }
+
+  public void setAvatar(byte[] avatar) {
+    this.avatar = avatar;
   }
 
   @GraphQLInputField(name = "avatar")
   public void setAvatar(String avatar) {
-    this.avatar = avatar;
+    this.avatar = avatar == null ? null : Base64.getDecoder().decode(avatar);
   }
 
   public String getCode() {

--- a/src/main/java/mil/dds/anet/database/PersonDao.java
+++ b/src/main/java/mil/dds/anet/database/PersonDao.java
@@ -1,15 +1,11 @@
 package mil.dds.anet.database;
 
 import com.google.common.collect.ObjectArrays;
-import java.lang.invoke.MethodHandles;
-import java.sql.Blob;
-import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import javax.sql.rowset.serial.SerialBlob;
 import mil.dds.anet.AnetObjectEngine;
 import mil.dds.anet.beans.Person;
 import mil.dds.anet.beans.Person.PersonStatus;
@@ -23,8 +19,6 @@ import mil.dds.anet.utils.DaoUtils;
 import mil.dds.anet.utils.FkDataLoaderKey;
 import mil.dds.anet.utils.Utils;
 import mil.dds.anet.views.ForeignKeyFetcher;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import ru.vyarus.guicey.jdbi3.tx.InTransaction;
 
 public class PersonDao extends AnetBaseDao<Person, PersonSearchQuery> {
@@ -40,9 +34,6 @@ public class PersonDao extends AnetBaseDao<Person, PersonSearchQuery> {
   public static String PERSON_FIELDS = DaoUtils.buildFieldAliases(TABLE_NAME, allFields, true);
   public static String PERSON_FIELDS_NOAS =
       DaoUtils.buildFieldAliases(TABLE_NAME, allFields, false);
-
-  private static final Logger logger =
-      LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
   @Override
   public Person getByUuid(String uuid) {
@@ -101,8 +92,7 @@ public class PersonDao extends AnetBaseDao<Person, PersonSearchQuery> {
         .bind("updatedAt", DaoUtils.asLocalDateTime(p.getUpdatedAt()))
         .bind("endOfTourDate", DaoUtils.asLocalDateTime(p.getEndOfTourDate()))
         .bind("status", DaoUtils.getEnumId(p.getStatus()))
-        .bind("role", DaoUtils.getEnumId(p.getRole()))
-        .bind("avatar", convertImageToBlob(p.getAvatar())).execute();
+        .bind("role", DaoUtils.getEnumId(p.getRole())).execute();
     return p;
   }
 
@@ -128,8 +118,7 @@ public class PersonDao extends AnetBaseDao<Person, PersonSearchQuery> {
         .bind("updatedAt", DaoUtils.asLocalDateTime(p.getUpdatedAt()))
         .bind("endOfTourDate", DaoUtils.asLocalDateTime(p.getEndOfTourDate()))
         .bind("status", DaoUtils.getEnumId(p.getStatus()))
-        .bind("role", DaoUtils.getEnumId(p.getRole()))
-        .bind("avatar", convertImageToBlob(p.getAvatar())).execute();
+        .bind("role", DaoUtils.getEnumId(p.getRole())).execute();
   }
 
   @Override
@@ -247,12 +236,4 @@ public class PersonDao extends AnetBaseDao<Person, PersonSearchQuery> {
     }
   }
 
-  private static Blob convertImageToBlob(String image) {
-    try {
-      return image == null ? null : new SerialBlob(image.getBytes());
-    } catch (SQLException e) {
-      logger.error("Failed to save avatar", e);
-      return null;
-    }
-  }
 }

--- a/src/main/java/mil/dds/anet/database/mappers/MapperUtils.java
+++ b/src/main/java/mil/dds/anet/database/mappers/MapperUtils.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import java.lang.invoke.MethodHandles;
-import java.sql.Blob;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
@@ -86,12 +85,12 @@ public class MapperUtils {
     return rs.getBoolean(columnName);
   }
 
-  public static Blob getOptionalBlob(final ResultSet rs, final String columnName)
+  public static byte[] getOptionalBytes(final ResultSet rs, final String columnName)
       throws SQLException {
     if (!containsColumnNamed(rs, columnName)) {
       return null;
     }
-    return rs.getBlob(columnName);
+    return rs.getBytes(columnName);
   }
 
   public static <T extends Enum<T>> T getEnumIdx(ResultSet rs, String columnName, Class<T> clazz)

--- a/src/main/java/mil/dds/anet/database/mappers/PersonMapper.java
+++ b/src/main/java/mil/dds/anet/database/mappers/PersonMapper.java
@@ -1,6 +1,5 @@
 package mil.dds.anet.database.mappers;
 
-import java.sql.Blob;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import mil.dds.anet.beans.Person;
@@ -45,10 +44,7 @@ public class PersonMapper implements RowMapper<Person> {
     a.setBiography(MapperUtils.getOptionalString(rs, "people_biography"));
     a.setDomainUsername(MapperUtils.getOptionalString(rs, "people_domainUsername"));
     a.setPendingVerification(MapperUtils.getOptionalBoolean(rs, "people_pendingVerification"));
-    final Blob avatarBlob = MapperUtils.getOptionalBlob(rs, "people_avatar");
-    final String avatar =
-        avatarBlob == null ? null : new String(avatarBlob.getBytes(1L, (int) avatarBlob.length()));
-    a.setAvatar(avatar);
+    a.setAvatar(MapperUtils.getOptionalBytes(rs, "people_avatar"));
 
     return a;
   }

--- a/src/main/java/mil/dds/anet/utils/Utils.java
+++ b/src/main/java/mil/dds/anet/utils/Utils.java
@@ -7,7 +7,6 @@ import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Base64;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -415,18 +414,20 @@ public class Utils {
   /**
    * Resizes an image.
    * 
-   * @param imageBase64 The image as a Base64 string
+   * @param imageBytes The image as a byte-array
    * @param width The desired output width
    * @param height The desired output height
    * @param imageFormatName The desired output format (png, jpg)
-   * @return The resized image as a Base64 string
+   * @return The resized image as a byte-array
    * @throws Exception When the binary data cannot be converted to an image string representation
    */
-  public static String resizeImageBase64(String imageBase64, int width, int height,
-      String imageFormatName) throws Exception {
-
-    // From Base64-string to BufferedImage
-    final BufferedImage imageBinary = convert(imageBase64);
+  public static byte[] resizeImage(byte[] imageBytes, int width, int height, String imageFormatName)
+      throws Exception {
+    if (imageBytes == null) {
+      return null;
+    }
+    // From byte-array to BufferedImage
+    final BufferedImage imageBinary = convert(imageBytes);
 
     if (imageBinary == null) {
       throw new Exception("Cannot interpret image binary data.");
@@ -436,36 +437,35 @@ public class Utils {
     final BufferedImage thumbnail =
         Scalr.resize(imageBinary, Method.AUTOMATIC, Mode.AUTOMATIC, width, height);
 
-    // From BufferedImage back to Base64-string
+    // From BufferedImage back to byte-array
     return convert(thumbnail, imageFormatName);
   }
 
   /**
-   * Converts an image represented as a Base64 string into a BufferedImage.
+   * Converts an image represented as a byte-array into a BufferedImage.
    * 
-   * @param imageBase64 The image as a Base64 string
+   * @param imageBytes The image as a byte-array
    * @return The BufferedImage object
    * @throws IOException When an error occurs while reading the string
    */
-  public static BufferedImage convert(String imageBase64) throws IOException {
-    final byte[] imageBytes = Base64.getDecoder().decode(imageBase64);
+  public static BufferedImage convert(byte[] imageBytes) throws IOException {
     final ByteArrayInputStream is = new ByteArrayInputStream(imageBytes);
     return ImageIO.read(is);
   }
 
   /**
-   * Converts a BufferedImage representing an image into a Base64 string.
+   * Converts a BufferedImage representing an image into a byte-array.
    * 
    * @param imageBytes The image as bytes
    * @param imageFormatName The desired output format
-   * @return The image as Base64 string
+   * @return The image as byte-array
    * @throws IOException When an error occurs while writing the string
    */
-  public static String convert(BufferedImage imageBytes, String imageFormatName)
+  public static byte[] convert(BufferedImage imageBytes, String imageFormatName)
       throws IOException {
     final ByteArrayOutputStream os = new ByteArrayOutputStream();
     ImageIO.write(imageBytes, imageFormatName, os);
-    return Base64.getEncoder().encodeToString(os.toByteArray());
+    return os.toByteArray();
   }
 
   public static void updateApprovalSteps(AbstractAnetBean entity,

--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -30,6 +30,10 @@
 	<property name="fts_high" value="'A'" dbms="postgresql" />
 	<property name="fts_low" value="'B'" dbms="postgresql" />
 
+	<!-- For storing the avatar -->
+	<property name="blob_type" value="blob" dbms="mssql" />
+	<property name="blob_type" value="bytea" dbms="postgresql" />
+
 	<changeSet id="1" author="hpitelka">
 		<createTable tableName="people">
 			<column name="id" type="int" autoIncrement="true">
@@ -3100,6 +3104,42 @@
 			tableName="approvalSteps" indexName="IDX_approvalSteps_relatedObjectUuid">
 			<column name="relatedObjectUuid" />
 		</createIndex>
+	</changeSet>
+
+	<changeSet id="change-avatar-type" author="gjvoosten">
+		<!-- This temporarily needs about twice the storage space for all avatars -->
+		<addColumn tableName="people">
+			<column name="b64_avatar" type="${long_text_type}" />
+		</addColumn>
+		<sql dbms="postgresql">
+			UPDATE people SET b64_avatar = encode(lo_get(avatar), 'escape') WHERE avatar IS NOT NULL;
+			SELECT lo_unlink(oid) FROM pg_largeobject_metadata;
+		</sql>
+		<sql dbms="mssql">
+			UPDATE people SET b64_avatar = cast(avatar as varchar(max)) WHERE avatar IS NOT NULL;
+		</sql>
+		<dropColumn tableName="people" columnName="avatar" />
+		<addColumn tableName="people">
+			<column name="new_avatar" type="${blob_type}" />
+		</addColumn>
+		<sql dbms="postgresql">
+			UPDATE people SET new_avatar = decode(b64_avatar, 'base64') WHERE b64_avatar IS NOT NULL;
+		</sql>
+		<sql dbms="mssql">
+			UPDATE people SET new_avatar = cast(N'' AS xml).value('xs:base64Binary(sql:column("people.b64_avatar"))', 'varbinary(max)') WHERE b64_avatar IS NOT NULL;
+		</sql>
+		<dropColumn tableName="people" columnName="b64_avatar" />
+		<renameColumn
+			columnDataType="${blob_type}"
+			oldColumnName="new_avatar"
+			newColumnName="avatar"
+			tableName="people" />
+	</changeSet>
+
+	<changeSet id="clean-postgresql-large-objects" author="gjvoosten" dbms="postgresql" runInTransaction="false">
+		<sql>
+			VACUUM FULL ANALYZE pg_largeobject;
+		</sql>
 	</changeSet>
 
 </databaseChangeLog>

--- a/src/test/java/mil/dds/anet/test/beans/PersonTest.java
+++ b/src/test/java/mil/dds/anet/test/beans/PersonTest.java
@@ -67,7 +67,7 @@ public class PersonTest extends BeanTester<Person> {
   @Test
   public void testAvatarResizingNoAvatar() {
     Person person = new Person();
-    person.setAvatar(null);
+    person.setAvatar((String) null);
     assertThat(person.getAvatar(32)).isNull();
   }
 
@@ -92,7 +92,7 @@ public class PersonTest extends BeanTester<Person> {
     String resizedAvatar = person.getAvatar(32);
 
     assertThat(resizedAvatar).isNotNull();
-    imageBinary = Utils.convert(resizedAvatar);
+    imageBinary = Utils.convert(Base64.getDecoder().decode(resizedAvatar));
 
     assertThat(imageBinary.getWidth()).isEqualTo(32);
     assertThat(imageBinary.getHeight()).isEqualTo(32);


### PR DESCRIPTION
Previously, it was stored as base64-encoded data in a binary field.
It was also using Liquibase's default blob type for PostgreSQL (oid), which is cumbersome to use (and would make it harder to migrate from MS SQL Server to PostgreSQL).

Note: the database migration temporarily needs about twice the storage space for all avatars.
