### PR TITLE
Fix error when loading the LikertScale

### DIFF
--- a/client/src/components/graphs/LikertScale.js
+++ b/client/src/components/graphs/LikertScale.js
@@ -72,8 +72,8 @@ const LikertScale = ({ onChange, value, levels, width, height, readonly }) => {
               style={{ fill: fillColor, stroke: "gray", strokeWidth: 1 }}
               y={0}
               x={startX}
-              height={containerHeight - 11}
-              width={endX - startX}
+              height={Math.max(0, containerHeight - 11)}
+              width={Math.max(0, endX - startX)}
             />
             <Text
               fill={active ? "black" : "gray"}


### PR DESCRIPTION
On the report form we were getting the following error (coming from the LikertScale):
Error: <rect> attribute height: A negative value is not valid. ("-11").

This has been fixed now.