### PR TITLE
Defensively copy objects in the domainUsersCache

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -79,6 +79,7 @@ dependencies {
 	// For caching domain users (used in every request in the AuthenticationFilter)
 	implementation 'org.ehcache:ehcache:3.8.1'
 	implementation 'javax.cache:cache-api:1.1.1'
+	implementation 'commons-beanutils:commons-beanutils:1.9.4'
 
 	implementation 'javax.mail:mail:1.4.7'
 	implementation 'ch.qos.logback:logback-classic:1.2.3'

--- a/src/main/java/mil/dds/anet/beans/Position.java
+++ b/src/main/java/mil/dds/anet/beans/Position.java
@@ -146,6 +146,18 @@ public class Position extends AbstractAnetBean {
     return person.getForeignObject();
   }
 
+  // for easy access through reflection
+  @JsonIgnore
+  public void setCurrentPersonUuid(String personUuid) {
+    setPersonUuid(personUuid);
+  }
+
+  // for easy access through reflection
+  @JsonIgnore
+  public String getCurrentPersonUuid() {
+    return getPersonUuid();
+  }
+
   @GraphQLQuery(name = "associatedPositions")
   public CompletableFuture<List<Position>> loadAssociatedPositions(
       @GraphQLRootContext Map<String, Object> context) {

--- a/src/main/java/mil/dds/anet/database/PersonDao.java
+++ b/src/main/java/mil/dds/anet/database/PersonDao.java
@@ -157,13 +157,13 @@ public class PersonDao extends AnetBaseDao<Person, PersonSearchQuery> {
       sql.append(":endOfTourDate, ");
     }
     sql.append(":biography, :domainUsername, :createdAt, :updatedAt, :customFields);");
-    final int nr = getDbHandle().createUpdate(sql.toString()).bindBean(p)
+    getDbHandle().createUpdate(sql.toString()).bindBean(p)
         .bind("createdAt", DaoUtils.asLocalDateTime(p.getCreatedAt()))
         .bind("updatedAt", DaoUtils.asLocalDateTime(p.getUpdatedAt()))
         .bind("endOfTourDate", DaoUtils.asLocalDateTime(p.getEndOfTourDate()))
         .bind("status", DaoUtils.getEnumId(p.getStatus()))
         .bind("role", DaoUtils.getEnumId(p.getRole())).execute();
-    evictFromCache(p, nr > 0);
+    evictFromCache(p);
     return p;
   }
 
@@ -190,9 +190,9 @@ public class PersonDao extends AnetBaseDao<Person, PersonSearchQuery> {
         .bind("endOfTourDate", DaoUtils.asLocalDateTime(p.getEndOfTourDate()))
         .bind("status", DaoUtils.getEnumId(p.getStatus()))
         .bind("role", DaoUtils.getEnumId(p.getRole())).execute();
-    evictFromCache(p, nr > 0);
+    evictFromCache(p);
     // The domainUsername may have changed, evict original person as well
-    evictFromCache(findInCache(p), true);
+    evictFromCache(findInCache(p));
     return nr;
   }
 
@@ -232,7 +232,7 @@ public class PersonDao extends AnetBaseDao<Person, PersonSearchQuery> {
    * @param personUuid the uuid of the person to be evicted from the cache
    */
   public void evictFromCacheByPersonUuid(String personUuid) {
-    evictFromCache(findInCacheByPersonUuid(personUuid), true);
+    evictFromCache(findInCacheByPersonUuid(personUuid));
   }
 
   /**
@@ -241,7 +241,7 @@ public class PersonDao extends AnetBaseDao<Person, PersonSearchQuery> {
    * @param positionUuid the uuid of the position for the person to be evicted from the cache
    */
   public void evictFromCacheByPositionUuid(String positionUuid) {
-    evictFromCache(findInCacheByPositionUuid(positionUuid), true);
+    evictFromCache(findInCacheByPositionUuid(positionUuid));
   }
 
   private Person getFromCache(String domainUsername) {
@@ -276,11 +276,9 @@ public class PersonDao extends AnetBaseDao<Person, PersonSearchQuery> {
    * {@link #findByDomainUsername(String)}.
    *
    * @param person the person to be evicted from the domain users cache
-   * @param evict if the person should be evicted from the cache (because the object has been
-   *        updated or deleted)
    */
-  private void evictFromCache(Person person, boolean evict) {
-    if (domainUsersCache != null && evict && person != null && person.getDomainUsername() != null) {
+  private void evictFromCache(Person person) {
+    if (domainUsersCache != null && person != null && person.getDomainUsername() != null) {
       domainUsersCache.remove(person.getDomainUsername());
     }
   }
@@ -400,9 +398,9 @@ public class PersonDao extends AnetBaseDao<Person, PersonSearchQuery> {
     // delete the person!
     final int nr = getDbHandle().createUpdate("DELETE FROM people WHERE uuid = :loserUuid")
         .bind("loserUuid", loser.getUuid()).execute();
-    // E.g. positions may have been updated, so always evict
-    evictFromCache(winner, true);
-    evictFromCache(loser, true);
+    // E.g. positions may have been updated, so evict from the cache
+    evictFromCache(winner);
+    evictFromCache(loser);
     return nr;
   }
 

--- a/src/main/java/mil/dds/anet/database/PersonDao.java
+++ b/src/main/java/mil/dds/anet/database/PersonDao.java
@@ -226,6 +226,24 @@ public class PersonDao extends AnetBaseDao<Person, PersonSearchQuery> {
     return people;
   }
 
+  /**
+   * Evict the person from the cache.
+   *
+   * @param personUuid the uuid of the person to be evicted from the cache
+   */
+  public void evictFromCacheByPersonUuid(String personUuid) {
+    evictFromCache(findInCacheByPersonUuid(personUuid), true);
+  }
+
+  /**
+   * Evict the person holding the position from the cache.
+   *
+   * @param positionUuid the uuid of the position for the person to be evicted from the cache
+   */
+  public void evictFromCacheByPositionUuid(String positionUuid) {
+    evictFromCache(findInCacheByPositionUuid(positionUuid), true);
+  }
+
   private Person getFromCache(String domainUsername) {
     if (domainUsersCache == null || domainUsername == null) {
       return null;
@@ -268,9 +286,24 @@ public class PersonDao extends AnetBaseDao<Person, PersonSearchQuery> {
   }
 
   private Person findInCache(Person person) {
-    if (domainUsersCache != null && person != null) {
+    return findInCacheByPersonUuid(DaoUtils.getUuid(person));
+  }
+
+  private Person findInCacheByPersonUuid(String personUuid) {
+    if (domainUsersCache != null && personUuid != null) {
       for (final Entry<String, Person> entry : domainUsersCache) {
-        if (Objects.equals(DaoUtils.getUuid(entry.getValue()), DaoUtils.getUuid(person))) {
+        if (Objects.equals(DaoUtils.getUuid(entry.getValue()), personUuid)) {
+          return entry.getValue();
+        }
+      }
+    }
+    return null;
+  }
+
+  private Person findInCacheByPositionUuid(String positionUuid) {
+    if (domainUsersCache != null && positionUuid != null) {
+      for (final Entry<String, Person> entry : domainUsersCache) {
+        if (Objects.equals(DaoUtils.getUuid(entry.getValue().getPosition()), positionUuid)) {
           return entry.getValue();
         }
       }

--- a/src/main/java/mil/dds/anet/database/PositionDao.java
+++ b/src/main/java/mil/dds/anet/database/PositionDao.java
@@ -177,7 +177,7 @@ public class PositionDao extends AnetBaseDao<Position, PositionSearchQuery> {
   @InTransaction
   public int setPersonInPosition(String personUuid, String positionUuid) {
     // If the position is already assigned to another person, remove the person from the position
-    AnetObjectEngine.getInstance().getPositionDao().removePersonFromPosition(positionUuid);
+    removePersonFromPosition(positionUuid);
 
     // If this person is in a position already, we need to remove them.
     Position currPos = getDbHandle()

--- a/src/main/java/mil/dds/anet/database/PositionDao.java
+++ b/src/main/java/mil/dds/anet/database/PositionDao.java
@@ -30,7 +30,7 @@ import ru.vyarus.guicey.jdbi3.tx.InTransaction;
 
 public class PositionDao extends AnetBaseDao<Position, PositionSearchQuery> {
 
-  private static String[] fields = {"uuid", "name", "code", "createdAt", "updatedAt",
+  public static String[] fields = {"uuid", "name", "code", "createdAt", "updatedAt",
       "organizationUuid", "currentPersonUuid", "type", "status", "locationUuid"};
   public static String TABLE_NAME = "positions";
   public static String POSITIONS_FIELDS = DaoUtils.buildFieldAliases(TABLE_NAME, fields, true);


### PR DESCRIPTION
To prevent other code from updating the cached object (and possibly [transitively] caching more than we would like), defensively copy objects when adding them to or retrieving them from the domainUsersCache.
Since the position is also cached (it has to be, as the object returned by the authentication filter needs to be checked for permissions), evict a person from the cache when their position is changed or deleted.