### PR TITLE
Conservatively cache domain users

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -76,6 +76,10 @@ dependencies {
 	implementation 'org.postgresql:postgresql:42.2.12' // If using postgresql
 	implementation 'org.liquibase:liquibase-core:3.8.8'
 
+	// For caching domain users (used in every request in the AuthenticationFilter)
+	implementation 'org.ehcache:ehcache:3.8.1'
+	implementation 'javax.cache:cache-api:1.1.0'
+
 	implementation 'javax.mail:mail:1.4.7'
 	implementation 'ch.qos.logback:logback-classic:1.2.3'
 	implementation 'ch.qos.logback:logback-core:1.2.3'

--- a/src/main/java/mil/dds/anet/AnetApplication.java
+++ b/src/main/java/mil/dds/anet/AnetApplication.java
@@ -176,7 +176,7 @@ public class AnetApplication extends Application<AnetConfiguration> {
 
     // The Object Engine is the core place where we store all of the Dao's
     // You can always grab the engine from anywhere with AnetObjectEngine.getInstance()
-    final AnetObjectEngine engine = new AnetObjectEngine(dbUrl, this);
+    final AnetObjectEngine engine = new AnetObjectEngine(dbUrl, this, metricRegistry);
     environment.servlets().setSessionHandler(new SessionHandler());
 
     if (configuration.isDevelopmentMode()) {

--- a/src/main/java/mil/dds/anet/AnetObjectEngine.java
+++ b/src/main/java/mil/dds/anet/AnetObjectEngine.java
@@ -1,5 +1,6 @@
 package mil.dds.anet;
 
+import com.codahale.metrics.MetricRegistry;
 import com.google.inject.Injector;
 import io.dropwizard.Application;
 import java.util.Collections;
@@ -69,10 +70,11 @@ public class AnetObjectEngine {
   private final String dbUrl;
   private final Injector injector;
 
-  public AnetObjectEngine(String dbUrl, Application<?> application) {
+  public AnetObjectEngine(String dbUrl, Application<?> application, MetricRegistry metricRegistry) {
     this.dbUrl = dbUrl;
     injector = InjectorLookup.getInjector(application).get();
     personDao = injector.getInstance(PersonDao.class);
+    personDao.setMetricRegistry(metricRegistry);
     taskDao = injector.getInstance(TaskDao.class);
     locationDao = injector.getInstance(LocationDao.class);
     orgDao = injector.getInstance(OrganizationDao.class);

--- a/src/main/resources/ehcache-config.xml
+++ b/src/main/resources/ehcache-config.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<config
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="http://www.ehcache.org/v3"
+    xsi:schemaLocation="http://www.ehcache.org/v3
+      http://www.ehcache.org/schema/ehcache-core-3.0.xsd">
+  <cache alias="domainUsersCache">
+    <key-type>java.lang.String</key-type>
+    <value-type>mil.dds.anet.beans.Person</value-type>
+    <heap unit="entries">10000</heap>
+  </cache>
+</config>


### PR DESCRIPTION
Since we know that `PersonDao::findByDomainUsername()` is by far the most executed query,
use Ehcache to cache domain users.

Partially addresses NCI-Agency/anet#1968