### PR TITLE
Fix comment email when report was deleted

### DIFF
--- a/src/main/java/mil/dds/anet/emails/ApprovalNeededEmail.java
+++ b/src/main/java/mil/dds/anet/emails/ApprovalNeededEmail.java
@@ -23,6 +23,10 @@ public class ApprovalNeededEmail implements AnetEmailAction {
   @Override
   public Map<String, Object> buildContext(Map<String, Object> context) {
     final Report r = AnetObjectEngine.getInstance().getReportDao().getByUuid(report.getUuid());
+    if (r == null) {
+      return null;
+    }
+
     final ApprovalStep step =
         r.loadApprovalStep(AnetObjectEngine.getInstance().getContext()).join();
     context.put("report", r);

--- a/src/main/java/mil/dds/anet/emails/FutureEngagementUpdated.java
+++ b/src/main/java/mil/dds/anet/emails/FutureEngagementUpdated.java
@@ -22,6 +22,10 @@ public class FutureEngagementUpdated implements AnetEmailAction {
   @Override
   public Map<String, Object> buildContext(Map<String, Object> context) {
     Report r = AnetObjectEngine.getInstance().getReportDao().getByUuid(report.getUuid());
+    if (r == null) {
+      return null;
+    }
+
     context.put("report", r);
     context.put("reportIntent", StringUtils.abbreviate(r.getIntent(), MAX_REPORT_INTENT_LENGTH));
 

--- a/src/main/java/mil/dds/anet/emails/NewReportCommentEmail.java
+++ b/src/main/java/mil/dds/anet/emails/NewReportCommentEmail.java
@@ -23,6 +23,9 @@ public class NewReportCommentEmail implements AnetEmailAction {
   @Override
   public Map<String, Object> buildContext(Map<String, Object> context) {
     Report r = AnetObjectEngine.getInstance().getReportDao().getByUuid(report.getUuid());
+    if (r == null) {
+      return null;
+    }
     comment = AnetObjectEngine.getInstance().getCommentDao().getByUuid(comment.getUuid());
 
     context.put("report", r);

--- a/src/main/java/mil/dds/anet/emails/ReportEditedEmail.java
+++ b/src/main/java/mil/dds/anet/emails/ReportEditedEmail.java
@@ -23,6 +23,10 @@ public class ReportEditedEmail implements AnetEmailAction {
   @Override
   public Map<String, Object> buildContext(Map<String, Object> context) {
     Report r = AnetObjectEngine.getInstance().getReportDao().getByUuid(report.getUuid());
+    if (r == null) {
+      return null;
+    }
+
     editor = AnetObjectEngine.getInstance().getPersonDao().getByUuid(editor.getUuid());
 
     context.put("report", r);

--- a/src/main/java/mil/dds/anet/emails/ReportEmail.java
+++ b/src/main/java/mil/dds/anet/emails/ReportEmail.java
@@ -24,6 +24,9 @@ public class ReportEmail implements AnetEmailAction {
   @Override
   public Map<String, Object> buildContext(Map<String, Object> context) {
     Report r = AnetObjectEngine.getInstance().getReportDao().getByUuid(report.getUuid());
+    if (r == null) {
+      return null;
+    }
     sender = AnetObjectEngine.getInstance().getPersonDao().getByUuid(sender.getUuid());
 
     context.put("report", r);

--- a/src/main/java/mil/dds/anet/emails/ReportPublishedEmail.java
+++ b/src/main/java/mil/dds/anet/emails/ReportPublishedEmail.java
@@ -21,6 +21,9 @@ public class ReportPublishedEmail implements AnetEmailAction {
   @Override
   public Map<String, Object> buildContext(Map<String, Object> context) {
     Report r = AnetObjectEngine.getInstance().getReportDao().getByUuid(report.getUuid());
+    if (r == null) {
+      return null;
+    }
 
     context.put("report", r);
     context.put("reportIntent", StringUtils.abbreviate(r.getIntent(), MAX_REPORT_INTENT_LENGTH));

--- a/src/main/java/mil/dds/anet/emails/ReportRejectionEmail.java
+++ b/src/main/java/mil/dds/anet/emails/ReportRejectionEmail.java
@@ -25,6 +25,10 @@ public class ReportRejectionEmail implements AnetEmailAction {
   @Override
   public Map<String, Object> buildContext(Map<String, Object> context) {
     Report r = AnetObjectEngine.getInstance().getReportDao().getByUuid(report.getUuid());
+    if (r == null) {
+      return null;
+    }
+
     rejector = AnetObjectEngine.getInstance().getPersonDao().getByUuid(rejector.getUuid());
     comment = AnetObjectEngine.getInstance().getCommentDao().getByUuid(comment.getUuid());
 

--- a/src/main/java/mil/dds/anet/threads/AnetEmailWorker.java
+++ b/src/main/java/mil/dds/anet/threads/AnetEmailWorker.java
@@ -151,13 +151,14 @@ public class AnetEmailWorker implements Runnable {
 
       try {
         context = buildContext(email);
-        logger.info("{} Sending email to {} re: {}", disabled ? "[Disabled] " : "",
-            email.getToAddresses(), email.getAction().getSubject(context));
+        if (context != null) {
+          logger.info("{} Sending email to {} re: {}", disabled ? "[Disabled] " : "",
+              email.getToAddresses(), email.getAction().getSubject(context));
 
-        if (!disabled) {
-          sendEmail(email, context);
+          if (!disabled) {
+            sendEmail(email, context);
+          }
         }
-
         processedEmails.add(email.getId());
       } catch (Throwable t) {
         logger.error("Error sending email", t);


### PR DESCRIPTION
We used to get an error when a user had made a comment on a report and afterwards - before the e-mail queue was processed - the report was deleted.
This was happening because when trying to send an e-mail about the new comment the report didn't exist any more and the code was expecting it to exist.

We've fixed it by making sure that if the report has been deleted, we no longer send it's comment e-mail. This check has also been added to other e-mails.