### PR TITLE
Update person customFields

### DIFF
--- a/anet.yml
+++ b/anet.yml
@@ -466,9 +466,6 @@ dictionary:
           label: Text field
           placeholder: Placeholder text for input field
           helpText: Help text for text field
-          validations:
-            - type: required
-              params: [You must provide the text field]
         colourOptions:
           type: enum
           label: Choose one of the colours

--- a/client/tests/e2e/permissions.js
+++ b/client/tests/e2e/permissions.js
@@ -266,10 +266,6 @@ async function validateUserCanEditUserForCurrentPage(t) {
 
   const fakeBioText = ` fake bio ${uuidv4()}`
   await $bioTextArea.sendKeys(t.context.Key.END + fakeBioText)
-  await t.context.pageHelpers.writeInForm(
-    "[id='formCustomFields.inputFieldName']",
-    "custom field text"
-  )
   // wait for component to update (internal) state
   await t.context.driver.sleep(shortWaitMs)
 

--- a/client/tests/webdriver/pages/createNewPerson.page.js
+++ b/client/tests/webdriver/pages/createNewPerson.page.js
@@ -55,10 +55,6 @@ class CreatePerson extends Page {
     return browser.$(".biography .public-DraftEditor-content")
   }
 
-  get customFieldsTextField() {
-    return browser.$('input[name="formCustomFields.inputFieldName"]')
-  }
-
   get submitButton() {
     return browser.$("#formBottomSubmit")
   }

--- a/client/tests/webdriver/specs/createNewPerson.spec.js
+++ b/client/tests/webdriver/specs/createNewPerson.spec.js
@@ -17,9 +17,6 @@ describe("Create new Person form page", () => {
       CreatePerson.openAsSuperUser()
       CreatePerson.form.waitForExist()
       CreatePerson.form.waitForDisplayed()
-      // Fill required custom field of type text
-      CreatePerson.customFieldsTextField.waitForDisplayed()
-      CreatePerson.customFieldsTextField.setValue("test")
       CreatePerson.lastName.waitForDisplayed()
       CreatePerson.lastName.setValue(VALID_PERSON_PRINCIPAL.lastName)
       CreatePerson.gender.click()
@@ -46,9 +43,6 @@ describe("Create new Person form page", () => {
       CreatePerson.openAsSuperUser()
       CreatePerson.form.waitForExist()
       CreatePerson.form.waitForDisplayed()
-      // Fill required custom field of type text
-      CreatePerson.customFieldsTextField.waitForDisplayed()
-      CreatePerson.customFieldsTextField.setValue("test")
       CreatePerson.lastName.waitForDisplayed()
       CreatePerson.lastName.setValue(VALID_PERSON_PRINCIPAL.lastName)
       CreatePerson.rank.selectByAttribute(
@@ -68,9 +62,6 @@ describe("Create new Person form page", () => {
       CreatePerson.openAsSuperUser()
       CreatePerson.form.waitForExist()
       CreatePerson.form.waitForDisplayed()
-      // Fill required custom field of type text
-      CreatePerson.customFieldsTextField.waitForDisplayed()
-      CreatePerson.customFieldsTextField.setValue("test")
       CreatePerson.lastName.waitForDisplayed()
       CreatePerson.lastName.setValue(VALID_PERSON_PRINCIPAL.lastName)
       CreatePerson.rank.selectByAttribute(
@@ -107,9 +98,6 @@ describe("Create new Person form page", () => {
       CreatePerson.openAsAdmin()
       CreatePerson.form.waitForExist()
       CreatePerson.form.waitForDisplayed()
-      // Fill required custom field of type text
-      CreatePerson.customFieldsTextField.waitForDisplayed()
-      CreatePerson.customFieldsTextField.setValue("test")
       CreatePerson.roleAdvisorButton.waitForExist()
       CreatePerson.roleAdvisorButton.click()
       const warningMessage = browser.$(".alert.alert-warning")
@@ -121,8 +109,6 @@ describe("Create new Person form page", () => {
     })
     it("Should not save if endOfTourDate is not filled in", () => {
       // Continue on the same page to prevent "Are you sure you wish to navigate away from the page" warning
-      CreatePerson.customFieldsTextField.waitForDisplayed()
-      CreatePerson.customFieldsTextField.setValue("test")
       CreatePerson.lastName.setValue(VALID_PERSON_ADVISOR.lastName)
       CreatePerson.firstName.setValue(VALID_PERSON_ADVISOR.firstName)
       CreatePerson.roleAdvisorButton.waitForExist()
@@ -161,8 +147,6 @@ describe("Create new Person form page", () => {
 
     it("Should save with a valid email address in uppercase", () => {
       // Continue on the same page to prevent "Are you sure you wish to navigate away from the page" warning
-      CreatePerson.customFieldsTextField.waitForDisplayed()
-      CreatePerson.customFieldsTextField.setValue("test")
       CreatePerson.lastName.setValue(VALID_PERSON_ADVISOR.lastName)
       CreatePerson.firstName.setValue(VALID_PERSON_ADVISOR.firstName)
       CreatePerson.roleAdvisorButton.waitForExist()


### PR DESCRIPTION
This makes sure the inputTextField customField of a person is no longer required because it was annoying the development work when testing. Note that the current custom fields in development are just there as example and for testing.