### PR TITLE
Match report task approvers to tasked organizations

### DIFF
--- a/client/src/components/ReportWorkflow.js
+++ b/client/src/components/ReportWorkflow.js
@@ -1,6 +1,7 @@
 import { Settings } from "api"
 import Fieldset from "components/Fieldset"
 import LinkTo from "components/LinkTo"
+import _isEmpty from "lodash/isEmpty"
 import moment from "moment"
 import PropTypes from "prop-types"
 import React, { useState } from "react"
@@ -48,7 +49,10 @@ const ApprovalStepModal = ({ action }) => {
   const [showModal, setShowModal] = useState(false)
 
   const step = action.step
-  const actionTypeCss = ACTION_TYPE_DETAILS[action.type].cssClass
+  const noApprovers = _isEmpty(step.approvers)
+  const actionTypeCss = noApprovers
+    ? "btn-warning default"
+    : ACTION_TYPE_DETAILS[action.type].cssClass
 
   return step ? (
     <>
@@ -64,12 +68,13 @@ const ApprovalStepModal = ({ action }) => {
         </Modal.Header>
         <Modal.Body>
           <ul>
-            {step.approvers.map(position => (
-              <li key={position.uuid}>
-                <LinkTo modelType="Position" model={position} /> -{" "}
-                <LinkTo modelType="Person" model={position.person} />
-              </li>
-            ))}
+            {(noApprovers && "This step has no approvers!") ||
+              step.approvers.map(position => (
+                <li key={position.uuid}>
+                  <LinkTo modelType="Position" model={position} /> -{" "}
+                  <LinkTo modelType="Person" model={position.person} />
+                </li>
+              ))}
           </ul>
         </Modal.Body>
         <Modal.Footer>

--- a/client/src/components/approvals/Approvals.js
+++ b/client/src/components/approvals/Approvals.js
@@ -3,9 +3,9 @@ import LinkTo from "components/LinkTo"
 import { Location, Organization, Task } from "models"
 import PropTypes from "prop-types"
 import React from "react"
-import { Table } from "react-bootstrap"
+import { Checkbox, Table } from "react-bootstrap"
 
-const Approvals = ({ relatedObject }) => {
+const Approvals = ({ restrictedApprovalLabel, relatedObject }) => {
   const approvalSteps = relatedObject.approvalSteps
   const planningApprovalSteps = relatedObject.planningApprovalSteps
 
@@ -17,6 +17,11 @@ const Approvals = ({ relatedObject }) => {
       >
         {planningApprovalSteps.map((step, idx) => (
           <Fieldset title={`Step ${idx + 1}: ${step.name}`} key={"step_" + idx}>
+            {restrictedApprovalLabel && (
+              <Checkbox inline checked={step.restrictedApproval} readOnly>
+                {restrictedApprovalLabel}
+              </Checkbox>
+            )}
             <Table>
               <thead>
                 <tr>
@@ -57,6 +62,11 @@ const Approvals = ({ relatedObject }) => {
       <Fieldset id="approvals" title="Report publication approval process">
         {approvalSteps.map((step, idx) => (
           <Fieldset title={`Step ${idx + 1}: ${step.name}`} key={"step_" + idx}>
+            {restrictedApprovalLabel && (
+              <Checkbox inline checked={step.restrictedApproval} readOnly>
+                {restrictedApprovalLabel}
+              </Checkbox>
+            )}
             <Table>
               <thead>
                 <tr>
@@ -99,6 +109,7 @@ const Approvals = ({ relatedObject }) => {
 }
 
 Approvals.propTypes = {
+  restrictedApprovalLabel: PropTypes.string,
   relatedObject: PropTypes.oneOfType([
     PropTypes.instanceOf(Location),
     PropTypes.instanceOf(Organization),

--- a/client/src/components/approvals/ApprovalsDefinition.js
+++ b/client/src/components/approvals/ApprovalsDefinition.js
@@ -9,7 +9,7 @@ import { FastField, FieldArray } from "formik"
 import { Position } from "models"
 import PropTypes from "prop-types"
 import React, { useState } from "react"
-import { Button, Modal, Table } from "react-bootstrap"
+import { Button, Checkbox, Modal, Table } from "react-bootstrap"
 import REMOVE_ICON from "resources/delete.png"
 import POSITIONS_ICON from "resources/positions.png"
 
@@ -60,6 +60,7 @@ const ApprovalsDefinition = ({
   fieldName,
   values,
   title,
+  restrictedApprovalLabel,
   addButtonLabel,
   approversFilters,
   setFieldTouched,
@@ -138,6 +139,7 @@ const ApprovalsDefinition = ({
                   setFieldTouched,
                   step,
                   index,
+                  restrictedApprovalLabel,
                   approversFilters
                 )
               )}
@@ -155,6 +157,7 @@ const ApprovalsDefinition = ({
     setFieldTouched,
     step,
     index,
+    restrictedApprovalLabel,
     approversFilters
   ) {
     const approvers = step.approvers
@@ -174,6 +177,21 @@ const ApprovalsDefinition = ({
           component={FieldHelper.InputField}
           label="Step name"
         />
+        {restrictedApprovalLabel && (
+          <FastField
+            name={`${fieldName}.${index}.restrictedApproval`}
+            component={FieldHelper.SpecialField}
+            label=""
+            widget={
+              <Checkbox
+                inline
+                checked={values?.[fieldName]?.[index].restrictedApproval}
+              >
+                {restrictedApprovalLabel}
+              </Checkbox>
+            }
+          />
+        )}
         <FastField
           name={`${fieldName}.${index}.approvers`}
           label="Add an approver"
@@ -228,7 +246,7 @@ const ApprovalsDefinition = ({
         return
       }
     }
-    arrayHelpers.push({ name: "", approvers: [] })
+    arrayHelpers.push({ name: "", restrictedApproval: false, approvers: [] })
   }
 
   function removeApprovalStep(arrayHelpers, index, step) {
@@ -251,6 +269,7 @@ const ApprovalsDefinition = ({
 ApprovalsDefinition.propTypes = {
   fieldName: PropTypes.string.isRequired,
   title: PropTypes.string,
+  restrictedApprovalLabel: PropTypes.string,
   addButtonLabel: PropTypes.string,
   values: PropTypes.object,
   approversFilters: PropTypes.object,

--- a/client/src/models/Task.js
+++ b/client/src/models/Task.js
@@ -134,6 +134,7 @@ export default class Task extends Model {
               .string()
               .required()
               .default(() => Task.APPROVAL_STEP_TYPE.PLANNING_APPROVAL),
+            restrictedApproval: yup.boolean().default(false),
             approvers: yup
               .array()
               .required("You must select at least one approver")
@@ -154,6 +155,7 @@ export default class Task extends Model {
               .string()
               .required()
               .default(() => Task.APPROVAL_STEP_TYPE.REPORT_APPROVAL),
+            restrictedApproval: yup.boolean().default(false),
             approvers: yup
               .array()
               .required("You must select at least one approver")

--- a/client/src/pages/positions/Form.js
+++ b/client/src/pages/positions/Form.js
@@ -12,6 +12,7 @@ import LinkTo from "components/LinkTo"
 import Messages from "components/Messages"
 import NavigationWarning from "components/NavigationWarning"
 import { jumpToTop } from "components/Page"
+import { RECURSE_STRATEGY } from "components/SearchFilters"
 import { FastField, Field, Form, Formik } from "formik"
 import DictionaryField from "HOC/DictionaryField"
 import { Location, Organization, Person, Position } from "models"
@@ -138,7 +139,7 @@ const BasePositionForm = ({ currentUser, edit, title, initialValues }) => {
             orgSearchQuery.parentOrgUuid = [
               currentUser.position.organization.uuid
             ]
-            orgSearchQuery.parentOrgRecursively = true
+            orgSearchQuery.orgRecurseStrategy = RECURSE_STRATEGY.CHILDREN
           }
         }
         // Reset the organization property when changing the organization type

--- a/client/src/pages/tasks/Edit.js
+++ b/client/src/pages/tasks/Edit.js
@@ -59,6 +59,7 @@ const GQL_GET_TASK = gql`
       planningApprovalSteps {
         uuid
         name
+        restrictedApproval
         approvers {
           uuid
           name
@@ -74,6 +75,7 @@ const GQL_GET_TASK = gql`
       approvalSteps {
         uuid
         name
+        restrictedApproval
         approvers {
           uuid
           name

--- a/client/src/pages/tasks/Form.js
+++ b/client/src/pages/tasks/Form.js
@@ -415,6 +415,7 @@ const BaseTaskForm = ({ currentUser, edit, title, initialValues }) => {
                 fieldName="planningApprovalSteps"
                 values={values}
                 title="Engagement planning approval process"
+                restrictedApprovalLabel="Restrict to approvers descending from the same tasked organization as the report's primary advisor"
                 addButtonLabel="Add a Planning Approval Step"
                 setFieldTouched={setFieldTouched}
                 setFieldValue={setFieldValue}
@@ -425,6 +426,7 @@ const BaseTaskForm = ({ currentUser, edit, title, initialValues }) => {
                 fieldName="approvalSteps"
                 values={values}
                 title="Report publication approval process"
+                restrictedApprovalLabel="Restrict to approvers descending from the same tasked organization as the report's primary advisor"
                 addButtonLabel="Add a Publication Approval Step"
                 setFieldTouched={setFieldTouched}
                 setFieldValue={setFieldValue}

--- a/client/src/pages/tasks/Show.js
+++ b/client/src/pages/tasks/Show.js
@@ -72,6 +72,7 @@ const GQL_GET_TASK = gql`
       planningApprovalSteps {
         uuid
         name
+        restrictedApproval
         approvers {
           uuid
           name
@@ -87,6 +88,7 @@ const GQL_GET_TASK = gql`
       approvalSteps {
         uuid
         name
+        restrictedApproval
         approvers {
           uuid
           name
@@ -362,7 +364,10 @@ const BaseTaskShow = ({ pageDispatchers, currentUser }) => {
               <PositionTable positions={task.responsiblePositions} />
             </Fieldset>
 
-            <Approvals relatedObject={task} />
+            <Approvals
+              restrictedApprovalLabel="Restrict to approvers descending from the same tasked organization as the report's primary advisor"
+              relatedObject={task}
+            />
 
             <Fieldset title={`Reports for this ${fieldSettings.shortLabel}`}>
               <ReportCollection

--- a/src/main/java/mil/dds/anet/AnetObjectEngine.java
+++ b/src/main/java/mil/dds/anet/AnetObjectEngine.java
@@ -334,8 +334,7 @@ public class AnetObjectEngine {
     query.setParentOrgUuid(Collections.singletonList(parentOrgUuid));
     query.setOrgRecurseStrategy(RecurseStrategy.CHILDREN);
     query.setPageSize(0);
-    final List<Organization> orgList =
-        AnetObjectEngine.getInstance().getOrganizationDao().search(query).getList();
+    final List<Organization> orgList = orgDao.search(query).getList();
     return Utils.buildParentOrgMapping(orgList, parentOrgUuid);
   }
 
@@ -349,7 +348,7 @@ public class AnetObjectEngine {
     query.setCustomFieldRef1Uuid(Collections.singletonList(parentTaskUuid));
     query.setCustomFieldRef1Recursively(true);
     query.setPageSize(0);
-    final List<Task> taskList = AnetObjectEngine.getInstance().getTaskDao().search(query).getList();
+    final List<Task> taskList = taskDao.search(query).getList();
     return Utils.buildParentTaskMapping(taskList, parentTaskUuid);
   }
 

--- a/src/main/java/mil/dds/anet/AnetObjectEngine.java
+++ b/src/main/java/mil/dds/anet/AnetObjectEngine.java
@@ -16,6 +16,7 @@ import mil.dds.anet.beans.Organization.OrganizationType;
 import mil.dds.anet.beans.Person;
 import mil.dds.anet.beans.Position;
 import mil.dds.anet.beans.Task;
+import mil.dds.anet.beans.search.ISearchQuery.RecurseStrategy;
 import mil.dds.anet.beans.search.OrganizationSearchQuery;
 import mil.dds.anet.beans.search.TaskSearchQuery;
 import mil.dds.anet.database.AdminDao;
@@ -258,7 +259,7 @@ public class AnetObjectEngine {
   public Map<String, Organization> buildTopLevelOrgHash(String parentOrgUuid) {
     final OrganizationSearchQuery query = new OrganizationSearchQuery();
     query.setParentOrgUuid(Collections.singletonList(parentOrgUuid));
-    query.setParentOrgRecursively(true);
+    query.setOrgRecurseStrategy(RecurseStrategy.CHILDREN);
     query.setPageSize(0);
     final List<Organization> orgList =
         AnetObjectEngine.getInstance().getOrganizationDao().search(query).getList();

--- a/src/main/java/mil/dds/anet/beans/ApprovalStep.java
+++ b/src/main/java/mil/dds/anet/beans/ApprovalStep.java
@@ -31,9 +31,8 @@ public class ApprovalStep extends AbstractAnetBean {
   @GraphQLQuery
   @GraphQLInputField
   String name;
-  @GraphQLQuery
-  @GraphQLInputField
-  private boolean restrictedApproval;
+  // annotated below
+  private Boolean restrictedApproval;
 
   @GraphQLQuery(name = "approvers")
   public CompletableFuture<List<Position>> loadApprovers(
@@ -89,11 +88,13 @@ public class ApprovalStep extends AbstractAnetBean {
     this.type = type;
   }
 
+  @GraphQLQuery
   public boolean isRestrictedApproval() {
-    return restrictedApproval;
+    return Boolean.TRUE.equals(restrictedApproval);
   }
 
-  public void setRestrictedApproval(boolean restrictedApproval) {
+  @GraphQLInputField
+  public void setRestrictedApproval(Boolean restrictedApproval) {
     this.restrictedApproval = restrictedApproval;
   }
 
@@ -103,10 +104,11 @@ public class ApprovalStep extends AbstractAnetBean {
       return false;
     }
     ApprovalStep as = (ApprovalStep) o;
-    return Objects.equals(uuid, as.getUuid()) && Objects.equals(name, as.getName())
-        && Objects.equals(nextStepUuid, as.getNextStepUuid()) && Objects.equals(type, as.getType())
-        && Objects.equals(relatedObjectUuid, as.getRelatedObjectUuid())
-        && Objects.equals(restrictedApproval, as.isRestrictedApproval());
+    return Objects.equals(getUuid(), as.getUuid()) && Objects.equals(getName(), as.getName())
+        && Objects.equals(getNextStepUuid(), as.getNextStepUuid())
+        && Objects.equals(getType(), as.getType())
+        && Objects.equals(getRelatedObjectUuid(), as.getRelatedObjectUuid())
+        && Objects.equals(isRestrictedApproval(), as.isRestrictedApproval());
   }
 
   @Override

--- a/src/main/java/mil/dds/anet/beans/ApprovalStep.java
+++ b/src/main/java/mil/dds/anet/beans/ApprovalStep.java
@@ -123,4 +123,18 @@ public class ApprovalStep extends AbstractAnetBean {
         nextStepUuid);
   }
 
+  @Override
+  protected ApprovalStep clone() {
+    final ApprovalStep clone = new ApprovalStep();
+    clone.setUuid(uuid);
+    clone.setName(name);
+    clone.setNextStepUuid(nextStepUuid);
+    clone.setType(type);
+    clone.setRelatedObjectUuid(relatedObjectUuid);
+    clone.setRestrictedApproval(restrictedApproval);
+    clone.setCreatedAt(createdAt);
+    clone.setUpdatedAt(updatedAt);
+    return clone;
+  }
+
 }

--- a/src/main/java/mil/dds/anet/beans/ApprovalStep.java
+++ b/src/main/java/mil/dds/anet/beans/ApprovalStep.java
@@ -31,6 +31,9 @@ public class ApprovalStep extends AbstractAnetBean {
   @GraphQLQuery
   @GraphQLInputField
   String name;
+  @GraphQLQuery
+  @GraphQLInputField
+  private boolean restrictedApproval;
 
   @GraphQLQuery(name = "approvers")
   public CompletableFuture<List<Position>> loadApprovers(
@@ -86,6 +89,14 @@ public class ApprovalStep extends AbstractAnetBean {
     this.type = type;
   }
 
+  public boolean isRestrictedApproval() {
+    return restrictedApproval;
+  }
+
+  public void setRestrictedApproval(boolean restrictedApproval) {
+    this.restrictedApproval = restrictedApproval;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (!(o instanceof ApprovalStep)) {
@@ -94,12 +105,14 @@ public class ApprovalStep extends AbstractAnetBean {
     ApprovalStep as = (ApprovalStep) o;
     return Objects.equals(uuid, as.getUuid()) && Objects.equals(name, as.getName())
         && Objects.equals(nextStepUuid, as.getNextStepUuid()) && Objects.equals(type, as.getType())
-        && Objects.equals(relatedObjectUuid, as.getRelatedObjectUuid());
+        && Objects.equals(relatedObjectUuid, as.getRelatedObjectUuid())
+        && Objects.equals(restrictedApproval, as.isRestrictedApproval());
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(uuid, approvers, name, nextStepUuid, relatedObjectUuid, type);
+    return Objects.hash(uuid, approvers, name, nextStepUuid, relatedObjectUuid, type,
+        restrictedApproval);
   }
 
   @Override

--- a/src/main/java/mil/dds/anet/beans/Organization.java
+++ b/src/main/java/mil/dds/anet/beans/Organization.java
@@ -220,6 +220,19 @@ public class Organization extends AbstractAnetBean {
         uuid, query);
   }
 
+  @GraphQLQuery(name = "ascendantOrgs")
+  public CompletableFuture<List<Organization>> loadAscendantOrgs(
+      @GraphQLRootContext Map<String, Object> context,
+      @GraphQLArgument(name = "query") OrganizationSearchQuery query) {
+    if (query == null) {
+      query = new OrganizationSearchQuery();
+    }
+    // Note: recursion, includes transitive parents!
+    query.setBatchParams(new RecursiveFkBatchParams<Organization, OrganizationSearchQuery>(
+        "organizations", "uuid", "organizations", "\"parentOrgUuid\"", RecurseStrategy.PARENTS));
+    return AnetObjectEngine.getInstance().getOrganizationDao().getOrganizationsBySearch(context,
+        uuid, query);
+  }
 
   @GraphQLQuery(name = "tasks")
   public CompletableFuture<List<Task>> loadTasks(@GraphQLRootContext Map<String, Object> context) {

--- a/src/main/java/mil/dds/anet/beans/Organization.java
+++ b/src/main/java/mil/dds/anet/beans/Organization.java
@@ -11,6 +11,7 @@ import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import mil.dds.anet.AnetObjectEngine;
 import mil.dds.anet.beans.search.FkBatchParams;
+import mil.dds.anet.beans.search.ISearchQuery.RecurseStrategy;
 import mil.dds.anet.beans.search.M2mBatchParams;
 import mil.dds.anet.beans.search.OrganizationSearchQuery;
 import mil.dds.anet.beans.search.PositionSearchQuery;
@@ -212,8 +213,9 @@ public class Organization extends AbstractAnetBean {
       query = new OrganizationSearchQuery();
     }
     // Note: recursion, includes transitive children!
-    query.setBatchParams(new RecursiveFkBatchParams<Organization, OrganizationSearchQuery>(
-        "organizations", "\"parentOrgUuid\"", "organizations", "\"parentOrgUuid\""));
+    query.setBatchParams(
+        new RecursiveFkBatchParams<Organization, OrganizationSearchQuery>("organizations",
+            "\"parentOrgUuid\"", "organizations", "\"parentOrgUuid\"", RecurseStrategy.CHILDREN));
     return AnetObjectEngine.getInstance().getOrganizationDao().getOrganizationsBySearch(context,
         uuid, query);
   }

--- a/src/main/java/mil/dds/anet/beans/Person.java
+++ b/src/main/java/mil/dds/anet/beans/Person.java
@@ -235,20 +235,22 @@ public class Person extends AbstractCustomizableAnetBean implements Principal {
 
   // TODO: batch load? (used in admin/MergePeople.js)
   @GraphQLQuery(name = "authoredReports")
-  public AnetBeanList<Report> loadAuthoredReports(@GraphQLRootContext Map<String, Object> context,
+  public CompletableFuture<AnetBeanList<Report>> loadAuthoredReports(
+      @GraphQLRootContext Map<String, Object> context,
       @GraphQLArgument(name = "query") ReportSearchQuery query) {
     query.setAuthorUuid(uuid);
     query.setUser(DaoUtils.getUserFromContext(context));
-    return AnetObjectEngine.getInstance().getReportDao().search(query);
+    return AnetObjectEngine.getInstance().getReportDao().search(context, query);
   }
 
   // TODO: batch load? (used in admin/MergePeople.js)
   @GraphQLQuery(name = "attendedReports")
-  public AnetBeanList<Report> loadAttendedReports(@GraphQLRootContext Map<String, Object> context,
+  public CompletableFuture<AnetBeanList<Report>> loadAttendedReports(
+      @GraphQLRootContext Map<String, Object> context,
       @GraphQLArgument(name = "query") ReportSearchQuery query) {
     query.setAttendeeUuid(uuid);
     query.setUser(DaoUtils.getUserFromContext(context));
-    return AnetObjectEngine.getInstance().getReportDao().search(query);
+    return AnetObjectEngine.getInstance().getReportDao().search(context, query);
   }
 
   @GraphQLQuery(name = "avatar")

--- a/src/main/java/mil/dds/anet/beans/Report.java
+++ b/src/main/java/mil/dds/anet/beans/Report.java
@@ -6,15 +6,12 @@ import io.leangen.graphql.annotations.GraphQLQuery;
 import io.leangen.graphql.annotations.GraphQLRootContext;
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import javax.ws.rs.WebApplicationException;
@@ -504,15 +501,11 @@ public class Report extends AbstractCustomizableAnetBean {
         if (Utils.isEmptyOrNull(tasks)) {
           return CompletableFuture.completedFuture(steps);
         } else {
-          return loadAdvisorOrg(context).thenCompose(ao -> {
-            return loadAscendantOrgs(context, ao).thenCompose(orgsToMatch -> {
-              return getTaskWorkflow(context, engine, orgsToMatch, tasks.iterator())
-                  .thenCompose(taskApprovalSteps -> {
-                    steps.addAll(taskApprovalSteps);
-                    return CompletableFuture.completedFuture(steps);
-                  });
-            });
-          });
+          return getTaskWorkflow(context, engine, tasks.iterator())
+              .thenCompose(taskApprovalSteps -> {
+                steps.addAll(taskApprovalSteps);
+                return CompletableFuture.completedFuture(steps);
+              });
         }
       });
     }).thenCompose(steps -> {
@@ -527,17 +520,23 @@ public class Report extends AbstractCustomizableAnetBean {
               return CompletableFuture.completedFuture(steps);
             });
       }
-    });
-  }
+    }).thenCompose(steps -> {
+      @SuppressWarnings("unchecked")
+      final CompletableFuture<ApprovalStep>[] allSteps =
+          (CompletableFuture<ApprovalStep>[]) steps.stream()
+              .map(step -> getFilteredStep(context, step)).toArray(CompletableFuture<?>[]::new);
+      return CompletableFuture.allOf(allSteps).thenCompose(v -> {
+        final List<ApprovalStep> filteredSteps = new ArrayList<>();
+        for (final CompletableFuture<ApprovalStep> cas : allSteps) {
+          final ApprovalStep as = cas.join();
+          if (as != null) {
+            filteredSteps.add(as);
+          }
+        }
+        return CompletableFuture.completedFuture(filteredSteps);
+      });
 
-  private CompletableFuture<Set<String>> loadAscendantOrgs(Map<String, Object> context,
-      Organization org) {
-    if (org == null) {
-      return CompletableFuture.completedFuture(Collections.emptySet());
-    }
-    return org.loadAscendantOrgs(context, null)
-        .thenCompose(ascendantOrgs -> CompletableFuture.completedFuture(
-            ascendantOrgs.stream().map(o -> DaoUtils.getUuid(o)).collect(Collectors.toSet())));
+    });
   }
 
   /*
@@ -562,11 +561,9 @@ public class Report extends AbstractCustomizableAnetBean {
       } else {
         return computeApprovalSteps(context, engine).thenCompose(steps -> {
           final List<ReportAction> actionTail = getActionTail(actions);
-          return createApprovalStepsActions(context, actionTail, steps).thenCompose(asa -> {
-            actionTail.addAll(asa);
-            workflow = actionTail;
-            return CompletableFuture.completedFuture(workflow);
-          });
+          actionTail.addAll(createApprovalStepsActions(actionTail, steps));
+          workflow = actionTail;
+          return CompletableFuture.completedFuture(workflow);
         });
       }
     });
@@ -593,29 +590,18 @@ public class Report extends AbstractCustomizableAnetBean {
     this.workflow = workflow;
   }
 
-  private CompletableFuture<List<ReportAction>> createApprovalStepsActions(
-      Map<String, Object> context, List<ReportAction> actions, List<ApprovalStep> steps) {
-    final List<ReportAction> newActions = new LinkedList<ReportAction>();
-    @SuppressWarnings("unchecked")
-    final CompletableFuture<ApprovalStep>[] allSteps = (CompletableFuture<ApprovalStep>[]) steps
-        .stream().map(step -> createApprovalStep(context, actions, step))
-        .toArray(CompletableFuture<?>[]::new);
-    return CompletableFuture.allOf(allSteps).thenCompose(v -> {
-      for (final CompletableFuture<ApprovalStep> cas : allSteps) {
-        final ApprovalStep as = cas.join();
-        if (as != null) {
-          // If there is no action for this step, create a new one and attach this step
+  private List<ReportAction> createApprovalStepsActions(List<ReportAction> actions,
+      List<ApprovalStep> steps) {
+    return steps.stream().map(step -> createApprovalStep(actions, step)).filter(as -> as != null)
+        .map(as -> {
+          // There is no action for this step, create a new one and attach this step
           final ReportAction action = new ReportAction();
           action.setStep(as);
-          newActions.add(action);
-        }
-      }
-      return CompletableFuture.completedFuture(newActions);
-    });
+          return action;
+        }).collect(Collectors.toList());
   }
 
-  private CompletableFuture<ApprovalStep> createApprovalStep(Map<String, Object> context,
-      List<ReportAction> actions, ApprovalStep step) {
+  private ApprovalStep createApprovalStep(List<ReportAction> actions, ApprovalStep step) {
     // Check if there are report actions for this step
     final Optional<ReportAction> existing =
         actions.stream().filter(a -> Objects.equals(DaoUtils.getUuid(step), a.getStepUuid()))
@@ -625,10 +611,7 @@ public class Report extends AbstractCustomizableAnetBean {
                 return a.getCreatedAt().compareTo(b.getCreatedAt());
               }
             });
-    if (existing.isPresent()) {
-      return CompletableFuture.completedFuture(null);
-    }
-    return getFilteredStep(context, step);
+    return existing.isPresent() ? null : step;
   }
 
   private CompletableFuture<ApprovalStep> getFilteredStep(Map<String, Object> context,
@@ -636,10 +619,6 @@ public class Report extends AbstractCustomizableAnetBean {
     if (!step.isRestrictedApproval()) {
       return CompletableFuture.completedFuture(step);
     }
-    // Return a copy of the step, with the approvers filtered to those who can actually approve
-    final ApprovalStep filteredStep = new ApprovalStep();
-    filteredStep.setUuid(step.getUuid());
-    filteredStep.setName(step.getName());
     return step.loadApprovers(context).thenCompose(approvers -> {
       final AnetObjectEngine engine = AnetObjectEngine.getInstance();
       @SuppressWarnings("unchecked")
@@ -655,8 +634,17 @@ public class Report extends AbstractCustomizableAnetBean {
             filteredApprovers.add(approvers.get(i));
           }
         }
-        filteredStep.setApprovers(filteredApprovers);
-        return CompletableFuture.completedFuture(filteredStep);
+        if (filteredApprovers.isEmpty()
+            && !Objects.equals(getApprovalStepUuid(), DaoUtils.getUuid(step))) {
+          // No actual approvers, and step is not the current approval step: step does not apply
+          return CompletableFuture.completedFuture(null);
+        } else {
+          // Copy the step, but with the approvers filtered to those who can actually approve (might
+          // be empty)
+          final ApprovalStep filteredStep = step.clone();
+          filteredStep.setApprovers(filteredApprovers);
+          return CompletableFuture.completedFuture(filteredStep);
+        }
       });
     });
   }
@@ -709,39 +697,20 @@ public class Report extends AbstractCustomizableAnetBean {
   }
 
   private CompletableFuture<List<ApprovalStep>> getTaskWorkflow(Map<String, Object> context,
-      AnetObjectEngine engine, Set<String> orgsToMatch, Iterator<Task> taskIterator) {
+      AnetObjectEngine engine, Iterator<Task> taskIterator) {
     if (!taskIterator.hasNext()) {
       return CompletableFuture.completedFuture(new ArrayList<>());
     } else {
       final Task task = taskIterator.next();
-      return matchTaskedOrgs(context, orgsToMatch, task)
-          .thenCompose(taskedOrgsMatch -> (isFutureEngagement()
-              ? getPlanningWorkflowForRelatedObject(context, engine, DaoUtils.getUuid(task))
-              : getWorkflowForRelatedObject(context, engine, DaoUtils.getUuid(task))).thenCompose(
-                  taskSteps -> getTaskWorkflow(context, engine, orgsToMatch, taskIterator)
-                      .thenCompose(nextTaskSteps -> {
-                        final List<ApprovalStep> ts = filterTaskSteps(taskSteps, taskedOrgsMatch);
-                        ts.addAll(filterTaskSteps(nextTaskSteps, taskedOrgsMatch));
-                        return CompletableFuture.completedFuture(ts);
-                      })));
+      return (isFutureEngagement()
+          ? getPlanningWorkflowForRelatedObject(context, engine, DaoUtils.getUuid(task))
+          : getWorkflowForRelatedObject(context, engine, DaoUtils.getUuid(task)))
+              .thenCompose(taskSteps -> getTaskWorkflow(context, engine, taskIterator)
+                  .thenCompose(nextTaskSteps -> {
+                    taskSteps.addAll(nextTaskSteps);
+                    return CompletableFuture.completedFuture(taskSteps);
+                  }));
     }
-  }
-
-  private CompletableFuture<Boolean> matchTaskedOrgs(Map<String, Object> context,
-      Set<String> orgsToMatch, Task task) {
-    return task.loadTaskedOrganizations(context).thenCompose(taskedOrganizations -> {
-      final Set<String> matchingOrgs =
-          taskedOrganizations.stream().map(o -> DaoUtils.getUuid(o)).collect(Collectors.toSet());
-      matchingOrgs.retainAll(orgsToMatch);
-      return CompletableFuture.completedFuture(!matchingOrgs.isEmpty());
-    });
-  }
-
-  private List<ApprovalStep> filterTaskSteps(List<ApprovalStep> taskSteps,
-      Boolean taskedOrgsMatch) {
-    return taskSteps.stream()
-        .filter(taskStep -> !taskStep.isRestrictedApproval() || taskedOrgsMatch)
-        .collect(Collectors.toList());
   }
 
   private CompletableFuture<List<ApprovalStep>> getLocationWorkflow(Map<String, Object> context,

--- a/src/main/java/mil/dds/anet/beans/Report.java
+++ b/src/main/java/mil/dds/anet/beans/Report.java
@@ -666,14 +666,16 @@ public class Report extends AbstractCustomizableAnetBean {
       return CompletableFuture.completedFuture(new ArrayList<>());
     } else {
       final Task task = taskIterator.next();
-      return matchTaskedOrgs(context, orgsToMatch, task).thenCompose(
-          taskedOrgsMatch -> getWorkflowForRelatedObject(context, engine, DaoUtils.getUuid(task))
-              .thenCompose(taskSteps -> getTaskWorkflow(context, engine, orgsToMatch, taskIterator)
-                  .thenCompose(nextTaskSteps -> {
-                    final List<ApprovalStep> ts = filterTaskSteps(taskSteps, taskedOrgsMatch);
-                    ts.addAll(filterTaskSteps(nextTaskSteps, taskedOrgsMatch));
-                    return CompletableFuture.completedFuture(ts);
-                  })));
+      return matchTaskedOrgs(context, orgsToMatch, task)
+          .thenCompose(taskedOrgsMatch -> (isFutureEngagement()
+              ? getPlanningWorkflowForRelatedObject(context, engine, DaoUtils.getUuid(task))
+              : getWorkflowForRelatedObject(context, engine, DaoUtils.getUuid(task))).thenCompose(
+                  taskSteps -> getTaskWorkflow(context, engine, orgsToMatch, taskIterator)
+                      .thenCompose(nextTaskSteps -> {
+                        final List<ApprovalStep> ts = filterTaskSteps(taskSteps, taskedOrgsMatch);
+                        ts.addAll(filterTaskSteps(nextTaskSteps, taskedOrgsMatch));
+                        return CompletableFuture.completedFuture(ts);
+                      })));
     }
   }
 

--- a/src/main/java/mil/dds/anet/beans/search/OrganizationSearchQuery.java
+++ b/src/main/java/mil/dds/anet/beans/search/OrganizationSearchQuery.java
@@ -23,12 +23,9 @@ public class OrganizationSearchQuery extends AbstractSearchQuery<OrganizationSea
   @GraphQLQuery
   @GraphQLInputField
   private List<String> parentOrgUuid;
-  // Include descendants recursively from the specified parent.
-  // If true will include all orgs in the tree of the parentOrg
-  // Including the parent Org.
   @GraphQLQuery
   @GraphQLInputField
-  private Boolean parentOrgRecursively;
+  private RecurseStrategy orgRecurseStrategy;
 
   public OrganizationSearchQuery() {
     super(OrganizationSearchSortBy.NAME);
@@ -66,18 +63,18 @@ public class OrganizationSearchQuery extends AbstractSearchQuery<OrganizationSea
     this.parentOrgUuid = parentOrgUuid;
   }
 
-  public boolean getParentOrgRecursively() {
-    return Boolean.TRUE.equals(parentOrgRecursively);
+  public RecurseStrategy getOrgRecurseStrategy() {
+    return orgRecurseStrategy;
   }
 
-  public void setParentOrgRecursively(Boolean parentOrgRecursively) {
-    this.parentOrgRecursively = parentOrgRecursively;
+  public void setOrgRecurseStrategy(RecurseStrategy orgRecurseStrategy) {
+    this.orgRecurseStrategy = orgRecurseStrategy;
   }
 
   @Override
   public int hashCode() {
     return Objects.hash(super.hashCode(), status, type, hasParentOrg, parentOrgUuid,
-        parentOrgRecursively);
+        orgRecurseStrategy);
   }
 
   @Override
@@ -90,7 +87,7 @@ public class OrganizationSearchQuery extends AbstractSearchQuery<OrganizationSea
         && Objects.equals(getType(), other.getType())
         && Objects.equals(getHasParentOrg(), other.getHasParentOrg())
         && Objects.equals(getParentOrgUuid(), other.getParentOrgUuid())
-        && Objects.equals(getParentOrgRecursively(), other.getParentOrgRecursively());
+        && Objects.equals(getOrgRecurseStrategy(), other.getOrgRecurseStrategy());
   }
 
 }

--- a/src/main/java/mil/dds/anet/beans/search/RecursiveFkBatchParams.java
+++ b/src/main/java/mil/dds/anet/beans/search/RecursiveFkBatchParams.java
@@ -1,6 +1,7 @@
 package mil.dds.anet.beans.search;
 
 import java.util.Objects;
+import mil.dds.anet.beans.search.ISearchQuery.RecurseStrategy;
 import mil.dds.anet.search.AbstractSearchQueryBuilder;
 import mil.dds.anet.views.AbstractAnetBean;
 
@@ -8,19 +9,22 @@ public class RecursiveFkBatchParams<B extends AbstractAnetBean, T extends Abstra
     extends FkBatchParams<B, T> {
   private String recursiveTableName;
   private String recursiveForeignKey;
+  private RecurseStrategy recurseStrategy;
 
   public RecursiveFkBatchParams(String tableName, String foreignKey, String recursiveTableName,
-      String recursiveForeignKey) {
+      String recursiveForeignKey, RecurseStrategy recurseStrategy) {
     super(tableName, foreignKey);
     this.recursiveTableName = recursiveTableName;
     this.recursiveForeignKey = recursiveForeignKey;
+    this.recurseStrategy = recurseStrategy;
   }
 
   @Override
   public void addQuery(AbstractSearchQueryBuilder<B, T> outerQb,
       AbstractSearchQueryBuilder<B, T> qb) {
     qb.addRecursiveBatchClause(outerQb, getTableName(), new String[] {getForeignKey()},
-        "batch_parents", recursiveTableName, recursiveForeignKey, "batchUuids", getBatchUuids());
+        "batch_parents", recursiveTableName, recursiveForeignKey, "batchUuids", getBatchUuids(),
+        recurseStrategy);
   }
 
   public String getRecursiveTableName() {
@@ -39,9 +43,18 @@ public class RecursiveFkBatchParams<B extends AbstractAnetBean, T extends Abstra
     this.recursiveForeignKey = recursiveForeignKey;
   }
 
+  public RecurseStrategy getRecurseStrategy() {
+    return recurseStrategy;
+  }
+
+  public void setRecurseStrategy(RecurseStrategy recurseStrategy) {
+    this.recurseStrategy = recurseStrategy;
+  }
+
   @Override
   public int hashCode() {
-    return Objects.hash(super.hashCode(), getRecursiveTableName(), getRecursiveForeignKey());
+    return Objects.hash(super.hashCode(), getRecursiveTableName(), getRecursiveForeignKey(),
+        getRecurseStrategy());
   }
 
   @Override
@@ -52,6 +65,7 @@ public class RecursiveFkBatchParams<B extends AbstractAnetBean, T extends Abstra
     final RecursiveFkBatchParams<?, ?> other = (RecursiveFkBatchParams<?, ?>) obj;
     return super.equals(obj)
         && Objects.equals(getRecursiveTableName(), other.getRecursiveTableName())
-        && Objects.equals(getRecursiveForeignKey(), other.getRecursiveForeignKey());
+        && Objects.equals(getRecursiveForeignKey(), other.getRecursiveForeignKey())
+        && Objects.equals(getRecurseStrategy(), other.getRecurseStrategy());
   }
 }

--- a/src/main/java/mil/dds/anet/database/ApprovalStepDao.java
+++ b/src/main/java/mil/dds/anet/database/ApprovalStepDao.java
@@ -117,9 +117,9 @@ public class ApprovalStepDao extends AnetBaseDao<ApprovalStep, AbstractSearchQue
 
   @Override
   public ApprovalStep insertInternal(ApprovalStep as) {
-    getDbHandle().createUpdate(
-        "/* insertApprovalStep */ INSERT into \"approvalSteps\" (uuid, name, \"nextStepUuid\", \"relatedObjectUuid\", type) "
-            + "VALUES (:uuid, :name, :nextStepUuid, :relatedObjectUuid, :type)")
+    getDbHandle().createUpdate("/* insertApprovalStep */ INSERT into \"approvalSteps\" "
+        + "(uuid, name, \"nextStepUuid\", \"relatedObjectUuid\", type, \"restrictedApproval\") "
+        + "VALUES (:uuid, :name, :nextStepUuid, :relatedObjectUuid, :type, :restrictedApproval)")
         .bindBean(as).bind("type", DaoUtils.getEnumId(as.getType())).execute();
 
     if (as.getApprovers() != null) {
@@ -161,8 +161,8 @@ public class ApprovalStepDao extends AnetBaseDao<ApprovalStep, AbstractSearchQue
   public int updateInternal(ApprovalStep as) {
     return getDbHandle()
         .createUpdate("/* updateApprovalStep */ UPDATE \"approvalSteps\" SET name = :name, "
-            + "\"nextStepUuid\" = :nextStepUuid, \"relatedObjectUuid\" = :relatedObjectUuid "
-            + "WHERE uuid = :uuid")
+            + "\"nextStepUuid\" = :nextStepUuid, \"relatedObjectUuid\" = :relatedObjectUuid, "
+            + "\"restrictedApproval\" = :restrictedApproval WHERE uuid = :uuid")
         .bindBean(as).execute();
   }
 

--- a/src/main/java/mil/dds/anet/database/ApprovalStepDao.java
+++ b/src/main/java/mil/dds/anet/database/ApprovalStepDao.java
@@ -77,7 +77,8 @@ public class ApprovalStepDao extends AnetBaseDao<ApprovalStep, AbstractSearchQue
 
   static class PlanningApprovalStepsBatcher extends ForeignKeyBatcher<ApprovalStep> {
     private static final String sql =
-        "/* batch.getApprovalStepsByOrg */ SELECT * from \"approvalSteps\" WHERE \"relatedObjectUuid\" IN ( <foreignKeys> ) AND \"approvalSteps\".type = :type";
+        "/* batch.getPlanningApprovalStepsByRelatedObject */ SELECT * from \"approvalSteps\""
+            + " WHERE \"relatedObjectUuid\" IN ( <foreignKeys> ) AND \"approvalSteps\".type = :type";
     private static final Map<String, Object> additionalParams = new HashMap<>();
 
     static {
@@ -91,7 +92,8 @@ public class ApprovalStepDao extends AnetBaseDao<ApprovalStep, AbstractSearchQue
 
   static class ApprovalStepsBatcher extends ForeignKeyBatcher<ApprovalStep> {
     private static final String sql =
-        "/* batch.getApprovalStepsByOrg */ SELECT * from \"approvalSteps\" WHERE \"relatedObjectUuid\" IN ( <foreignKeys> ) AND \"approvalSteps\".type = :type";
+        "/* batch.getApprovalStepsByRelatedObject */ SELECT * from \"approvalSteps\""
+            + " WHERE \"relatedObjectUuid\" IN ( <foreignKeys> ) AND \"approvalSteps\".type = :type";
     private static final Map<String, Object> additionalParams = new HashMap<>();
 
     static {

--- a/src/main/java/mil/dds/anet/database/ReportDao.java
+++ b/src/main/java/mil/dds/anet/database/ReportDao.java
@@ -36,6 +36,7 @@ import mil.dds.anet.beans.RollupGraph;
 import mil.dds.anet.beans.Tag;
 import mil.dds.anet.beans.Task;
 import mil.dds.anet.beans.lists.AnetBeanList;
+import mil.dds.anet.beans.search.ISearchQuery.RecurseStrategy;
 import mil.dds.anet.beans.search.OrganizationSearchQuery;
 import mil.dds.anet.beans.search.ReportSearchQuery;
 import mil.dds.anet.database.AdminDao.AdminSettingKeys;
@@ -447,7 +448,7 @@ public class ReportDao extends AnetBaseDao<Report, ReportSearchQuery> {
       // organizations
       OrganizationSearchQuery query = new OrganizationSearchQuery();
       query.setParentOrgUuid(Collections.singletonList(parentOrgUuid));
-      query.setParentOrgRecursively(true);
+      query.setOrgRecurseStrategy(RecurseStrategy.CHILDREN);
       query.setPageSize(0);
       orgList = AnetObjectEngine.getInstance().getOrganizationDao().search(query).getList();
       Optional<Organization> parentOrg =

--- a/src/main/java/mil/dds/anet/database/ReportDao.java
+++ b/src/main/java/mil/dds/anet/database/ReportDao.java
@@ -782,10 +782,9 @@ public class ReportDao extends AnetBaseDao<Report, ReportSearchQuery> {
         SqDataLoaderKey.REPORTS_SEARCH, new ImmutablePair<>(uuid, query));
   }
 
-  public void sendApprovalNeededEmail(Report r) {
+  public void sendApprovalNeededEmail(Report r, ApprovalStep approvalStep) {
     final AnetObjectEngine engine = AnetObjectEngine.getInstance();
-    final ApprovalStep step = r.loadApprovalStep(engine.getContext()).join();
-    final List<Position> approvers = step.loadApprovers(engine.getContext()).join();
+    final List<Position> approvers = approvalStep.loadApprovers(engine.getContext()).join();
     final AnetEmail approverEmail = new AnetEmail();
     final ApprovalNeededEmail action = new ApprovalNeededEmail();
     action.setReport(r);
@@ -818,9 +817,9 @@ public class ReportDao extends AnetBaseDao<Report, ReportSearchQuery> {
     AnetObjectEngine.getInstance().getReportActionDao().insert(action);
 
     // Update the report
-    final String nextStepUuid = getNextStepUuid(r, step);
-    r.setApprovalStepUuid(nextStepUuid);
-    if (nextStepUuid == null) {
+    final ApprovalStep nextStep = getNextStep(r, step);
+    r.setApprovalStepUuid(DaoUtils.getUuid(nextStep));
+    if (nextStep == null) {
       if (r.getCancelledReason() != null) {
         // Done with cancel, move to CANCELLED and set releasedAt
         r.setState(ReportState.CANCELLED);
@@ -831,34 +830,30 @@ public class ReportDao extends AnetBaseDao<Report, ReportSearchQuery> {
       }
     }
     final int numRows = update(r, r.getAuthor());
-    if (numRows != 0 && nextStepUuid != null) {
-      sendApprovalNeededEmail(r);
+    if (numRows != 0 && nextStep != null) {
+      sendApprovalNeededEmail(r, nextStep);
     }
     return numRows;
   }
 
-  private String getNextStepUuid(Report report, ApprovalStep step) {
+  private ApprovalStep getNextStep(Report report, ApprovalStep step) {
     final AnetObjectEngine engine = AnetObjectEngine.getInstance();
     final String currentStepUuid = step.getUuid();
-    String nextStepUuid = step.getNextStepUuid();
-    if (nextStepUuid == null) {
-      // Find out if there's a next approval chain
-      final List<ApprovalStep> reportApprovalSteps =
-          report.computeApprovalSteps(engine.getContext(), engine).join();
-      final Iterator<ApprovalStep> iterator = reportApprovalSteps.iterator();
-      while (iterator.hasNext()) {
-        final ApprovalStep reportApprovalStep = iterator.next();
-        if (Objects.equals(DaoUtils.getUuid(reportApprovalStep), currentStepUuid)) {
-          // Found the current step, update the next step
-          if (iterator.hasNext()) {
-            final ApprovalStep reportApprovalStepNext = iterator.next();
-            nextStepUuid = DaoUtils.getUuid(reportApprovalStepNext);
-          }
-          break;
+    // Find out if there's a next approval chain
+    final List<ApprovalStep> reportApprovalSteps =
+        report.computeApprovalSteps(engine.getContext(), engine).join();
+    for (final Iterator<ApprovalStep> iterator = reportApprovalSteps.iterator(); iterator
+        .hasNext();) {
+      final ApprovalStep reportApprovalStep = iterator.next();
+      if (Objects.equals(DaoUtils.getUuid(reportApprovalStep), currentStepUuid)) {
+        // Found the current step, update the next step
+        if (iterator.hasNext()) {
+          return iterator.next();
         }
+        break;
       }
     }
-    return nextStepUuid;
+    return null;
   }
 
   public int publish(Report r, Person user) {

--- a/src/main/java/mil/dds/anet/database/ReportDao.java
+++ b/src/main/java/mil/dds/anet/database/ReportDao.java
@@ -64,13 +64,12 @@ import ru.vyarus.guicey.jdbi3.tx.InTransaction;
 
 public class ReportDao extends AnetBaseDao<Report, ReportSearchQuery> {
 
-  // Must always retrieve these e.g. for ORDER BY
-  public static final String[] minimalFields =
-      {"uuid", "createdAt", "updatedAt", "engagementDate", "releasedAt"};
+  // Must always retrieve these e.g. for ORDER BY or search post-processing
+  public static final String[] minimalFields = {"uuid", "approvalStepUuid",
+      "advisorOrganizationUuid", "createdAt", "updatedAt", "engagementDate", "releasedAt"};
   public static final String[] additionalFields = {"state", "duration", "intent", "exsum",
-      "locationUuid", "approvalStepUuid", "advisorOrganizationUuid", "principalOrganizationUuid",
-      "authorUuid", "atmosphere", "cancelledReason", "atmosphereDetails", "text", "keyOutcomes",
-      "nextSteps", "customFields"};
+      "locationUuid", "principalOrganizationUuid", "authorUuid", "atmosphere", "cancelledReason",
+      "atmosphereDetails", "text", "keyOutcomes", "nextSteps", "customFields"};
   public static final String[] allFields =
       ObjectArrays.concat(minimalFields, additionalFields, String.class);
   public static final String TABLE_NAME = "reports";
@@ -361,12 +360,18 @@ public class ReportDao extends AnetBaseDao<Report, ReportSearchQuery> {
 
   @Override
   public AnetBeanList<Report> search(ReportSearchQuery query) {
-    return search(null, query);
+    return search(AnetObjectEngine.getInstance().getContext(), query).join();
   }
 
-  public AnetBeanList<Report> search(Set<String> subFields, ReportSearchQuery query) {
-    return AnetObjectEngine.getInstance().getSearcher().getReportSearcher().runSearch(subFields,
-        query);
+  public CompletableFuture<AnetBeanList<Report>> search(Map<String, Object> context,
+      ReportSearchQuery query) {
+    return search(context, null, query);
+  }
+
+  public CompletableFuture<AnetBeanList<Report>> search(Map<String, Object> context,
+      Set<String> subFields, ReportSearchQuery query) {
+    return AnetObjectEngine.getInstance().getSearcher().getReportSearcher().runSearch(context,
+        subFields, query);
   }
 
   /*

--- a/src/main/java/mil/dds/anet/database/mappers/ApprovalStepMapper.java
+++ b/src/main/java/mil/dds/anet/database/mappers/ApprovalStepMapper.java
@@ -17,6 +17,7 @@ public class ApprovalStepMapper implements RowMapper<ApprovalStep> {
     step.setRelatedObjectUuid(r.getString("relatedObjectUuid"));
     step.setName(r.getString("name"));
     step.setType(MapperUtils.getEnumIdx(r, "type", ApprovalStepType.class));
+    step.setRestrictedApproval(r.getBoolean("restrictedApproval"));
 
     return step;
   }

--- a/src/main/java/mil/dds/anet/resources/GraphQlResource.java
+++ b/src/main/java/mil/dds/anet/resources/GraphQlResource.java
@@ -234,9 +234,9 @@ public class GraphQlResource {
             .variables(variables).dataLoaderRegistry(dataLoaderRegistry).context(context).build();
 
     final GraphQL graphql = GraphQL.newGraphQL(graphqlSchema)
-        // .instrumentation(new DataLoaderDispatcherInstrumentation()) — use our own dispatcher
-        // instead
-        .build();
+        // Prevent adding .instrumentation(new DataLoaderDispatcherInstrumentation())
+        // — use our own dispatcher instead
+        .doNotAddDefaultInstrumentations().build();
     final CompletableFuture<ExecutionResult> request = graphql.executeAsync(executionInput);
     final Runnable dispatcher = () -> {
       while (!request.isDone()) {

--- a/src/main/java/mil/dds/anet/resources/ReportResource.java
+++ b/src/main/java/mil/dds/anet/resources/ReportResource.java
@@ -154,7 +154,7 @@ public class ReportResource {
 
     if (sendEmail && existing.getState() == ReportState.PENDING_APPROVAL) {
       boolean canApprove = engine.canUserApproveStep(engine.getContext(), editor.getUuid(),
-          existing.getApprovalStepUuid(), existing.getAdvisorOrgUuid());
+          existing.getApprovalStepUuid(), existing.getAdvisorOrgUuid()).join();
       if (canApprove) {
         AnetEmail email = new AnetEmail();
         ReportEditedEmail action = new ReportEditedEmail();
@@ -346,7 +346,7 @@ public class ReportResource {
       case PENDING_APPROVAL:
         // Must be the author or the approver
         boolean canApprove = engine.canUserApproveStep(engine.getContext(), editor.getUuid(),
-            report.getApprovalStepUuid(), report.getAdvisorOrgUuid());
+            report.getApprovalStepUuid(), report.getAdvisorOrgUuid()).join();
         if (!isAuthor && !canApprove) {
           throw new WebApplicationException(
               permError + "Must be the author of this report or the current approver.",
@@ -463,8 +463,9 @@ public class ReportResource {
     }
 
     // Verify that this user can approve for this step.
-    final boolean canApprove = engine.canUserApproveStep(engine.getContext(), approver.getUuid(),
-        step, r.getAdvisorOrgUuid());
+    final boolean canApprove = engine
+        .canUserApproveStep(engine.getContext(), approver.getUuid(), step, r.getAdvisorOrgUuid())
+        .join();
     if (!canApprove) {
       logger.info("User UUID {} cannot approve report UUID {} for step UUID {}", approver.getUuid(),
           r.getUuid(), step.getUuid());
@@ -508,8 +509,9 @@ public class ReportResource {
       throw new WebApplicationException("This report is not pending approval", Status.BAD_REQUEST);
     } else if (step != null) {
       // Verify that this user can reject for this step.
-      final boolean canReject = engine.canUserRejectStep(engine.getContext(), approver.getUuid(),
-          step, r.getAdvisorOrgUuid());
+      final boolean canReject = engine
+          .canUserRejectStep(engine.getContext(), approver.getUuid(), step, r.getAdvisorOrgUuid())
+          .join();
       if (!canReject) {
         logger.info("User UUID {} cannot request changes to report UUID {} for step UUID {}",
             approver.getUuid(), r.getUuid(), step.getUuid());

--- a/src/main/java/mil/dds/anet/resources/ReportResource.java
+++ b/src/main/java/mil/dds/anet/resources/ReportResource.java
@@ -154,7 +154,7 @@ public class ReportResource {
 
     if (sendEmail && existing.getState() == ReportState.PENDING_APPROVAL) {
       boolean canApprove = engine.canUserApproveStep(engine.getContext(), editor.getUuid(),
-          existing.getApprovalStepUuid());
+          existing.getApprovalStepUuid(), existing.getAdvisorOrgUuid());
       if (canApprove) {
         AnetEmail email = new AnetEmail();
         ReportEditedEmail action = new ReportEditedEmail();
@@ -346,7 +346,7 @@ public class ReportResource {
       case PENDING_APPROVAL:
         // Must be the author or the approver
         boolean canApprove = engine.canUserApproveStep(engine.getContext(), editor.getUuid(),
-            report.getApprovalStepUuid());
+            report.getApprovalStepUuid(), report.getAdvisorOrgUuid());
         if (!isAuthor && !canApprove) {
           throw new WebApplicationException(
               permError + "Must be the author of this report or the current approver.",
@@ -463,9 +463,9 @@ public class ReportResource {
     }
 
     // Verify that this user can approve for this step.
-    boolean canApprove =
-        engine.canUserApproveStep(engine.getContext(), approver.getUuid(), step.getUuid());
-    if (canApprove == false) {
+    final boolean canApprove = engine.canUserApproveStep(engine.getContext(), approver.getUuid(),
+        step, r.getAdvisorOrgUuid());
+    if (!canApprove) {
       logger.info("User UUID {} cannot approve report UUID {} for step UUID {}", approver.getUuid(),
           r.getUuid(), step.getUuid());
       throw new WebApplicationException("User cannot approve report", Status.FORBIDDEN);
@@ -508,9 +508,9 @@ public class ReportResource {
       throw new WebApplicationException("This report is not pending approval", Status.BAD_REQUEST);
     } else if (step != null) {
       // Verify that this user can reject for this step.
-      boolean canReject =
-          engine.canUserRejectStep(engine.getContext(), approver.getUuid(), step.getUuid());
-      if (canReject == false) {
+      final boolean canReject = engine.canUserRejectStep(engine.getContext(), approver.getUuid(),
+          step, r.getAdvisorOrgUuid());
+      if (!canReject) {
         logger.info("User UUID {} cannot request changes to report UUID {} for step UUID {}",
             approver.getUuid(), r.getUuid(), step.getUuid());
         throw new WebApplicationException("User cannot request changes to report",

--- a/src/main/java/mil/dds/anet/resources/ReportResource.java
+++ b/src/main/java/mil/dds/anet/resources/ReportResource.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.ws.rs.WebApplicationException;
@@ -671,11 +672,11 @@ public class ReportResource {
   }
 
   @GraphQLQuery(name = "reportList")
-  public AnetBeanList<Report> search(@GraphQLRootContext Map<String, Object> context,
-      @GraphQLEnvironment Set<String> subFields,
+  public CompletableFuture<AnetBeanList<Report>> search(
+      @GraphQLRootContext Map<String, Object> context, @GraphQLEnvironment Set<String> subFields,
       @GraphQLArgument(name = "query") ReportSearchQuery query) {
     query.setUser(DaoUtils.getUserFromContext(context));
-    return dao.search(subFields, query);
+    return dao.search(context, subFields, query);
   }
 
   /**

--- a/src/main/java/mil/dds/anet/resources/ReportResource.java
+++ b/src/main/java/mil/dds/anet/resources/ReportResource.java
@@ -367,6 +367,7 @@ public class ReportResource {
   @GraphQLMutation(name = "submitReport")
   public Report submitReport(@GraphQLRootContext Map<String, Object> context,
       @GraphQLArgument(name = "uuid") String uuid) {
+    // TODO: this needs to be done by either the Author, a Superuser for the AO, or an Administrator
     Person user = DaoUtils.getUserFromContext(context);
     final Report r = dao.getByUuid(uuid);
     if (r == null) {
@@ -375,7 +376,6 @@ public class ReportResource {
     logger.debug("Attempting to submit report {}, which has advisor org {} and primary advisor {}",
         r, r.getAdvisorOrg(), r.getPrimaryAdvisor());
 
-    // TODO: this needs to be done by either the Author, a Superuser for the AO, or an Administrator
     if (r.getAdvisorOrgUuid() == null) {
       final ReportPerson advisor = r.loadPrimaryAdvisor(engine.getContext()).join();
       if (advisor == null) {
@@ -427,7 +427,7 @@ public class ReportResource {
     }
 
     if (!Utils.isEmptyOrNull(steps)) {
-      dao.sendApprovalNeededEmail(r);
+      dao.sendApprovalNeededEmail(r, steps.get(0));
       logger.info("Putting report {} into step {}", r.getUuid(), steps.get(0).getUuid());
     }
 

--- a/src/main/java/mil/dds/anet/search/AbstractOrganizationSearcher.java
+++ b/src/main/java/mil/dds/anet/search/AbstractOrganizationSearcher.java
@@ -3,6 +3,7 @@ package mil.dds.anet.search;
 import mil.dds.anet.beans.Organization;
 import mil.dds.anet.beans.lists.AnetBeanList;
 import mil.dds.anet.beans.search.AbstractBatchParams;
+import mil.dds.anet.beans.search.ISearchQuery.RecurseStrategy;
 import mil.dds.anet.beans.search.ISearchQuery.SortOrder;
 import mil.dds.anet.beans.search.OrganizationSearchQuery;
 import mil.dds.anet.database.OrganizationDao;
@@ -65,9 +66,11 @@ public abstract class AbstractOrganizationSearcher extends
   }
 
   protected void addParentOrgUuidQuery(OrganizationSearchQuery query) {
-    if (query.getParentOrgRecursively()) {
+    if (RecurseStrategy.CHILDREN.equals(query.getOrgRecurseStrategy())
+        || RecurseStrategy.PARENTS.equals(query.getOrgRecurseStrategy())) {
       qb.addRecursiveClause(null, "organizations", "\"uuid\"", "parent_orgs", "organizations",
-          "\"parentOrgUuid\"", "parentOrgUuid", query.getParentOrgUuid(), true);
+          "\"parentOrgUuid\"", "parentOrgUuid", query.getParentOrgUuid(),
+          RecurseStrategy.CHILDREN.equals(query.getOrgRecurseStrategy()));
     } else {
       qb.addInListClause("parentOrgUuid", "organizations.\"parentOrgUuid\"",
           query.getParentOrgUuid());

--- a/src/main/java/mil/dds/anet/search/AbstractSearchQueryBuilder.java
+++ b/src/main/java/mil/dds/anet/search/AbstractSearchQueryBuilder.java
@@ -12,6 +12,7 @@ import java.util.stream.Collectors;
 import mil.dds.anet.beans.lists.AnetBeanList;
 import mil.dds.anet.beans.search.AbstractBatchParams;
 import mil.dds.anet.beans.search.AbstractSearchQuery;
+import mil.dds.anet.beans.search.ISearchQuery.RecurseStrategy;
 import mil.dds.anet.utils.DaoUtils;
 import mil.dds.anet.utils.Utils;
 import mil.dds.anet.views.AbstractAnetBean;
@@ -246,10 +247,13 @@ public abstract class AbstractSearchQueryBuilder<B extends AbstractAnetBean, T e
 
   public final void addRecursiveBatchClause(AbstractSearchQueryBuilder<B, T> outerQb,
       String tableName, String[] foreignKeys, String withTableName, String recursiveTableName,
-      String recursiveForeignKey, String paramName, List<String> fieldValues) {
+      String recursiveForeignKey, String paramName, List<String> fieldValues,
+      RecurseStrategy recurseStrategy) {
+    final boolean findChildren = RecurseStrategy.CHILDREN.equals(recurseStrategy);
     addRecursiveClause(outerQb, tableName, foreignKeys, withTableName, recursiveTableName,
-        recursiveForeignKey, paramName, fieldValues, true);
-    addSelectClause(String.format("%1$s.parent_uuid AS \"batchUuid\"", withTableName));
+        recursiveForeignKey, paramName, fieldValues, findChildren);
+    addSelectClause(String.format("%1$s.%2$s AS \"batchUuid\"", withTableName,
+        findChildren ? "parent_uuid" : "uuid"));
   }
 
   private final void addRecursiveClause(AbstractSearchQueryBuilder<B, T> outerQb, String tableName,

--- a/src/main/java/mil/dds/anet/search/IReportSearcher.java
+++ b/src/main/java/mil/dds/anet/search/IReportSearcher.java
@@ -1,12 +1,15 @@
 package mil.dds.anet.search;
 
+import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import mil.dds.anet.beans.Report;
 import mil.dds.anet.beans.lists.AnetBeanList;
 import mil.dds.anet.beans.search.ReportSearchQuery;
 
 public interface IReportSearcher {
 
-  public AnetBeanList<Report> runSearch(Set<String> subFields, ReportSearchQuery query);
+  public CompletableFuture<AnetBeanList<Report>> runSearch(Map<String, Object> context,
+      Set<String> subFields, ReportSearchQuery query);
 
 }

--- a/src/main/java/mil/dds/anet/search/pg/PostgresqlReportSearcher.java
+++ b/src/main/java/mil/dds/anet/search/pg/PostgresqlReportSearcher.java
@@ -1,6 +1,8 @@
 package mil.dds.anet.search.pg;
 
+import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import mil.dds.anet.beans.Report;
 import mil.dds.anet.beans.lists.AnetBeanList;
 import mil.dds.anet.beans.search.ISearchQuery.SortOrder;
@@ -21,9 +23,11 @@ public class PostgresqlReportSearcher extends AbstractReportSearcher {
 
   @InTransaction
   @Override
-  public AnetBeanList<Report> runSearch(Set<String> subFields, ReportSearchQuery query) {
+  public CompletableFuture<AnetBeanList<Report>> runSearch(Map<String, Object> context,
+      Set<String> subFields, ReportSearchQuery query) {
     buildQuery(subFields, query);
-    return qb.buildAndRun(getDbHandle(), query, new ReportMapper());
+    return postProcessResults(context, query,
+        qb.buildAndRun(getDbHandle(), query, new ReportMapper()));
   }
 
   @Override

--- a/src/main/java/mil/dds/anet/threads/AnetEmailWorker.java
+++ b/src/main/java/mil/dds/anet/threads/AnetEmailWorker.java
@@ -233,7 +233,7 @@ public class AnetEmailWorker implements Runnable {
       logger.error("Send failed", e);
       return;
     }
-    // Other errors are intentially thrown, as we want ANET to try again.
+    // Other errors are intentionally thrown, as we want ANET to try again.
   }
 
   public static void sendEmailAsync(AnetEmail email) {

--- a/src/main/java/mil/dds/anet/utils/Utils.java
+++ b/src/main/java/mil/dds/anet/utils/Utils.java
@@ -23,6 +23,7 @@ import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response.Status;
 import mil.dds.anet.AnetObjectEngine;
 import mil.dds.anet.beans.ApprovalStep;
+import mil.dds.anet.beans.ApprovalStep.ApprovalStepType;
 import mil.dds.anet.beans.Organization;
 import mil.dds.anet.beans.Task;
 import mil.dds.anet.database.ApprovalStepDao;
@@ -474,6 +475,7 @@ public class Utils {
       logger.debug("Editing planning approval steps for {}", entity);
       for (ApprovalStep step : planningApprovalSteps) {
         Utils.validateApprovalStep(step);
+        step.setType(ApprovalStepType.PLANNING_APPROVAL);
         step.setRelatedObjectUuid(entity.getUuid());
       }
 
@@ -488,6 +490,7 @@ public class Utils {
       logger.debug("Editing approval steps for {}", entity);
       for (ApprovalStep step : approvalSteps) {
         Utils.validateApprovalStep(step);
+        step.setType(ApprovalStepType.REPORT_APPROVAL);
         step.setRelatedObjectUuid(entity.getUuid());
       }
 

--- a/src/main/java/mil/dds/anet/utils/Utils.java
+++ b/src/main/java/mil/dds/anet/utils/Utils.java
@@ -503,12 +503,8 @@ public class Utils {
   private static void updateStep(ApprovalStep newStep, ApprovalStep oldStep) {
     final AnetObjectEngine engine = AnetObjectEngine.getInstance();
     final ApprovalStepDao approvalStepDao = engine.getApprovalStepDao();
-    newStep.setUuid(oldStep.getUuid()); // Always want to make changes to the existing group
-    if (!newStep.getName().equals(oldStep.getName())) {
-      approvalStepDao.update(newStep);
-    } else if (!Objects.equals(newStep.getNextStepUuid(), oldStep.getNextStepUuid())) {
-      approvalStepDao.update(newStep);
-    }
+    newStep.setUuid(oldStep.getUuid()); // Always want to make changes to the existing step
+    approvalStepDao.update(newStep);
 
     if (newStep.getApprovers() != null) {
       Utils.addRemoveElementsByUuid(oldStep.loadApprovers(engine.getContext()).join(),

--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -3142,10 +3142,10 @@
 		</sql>
 	</changeSet>
 
-        <changeSet id="add-approvalSteps-restrictedApproval" author="gjvoosten">
-                <addColumn tableName="approvalSteps">
-                        <column name="restrictedApproval" type="boolean" defaultValue="false" />
-                </addColumn>
-        </changeSet>
+	<changeSet id="add-approvalSteps-restrictedApproval" author="gjvoosten">
+		<addColumn tableName="approvalSteps">
+			<column name="restrictedApproval" type="boolean" defaultValue="false" />
+		</addColumn>
+	</changeSet>
 
 </databaseChangeLog>

--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -3142,4 +3142,10 @@
 		</sql>
 	</changeSet>
 
+        <changeSet id="add-approvalSteps-restrictedApproval" author="gjvoosten">
+                <addColumn tableName="approvalSteps">
+                        <column name="restrictedApproval" type="boolean" defaultValue="false" />
+                </addColumn>
+        </changeSet>
+
 </databaseChangeLog>

--- a/src/test/java/mil/dds/anet/test/integration/db/FutureEngagementWorkerTest.java
+++ b/src/test/java/mil/dds/anet/test/integration/db/FutureEngagementWorkerTest.java
@@ -51,7 +51,7 @@ public class FutureEngagementWorkerTest {
   public static void setUpClass() throws Exception {
     final DropwizardAppExtension<AnetConfiguration> app = TestApp.app;
     if (app.getConfiguration().getSmtp().isDisabled()) {
-      fail("'ANET_SMTP_DISABLE' system environment variable must have value 'true' to run test.");
+      fail("'ANET_SMTP_DISABLE' system environment variable must have value 'false' to run test.");
     }
 
     executeEmailServerTests = Boolean.parseBoolean(

--- a/src/test/java/mil/dds/anet/test/resources/GraphQlResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/GraphQlResourceTest.java
@@ -41,6 +41,7 @@ public class GraphQlResourceTest extends AbstractResourceTest {
     variables.put("personUuid", jack.getUuid());
     variables.put("positionUuid", steve.loadPosition().getUuid());
     variables.put("orgUuid", steve.getPosition().getOrganizationUuid());
+    variables.put("taskUuid", "7b2ad5c3-018b-48f5-b679-61fbbda21693"); // 1.1.A
     variables.put("searchQuery", "hospital");
     final ReportSearchQuery jaQuery = new ReportSearchQuery();
     jaQuery.setPageSize(1);

--- a/src/test/java/mil/dds/anet/test/resources/GraphQlResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/GraphQlResourceTest.java
@@ -45,7 +45,7 @@ public class GraphQlResourceTest extends AbstractResourceTest {
     final ReportSearchQuery jaQuery = new ReportSearchQuery();
     jaQuery.setPageSize(1);
     variables.put("reportUuid",
-        jack.loadAttendedReports(context, jaQuery).getList().get(0).getUuid());
+        jack.loadAttendedReports(context, jaQuery).join().getList().get(0).getUuid());
     variables.put("pageNum", 0);
     variables.put("pageSize", 10);
     variables.put("maxResults", 6);

--- a/src/test/java/mil/dds/anet/test/resources/ReportsResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/ReportsResourceTest.java
@@ -101,7 +101,7 @@ public class ReportsResourceTest extends AbstractResourceTest {
   @Test
   public void createReport() {
     // Create a report writer
-    final Person author = getJackJackson();
+    final Person author = getNickNicholson();
 
     // Create a principal for the report
     final Person principalPerson = getSteveSteveson();

--- a/src/test/java/mil/dds/anet/test/resources/TaskApprovalTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/TaskApprovalTest.java
@@ -1,0 +1,563 @@
+package mil.dds.anet.test.resources;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.google.common.collect.Lists;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import javax.ws.rs.BadRequestException;
+import javax.ws.rs.ForbiddenException;
+import mil.dds.anet.beans.ApprovalStep;
+import mil.dds.anet.beans.ApprovalStep.ApprovalStepType;
+import mil.dds.anet.beans.Location;
+import mil.dds.anet.beans.Person;
+import mil.dds.anet.beans.Position;
+import mil.dds.anet.beans.Report;
+import mil.dds.anet.beans.Report.Atmosphere;
+import mil.dds.anet.beans.Report.ReportState;
+import mil.dds.anet.beans.ReportAction;
+import mil.dds.anet.beans.ReportPerson;
+import mil.dds.anet.beans.Task;
+import mil.dds.anet.beans.lists.AnetBeanList;
+import mil.dds.anet.beans.search.PersonSearchQuery;
+import mil.dds.anet.beans.search.ReportSearchQuery;
+import mil.dds.anet.test.beans.PersonTest;
+import mil.dds.anet.test.resources.utils.GraphQlResponse;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class TaskApprovalTest extends AbstractResourceTest {
+
+  private static final String ORGANIZATION_FIELDS =
+      "uuid shortName longName status identificationCode type";
+  private static final String POSITION_FIELDS =
+      "uuid name code type status organization { " + ORGANIZATION_FIELDS + " }";
+  private static final String PERSON_FIELDS =
+      "uuid name status role rank domainUsername position { " + POSITION_FIELDS + " }";
+  private static final String APPROVAL_STEP_FIELDS =
+      "uuid name restrictedApproval relatedObjectUuid nextStepUuid approvers"
+          + " { uuid name person { uuid name rank role } }";
+  private static final String REPORT_FIELDS =
+      "uuid state workflow { type createdAt person { uuid } step { " + APPROVAL_STEP_FIELDS
+          + " } }";
+  private static final String TASK_FIELDS = "uuid shortName longName status"
+      + " customField customFieldEnum1 customFieldEnum2 plannedCompletion projectedCompletion"
+      + " taskedOrganizations { uuid shortName longName identificationCode }"
+      + " customFieldRef1 { uuid } responsiblePositions { uuid } planningApprovalSteps { "
+      + APPROVAL_STEP_FIELDS + " } approvalSteps { " + APPROVAL_STEP_FIELDS + " } customFields";
+
+  // Test report approval scenarios for tasks mostly use the following data:
+  // - report task 2.A (which has tasked org EF 2)
+  // - task 2.A has approver for planning OF-9 JACKSON, Jack (from org EF 2.1)
+  // - task 2.A has approver for publication BGen HENDERSON, Henry (from org EF 2.1)
+  // - report primary advisor CIV REINTON, Reina (from org EF 2.2)
+
+  // Task 2.A
+  private static final String TEST_TASK_UUID = "75d4009d-7c79-42e0-aa2f-d79d158ec8d6";
+  // Location Fort Amherst
+  private static final String TEST_LOCATION_UUID = "c7a9f420-457a-490c-a810-b504c022cf1e";
+
+  private static List<ApprovalStep> savedPlanningApprovalSteps;
+  private static List<Position> savedPlanningApprovers;
+  private static List<ApprovalStep> savedApprovalSteps;
+  private static List<Position> savedApprovers;
+
+  @BeforeAll
+  public static void saveTaskApprovalSteps() {
+    final Task task = getTaskFromDb(TEST_TASK_UUID);
+    savedPlanningApprovalSteps = Lists.newArrayList(task.getPlanningApprovalSteps());
+    savedPlanningApprovalSteps.stream().findFirst()
+        .ifPresent(as -> savedPlanningApprovers = as.getApprovers());
+    savedApprovalSteps = Lists.newArrayList(task.getApprovalSteps());
+    savedApprovalSteps.stream().findFirst().ifPresent(as -> savedApprovers = as.getApprovers());
+  }
+
+  @AfterAll
+  public static void restoreTaskApprovalSteps() {
+    final Task task = getTaskFromDb(TEST_TASK_UUID);
+    savedPlanningApprovalSteps.stream().findFirst()
+        .ifPresent(as -> as.setApprovers(savedPlanningApprovers));
+    task.setPlanningApprovalSteps(savedPlanningApprovalSteps);
+    savedApprovalSteps.stream().findFirst().ifPresent(as -> as.setApprovers(savedApprovers));
+    task.setApprovalSteps(savedApprovalSteps);
+    updateTask(task);
+  }
+
+  // submitted report, no approval step for effort
+  // => there should be no approval step for the effort on the report workflow
+  @Test
+  public void testNoSteps() {
+    final Task task = clearTaskApprovalSteps(TEST_TASK_UUID);
+
+    final Report report = submitReport("testNoSteps", getPersonFromDb("ERINSON, Erin"), task, false,
+        ReportState.PENDING_APPROVAL);
+    assertWorkflowSize(report, task.getUuid(), 0);
+
+    // Go through organization approval
+    organizationalApproval(report, false);
+  }
+
+  // submitted report, unrestricted approval step for effort has matching org
+  // => there should be an approval step for the effort
+  // => approver should see the report as pending approval
+  // => approver should be able to approve the report
+  @Test
+  public void testUnrestrictedStepMatchingOrgReportPublication() {
+    testUnrestrictedStepMatchingOrg("testUnrestrictedStepMatchingOrgReportPublication", false);
+  }
+
+  @Test
+  public void testUnrestrictedStepMatchingOrgPlannedEngagement() {
+    testUnrestrictedStepMatchingOrg("testUnrestrictedStepMatchingOrgPlannedEngagement", true);
+  }
+
+  private void testUnrestrictedStepMatchingOrg(String text, boolean isPlanned) {
+    final Task task = clearTaskApprovalSteps(TEST_TASK_UUID);
+
+    final Person approver = getApprover(isPlanned);
+    final Task updatedTask = updateTaskApprovalSteps(task, approver, isPlanned, false);
+
+    final Report report = submitReport(text, getPersonFromDb("ERINSON, Erin"), updatedTask,
+        isPlanned, ReportState.PENDING_APPROVAL);
+    assertWorkflowSize(report, updatedTask.getUuid(), 1);
+
+    // Go through organization approval first
+    organizationalApproval(report, isPlanned);
+
+    // Check reports pending approval
+    checkPendingApproval(approver, report, 1);
+
+    // Approve the report
+    approveReport(report, approver, false);
+  }
+
+  // submitted report, unrestricted approval step for effort has no matching org
+  // => there should be an approval step for the effort
+  // => approver should see the report as pending approval
+  // => approver should be able to approve the report
+  @Test
+  public void testUnrestrictedStepNoMatchingOrgReportPublication() {
+    testUnrestrictedStepNoMatchingOrg("testUnrestrictedStepNoMatchingOrgReportPublication", false);
+  }
+
+  @Test
+  public void testUnrestrictedStepNoMatchingOrgPlannedEngagement() {
+    testUnrestrictedStepNoMatchingOrg("testUnrestrictedStepNoMatchingOrgPlannedEngagement", true);
+  }
+
+  private void testUnrestrictedStepNoMatchingOrg(String text, boolean isPlanned) {
+    final Task task = clearTaskApprovalSteps(TEST_TASK_UUID);
+
+    // Someone from EF 1.1
+    final Person approver = getPersonFromDb("ELIZAWELL, Elizabeth");
+    final Task updatedTask = updateTaskApprovalSteps(task, approver, isPlanned, false);
+
+    final Report report = submitReport(text, getPersonFromDb("ERINSON, Erin"), updatedTask,
+        isPlanned, ReportState.PENDING_APPROVAL);
+    assertWorkflowSize(report, updatedTask.getUuid(), 1);
+
+    // Go through organization approval first
+    organizationalApproval(report, isPlanned);
+
+    // Check reports pending approval
+    checkPendingApproval(approver, report, 1);
+
+    // Approve the report
+    approveReport(report, approver, false);
+  }
+
+  // submitted report, restricted approval step for effort has no matching org
+  // => there should be no approval step for the effort
+  // => approver should not see the report as pending approval
+  // => approver should not be able to approve the report
+  @Test
+  public void testRestrictedStepNoMatchingOrgReportPublication() {
+    testRestrictedStepNoMatchingOrg("testRestrictedStepNoMatchingOrgReportPublication", false);
+  }
+
+  @Test
+  public void testRestrictedStepNoMatchingOrgPlannedEngagement() {
+    testRestrictedStepNoMatchingOrg("testRestrictedStepNoMatchingOrgPlannedEngagement", true);
+  }
+
+  private void testRestrictedStepNoMatchingOrg(String text, boolean isPlanned) {
+    final Task task = clearTaskApprovalSteps(TEST_TASK_UUID);
+
+    // Someone from EF 1.1
+    final Person approver = getPersonFromDb("ELIZAWELL, Elizabeth");
+    final Task updatedTask = updateTaskApprovalSteps(task, approver, isPlanned, true);
+
+    final Person author = getPersonFromDb("ERINSON, Erin");
+    final Report report = submitReport(text, author, updatedTask, isPlanned,
+        isPlanned ? ReportState.APPROVED : ReportState.PENDING_APPROVAL);
+    assertWorkflowSize(report, updatedTask.getUuid(), 0);
+
+    // Go through organization approval first
+    organizationalApproval(report, isPlanned);
+
+    // Check reports pending approval
+    checkPendingApproval(approver, report, 0);
+
+    // Try to approve the report
+    approveReport(report, approver, true);
+
+    // Delete the report
+    deleteReport(author, report);
+  }
+
+  // submitted report, restricted approval step for effort has matching org
+  // => there should be an approval step for the effort
+  // => approver should see the report as pending approval
+  // => approver should be able to approve the report
+  @Test
+  public void testRestrictedStepMatchingOrgReportPublication() {
+    testRestrictedStepMatchingOrg("testRestrictedStepMatchingOrgReportPublication", false);
+  }
+
+  @Test
+  public void testRestrictedStepMatchingOrgPlannedEngagement() {
+    testRestrictedStepMatchingOrg("testRestrictedStepMatchingOrgPlannedEngagement", true);
+  }
+
+  private void testRestrictedStepMatchingOrg(String text, boolean isPlanned) {
+    final Task task = clearTaskApprovalSteps(TEST_TASK_UUID);
+
+    final Person approver = getApprover(isPlanned);
+    final Task updatedTask = updateTaskApprovalSteps(task, approver, isPlanned, true);
+
+    final Report report = submitReport(text, getPersonFromDb("ERINSON, Erin"), updatedTask,
+        isPlanned, ReportState.PENDING_APPROVAL);
+    assertWorkflowSize(report, updatedTask.getUuid(), 1);
+
+    // Go through organization approval first
+    organizationalApproval(report, isPlanned);
+
+    // Check reports pending approval
+    checkPendingApproval(approver, report, 1);
+
+    // Approve the report
+    approveReport(report, approver, false);
+  }
+
+  // submitted report, restricted approval step for effort has matching org,
+  // but then task is edited to remove approver from matching org
+  // => first, there should be an approval step for the effort,
+  // after the edit the step should still be there but have no approvers
+  // => first, approver should see the report as pending approval,
+  // after the edit approver should not see the report as pending approval
+  // and approver should not be able to approve the report
+  @Test
+  public void testRestrictedStepEditedMatchingOrgReportPublication() {
+    testRestrictedStepEditedMatchingOrg("testRestrictedStepEditedMatchingOrgReportPublication",
+        false);
+  }
+
+  @Test
+  public void testRestrictedStepEditedMatchingOrgPlannedEngagement() {
+    testRestrictedStepEditedMatchingOrg("testRestrictedStepEditedMatchingOrgPlannedEngagement",
+        true);
+  }
+
+  private void testRestrictedStepEditedMatchingOrg(String text, boolean isPlanned) {
+    final Task task = clearTaskApprovalSteps(TEST_TASK_UUID);
+
+    final Person approver = getApprover(isPlanned);
+    final Task updatedTask = updateTaskApprovalSteps(task, approver, isPlanned, true);
+
+    final Person author = getPersonFromDb("ERINSON, Erin");
+    final Report report =
+        submitReport(text, author, updatedTask, isPlanned, ReportState.PENDING_APPROVAL);
+    assertWorkflowSize(report, updatedTask.getUuid(), 1);
+
+    // Go through organization approval first
+    organizationalApproval(report, isPlanned);
+
+    // Check reports pending approval
+    checkPendingApproval(approver, report, 1);
+
+    // Replace the approver from the approval step
+    final Task replacedTask = replaceApproversFromTaskApprovalSteps(updatedTask,
+        getPersonFromDb("ELIZAWELL, Elizabeth"), isPlanned);
+
+    // Check that approval step has no approvers
+    final Report report2 = getReport(author, report);
+    assertWorkflowSize(report2, replacedTask.getUuid(), 1);
+    final Optional<ReportAction> taskStep =
+        report2.getWorkflow().stream().filter(wfs -> wfs.getStep() != null
+            && replacedTask.getUuid().equals(wfs.getStep().getRelatedObjectUuid())).findFirst();
+    assertThat(taskStep).isPresent();
+    assertThat(taskStep.get().getStep().getApprovers()).isEmpty();
+
+    // Check reports pending approval
+    checkPendingApproval(approver, report2, 0);
+
+    // Try to approve the report
+    approveReport(report2, approver, true);
+
+    // Delete the report
+    deleteReport(author, report2);
+  }
+
+  // submitted report, three approval steps for the effort:
+  // 1. unrestricted approval step
+  // 2. restricted approval step with no matching org
+  // 3. restricted approval step with matching org
+  //
+  // => there should be two approval steps for the effort (middle one should be filtered out)
+  // => approver 1 should see the report as pending approval
+  // => approver 1 should be able to approve the report
+  // => approver 2 should not see the report as pending approval
+  // => approver 2 should not be able to approve the report
+  // => approver 3 should see the report as pending approval
+  // => approver 3 should be able to approve the report
+  @Test
+  public void testMultipleStepsReportPublication() {
+    testMultipleSteps("testMultipleStepsReportPublication", false);
+  }
+
+  @Test
+  public void testMultipleStepsPlannedEngagement() {
+    testMultipleSteps("testMultipleStepsPlannedEngagement", false);
+  }
+
+  private void testMultipleSteps(String text, boolean isPlanned) {
+    final Task task = clearTaskApprovalSteps(TEST_TASK_UUID);
+
+    // An unrestricted step
+    final Person approverStep1 = getApprover(isPlanned);
+    final ApprovalStep as1 = getApprovalStep(approverStep1, isPlanned, false);
+
+    // A restricted step from a non-matching org
+    // Someone from EF 1.1
+    final Person approverStep2 = getPersonFromDb("ELIZAWELL, Elizabeth");
+    final ApprovalStep as2 = getApprovalStep(approverStep2, isPlanned, true);
+
+    // A restricted step from a matching org
+    final Person approverStep3 = getApprover(isPlanned);
+    final ApprovalStep as3 = getApprovalStep(approverStep3, isPlanned, true);
+
+    if (isPlanned) {
+      task.setPlanningApprovalSteps(Lists.newArrayList(as1, as2, as3));
+    } else {
+      task.setApprovalSteps(Lists.newArrayList(as1, as2, as3));
+    }
+    final Task updatedTask = updateTask(task);
+
+    final Report report = submitReport(text, getPersonFromDb("ERINSON, Erin"), updatedTask,
+        isPlanned, ReportState.PENDING_APPROVAL);
+    assertWorkflowSize(report, updatedTask.getUuid(), 2);
+
+    // Go through organization approval first
+    organizationalApproval(report, isPlanned);
+
+    // Check reports pending approval
+    checkPendingApproval(approverStep1, report, 1);
+
+    // Approve the report
+    approveReport(report, approverStep1, false);
+
+    // Check reports pending approval
+    checkPendingApproval(approverStep2, report, 0);
+
+    // Try to approve the report
+    approveReport(report, approverStep2, true);
+
+    // Check reports pending approval
+    checkPendingApproval(approverStep3, report, 1);
+
+    // Approve the report
+    approveReport(report, approverStep3, false);
+  }
+
+  // Helper methods below
+
+  private Task clearTaskApprovalSteps(String uuid) {
+    final Task task = getTaskFromDb(uuid);
+    task.setPlanningApprovalSteps(Collections.emptyList());
+    task.setApprovalSteps(Collections.emptyList());
+    updateTask(task);
+    return task;
+  }
+
+  private Task updateTaskApprovalSteps(Task task, Person approver, boolean isPlanned,
+      boolean restrictedApproval) {
+    final ApprovalStep as = getApprovalStep(approver, isPlanned, restrictedApproval);
+    if (isPlanned) {
+      task.setPlanningApprovalSteps(Lists.newArrayList(as));
+    } else {
+      task.setApprovalSteps(Lists.newArrayList(as));
+    }
+    return updateTask(task);
+  }
+
+  private ApprovalStep getApprovalStep(Person approver, boolean isPlanned,
+      boolean restrictedApproval) {
+    final ApprovalStep as = new ApprovalStep();
+    as.setName("Task approval by " + approver.getName());
+    as.setType(isPlanned ? ApprovalStepType.PLANNING_APPROVAL : ApprovalStepType.REPORT_APPROVAL);
+    as.setRestrictedApproval(restrictedApproval);
+    final Person unrelatedApprover = getPersonFromDb("ANDERSON, Andrew");
+    as.setApprovers(Lists.newArrayList(approver.getPosition(), unrelatedApprover.getPosition()));
+    return as;
+  }
+
+  private Person getApprover(boolean isPlanned) {
+    // Both from EF 2.1
+    return getPersonFromDb(isPlanned ? "JACKSON, Jack" : "HENDERSON, Henry");
+  }
+
+  private Task replaceApproversFromTaskApprovalSteps(Task task, Person approver,
+      boolean isPlanned) {
+    if (isPlanned) {
+      task.getPlanningApprovalSteps().get(0)
+          .setApprovers(Lists.newArrayList(approver.getPosition()));
+    } else {
+      task.getApprovalSteps().get(0).setApprovers(Lists.newArrayList(approver.getPosition()));
+    }
+    return updateTask(task);
+  }
+
+  private void organizationalApproval(Report report, boolean isPlanned) {
+    // No organizational workflow for planned engagements
+    if (!isPlanned) {
+      approveReport(report, getPersonFromDb("JACOBSON, Jacob"), false);
+      approveReport(report, getPersonFromDb("BECCABON, Rebecca"), false);
+    }
+  }
+
+  private void approveReport(Report report, Person person, boolean shouldFail) {
+    try {
+      final Report approved =
+          graphQLHelper.updateObject(person, "approveReport", "uuid", REPORT_FIELDS, "String",
+              report.getUuid(), new TypeReference<GraphQlResponse<Report>>() {});
+      if (shouldFail) {
+        fail("Expected an exception");
+      }
+      assertThat(approved).isNotNull();
+    } catch (BadRequestException | ForbiddenException e) {
+      if (!shouldFail) {
+        fail("Unexpected exception");
+      }
+    }
+  }
+
+  private void checkPendingApproval(Person approver, Report report, int size) {
+    final ReportSearchQuery pendingQuery = new ReportSearchQuery();
+    pendingQuery.setPendingApprovalOf(approver.getUuid());
+    final AnetBeanList<Report> pendingApproval = graphQLHelper.searchObjects(approver, "reportList",
+        "query", "ReportSearchQueryInput", REPORT_FIELDS, pendingQuery,
+        new TypeReference<GraphQlResponse<AnetBeanList<Report>>>() {});
+    assertThat(pendingApproval.getList()).filteredOn(rpt -> rpt.getUuid().equals(report.getUuid()))
+        .hasSize(size);
+  }
+
+  private Report submitReport(String text, Person author, Task task, boolean isPlanned,
+      ReportState expectedState) {
+    final Report r = new Report();
+    r.setAuthor(author);
+    final Instant engagementDate = Instant.now().plus(isPlanned ? 14 : -14, ChronoUnit.DAYS);
+    r.setEngagementDate(engagementDate);
+    r.setDuration(120);
+    final Person reina = getPersonFromDb("REINTON, Reina");
+    final Person steve = getPersonFromDb("STEVESON, Steve");
+    final ReportPerson advisor = PersonTest.personToReportPerson(reina);
+    advisor.setPrimary(true);
+    final ReportPerson principal = PersonTest.personToReportPerson(steve);
+    principal.setPrimary(true);
+    r.setAttendees(Lists.newArrayList(advisor, principal));
+    r.setTasks(Lists.newArrayList(task));
+    final Location testLocation = new Location();
+    testLocation.setUuid(TEST_LOCATION_UUID);
+    r.setLocation(testLocation);
+    r.setAtmosphere(Atmosphere.POSITIVE);
+    final String testText = String.format("Test report for task approval workflow — %1$s", text);
+    r.setIntent(testText);
+    r.setReportText(testText);
+    r.setNextSteps(testText);
+    r.setKeyOutcomes(testText);
+
+    // Create the report
+    final String createdUuid = graphQLHelper.createObject(author, "createReport", "report",
+        "ReportInput", r, new TypeReference<GraphQlResponse<Report>>() {});
+    assertThat(createdUuid).isNotNull();
+
+    // Retrieve the created report
+    final Report created =
+        graphQLHelper.getObjectById(author, "report", "uuid state advisorOrg { uuid }", createdUuid,
+            new TypeReference<GraphQlResponse<Report>>() {});
+    assertThat(created.getUuid()).isNotNull();
+    assertThat(created.getState()).isEqualTo(ReportState.DRAFT);
+    assertThat(created.getAdvisorOrgUuid()).isEqualTo(reina.getPosition().getOrganizationUuid());
+
+    // Have the author submit the report
+    final Report submitted = graphQLHelper.updateObject(author, "submitReport", "uuid", "uuid",
+        "String", created.getUuid(), new TypeReference<GraphQlResponse<Report>>() {});
+    assertThat(submitted).isNotNull();
+    assertThat(submitted.getUuid()).isEqualTo(created.getUuid());
+
+    // Retrieve the submitted report
+    final Report returned = getReport(author, submitted);
+    assertThat(returned.getUuid()).isEqualTo(submitted.getUuid());
+    assertThat(returned.getState()).isEqualTo(expectedState);
+
+    return returned;
+  }
+
+  private Report getReport(Person author, final Report report) {
+    final Report returned = graphQLHelper.getObjectById(author, "report", REPORT_FIELDS,
+        report.getUuid(), new TypeReference<GraphQlResponse<Report>>() {});
+    assertThat(returned).isNotNull();
+    return returned;
+  }
+
+  private void deleteReport(Person author, Report report) {
+    final Report updated = graphQLHelper.updateObject(author, "updateReport", "report",
+        REPORT_FIELDS, "ReportInput", report, new TypeReference<GraphQlResponse<Report>>() {});
+    assertThat(updated).isNotNull();
+    assertThat(updated.getState()).isEqualTo(ReportState.DRAFT);
+    graphQLHelper.deleteObject(author, "deleteReport", report.getUuid());
+  }
+
+  private void assertWorkflowSize(Report report, String taskUuid, int size) {
+    assertThat(report.getWorkflow()).isNotNull();
+    assertThat(report.getWorkflow())
+        .filteredOn(
+            wfs -> wfs.getStep() != null && taskUuid.equals(wfs.getStep().getRelatedObjectUuid()))
+        .hasSize(size);
+  }
+
+  private static Person getPersonFromDb(String name) {
+    final PersonSearchQuery personQuery = new PersonSearchQuery();
+    personQuery.setText(name);
+    final AnetBeanList<Person> searchResults = graphQLHelper.searchObjects(admin, "personList",
+        "query", "PersonSearchQueryInput", PERSON_FIELDS, personQuery,
+        new TypeReference<GraphQlResponse<AnetBeanList<Person>>>() {});
+    assertThat(searchResults.getTotalCount()).isGreaterThan(0);
+    final Optional<Person> personResult =
+        searchResults.getList().stream().filter(p -> p.getName().equals(name)).findFirst();
+    assertThat(personResult).isNotEmpty();
+    return personResult.get();
+  }
+
+  private static Task getTaskFromDb(String uuid) {
+    final Task task = graphQLHelper.getObjectById(admin, "task", TASK_FIELDS, uuid,
+        new TypeReference<GraphQlResponse<Task>>() {});
+    assertThat(task).isNotNull();
+    assertThat(task.getUuid()).isEqualTo(uuid);
+    return task;
+  }
+
+  private static Task updateTask(Task task) {
+    final Integer nrUpdated =
+        graphQLHelper.updateObject(admin, "updateTask", "task", "TaskInput", task);
+    assertThat(nrUpdated).isEqualTo(1);
+    return getTaskFromDb(task.getUuid());
+  }
+
+}

--- a/src/test/resources/graphQLTests/taskShow.gql
+++ b/src/test/resources/graphQLTests/taskShow.gql
@@ -1,0 +1,137 @@
+task(uuid: "${taskUuid}") {
+  uuid
+  shortName
+  longName
+  status
+  customField
+  customFieldEnum1
+  customFieldEnum2
+  plannedCompletion
+  projectedCompletion
+  taskedOrganizations {
+    uuid
+    shortName
+    longName
+    identificationCode
+  }
+  customFieldRef1 {
+    uuid
+    shortName
+    longName
+  }
+  responsiblePositions {
+    uuid
+    name
+    code
+    type
+    status
+    organization {
+      uuid
+      shortName
+    }
+    person {
+      uuid
+      name
+      rank
+      role
+      avatar(size: 32)
+    }
+  }
+  planningApprovalSteps {
+    uuid
+    name
+    restrictedApproval
+    approvers {
+      uuid
+      name
+      person {
+        uuid
+        name
+        rank
+        role
+        avatar(size: 32)
+      }
+    }
+  }
+  approvalSteps {
+    uuid
+    name
+    restrictedApproval
+    approvers {
+      uuid
+      name
+      person {
+        uuid
+        name
+        rank
+        role
+        avatar(size: 32)
+      }
+    }
+  }
+  customFields
+  notes {
+    uuid
+    createdAt
+    updatedAt
+    type
+    text
+    author {
+      uuid
+      name
+      rank
+      role
+    }
+    noteRelatedObjects {
+      noteUuid
+      relatedObjectType
+      relatedObjectUuid
+    }
+  }
+  publishedReports: reports(query: {
+    pageSize: 0
+    state: [PUBLISHED]
+  }) {
+    uuid
+  }
+}
+subTasks: taskList(query: {
+  pageSize: 0
+  customFieldRef1Uuid: ["${taskUuid}"]
+  customFieldRef1Recursively: true
+}) {
+  list {
+    uuid
+    shortName
+    longName
+    customFieldRef1 {
+      uuid
+      shortName
+    }
+    customFields
+    notes {
+      uuid
+      createdAt
+      updatedAt
+      type
+      text
+      author {
+        uuid
+        name
+        rank
+        role
+      }
+      noteRelatedObjects {
+        noteUuid
+        relatedObjectType
+        relatedObjectUuid
+      }
+    }
+    publishedReports: reports(query: {
+      pageSize: 0
+      state: [PUBLISHED]
+    }) {
+      uuid
+    }
+  }
+}


### PR DESCRIPTION
…change description goes here…

### Release notes

Closes NCI-Agency/anet#2989
Closes NCI-Agency/anet#3003

#### User changes
- Task approval steps may now be restricted to approvers descending from the same tasked organization as the report's primary advisor. If there are no matching approvers, such an approval step will be highlighted in orange, with **This step has no approvers!** in the text of the pop-up. Be sure to notify your super user about this.

#### Super User changes
- Tasks now have two separate approval workflows; in addition to the existing one for _Report publication_ there's now also one for _Engagement planning_
- Task approval steps have a new checkbox labeled _Restrict to approvers descending from the same tasked organization as the report's primary advisor_; ticking that box means the approvers you add to that step will have to descend from the same tasked organization of this task as the primray advisor of the report to be approved. Be careful to add at least one active approver position for each tasked organization of this task, as otherwise some approval steps may have no approvers. (Such an approval step will be highlighted in orange, with **This step has no approvers!** in the text of the pop-up.)

#### Admin changes
- none

#### System admin changes
- [ ] anet.yml needs change
- [x] db needs migration
- [ ] documentation has changed
- [x] graphql schema has changed:
  - approvalStep has a new field `restrictedApproval`
  - organization has a new accessor `ascendantOrgs` (counterpart of `descendantOrgs`)
  - the organization search field `parentOrgRecursively` is replaced by `orgRecurseStrategy`

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [x] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [x] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here