### PR TITLE
Update dev setup documentation

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -528,8 +528,8 @@ assets:
   overrides:
     /imagery: imagery
 ```
-1. Copy your imagery set into the `imagery` directory.  You should end up with a file structure that looks like `imagery/street/{0,1,2,...}/{0,1,2...}/{0,1,2,3...}.png`
-1. To use this new tile source, add under `baseLayers`:
+2. Copy your imagery set into the `imagery` directory.  You should end up with a file structure that looks like `imagery/street/{0,1,2,...}/{0,1,2...}/{0,1,2,3...}.png`
+3. To use this new tile source, add under `baseLayers`:
 ```yaml
       - name: OSM
         default: true

--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -5,7 +5,6 @@ This section describes the recommended Developer Environment and how to set it u
 - [JDK 8](http://www.oracle.com/technetwork/java/javase/downloads/index.html).  This can also be either installed, or downloaded as a .zip.  If you do not use the installer, be sure to set the `JAVA_HOME` environment variable to the location of the JDK.
 - [Eclipse](http://www.eclipse.org/downloads/).  Eclipse is a Java IDE.  It can be downloaded as an installer or as a .zip file that does not require installation.
   - When the installer asks which version you'd like to install, choose "Eclipse IDE for Java Developers".
-- [node.js 10.x LTS](https://nodejs.org/en/).
 - [git](https://git-scm.com/).  While this is not required, it is highly recommended if you will be doing active development on ANET.
 
 ## Download ANET source code
@@ -23,7 +22,7 @@ This section describes the recommended Developer Environment and how to set it u
 - **You cannot access [the source code repo](https://github.com/NCI-Agency/anet).** Solution: Get someone who does have admin access to add you as a collaborator. Ensure that you have the correct public key installed to github. See https://help.github.com/articles/connecting-to-github-with-ssh/ for more information on troubleshooting this step. 
 - **The git clone command takes a long time, then fails.** Solution: Some networks block ssh. Try using the `https` URL from github to download the source code. 
 
-## Set Up Gradle, Eclipse and NPM
+## Set Up Gradle and Eclipse
 The frontend is run with `yarn`.  We recommend running the backend via `eclipse` if you are doing any backend development, and `gradle` if you are only doing frontend development.
 
 1. Set up Gradle
@@ -40,12 +39,8 @@ The frontend is run with `yarn`.  We recommend running the backend via `eclipse`
    1. Ensure there are no compile errors. If there are, you are probably missing dependencies or forgot to set environment variables in Eclipse. Try re-running `./gradlew eclipse` or checking the Eclipse run configuration vs gradle configs.
 1. Update the settings in `anet.yml` for your environment.  See the [ANET Configuration documentation](https://github.com/NCI-Agency/anet/blob/master/DOCUMENTATION.md#anet-configuration) for more details on these configuration options. You are most likely to change:
    1. `emailFromAddr` - use your own email address for testing.
-1. Set up npm
-   1. Change Directories into the `client/` directory
-   1. Run `yarn install`  to download all the javascript dependencies.  This can take several minutes depending on your internet connection. If the command hangs, it may be because your network blocks ssh. Try the command again on a different network.
 
 ## Java Backend
-
 ### Initial Setup
 1. You can either use PostgreSQL or Microsoft SQL Server for your database. Both allow you to run entirely on your local machine and develop offline.
    - MSSQL
@@ -72,7 +67,8 @@ The frontend is run with `yarn`.  We recommend running the backend via `eclipse`
    - The database schema is stored in `src/main/resources/migrations.xml`.
 1. Seed the initial data:
    - If you're using the Docker container for the database (and you should), you can load the data with: `./gradlew dbLoad`. Otherwise, you'll need to manually connect to your sqlserver instance and load the data.
-1. Run `./gradlew build` to download all dependencies and build the project.
+1. Run `./gradlew run` to download all dependencies (including client dependencies like nodejs and yarn) and build the project
+_Note_: it will also start the back-end but at this step we are not interested in that.
 
 ### The Base Data Set
 Provided with the ANET source code is the file `insertBaseData-mssql.sql`.  This file contains a series of raw SQL commands that insert some sample data into the database that is both required in order to pass all the unit tests, and also helpful for quickly developing and testing new features.  The Base Data Set includes a set of fake users, organizations, locations, and reports.  Here are some of the accounts that you can use to log in and test with:
@@ -162,6 +158,7 @@ The tests are reliant on the data looking pretty similar to what you'd get after
 1. Start with a clean test-database when running tests: `./gradlew -PtestEnv dbDrop dbMigrate dbLoad`
 1. Start a test SMTP server (in a Docker container) in your local development environment: `./gradlew -PtestEnv dockerCreateFakeSmtpServer dockerStartFakeSmtpServer`
 1. In order to run the client-side tests you must start a server using the test-database: `./gradlew -PtestEnv run`
+1. Make sure you have the proper nodejs and yarn in your path (see the [React Frontend](#react-frontend) instructions).
 
 Run `yarn run lint-fix` to automatically fix some kinds of lint errors.
 
@@ -225,10 +222,15 @@ The simulator can be started by running 'yarn run sim' in 'client'.
 
 ## React Frontend
 ### Initial Setup
-1. Make sure you have node.js v10.x LTS installed: ( http://nodejs.org )
+1. Make sure you have the proper nodejs and yarn in your path. Example:
+    ```
+    export YARN_HOME=<anet_root_path>/.gradle/yarn/yarn-latest
+    export NODEJS_HOME=<anet_root_path>/.gradle/nodejs/node-v12.14.1-linux-x64
+    export PATH="$YARN_HOME/bin:$NODEJS_HOME/bin:$PATH"
+    ```
+_Note_: nodejs version might have changed in the meanwhile, check inside <anet_root_path>/.gradle/nodejs/ for which version is being used and change the path accordingly.
 1. `cd client/`
     - All of the frontend code is in the `client/` directory.
-1. Install the development dependencies: `yarn install`
 1. Run the server: `yarn run start`
 1. Go to [http://localhost:3000/](http://localhost:3000/) in your browser.
    - When prompted for credentials:

--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -1,10 +1,8 @@
-# Setting up your Developer Environment (Eclipse, gradle, node, Chrome/Firefox)
+# Setting up your Developer Environment (gradle, node, Chrome/Firefox)
 This section describes the recommended Developer Environment and how to set it up.  You are welcome to use any other tools you prefer.
 
 ## Download open source software
 - [JDK 8](http://www.oracle.com/technetwork/java/javase/downloads/index.html).  This can also be either installed, or downloaded as a .zip.  If you do not use the installer, be sure to set the `JAVA_HOME` environment variable to the location of the JDK.
-- [Eclipse](http://www.eclipse.org/downloads/).  Eclipse is a Java IDE.  It can be downloaded as an installer or as a .zip file that does not require installation.
-  - When the installer asks which version you'd like to install, choose "Eclipse IDE for Java Developers".
 - [git](https://git-scm.com/).  While this is not required, it is highly recommended if you will be doing active development on ANET.
 
 ## Download ANET source code
@@ -22,21 +20,13 @@ This section describes the recommended Developer Environment and how to set it u
 - **You cannot access [the source code repo](https://github.com/NCI-Agency/anet).** Solution: Get someone who does have admin access to add you as a collaborator. Ensure that you have the correct public key installed to github. See https://help.github.com/articles/connecting-to-github-with-ssh/ for more information on troubleshooting this step. 
 - **The git clone command takes a long time, then fails.** Solution: Some networks block ssh. Try using the `https` URL from github to download the source code. 
 
-## Set Up Gradle and Eclipse
-The frontend is run with `yarn`.  We recommend running the backend via `eclipse` if you are doing any backend development, and `gradle` if you are only doing frontend development.
+## Set Up Gradle
+The frontend is run with `yarn`.  We recommend running the backend `gradle` if you are only doing frontend development.
 
 1. Set up Gradle
    1. This step is not needed unless want to use other settings and passwords than the default ones (see `build.gradle` for the defaults). You can define custom settings in a local settings file as follows:
    - Open a command line in the `anet` directory that was retrieved from github.
    - Create a new empty file at `localSettings.gradle`. (`touch localSettings.gradle` on linux/mac).  This will be a file for all of your local settings and passwords that should not be checked into GitHub.
-1. Set up Eclipse
-   1. Eclipse will ask you for a `workspace` directory. You can choose any empty directory.
-   1. Import the `anet/` directory into Eclipse as an existing `Gradle project`. This changes the .classpath and makes sure Eclipse finds the Java dependencies through the `build.gradle`.
-   1. Run the project as a Java Application.  Open the Run Configuration and make sure:
-      1. The main method is `mil.dds.anet.AnetApplication`
-      1. Arguments includes `server anet.yml`
-      1. Environment variables include anything set in build.gradle or localSettings.gradle.
-   1. Ensure there are no compile errors. If there are, you are probably missing dependencies or forgot to set environment variables in Eclipse. Try re-running `./gradlew eclipse` or checking the Eclipse run configuration vs gradle configs.
 1. Update the settings in `anet.yml` for your environment.  See the [ANET Configuration documentation](https://github.com/NCI-Agency/anet/blob/master/DOCUMENTATION.md#anet-configuration) for more details on these configuration options. You are most likely to change:
    1. `emailFromAddr` - use your own email address for testing.
 
@@ -92,7 +82,7 @@ To log in as one of the base data users, when prompted for a username and passwo
    - You can try out rolling back the very last one of the successfully applied migrations with a dry-run: `./gradlew dbRollback -Pdry-run`; this shows you the SQL commands that would be executed
    - You can roll back the very last one of the applied migrations with: `./gradlew dbRollback`
    - You may need to occasionally destroy, re-migrate, and re-seed your database if it has fallen too far out of sync with master; you can do this with `./gradlew dbDrop dbMigrate dbLoad` -- BE CAREFUL, this **will** drop and re-populate your database unconditionally!
-1. Run `./gradlew run` to run the server via Gradle, or hit Run in Eclipse
+1. Run `./gradlew run` to run the server via Gradle
    - If you have set **smtp: disabled** to **true** in `anet.yml`, you're good to go; otherwise, you can start an SMTP server (in a Docker container) in your local development environment: `./gradlew dockerCreateFakeSmtpServer dockerStartFakeSmtpServer`
    - The following output indicates that the server is ready:
     ```
@@ -126,21 +116,6 @@ After successfully creating and building the MSSQL Docker container it is posisb
 Override the default gradle settings if you want to run your tests on a different database:
    1. Open a command line in the `anet` directory that was retrieved from github.
    1. Create a new empty file at `localTestSettings.gradle`. (`touch localTestSettings.gradle` on linux/mac).  This will be a file for all of your local test settings and passwords that should not be checked into GitHub.
-
-_Note_: You can run the backend with either `gradle` or with Eclipse. Eclipse does not use gradle's configurations, so you'll have to set them up yourself.  You'll want to create a run configuration with:
-   - Main Class: `mil.dds.anet.AnetApplication`
-   - Program Arguments: `server anet.yml`
-   - Environment Variables: These values are used in anet.yml. We set them through environment variables rather than checking them into the git repository to allow each developer to use different settings.
-     - MSSQL:
-       - `ANET_DB_URL` : `jdbc:sqlserver://[sqlserver hostname]:1433;databaseName=[dbName]`
-       - `ANET_DB_USERNAME` : username to your db
-       - `ANET_DB_PASSWORD` : password to your db
-       - `ANET_DB_DRIVER` : `com.microsoft.sqlserver.jdbc.SQLServerDriver`
-     - PostgreSQL:
-       - `ANET_DB_URL` : `jdbc:postgresql://[psqlserver hostname]:5432/[dbName]`
-       - `ANET_DB_USERNAME` : username to your db
-       - `ANET_DB_PASSWORD` : password to your db
-       - `ANET_DB_DRIVER` : `org.postgresql.Driver`
 
 ### Server side tests
 1. Start with a clean test-database when running tests: `./gradlew -PtestEnv dbDrop dbMigrate dbLoad`
@@ -241,6 +216,6 @@ NB: You only need node.js and the npm dependencies for developing. When we deplo
 
 ## Development Mode
 In the `anet.yml` file there is a flag for `developmentMode`.  This flag does several valuable things::
-1. On every graphql query, the entire graphql graph is reloaded and re-parsed.  This helps in backend evelopment by allowing you to make quick changes without having to restart the server.  (Note: this only helps if you're running ANET out of eclipse in debug mode). 
+1. On every graphql query, the entire graphql graph is reloaded and re-parsed.  This helps in backend evelopment by allowing you to make quick changes without having to restart the server.  (Note: this only helps if you're running ANET with gradle in debug mode).
 1. ANET will use AuthType Basic rather than windows authentication.  This allows you to develop on non-windows computers and also quickly impersonate other accounts for testing.  To log in with an account, enter the `domainUsername` value for that user in the 'Username' field when prompted by your browser.  Leave the password field blank. 
 1. You can easily simulate a "new user" in development mode by entering a new username into both the username and password field.  This will activate the same code path as if a user came to the production system with a valid Windows Authentication Principal but we don't find them in the `people` table.  If you enter an unknown username and no password, ANET will reject you. If you enter an unknown username and the same unknown username into the password field, it will create that account and drop you into the new user workflow. 

--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -27,15 +27,12 @@ This section describes the recommended Developer Environment and how to set it u
 The frontend is run with `yarn`.  We recommend running the backend via `eclipse` if you are doing any backend development, and `gradle` if you are only doing frontend development.
 
 1. Set up Gradle
-   1. Open a command line in the `anet` directory that was retrieved from github.
-   1. Create a new empty file at `localSettings.gradle`. (`touch localSettings.gradle` on linux/mac).  This will be a file for all of your local settings and passwords that should not be checked into GitHub.
-   1. Run `./gradlew eclipse` (linux/mac) or `./gradlew.bat eclipse` (windows) to download all the java dependencies.  This can take several minutes depending on your internet connection.
-1. Set up npm
-   1. Change Directories into the `client/` directory
-   1. Run `yarn install`  to download all the javascript dependencies.  This can take several minutes depending on your internet connection. If the command hangs, it may be because your network blocks ssh. Try the command again on a different network.
+   1. This step is not needed unless want to use other settings and passwords than the default ones (see `build.gradle` for the defaults). You can define custom settings in a local settings file as follows:
+   - Open a command line in the `anet` directory that was retrieved from github.
+   - Create a new empty file at `localSettings.gradle`. (`touch localSettings.gradle` on linux/mac).  This will be a file for all of your local settings and passwords that should not be checked into GitHub.
 1. Set up Eclipse
    1. Eclipse will ask you for a `workspace` directory. You can choose any empty directory.
-   1. Import the `anet/` directory into eclipse as an existing project.
+   1. Import the `anet/` directory into Eclipse as an existing `Gradle project`. This changes the .classpath and makes sure Eclipse finds the Java dependencies through the `build.gradle`.
    1. Run the project as a Java Application.  Open the Run Configuration and make sure:
       1. The main method is `mil.dds.anet.AnetApplication`
       1. Arguments includes `server anet.yml`
@@ -43,6 +40,9 @@ The frontend is run with `yarn`.  We recommend running the backend via `eclipse`
    1. Ensure there are no compile errors. If there are, you are probably missing dependencies or forgot to set environment variables in Eclipse. Try re-running `./gradlew eclipse` or checking the Eclipse run configuration vs gradle configs.
 1. Update the settings in `anet.yml` for your environment.  See the [ANET Configuration documentation](https://github.com/NCI-Agency/anet/blob/master/DOCUMENTATION.md#anet-configuration) for more details on these configuration options. You are most likely to change:
    1. `emailFromAddr` - use your own email address for testing.
+1. Set up npm
+   1. Change Directories into the `client/` directory
+   1. Run `yarn install`  to download all the javascript dependencies.  This can take several minutes depending on your internet connection. If the command hangs, it may be because your network blocks ssh. Try the command again on a different network.
 
 ## Java Backend
 
@@ -50,7 +50,7 @@ The frontend is run with `yarn`.  We recommend running the backend via `eclipse`
 1. You can either use PostgreSQL or Microsoft SQL Server for your database. Both allow you to run entirely on your local machine and develop offline.
    - MSSQL
      - This is currently the default, so you don't need to do anything special
-     - Paste the following in your `localSettings.gradle` file (with the correct values):
+     - If you want to change any of the default database settings (see `build.gradle` for the defaults), you can paste them as following in your `localSettings.gradle` file (do it for the ones you want to change and with the correct values):
 
       ```java
       run.environment("DB_DRIVER", "sqlserver")

--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -9,9 +9,9 @@ This section describes the recommended Developer Environment and how to set it u
 - [git](https://git-scm.com/).  While this is not required, it is highly recommended if you will be doing active development on ANET.
 
 ## Download ANET source code
-- Checkout the [source code](https://github.com/deptofdefense/anet) from github.
+- Checkout the [source code](https://github.com/NCI-Agency/anet) from github.
    ```
-   git clone git@github.com:deptofdefense/anet.git
+   git clone git@github.com:NCI-Agency/anet.git
    ```
 - Install the recommended git hooks
    ```
@@ -20,7 +20,7 @@ This section describes the recommended Developer Environment and how to set it u
    ```
 
 ### Possible Problems
-- **You cannot access [the source code repo](https://github.com/deptofdefense/anet).** Solution: Get someone who does have admin access to add you as a collaborator. Ensure that you have the correct public key installed to github. See https://help.github.com/articles/connecting-to-github-with-ssh/ for more information on troubleshooting this step. 
+- **You cannot access [the source code repo](https://github.com/NCI-Agency/anet).** Solution: Get someone who does have admin access to add you as a collaborator. Ensure that you have the correct public key installed to github. See https://help.github.com/articles/connecting-to-github-with-ssh/ for more information on troubleshooting this step. 
 - **The git clone command takes a long time, then fails.** Solution: Some networks block ssh. Try using the `https` URL from github to download the source code. 
 
 ## Set Up Gradle, Eclipse and NPM
@@ -41,7 +41,7 @@ The frontend is run with `yarn`.  We recommend running the backend via `eclipse`
       1. Arguments includes `server anet.yml`
       1. Environment variables include anything set in build.gradle or localSettings.gradle.
    1. Ensure there are no compile errors. If there are, you are probably missing dependencies or forgot to set environment variables in Eclipse. Try re-running `./gradlew eclipse` or checking the Eclipse run configuration vs gradle configs.
-1. Update the settings in `anet.yml` for your environment.  See the [ANET Configuration documentation](https://github.com/deptofdefense/anet/blob/master/DOCUMENTATION.md#anet-configuration) for more details on these configuration options. You are most likely to change:
+1. Update the settings in `anet.yml` for your environment.  See the [ANET Configuration documentation](https://github.com/NCI-Agency/anet/blob/master/DOCUMENTATION.md#anet-configuration) for more details on these configuration options. You are most likely to change:
    1. `emailFromAddr` - use your own email address for testing.
 
 ## Java Backend

--- a/docs/frontend-overview.md
+++ b/docs/frontend-overview.md
@@ -1,16 +1,6 @@
 # How the frontend works
 React structures the application into components instead of technologies. This means that everything that gets rendered on the page has its own file based on its functionality instead of regular HTML, CSS, and JS files. For example, the new report form lives in `client/src/pages/reports/New.js` and contains everything needed to render that form (all the CSS, HTML, and JS). It comprises a number of other components, for example the `Form` and `FormField` components which live in `client/src/components/Form.js` and `client/src/components/FormField.js`, which likewise contains everything needed to render a form field to the screen. This makes it very easy to figure out where any given element on screen comes from; it's either in `client/src/pages` or `client/src/components`. Pages are just compositions of components written in HTML syntax, and components can also compose other components for reusability.
 
-# How to pull down new changes and update your local server
-1. Close any servers you have running (the `./gradlew` or `yarn` commands)
-1. Pull down any updates `git pull`
-1. If you see any changes to `src/main/resources/migrations.xml` this means there are updates to the database schema.  Run `./gradlew dbMigrate` to update your database schema.
-  - If you are using sqlserver then you need to run `export DB_DRIVER='sqlserver'` to tell gradle to use your sqlserver configuration
-1. If you see any changes to `insertBaseData-mssql.sql` then there are updates to the base data set.
-  - Run `./gradlew dbDrop dbMigrate dbLoad` to start with a freshly updated database.
-1. Re launch the backend server with `./gradlew run`
-1. Re launch the frontend server with `./yarn run start`
-
 # Random Documentation!!
 
 ## How to add a new field to an object


### PR DESCRIPTION
Made some changes in the documentation of the development environment setup:
- updated git repository path, it was no longer up to dat
- updated Gradle and Eclipse setup, some steps are no longer needed if we use an Eclipse Gradle project
- updated nodejs and yarn setup, these dependencies are being installed by the gradle client build, so we can just use those dependencies

  - [x] Updated documentation