### PR TITLE
Refactor GraphQL for organizations

### DIFF
--- a/client/src/pages/App.js
+++ b/client/src/pages/App.js
@@ -85,7 +85,14 @@ const GQL_GET_APP_DATA = gql`
       value
     }
 
-    organizationTopLevelOrgs(type: ADVISOR_ORG) {
+    organizationTopLevelOrgs: organizationList(
+      query: {
+        pageSize: 0
+        hasParentOrg: false
+        status: ACTIVE
+        type: ADVISOR_ORG
+      }
+    ) {
       list {
         uuid
         shortName

--- a/client/src/pages/positions/Form.js
+++ b/client/src/pages/positions/Form.js
@@ -135,8 +135,9 @@ const BasePositionForm = ({ currentUser, edit, title, initialValues }) => {
             currentUser.position &&
             currentUser.position.type === Position.TYPE.SUPER_USER
           ) {
-            orgSearchQuery.parentOrgUuid =
+            orgSearchQuery.parentOrgUuid = [
               currentUser.position.organization.uuid
+            ]
             orgSearchQuery.parentOrgRecursively = true
           }
         }

--- a/src/main/java/mil/dds/anet/AnetObjectEngine.java
+++ b/src/main/java/mil/dds/anet/AnetObjectEngine.java
@@ -255,7 +255,7 @@ public class AnetObjectEngine {
    */
   public Map<String, Organization> buildTopLevelOrgHash(String parentOrgUuid) {
     final OrganizationSearchQuery query = new OrganizationSearchQuery();
-    query.setParentOrgUuid(parentOrgUuid);
+    query.setParentOrgUuid(Collections.singletonList(parentOrgUuid));
     query.setParentOrgRecursively(true);
     query.setPageSize(0);
     final List<Organization> orgList =

--- a/src/main/java/mil/dds/anet/beans/search/OrganizationSearchQuery.java
+++ b/src/main/java/mil/dds/anet/beans/search/OrganizationSearchQuery.java
@@ -2,6 +2,7 @@ package mil.dds.anet.beans.search;
 
 import io.leangen.graphql.annotations.GraphQLInputField;
 import io.leangen.graphql.annotations.GraphQLQuery;
+import java.util.List;
 import java.util.Objects;
 import mil.dds.anet.beans.Organization.OrganizationStatus;
 import mil.dds.anet.beans.Organization.OrganizationType;
@@ -18,10 +19,10 @@ public class OrganizationSearchQuery extends AbstractSearchQuery<OrganizationSea
   @GraphQLQuery
   @GraphQLInputField
   private Boolean hasParentOrg;
-  // Search for organizations with a specific parent Org.
+  // Search for organizations with a specific parent Org(s).
   @GraphQLQuery
   @GraphQLInputField
-  private String parentOrgUuid;
+  private List<String> parentOrgUuid;
   // Include descendants recursively from the specified parent.
   // If true will include all orgs in the tree of the parentOrg
   // Including the parent Org.
@@ -57,11 +58,11 @@ public class OrganizationSearchQuery extends AbstractSearchQuery<OrganizationSea
     this.hasParentOrg = hasParentOrg;
   }
 
-  public String getParentOrgUuid() {
+  public List<String> getParentOrgUuid() {
     return parentOrgUuid;
   }
 
-  public void setParentOrgUuid(String parentOrgUuid) {
+  public void setParentOrgUuid(List<String> parentOrgUuid) {
     this.parentOrgUuid = parentOrgUuid;
   }
 

--- a/src/main/java/mil/dds/anet/beans/search/OrganizationSearchQuery.java
+++ b/src/main/java/mil/dds/anet/beans/search/OrganizationSearchQuery.java
@@ -14,7 +14,10 @@ public class OrganizationSearchQuery extends AbstractSearchQuery<OrganizationSea
   @GraphQLQuery
   @GraphQLInputField
   private OrganizationType type;
-
+  // Find organizations who (don't) have the parentOrg filled in
+  @GraphQLQuery
+  @GraphQLInputField
+  private Boolean hasParentOrg;
   // Search for organizations with a specific parent Org.
   @GraphQLQuery
   @GraphQLInputField
@@ -46,6 +49,14 @@ public class OrganizationSearchQuery extends AbstractSearchQuery<OrganizationSea
     this.type = type;
   }
 
+  public Boolean getHasParentOrg() {
+    return hasParentOrg;
+  }
+
+  public void setHasParentOrg(Boolean hasParentOrg) {
+    this.hasParentOrg = hasParentOrg;
+  }
+
   public String getParentOrgUuid() {
     return parentOrgUuid;
   }
@@ -64,7 +75,8 @@ public class OrganizationSearchQuery extends AbstractSearchQuery<OrganizationSea
 
   @Override
   public int hashCode() {
-    return Objects.hash(super.hashCode(), status, type, parentOrgUuid, parentOrgRecursively);
+    return Objects.hash(super.hashCode(), status, type, hasParentOrg, parentOrgUuid,
+        parentOrgRecursively);
   }
 
   @Override
@@ -75,6 +87,7 @@ public class OrganizationSearchQuery extends AbstractSearchQuery<OrganizationSea
     final OrganizationSearchQuery other = (OrganizationSearchQuery) obj;
     return super.equals(obj) && Objects.equals(getStatus(), other.getStatus())
         && Objects.equals(getType(), other.getType())
+        && Objects.equals(getHasParentOrg(), other.getHasParentOrg())
         && Objects.equals(getParentOrgUuid(), other.getParentOrgUuid())
         && Objects.equals(getParentOrgRecursively(), other.getParentOrgRecursively());
   }

--- a/src/main/java/mil/dds/anet/beans/search/TaskSearchQuery.java
+++ b/src/main/java/mil/dds/anet/beans/search/TaskSearchQuery.java
@@ -39,12 +39,10 @@ public class TaskSearchQuery extends AbstractSearchQuery<TaskSearchSortBy> {
   @GraphQLQuery
   @GraphQLInputField
   private String customField;
-
   // Find tasks who (don't) have the customFieldRef1 filled in
   @GraphQLQuery
   @GraphQLInputField
-  Boolean hasCustomFieldRef1;
-
+  private Boolean hasCustomFieldRef1;
   // Search for tasks with one of the given parent Task(s)
   @GraphQLQuery
   @GraphQLInputField

--- a/src/main/java/mil/dds/anet/database/OrganizationDao.java
+++ b/src/main/java/mil/dds/anet/database/OrganizationDao.java
@@ -7,8 +7,6 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import mil.dds.anet.AnetObjectEngine;
 import mil.dds.anet.beans.Organization;
-import mil.dds.anet.beans.Organization.OrganizationStatus;
-import mil.dds.anet.beans.Organization.OrganizationType;
 import mil.dds.anet.beans.lists.AnetBeanList;
 import mil.dds.anet.beans.search.OrganizationSearchQuery;
 import mil.dds.anet.database.mappers.OrganizationMapper;
@@ -93,15 +91,6 @@ public class OrganizationDao extends AnetBaseDao<Organization, OrganizationSearc
       Map<String, Object> context, String personUuid) {
     return new ForeignKeyFetcher<Organization>().load(context, FkDataLoaderKey.PERSON_ORGANIZATIONS,
         personUuid);
-  }
-
-  @InTransaction
-  public List<Organization> getTopLevelOrgs(OrganizationType type) {
-    return getDbHandle()
-        .createQuery("/* getTopLevelOrgs */ SELECT " + ORGANIZATION_FIELDS + " FROM organizations "
-            + "WHERE \"parentOrgUuid\" IS NULL AND status = :status AND type = :type")
-        .bind("status", DaoUtils.getEnumId(OrganizationStatus.ACTIVE))
-        .bind("type", DaoUtils.getEnumId(type)).map(new OrganizationMapper()).list();
   }
 
   public interface OrgListQueries {

--- a/src/main/java/mil/dds/anet/database/ReportDao.java
+++ b/src/main/java/mil/dds/anet/database/ReportDao.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ObjectArrays;
 import io.leangen.graphql.annotations.GraphQLRootContext;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedList;
@@ -445,7 +446,7 @@ public class ReportDao extends AnetBaseDao<Report, ReportSearchQuery> {
       // doing this as two separate queries because I do need all the information about the
       // organizations
       OrganizationSearchQuery query = new OrganizationSearchQuery();
-      query.setParentOrgUuid(parentOrgUuid);
+      query.setParentOrgUuid(Collections.singletonList(parentOrgUuid));
       query.setParentOrgRecursively(true);
       query.setPageSize(0);
       orgList = AnetObjectEngine.getInstance().getOrganizationDao().search(query).getList();

--- a/src/main/java/mil/dds/anet/resources/OrganizationResource.java
+++ b/src/main/java/mil/dds/anet/resources/OrganizationResource.java
@@ -12,7 +12,6 @@ import javax.ws.rs.core.Response.Status;
 import mil.dds.anet.AnetObjectEngine;
 import mil.dds.anet.beans.ApprovalStep;
 import mil.dds.anet.beans.Organization;
-import mil.dds.anet.beans.Organization.OrganizationType;
 import mil.dds.anet.beans.Person;
 import mil.dds.anet.beans.Task;
 import mil.dds.anet.beans.lists.AnetBeanList;
@@ -38,12 +37,6 @@ public class OrganizationResource {
   public OrganizationResource(AnetObjectEngine engine) {
     this.dao = engine.getOrganizationDao();
     this.engine = engine;
-  }
-
-  @GraphQLQuery(name = "organizationTopLevelOrgs")
-  public AnetBeanList<Organization> getTopLevelOrgs(
-      @GraphQLArgument(name = "type") OrganizationType type) {
-    return new AnetBeanList<Organization>(dao.getTopLevelOrgs(type));
   }
 
   @GraphQLQuery(name = "organization")

--- a/src/main/java/mil/dds/anet/search/AbstractOrganizationSearcher.java
+++ b/src/main/java/mil/dds/anet/search/AbstractOrganizationSearcher.java
@@ -69,7 +69,7 @@ public abstract class AbstractOrganizationSearcher extends
       qb.addRecursiveClause(null, "organizations", "\"uuid\"", "parent_orgs", "organizations",
           "\"parentOrgUuid\"", "parentOrgUuid", query.getParentOrgUuid(), true);
     } else {
-      qb.addEqualsClause("parentOrgUuid", "organizations.\"parentOrgUuid\"",
+      qb.addInListClause("parentOrgUuid", "organizations.\"parentOrgUuid\"",
           query.getParentOrgUuid());
     }
   }

--- a/src/main/java/mil/dds/anet/search/AbstractOrganizationSearcher.java
+++ b/src/main/java/mil/dds/anet/search/AbstractOrganizationSearcher.java
@@ -41,6 +41,14 @@ public abstract class AbstractOrganizationSearcher extends
     qb.addEqualsClause("status", "organizations.status", query.getStatus());
     qb.addEqualsClause("type", "organizations.type", query.getType());
 
+    if (query.getHasParentOrg() != null) {
+      if (query.getHasParentOrg()) {
+        qb.addWhereClause("organizations.\"parentOrgUuid\" IS NOT NULL");
+      } else {
+        qb.addWhereClause("organizations.\"parentOrgUuid\" IS NULL");
+      }
+    }
+
     if (query.getParentOrgUuid() != null) {
       addParentOrgUuidQuery(query);
     }

--- a/src/test/java/mil/dds/anet/test/resources/OrganizationResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/OrganizationResourceTest.java
@@ -96,7 +96,7 @@ public class OrganizationResourceTest extends AbstractResourceTest {
     assertThat(child.getUuid()).isNotNull();
 
     OrganizationSearchQuery query = new OrganizationSearchQuery();
-    query.setParentOrgUuid(created.getUuid());
+    query.setParentOrgUuid(ImmutableList.of(created.getUuid()));
     final AnetBeanList<Organization> children = graphQLHelper.searchObjects(admin,
         "organizationList", "query", "OrganizationSearchQueryInput", FIELDS, query,
         new TypeReference<GraphQlResponse<AnetBeanList<Organization>>>() {});

--- a/src/test/resources/graphQLTests/appQuery.gql
+++ b/src/test/resources/graphQLTests/appQuery.gql
@@ -6,6 +6,7 @@ me {
   emailAddress
   status
   avatar(size: 32)
+  code
   position {
     uuid
     name
@@ -60,7 +61,14 @@ adminSettings {
   value
 }
 
-organizationTopLevelOrgs(type: ADVISOR_ORG) {
+organizationTopLevelOrgs: organizationList(
+  query: {
+    pageSize: 0
+    hasParentOrg: false
+    status: ACTIVE
+    type: ADVISOR_ORG
+  }
+) {
   list {
     uuid
     shortName


### PR DESCRIPTION
Change custom GraphQL query 'organizationTopLevelOrgs' to generic search.
Let organization search for parentOrgUuid take a list.

Part of NCI-Agency/anet#1705