### PR TITLE
Lazy-load avatars

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -98,7 +98,7 @@ dependencies {
 	implementation 'org.jsoup:jsoup:1.13.1'
 
 	// For fast and simple image scaling
-	implementation 'org.imgscalr:imgscalr-lib:4.2'
+	implementation 'net.coobird:thumbnailator:0.4.11'
 
 	testImplementation 'io.dropwizard:dropwizard-testing:2.0.4'
 	testImplementation 'io.dropwizard:dropwizard-client:2.0.4'

--- a/client/src/components/AvatarDisplayComponent.js
+++ b/client/src/components/AvatarDisplayComponent.js
@@ -2,11 +2,9 @@ import React from "react"
 import DEFAULT_AVATAR from "resources/default_avatar.svg"
 import PropTypes from "prop-types"
 
-export const AVATAR_IMAGE_DATA_PREFIX = "data:image/png;base64,"
-
 const AvatarDisplayComponent = ({ avatar, height, width, style }) => (
   <img
-    src={avatar ? `${AVATAR_IMAGE_DATA_PREFIX}${avatar}` : DEFAULT_AVATAR}
+    src={avatar || DEFAULT_AVATAR}
     height={height}
     width={width}
     alt="Avatar"

--- a/client/src/components/AvatarEditModal.js
+++ b/client/src/components/AvatarEditModal.js
@@ -1,5 +1,4 @@
 import AvatarComponent from "components/AvatarComponent"
-import { AVATAR_IMAGE_DATA_PREFIX } from "components/AvatarDisplayComponent"
 import PropTypes from "prop-types"
 import React, { useState } from "react"
 import { Button, Modal } from "react-bootstrap"
@@ -36,10 +35,7 @@ const AvatarEditModal = ({ title, onAvatarUpdate }) => {
   }
 
   function save() {
-    const updatedAvatar = currentPreview.substring(
-      AVATAR_IMAGE_DATA_PREFIX.length
-    )
-    onAvatarUpdate(updatedAvatar)
+    onAvatarUpdate(currentPreview)
     close()
   }
 }

--- a/client/src/components/graphs/OrganizationalChart.js
+++ b/client/src/components/graphs/OrganizationalChart.js
@@ -1,6 +1,5 @@
 import API, { Settings } from "api"
 import { gql } from "apollo-boost"
-import { AVATAR_IMAGE_DATA_PREFIX } from "components/AvatarDisplayComponent"
 import SVGCanvas from "components/graphs/SVGCanvas"
 import {
   PageDispatchersPropType,
@@ -310,14 +309,7 @@ const OrganizationalChart = ({
       .attr("width", 26)
       .attr("height", 26)
       .attr("y", -15)
-      .attr(
-        "href",
-        d =>
-          d.person &&
-          (d.person.avatar
-            ? `${AVATAR_IMAGE_DATA_PREFIX}${d.person.avatar}`
-            : DEFAULT_AVATAR)
-      )
+      .attr("href", d => d.person && (d.person.avatar || DEFAULT_AVATAR))
 
     headGenter
       .append("text")
@@ -367,14 +359,7 @@ const OrganizationalChart = ({
       .attr("width", 13)
       .attr("height", 13)
       .attr("y", -10)
-      .attr(
-        "href",
-        d =>
-          d.person &&
-          (d.person.avatar
-            ? `${AVATAR_IMAGE_DATA_PREFIX}${d.person.avatar}`
-            : DEFAULT_AVATAR)
-      )
+      .attr("href", d => d.person && (d.person.avatar || DEFAULT_AVATAR))
 
     positionsGA
       .append("text")

--- a/client/src/exportUtils.js
+++ b/client/src/exportUtils.js
@@ -31,7 +31,6 @@ const GQL_GET_PERSON_LIST = gql`
         rank
         role
         emailAddress
-        avatar(size: 32)
         position {
           uuid
           name
@@ -75,7 +74,6 @@ const GQL_GET_POSITION_LIST = gql`
           name
           rank
           role
-          avatar(size: 32)
         }
       }
     }

--- a/src/main/java/mil/dds/anet/beans/Person.java
+++ b/src/main/java/mil/dds/anet/beans/Person.java
@@ -28,6 +28,8 @@ public class Person extends AbstractCustomizableAnetBean implements Principal {
     ADVISOR, PRINCIPAL
   }
 
+  private static final String AVATAR_TYPE = "png";
+
   @GraphQLQuery
   @GraphQLInputField
   private String name;
@@ -249,7 +251,8 @@ public class Person extends AbstractCustomizableAnetBean implements Principal {
   @GraphQLQuery(name = "avatar")
   public String getAvatar(@GraphQLArgument(name = "size", defaultValue = "256") int size) {
     try {
-      return Base64.getEncoder().encodeToString(Utils.resizeImage(avatar, size, size, "png"));
+      return String.format("data:image/%1$s;base64,%2$s", AVATAR_TYPE,
+          Base64.getEncoder().encodeToString(Utils.resizeImage(avatar, size, size, AVATAR_TYPE)));
     } catch (Exception e) {
       return null;
     }
@@ -265,7 +268,16 @@ public class Person extends AbstractCustomizableAnetBean implements Principal {
 
   @GraphQLInputField(name = "avatar")
   public void setAvatar(String avatar) {
-    this.avatar = avatar == null ? null : Base64.getDecoder().decode(avatar);
+    if (avatar == null) {
+      this.avatar = null;
+    } else {
+      try {
+        final String[] parts = avatar.split(",");
+        this.avatar = Base64.getDecoder().decode(parts[1]);
+      } catch (Exception e) {
+        this.avatar = null;
+      }
+    }
   }
 
   public String getCode() {

--- a/src/main/java/mil/dds/anet/beans/Person.java
+++ b/src/main/java/mil/dds/anet/beans/Person.java
@@ -10,13 +10,16 @@ import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import mil.dds.anet.AnetObjectEngine;
 import mil.dds.anet.beans.lists.AnetBeanList;
 import mil.dds.anet.beans.search.ReportSearchQuery;
 import mil.dds.anet.utils.DaoUtils;
+import mil.dds.anet.utils.IdDataLoaderKey;
 import mil.dds.anet.utils.Utils;
 import mil.dds.anet.views.AbstractCustomizableAnetBean;
+import mil.dds.anet.views.UuidFetcher;
 
 public class Person extends AbstractCustomizableAnetBean implements Principal {
 
@@ -71,7 +74,7 @@ public class Person extends AbstractCustomizableAnetBean implements Principal {
   // annotated below
   private List<PersonPositionHistory> previousPositions;
   // annotated below
-  private byte[] avatar;
+  private Optional<byte[]> avatar;
   @GraphQLQuery
   @GraphQLInputField
   private String code;
@@ -249,33 +252,46 @@ public class Person extends AbstractCustomizableAnetBean implements Principal {
   }
 
   @GraphQLQuery(name = "avatar")
-  public String getAvatar(@GraphQLArgument(name = "size", defaultValue = "256") int size) {
+  public CompletableFuture<String> loadAvatar(@GraphQLRootContext Map<String, Object> context,
+      @GraphQLArgument(name = "size", defaultValue = "256") int size) {
+    if (avatar != null) {
+      return CompletableFuture.completedFuture(resizeAvatar(size));
+    }
+    return new UuidFetcher<Person>().load(context, IdDataLoaderKey.PEOPLE_AVATARS, uuid)
+        .thenApply(o -> {
+          avatar = Optional.ofNullable(o.getAvatar());
+          return resizeAvatar(size);
+        });
+  }
+
+  public String resizeAvatar(int size) {
     try {
-      return String.format("data:image/%1$s;base64,%2$s", AVATAR_TYPE,
-          Base64.getEncoder().encodeToString(Utils.resizeImage(avatar, size, size, AVATAR_TYPE)));
+      return String.format("data:image/%1$s;base64,%2$s", AVATAR_TYPE, Base64.getEncoder()
+          .encodeToString(Utils.resizeImage(getAvatar(), size, size, AVATAR_TYPE)));
     } catch (Exception e) {
       return null;
     }
   }
 
   public byte[] getAvatar() {
-    return avatar;
+    return avatar == null ? null : avatar.orElse(null);
   }
 
   public void setAvatar(byte[] avatar) {
-    this.avatar = avatar;
+    this.avatar = Optional.ofNullable(avatar);
   }
 
   @GraphQLInputField(name = "avatar")
   public void setAvatar(String avatar) {
     if (avatar == null) {
-      this.avatar = null;
+      this.avatar = Optional.ofNullable(null);
     } else {
       try {
-        final String[] parts = avatar.split(",");
-        this.avatar = Base64.getDecoder().decode(parts[1]);
+        final String[] parts = avatar.split(",", 2);
+        final String dataPart = parts.length == 1 ? parts[0] : parts[1];
+        this.avatar = Optional.ofNullable(Base64.getDecoder().decode(dataPart));
       } catch (Exception e) {
-        this.avatar = null;
+        this.avatar = Optional.ofNullable(null);
       }
     }
   }
@@ -300,7 +316,7 @@ public class Person extends AbstractCustomizableAnetBean implements Principal {
         && Objects.equals(other.getPhoneNumber(), phoneNumber)
         && Objects.equals(other.getRank(), rank) && Objects.equals(other.getBiography(), biography)
         && Objects.equals(other.getPendingVerification(), pendingVerification)
-        && Objects.equals(other.getAvatar(), avatar) && Objects.equals(other.getCode(), code)
+        && Objects.equals(other.getAvatar(), getAvatar()) && Objects.equals(other.getCode(), code)
         && (createdAt != null)
             ? (createdAt.equals(other.getCreatedAt()))
             : (other.getCreatedAt() == null) && (updatedAt != null)

--- a/src/main/java/mil/dds/anet/database/ForeignKeyBatcher.java
+++ b/src/main/java/mil/dds/anet/database/ForeignKeyBatcher.java
@@ -23,14 +23,16 @@ public class ForeignKeyBatcher<T extends AbstractAnetBean> {
   private Provider<Handle> handle;
   private final String sql;
   private final String paramName;
-  private final ForeignKeyMapper<T> mapper;
+  private final RowMapper<T> objectMapper;
+  private final String foreignKeyName;
   private final Map<String, Object> additionalParams;
 
   public ForeignKeyBatcher(String sql, String paramName, RowMapper<T> objectMapper,
       String foreignKeyName, Map<String, Object> additionalParams) {
     this.sql = sql;
     this.paramName = paramName;
-    this.mapper = new ForeignKeyMapper<>(foreignKeyName, objectMapper);
+    this.objectMapper = objectMapper;
+    this.foreignKeyName = foreignKeyName;
     this.additionalParams = additionalParams;
   }
 
@@ -50,6 +52,7 @@ public class ForeignKeyBatcher<T extends AbstractAnetBean> {
     if (additionalParams != null && !additionalParams.isEmpty()) {
       query.bindMap(additionalParams);
     }
+    final ForeignKeyMapper<T> mapper = new ForeignKeyMapper<>(foreignKeyName, objectMapper);
     return query.map(mapper).withStream(result -> {
       final Map<String, List<T>> map = result.collect(Collectors.toMap(obj -> obj.getForeignKey(), // key
           obj -> new ArrayList<>(Collections.singletonList(obj.getObject())), // value

--- a/src/main/java/mil/dds/anet/database/PersonDao.java
+++ b/src/main/java/mil/dds/anet/database/PersonDao.java
@@ -27,11 +27,15 @@ public class PersonDao extends AnetBaseDao<Person, PersonSearchQuery> {
   public static String[] minimalFields = {"uuid", "name", "rank", "createdAt"};
   public static String[] additionalFields = {"status", "role", "emailAddress", "phoneNumber",
       "biography", "country", "gender", "endOfTourDate", "domainUsername", "pendingVerification",
-      "avatar", "code", "updatedAt", "customFields"};
+      "code", "updatedAt", "customFields"};
+  // "avatar" has its own batcher
+  public static String[] avatarFields = {"uuid", "avatar"};
   public static final String[] allFields =
       ObjectArrays.concat(minimalFields, additionalFields, String.class);
   public static String TABLE_NAME = "people";
   public static String PERSON_FIELDS = DaoUtils.buildFieldAliases(TABLE_NAME, allFields, true);
+  public static String PERSON_AVATAR_FIELDS =
+      DaoUtils.buildFieldAliases(TABLE_NAME, avatarFields, true);
   public static String PERSON_FIELDS_NOAS =
       DaoUtils.buildFieldAliases(TABLE_NAME, allFields, false);
 
@@ -49,11 +53,30 @@ public class PersonDao extends AnetBaseDao<Person, PersonSearchQuery> {
     }
   }
 
+  static class AvatarBatcher extends IdBatcher<Person> {
+    private static final String sql = "/* batch.getPeopleAvatars */ SELECT " + PERSON_AVATAR_FIELDS
+        + " FROM people WHERE uuid IN ( <uuids> )";
+
+    public AvatarBatcher() {
+      super(sql, "uuids", new PersonMapper());
+    }
+  }
+
   @Override
   public List<Person> getByIds(List<String> uuids) {
     final IdBatcher<Person> idBatcher =
         AnetObjectEngine.getInstance().getInjector().getInstance(SelfIdBatcher.class);
     return idBatcher.getByIds(uuids);
+  }
+
+  public Person getAvatar(String uuid) {
+    return getAvatars(Arrays.asList(uuid)).get(0);
+  }
+
+  public List<Person> getAvatars(List<String> uuids) {
+    final IdBatcher<Person> avatarBatcher =
+        AnetObjectEngine.getInstance().getInjector().getInstance(AvatarBatcher.class);
+    return avatarBatcher.getByIds(uuids);
   }
 
   static class PersonPositionHistoryBatcher extends ForeignKeyBatcher<PersonPositionHistory> {

--- a/src/main/java/mil/dds/anet/database/mappers/ForeignKeyMapper.java
+++ b/src/main/java/mil/dds/anet/database/mappers/ForeignKeyMapper.java
@@ -2,6 +2,8 @@ package mil.dds.anet.database.mappers;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.Map;
 import org.jdbi.v3.core.mapper.RowMapper;
 import org.jdbi.v3.core.statement.StatementContext;
 
@@ -9,17 +11,20 @@ public class ForeignKeyMapper<T> implements RowMapper<ForeignKeyTuple<T>> {
 
   private final String foreignKeyName;
   private final RowMapper<T> objectMapper;
+  private final Map<Integer, T> objectCache;
 
   public ForeignKeyMapper(String foreignKeyName, RowMapper<T> objectMapper) {
     this.foreignKeyName = foreignKeyName;
     this.objectMapper = objectMapper;
+    this.objectCache = new HashMap<>();
   }
 
   @Override
   public ForeignKeyTuple<T> map(ResultSet rs, StatementContext ctx) throws SQLException {
     final String foreignKey = rs.getString(foreignKeyName);
     final T object = objectMapper.map(rs, ctx);
-    return new ForeignKeyTuple<T>(foreignKey, object);
+    return new ForeignKeyTuple<T>(foreignKey,
+        objectCache.computeIfAbsent(object.hashCode(), k -> object));
   }
 
 }

--- a/src/main/java/mil/dds/anet/database/mappers/PersonMapper.java
+++ b/src/main/java/mil/dds/anet/database/mappers/PersonMapper.java
@@ -44,7 +44,10 @@ public class PersonMapper implements RowMapper<Person> {
     a.setBiography(MapperUtils.getOptionalString(rs, "people_biography"));
     a.setDomainUsername(MapperUtils.getOptionalString(rs, "people_domainUsername"));
     a.setPendingVerification(MapperUtils.getOptionalBoolean(rs, "people_pendingVerification"));
-    a.setAvatar(MapperUtils.getOptionalBytes(rs, "people_avatar"));
+    // Treat "avatar" special so it only gets loaded & set when explicitly requested
+    if (MapperUtils.containsColumnNamed(rs, "people_avatar")) {
+      a.setAvatar(rs.getBytes("people_avatar"));
+    }
 
     return a;
   }

--- a/src/main/java/mil/dds/anet/utils/BatchingUtils.java
+++ b/src/main/java/mil/dds/anet/utils/BatchingUtils.java
@@ -182,6 +182,14 @@ public final class BatchingUtils {
                 dispatcherService);
           }
         }, dataLoaderOptions));
+    dataLoaderRegistry.register(IdDataLoaderKey.PEOPLE_AVATARS.toString(),
+        new DataLoader<>(new BatchLoader<String, Person>() {
+          @Override
+          public CompletionStage<List<Person>> load(List<String> keys) {
+            return CompletableFuture.supplyAsync(() -> engine.getPersonDao().getAvatars(keys),
+                dispatcherService);
+          }
+        }, dataLoaderOptions));
     dataLoaderRegistry.register(FkDataLoaderKey.PERSON_ORGANIZATIONS.toString(),
         new DataLoader<>(new BatchLoader<String, List<Organization>>() {
           @Override

--- a/src/main/java/mil/dds/anet/utils/IdDataLoaderKey.java
+++ b/src/main/java/mil/dds/anet/utils/IdDataLoaderKey.java
@@ -21,6 +21,7 @@ public enum IdDataLoaderKey {
   LOCATIONS(LocationDao.TABLE_NAME), // -
   ORGANIZATIONS(OrganizationDao.TABLE_NAME), // -
   PEOPLE(PersonDao.TABLE_NAME), // -
+  PEOPLE_AVATARS((PersonDao.TABLE_NAME + ".avatar")), // -
   POSITIONS(PositionDao.TABLE_NAME), // -
   REPORTS(ReportDao.TABLE_NAME), // -
   TAGS(TagDao.TABLE_NAME), // -

--- a/src/main/java/mil/dds/anet/utils/Utils.java
+++ b/src/main/java/mil/dds/anet/utils/Utils.java
@@ -27,9 +27,7 @@ import mil.dds.anet.beans.Organization;
 import mil.dds.anet.beans.Task;
 import mil.dds.anet.database.ApprovalStepDao;
 import mil.dds.anet.views.AbstractAnetBean;
-import org.imgscalr.Scalr;
-import org.imgscalr.Scalr.Method;
-import org.imgscalr.Scalr.Mode;
+import net.coobird.thumbnailator.Thumbnails;
 import org.jsoup.Jsoup;
 import org.owasp.html.HtmlPolicyBuilder;
 import org.owasp.html.PolicyFactory;
@@ -434,11 +432,10 @@ public class Utils {
     }
 
     // Resizing
-    final BufferedImage thumbnail =
-        Scalr.resize(imageBinary, Method.AUTOMATIC, Mode.AUTOMATIC, width, height);
-
-    // From BufferedImage back to byte-array
-    return convert(thumbnail, imageFormatName);
+    final ByteArrayOutputStream os = new ByteArrayOutputStream();
+    Thumbnails.of(imageBinary).size(width, height).outputFormat(imageFormatName).outputQuality(1.0f)
+        .toOutputStream(os);
+    return os.toByteArray();
   }
 
   /**

--- a/src/test/java/mil/dds/anet/test/beans/PersonTest.java
+++ b/src/test/java/mil/dds/anet/test/beans/PersonTest.java
@@ -68,14 +68,14 @@ public class PersonTest extends BeanTester<Person> {
   public void testAvatarResizingNoAvatar() {
     Person person = new Person();
     person.setAvatar((String) null);
-    assertThat(person.getAvatar(32)).isNull();
+    assertThat(person.resizeAvatar(32)).isNull();
   }
 
   @Test
   public void testAvatarResizingMalformedData() {
     Person person = new Person();
     person.setAvatar("malformedImageData");
-    assertThat(person.getAvatar(32)).isNull();
+    assertThat(person.resizeAvatar(32)).isNull();
   }
 
   @Test
@@ -89,10 +89,11 @@ public class PersonTest extends BeanTester<Person> {
     assertThat(imageBinary.getWidth()).isNotEqualTo(32);
     assertThat(imageBinary.getHeight()).isNotEqualTo(32);
 
-    String resizedAvatar = person.getAvatar(32);
-
+    String resizedAvatar = person.resizeAvatar(32);
     assertThat(resizedAvatar).isNotNull();
-    imageBinary = Utils.convert(Base64.getDecoder().decode(resizedAvatar));
+
+    person.setAvatar(resizedAvatar);
+    imageBinary = Utils.convert(person.getAvatar());
 
     assertThat(imageBinary.getWidth()).isEqualTo(32);
     assertThat(imageBinary.getHeight()).isEqualTo(32);


### PR DESCRIPTION
Only (batch) load people's avatars when they are requested through the GraphQL. This prevents ANET from running out of memory when e.g. a full month of reports is retrieved on the ReportCalendar view and many attendees would have an avatar.