### PR TITLE
Explicitly set the FreeMarker Configuration version

### DIFF
--- a/src/main/java/mil/dds/anet/AnetApplication.java
+++ b/src/main/java/mil/dds/anet/AnetApplication.java
@@ -12,6 +12,8 @@ import com.networknt.schema.JsonSchema;
 import com.networknt.schema.JsonSchemaFactory;
 import com.networknt.schema.SpecVersion;
 import com.networknt.schema.ValidationMessage;
+import freemarker.template.Configuration;
+import freemarker.template.Version;
 import io.dropwizard.Application;
 import io.dropwizard.auth.AuthDynamicFeature;
 import io.dropwizard.auth.AuthFilter;
@@ -88,6 +90,8 @@ public class AnetApplication extends Application<AnetConfiguration> {
       LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
   private static final ObjectMapper yamlMapper = new ObjectMapper(new YAMLFactory());
   private static final ObjectMapper jsonMapper = new ObjectMapper();
+
+  public static final Version FREEMARKER_VERSION = Configuration.VERSION_2_3_30;
 
   private MetricRegistry metricRegistry;
 

--- a/src/main/java/mil/dds/anet/resources/ReportResource.java
+++ b/src/main/java/mil/dds/anet/resources/ReportResource.java
@@ -1,5 +1,7 @@
 package mil.dds.anet.resources;
 
+import static mil.dds.anet.AnetApplication.FREEMARKER_VERSION;
+
 import freemarker.template.Configuration;
 import freemarker.template.DefaultObjectWrapperBuilder;
 import freemarker.template.Template;
@@ -773,11 +775,11 @@ public class ReportResource {
     context.put("fields", fields);
 
     try {
-      Configuration freemarkerConfig = new Configuration(Configuration.getVersion());
+      Configuration freemarkerConfig = new Configuration(FREEMARKER_VERSION);
       // auto-escape HTML in our .ftlh templates
       freemarkerConfig.setRecognizeStandardFileExtensions(true);
       freemarkerConfig
-          .setObjectWrapper(new DefaultObjectWrapperBuilder(Configuration.getVersion()).build());
+          .setObjectWrapper(new DefaultObjectWrapperBuilder(FREEMARKER_VERSION).build());
       freemarkerConfig.loadBuiltInEncodingMap();
       freemarkerConfig.setDefaultEncoding(StandardCharsets.UTF_8.name());
       freemarkerConfig.setClassForTemplateLoading(this.getClass(), "/");

--- a/src/main/java/mil/dds/anet/threads/AnetEmailWorker.java
+++ b/src/main/java/mil/dds/anet/threads/AnetEmailWorker.java
@@ -1,5 +1,7 @@
 package mil.dds.anet.threads;
 
+import static mil.dds.anet.AnetApplication.FREEMARKER_VERSION;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Joiner;
@@ -112,11 +114,10 @@ public class AnetEmailWorker implements Runnable {
 
     disabled = smtpConfig.isDisabled();
 
-    freemarkerConfig = new Configuration(Configuration.getVersion());
+    freemarkerConfig = new Configuration(FREEMARKER_VERSION);
     // auto-escape HTML in our .ftlh templates
     freemarkerConfig.setRecognizeStandardFileExtensions(true);
-    freemarkerConfig
-        .setObjectWrapper(new DefaultObjectWrapperBuilder(Configuration.getVersion()).build());
+    freemarkerConfig.setObjectWrapper(new DefaultObjectWrapperBuilder(FREEMARKER_VERSION).build());
     freemarkerConfig.loadBuiltInEncodingMap();
     freemarkerConfig.setDefaultEncoding(StandardCharsets.UTF_8.name());
     freemarkerConfig.setClassForTemplateLoading(this.getClass(), "/");


### PR DESCRIPTION
Avoid
> "ERROR freemarker.configuration: DefaultObjectWrapper.incompatibleImprovements was set to the object returned by Configuration.getVersion(). That defeats the purpose of incompatibleImprovements, and makes upgrading FreeMarker a potentially breaking change. Also, this probably won't be allowed starting from 2.4.0. Instead, set incompatibleImprovements to the highest concrete version that's known to be compatible with your application."

by setting it to the version of FreeMarker we are currently using (v2.3.30, through dropwizard-views-freemarker v2.0.6).
See https://freemarker.apache.org/docs/pgui_config_incompatible_improvements.html