### PR TITLE
Gh 1839 Detect planning conflicts

### DIFF
--- a/client/config/wdio.config.js
+++ b/client/config/wdio.config.js
@@ -140,7 +140,7 @@ const config = {
   mochaOpts: {
     ui: "bdd",
     compilers: ["js:@babel/register"],
-    timeout: 60000
+    timeout: 90000
   },
   //
   // =====

--- a/client/package.json
+++ b/client/package.json
@@ -180,7 +180,7 @@
     "test-all": "yarn run test-jest && yarn run test-wdio && yarn run test-wdio-ie && yarn run test-e2e",
     "test-e2e": "export SERVER_URL=${SERVER_URL:-'http://localhost:8180'} ; NODE_ENV=test node $(npm bin)/ava --config ava.config.js",
     "test-wdio": "export SERVER_URL=${SERVER_URL:-'http://localhost:8180'} ; NODE_ENV=test wdio --baseUrl ${SERVER_URL} ./config/wdio.config.js",
-    "test-jest": "export ANET_CONFIG=../anet.yml ; NODE_ENV=test jest --testPathPattern='tests/(actions|reducers)'",
+    "test-jest": "export ANET_CONFIG=../anet.yml ; NODE_ENV=test jest --testPathPattern='tests/(actions|reducers|models)'",
     "test-wdio-ie": "export SERVER_URL=${SERVER_URL:-'http://localhost:8180'} ; NODE_ENV=test node ./tests/util/wdio.ie.js",
     "storybook": "start-storybook -p 9001 -c .storybook",
     "sim": "export ANET_CONFIG=../anet.yml SERVER_URL=${SERVER_URL:-'http://localhost:8080'} ; NODE_ENV=development webpack --mode development --config config/webpack.sim.dev.js && node build/anet.sim.dev.js"

--- a/client/src/components/PlanningConflictForPerson.js
+++ b/client/src/components/PlanningConflictForPerson.js
@@ -67,7 +67,7 @@ const BasePlanningConflictForPerson = ({ person, report }) => {
   }
 
   const conflictingReports = (data?.person?.attendedReports?.list || [])
-    .filter(ar => report.hasConflict(ar))
+    .filter(ar => Report.hasConflict(report, ar))
     .sort((a, b) =>
       a.engagementDate === b.engagementDate
         ? (a.duration || 0) - (b.duration || 0)
@@ -94,16 +94,7 @@ const BasePlanningConflictForPerson = ({ person, report }) => {
               model={report}
               style={{ display: "block" }}
             >
-              {moment(report.engagementDate).format(
-                Report.getEngagementDateFormat()
-              )}
-              {" >>> "}
-              {report.duration > 0
-                ? moment(report.engagementDate)
-                  .add(report.duration, "minutes")
-                  .format(Report.getEngagementDateFormat())
-                : "..."}
-              &nbsp;({report.state})
+              {Report.getFormattedEngagementDate(report)}&nbsp;({report.state})
             </LinkTo>
           ))}
         </Callout>

--- a/client/src/components/PlanningConflictForPerson.js
+++ b/client/src/components/PlanningConflictForPerson.js
@@ -1,0 +1,130 @@
+import {
+  Button,
+  Callout,
+  Icon,
+  Intent,
+  Popover,
+  PopoverInteractionKind,
+  Spinner,
+  Tooltip
+} from "@blueprintjs/core"
+import { IconNames } from "@blueprintjs/icons"
+import API from "api"
+import { gql } from "apollo-boost"
+import LinkTo from "components/LinkTo"
+import Person from "models/Person"
+import Report from "models/Report"
+import moment from "moment"
+import pluralize from "pluralize"
+import PropTypes from "prop-types"
+import React from "react"
+
+const GET_PERSON_WITH_REPORTS = gql`
+  query($uuid: String!, $attendedReportsQuery: ReportSearchQueryInput!) {
+    person(uuid: $uuid) {
+      uuid
+      name
+      attendedReports(query: $attendedReportsQuery) {
+        list {
+          uuid
+          engagementDate
+          duration
+          state
+        }
+      }
+    }
+  }
+`
+const PlanningConflictForPerson = ({ person, report }) => {
+  if (!person || !person.uuid || !report || !report.engagementDate) {
+    return null
+  }
+
+  const { loading, error, data } = API.useApiQuery(GET_PERSON_WITH_REPORTS, {
+    uuid: person.uuid,
+    attendedReportsQuery: {
+      engagementDateStart: moment(report.engagementDate)
+        .startOf("day")
+        .valueOf(),
+      engagementDateEnd: moment(report.engagementDate).endOf("day").valueOf()
+    }
+  })
+
+  if (loading) {
+    return (
+      <Tooltip content="Checking for planning conflicts...">
+        <Spinner intent={Intent.WARNING} size={20} />
+      </Tooltip>
+    )
+  }
+
+  if (error) {
+    return (
+      <Tooltip
+        content="Error occured while checking for planning conflicts!"
+        intent={Intent.DANGER}
+      >
+        <Icon icon={IconNames.ERROR} intent={Intent.DANGER} />
+      </Tooltip>
+    )
+  }
+
+  const conflictingReports = (data?.person?.attendedReports?.list || [])
+    .filter(ar => report.hasConflict(ar))
+    .sort((a, b) =>
+      a.engagementDate === b.engagementDate
+        ? (a.duration || 0) - (b.duration || 0)
+        : a.engagementDate - b.engagementDate
+    )
+
+  if (!conflictingReports.length) {
+    return null
+  }
+
+  return (
+    <Popover
+      content={
+        <Callout
+          title={`${person.toString()} has ${
+            conflictingReports.length
+          } conflicting ${pluralize("report", conflictingReports.length)}`}
+          intent={Intent.WARNING}
+        >
+          {conflictingReports.map(report => (
+            <LinkTo
+              key={report.uuid}
+              modelType="Report"
+              model={report}
+              style={{ display: "block" }}
+            >
+              {moment(report.engagementDate).format(
+                Report.getEngagementDateFormat()
+              )}
+              {" >>> "}
+              {report.duration > 0
+                ? moment(report.engagementDate)
+                  .add(report.duration, "minutes")
+                  .format(Report.getEngagementDateFormat())
+                : "..."}
+              &nbsp;({report.state})
+            </LinkTo>
+          ))}
+        </Callout>
+      }
+      target={
+        <Button icon={IconNames.WARNING_SIGN} intent={Intent.WARNING} minimal>
+          {conflictingReports.length}&nbsp;
+          {pluralize("conflict", conflictingReports.length)}
+        </Button>
+      }
+      interactionKind={PopoverInteractionKind.CLICK}
+    />
+  )
+}
+
+PlanningConflictForPerson.propTypes = {
+  person: PropTypes.instanceOf(Person),
+  report: PropTypes.instanceOf(Report)
+}
+
+export default PlanningConflictForPerson

--- a/client/src/components/PlanningConflictForPerson.js
+++ b/client/src/components/PlanningConflictForPerson.js
@@ -35,11 +35,8 @@ const GET_PERSON_WITH_REPORTS = gql`
     }
   }
 `
-const PlanningConflictForPerson = ({ person, report }) => {
-  if (!person || !person.uuid || !report || !report.engagementDate) {
-    return null
-  }
 
+const BasePlanningConflictForPerson = ({ person, report }) => {
   const { loading, error, data } = API.useApiQuery(GET_PERSON_WITH_REPORTS, {
     uuid: person.uuid,
     attendedReportsQuery: {
@@ -120,6 +117,18 @@ const PlanningConflictForPerson = ({ person, report }) => {
       interactionKind={PopoverInteractionKind.CLICK}
     />
   )
+}
+
+BasePlanningConflictForPerson.propTypes = {
+  person: PropTypes.instanceOf(Person).isRequired,
+  report: PropTypes.instanceOf(Report).isRequired
+}
+
+const PlanningConflictForPerson = ({ person, report }) => {
+  if (!person?.uuid || !report?.engagementDate) {
+    return null
+  }
+  return <BasePlanningConflictForPerson person={person} report={report} />
 }
 
 PlanningConflictForPerson.propTypes = {

--- a/client/src/components/PlanningConflictForReport.js
+++ b/client/src/components/PlanningConflictForReport.js
@@ -106,7 +106,7 @@ const PlanningConflictForReport = ({ report, text, largeIcon }) => {
   const attendees = currentReport?.attendees || []
 
   const conflictingAttendees = attendees.filter(at =>
-    at.attendedReports.list.some(ar => currentReport.hasConflict(ar))
+    at.attendedReports.list.some(ar => Report.hasConflict(currentReport, ar))
   )
 
   if (!conflictingAttendees.length) {

--- a/client/src/components/PlanningConflictForReport.js
+++ b/client/src/components/PlanningConflictForReport.js
@@ -1,0 +1,146 @@
+import { Icon, Intent, Spinner, Tooltip } from "@blueprintjs/core"
+import { IconNames } from "@blueprintjs/icons"
+import API from "api"
+import { gql } from "apollo-boost"
+import Report from "models/Report"
+import moment from "moment"
+import PropTypes from "prop-types"
+import React, { useEffect, useState } from "react"
+
+const GET_REPORT_WITH_ATTENDED_REPORTS = gql`
+  query($uuid: String, $attendedReportsQuery: ReportSearchQueryInput) {
+    report(uuid: $uuid) {
+      uuid
+      engagementDate
+      duration
+      attendees {
+        uuid
+        name
+        attendedReports(query: $attendedReportsQuery) {
+          list {
+            uuid
+            engagementDate
+            duration
+          }
+        }
+      }
+    }
+  }
+`
+
+const PlanningConflictForReport = ({ report, text, largeIcon }) => {
+  const [status, setStatus] = useState("loading")
+  const [data, setData] = useState(null)
+
+  useEffect(() => {
+    if (!report || !report.uuid || !report.engagementDate) {
+      setStatus("done")
+      return
+    }
+
+    API.query(GET_REPORT_WITH_ATTENDED_REPORTS, {
+      uuid: report.uuid,
+      attendedReportsQuery: {
+        engagementDateStart: moment(report.engagementDate)
+          .startOf("day")
+          .valueOf(),
+        engagementDateEnd: moment(report.engagementDate).endOf("day").valueOf()
+      }
+    })
+      .then(result => {
+        setStatus("done")
+        setData(result)
+      })
+      .catch(() => setStatus("error"))
+  }, [report])
+
+  if (status === "loading") {
+    return (
+      <span
+        style={{
+          verticalAlign: "middle",
+          display: "inline-flex",
+          alignItems: "center"
+        }}
+      >
+        <Spinner
+          intent={Intent.WARNING}
+          size={12}
+          style={{ margin: "0 2px" }}
+        />
+        {text}
+      </span>
+    )
+  }
+
+  if (status === "error") {
+    return (
+      <Tooltip
+        content="An error occured while checking planning conflicts!"
+        intent={Intent.DANGER}
+      >
+        <Icon
+          icon={IconNames.ERROR}
+          intent={Intent.DANGER}
+          iconSize={Icon.SIZE_STANDARD}
+        />
+      </Tooltip>
+    )
+  }
+
+  const currentReport = data?.report ? new Report(data.report) : null
+  const attendees = currentReport?.attendees || []
+
+  const conflictingAttendees = attendees.filter(at =>
+    at.attendedReports.list.some(ar => currentReport.hasConflict(ar))
+  )
+
+  if (!conflictingAttendees.length) {
+    return text || null
+  }
+
+  return (
+    <span
+      style={{
+        verticalAlign: "middle",
+        display: "inline-flex",
+        alignItems: "center"
+      }}
+    >
+      <Tooltip
+        content={
+          <>
+            {conflictingAttendees.length} of {attendees.length} attendees are
+            busy at the selected time!
+            <ul>
+              {conflictingAttendees.map(at => (
+                <li key={at.uuid}>{at.name}</li>
+              ))}
+            </ul>
+          </>
+        }
+        intent={Intent.WARNING}
+      >
+        <Icon
+          icon={IconNames.WARNING_SIGN}
+          intent={Intent.WARNING}
+          iconSize={largeIcon ? Icon.SIZE_LARGE : Icon.SIZE_STANDARD}
+          style={{ margin: "0 5px" }}
+        />
+      </Tooltip>
+      {text}
+    </span>
+  )
+}
+
+PlanningConflictForReport.propTypes = {
+  report: PropTypes.instanceOf(Report).isRequired,
+  text: PropTypes.string,
+  largeIcon: PropTypes.bool
+}
+
+PlanningConflictForReport.defaultProps = {
+  text: ""
+}
+
+export default PlanningConflictForReport

--- a/client/src/components/PlanningConflictForReport.js
+++ b/client/src/components/PlanningConflictForReport.js
@@ -56,13 +56,7 @@ const PlanningConflictForReport = ({ report, text, largeIcon }) => {
 
   if (status === "loading") {
     return (
-      <span
-        style={{
-          verticalAlign: "middle",
-          display: "inline-flex",
-          alignItems: "center"
-        }}
-      >
+      <span className="reportConflictLoadingIcon">
         <Spinner
           intent={Intent.WARNING}
           size={12}
@@ -100,24 +94,20 @@ const PlanningConflictForReport = ({ report, text, largeIcon }) => {
   }
 
   return (
-    <span
-      style={{
-        verticalAlign: "middle",
-        display: "inline-flex",
-        alignItems: "center"
-      }}
-    >
+    <span className="reportConflictIcon">
       <Tooltip
         content={
-          <>
-            {conflictingAttendees.length} of {attendees.length} attendees are
-            busy at the selected time!
+          <div className="reportConflictTooltipContainer">
+            <div>
+              {conflictingAttendees.length} of {attendees.length} attendees are
+              busy at the selected time!
+            </div>
             <ul>
               {conflictingAttendees.map(at => (
                 <li key={at.uuid}>{at.name}</li>
               ))}
             </ul>
-          </>
+          </div>
         }
         intent={Intent.WARNING}
       >

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1097,3 +1097,15 @@ header.searchPagination {
 		height: 100% !important;
 	}
 }
+
+/** wdio e2e tests rely on these class names */
+.reportConflictIcon, .reportConflictLoadingIcon {
+	vertical-align: middle;
+	display: inline-flex;
+	align-items: center
+}
+
+/** wdio e2e tests rely on this class name */
+.reportConflictTooltipContainer > div {
+	font-weight: bold;
+}

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1097,15 +1097,3 @@ header.searchPagination {
 		height: 100% !important;
 	}
 }
-
-/** wdio e2e tests rely on these class names */
-.reportConflictIcon, .reportConflictLoadingIcon {
-	vertical-align: middle;
-	display: inline-flex;
-	align-items: center
-}
-
-/** wdio e2e tests rely on this class name */
-.reportConflictTooltipContainer > div {
-	font-weight: bold;
-}

--- a/client/src/models/Report.js
+++ b/client/src/models/Report.js
@@ -468,4 +468,24 @@ export default class Report extends Model {
       Report.ATTENDEES_ASSESSMENTS_UUIDS_FIELD
     )
   }
+
+  hasConflict(that) {
+    if (this.uuid === that.uuid) {
+      return false // same report is not a conflicting report
+    }
+    const thisStart = moment(this.engagementDate)
+    const thisEnd = moment(this.engagementDate).add(
+      this.duration || 0,
+      "minute"
+    )
+    const thatStart = moment(that.engagementDate)
+    const thatEnd = moment(that.engagementDate).add(
+      that.duration || 0,
+      "minute"
+    )
+    return (
+      thisStart.isSame(thatStart) ||
+      (thisEnd.isAfter(thatStart) && thisStart.isBefore(thatEnd))
+    )
+  }
 }

--- a/client/src/models/Report.js
+++ b/client/src/models/Report.js
@@ -469,23 +469,69 @@ export default class Report extends Model {
     )
   }
 
-  hasConflict(that) {
-    if (this.uuid === that.uuid) {
+  static hasConflict(report01, report02) {
+    if (report01.uuid === report02.uuid) {
       return false // same report is not a conflicting report
     }
-    const thisStart = moment(this.engagementDate)
-    const thisEnd = moment(this.engagementDate).add(
-      this.duration || 0,
-      "minute"
-    )
-    const thatStart = moment(that.engagementDate)
-    const thatEnd = moment(that.engagementDate).add(
-      that.duration || 0,
-      "minute"
-    )
+
+    let start01
+    let end01
+
+    if (
+      !Settings.engagementsIncludeTimeAndDuration ||
+      report01.duration === null
+    ) {
+      // It is an all-day event
+      start01 = moment(report01.engagementDate).startOf("day")
+      end01 = moment(report01.engagementDate).endOf("day")
+    } else {
+      start01 = moment(report01.engagementDate)
+      end01 = moment(report01.engagementDate).add(report01.duration, "minute")
+    }
+
+    let start02
+    let end02
+
+    if (
+      !Settings.engagementsIncludeTimeAndDuration ||
+      report02.duration === null
+    ) {
+      // It is an all-day event
+      start02 = moment(report02.engagementDate).startOf("day")
+      end02 = moment(report02.engagementDate).endOf("day")
+    } else {
+      start02 = moment(report02.engagementDate)
+      end02 = moment(report02.engagementDate).add(report02.duration, "minute")
+    }
+
     return (
-      thisStart.isSame(thatStart) ||
-      (thisEnd.isAfter(thatStart) && thisStart.isBefore(thatEnd))
+      start01.isSame(start02) ||
+      (end01.isAfter(start02) && start01.isBefore(end02))
+    )
+  }
+
+  static getFormattedEngagementDate(report) {
+    if (!report?.engagementDate) {
+      return ""
+    }
+
+    const start = moment(report.engagementDate)
+    if (!report.duration) {
+      return Settings.engagementsIncludeTimeAndDuration
+        ? start.format(Settings.dateFormats.forms.displayLong.date) +
+            " (all day)"
+        : start.format(Report.getEngagementDateFormat())
+    }
+
+    const end = moment(report.engagementDate).add(report.duration, "minutes")
+
+    return (
+      start.format(Report.getEngagementDateFormat()) +
+      end.format(
+        start.isSame(end, "day")
+          ? " - HH:mm"
+          : " >>> " + Report.getEngagementDateFormat()
+      )
     )
   }
 }

--- a/client/src/pages/reports/AttendeesTable.js
+++ b/client/src/pages/reports/AttendeesTable.js
@@ -1,6 +1,8 @@
 import LinkTo from "components/LinkTo"
+import PlanningConflictForPerson from "components/PlanningConflictForPerson"
 import RemoveButton from "components/RemoveButton"
 import { Person } from "models"
+import Report from "models/Report"
 import PropTypes from "prop-types"
 import React from "react"
 import { Label, Radio, Table } from "react-bootstrap"
@@ -8,7 +10,7 @@ import "./AttendeesTable.css"
 
 const AttendeeDividerRow = () => (
   <tr className="attendee-divider-row">
-    <td colSpan={6}>
+    <td colSpan={7}>
       <hr />
     </td>
   </tr>
@@ -22,8 +24,9 @@ const TableHeader = ({ showDelete, hide }) => (
       </th>
       <th className="col-xs-3">{!hide && "Name"}</th>
       <th className="col-xs-3">{!hide && "Position"}</th>
-      <th className="col-xs-2">{!hide && "Location"}</th>
+      <th className="col-xs-1">{!hide && "Location"}</th>
       <th className="col-xs-2">{!hide && "Organization"}</th>
+      <th className="col-xs-1" />
       {showDelete && <th className="col-xs-1" />}
     </tr>
   </thead>
@@ -80,6 +83,7 @@ RadioButton.propTypes = {
 }
 
 const AttendeesTable = ({
+  report,
   attendees,
   disabled,
   onChange,
@@ -97,7 +101,7 @@ const AttendeesTable = ({
         />
       </TableContainer>
       <TableContainer className="principalAttendeesTable">
-        <TableHeader hide />
+        <TableHeader hide showDelete={showDelete} />
         <TableBody
           attendees={attendees}
           role={Person.ROLE.PRINCIPAL}
@@ -143,8 +147,11 @@ const AttendeesTable = ({
             whenUnspecified=""
           />
         </td>
+        <td style={{ verticalAlign: "middle" }}>
+          <PlanningConflictForPerson person={person} report={report} />
+        </td>
         {showDelete && (
-          <td>
+          <td style={{ verticalAlign: "middle" }}>
             <RemoveButton
               title="Remove attendee"
               altText="Remove attendee"
@@ -169,6 +176,7 @@ const AttendeesTable = ({
 }
 
 AttendeesTable.propTypes = {
+  report: PropTypes.instanceOf(Report),
   attendees: PropTypes.array,
   disabled: PropTypes.bool,
   onChange: PropTypes.func,

--- a/client/src/pages/reports/AttendeesTable.js
+++ b/client/src/pages/reports/AttendeesTable.js
@@ -84,7 +84,6 @@ RadioButton.propTypes = {
 
 const AttendeesTable = ({
   report,
-  attendees,
   disabled,
   onChange,
   showDelete,
@@ -95,7 +94,7 @@ const AttendeesTable = ({
       <TableContainer className="advisorAttendeesTable">
         <TableHeader showDelete={showDelete} />
         <TableBody
-          attendees={attendees}
+          attendees={report.attendees}
           role={Person.ROLE.ADVISOR}
           handleAttendeeRow={renderAttendeeRow}
         />
@@ -103,7 +102,7 @@ const AttendeesTable = ({
       <TableContainer className="principalAttendeesTable">
         <TableHeader hide showDelete={showDelete} />
         <TableBody
-          attendees={attendees}
+          attendees={report.attendees}
           role={Person.ROLE.PRINCIPAL}
           handleAttendeeRow={renderAttendeeRow}
           enableDivider
@@ -164,20 +163,19 @@ const AttendeesTable = ({
   }
 
   function setPrimaryAttendee(person) {
-    attendees.forEach(attendee => {
+    report.attendees.forEach(attendee => {
       if (Person.isEqual(attendee, person)) {
         attendee.primary = true
       } else if (attendee.role === person.role) {
         attendee.primary = false
       }
     })
-    onChange(attendees)
+    onChange(report.attendees)
   }
 }
 
 AttendeesTable.propTypes = {
   report: PropTypes.instanceOf(Report),
-  attendees: PropTypes.array,
   disabled: PropTypes.bool,
   onChange: PropTypes.func,
   showDelete: PropTypes.bool,

--- a/client/src/pages/reports/Form.js
+++ b/client/src/pages/reports/Form.js
@@ -742,6 +742,13 @@ const ReportForm = ({
                       renderSelected={
                         <AttendeesTable
                           attendees={values.attendees}
+                          report={
+                            new Report({
+                              uuid: values.uuid,
+                              engagementDate: values.engagementDate,
+                              duration: Number.parseInt(values.duration) || 0
+                            })
+                          }
                           onChange={value =>
                             setFieldValue("attendees", value, true)}
                           showDelete

--- a/client/src/pages/reports/Form.js
+++ b/client/src/pages/reports/Form.js
@@ -741,12 +741,12 @@ const ReportForm = ({
                       value={values.attendees}
                       renderSelected={
                         <AttendeesTable
-                          attendees={values.attendees}
                           report={
                             new Report({
                               uuid: values.uuid,
                               engagementDate: values.engagementDate,
-                              duration: Number.parseInt(values.duration) || 0
+                              duration: Number.parseInt(values.duration) || 0,
+                              attendees: values.attendees
                             })
                           }
                           onChange={value =>

--- a/client/src/pages/reports/Minimal.js
+++ b/client/src/pages/reports/Minimal.js
@@ -411,7 +411,7 @@ const ReportMinimal = ({ pageDispatchers }) => {
             </Fieldset>
 
             <Fieldset title="Meeting attendees">
-              <AttendeesTable attendees={report.attendees} disabled />
+              <AttendeesTable report={report} disabled />
             </Fieldset>
 
             <Fieldset title={Settings.fields.task.subLevel.longLabel}>

--- a/client/src/pages/reports/Show.js
+++ b/client/src/pages/reports/Show.js
@@ -17,11 +17,12 @@ import Messages from "components/Messages"
 import { DEFAULT_CUSTOM_FIELDS_PARENT } from "components/Model"
 import {
   AnchorLink,
-  PageDispatchersPropType,
   jumpToTop,
   mapPageDispatchersToProps,
+  PageDispatchersPropType,
   useBoilerplate
 } from "components/Page"
+import PlanningConflictForReport from "components/PlanningConflictForReport"
 import RelatedObjectNotes, {
   GRAPHQL_NOTES_FIELDS
 } from "components/RelatedObjectNotes"
@@ -528,10 +529,13 @@ const ReportShow = ({ setSearchQuery, pageDispatchers }) => {
                   name="engagementDate"
                   component={FieldHelper.ReadonlyField}
                   humanValue={
-                    report.engagementDate &&
-                    moment(report.engagementDate).format(
-                      Report.getEngagementDateFormat()
-                    )
+                    <>
+                      {report.engagementDate &&
+                        moment(report.engagementDate).format(
+                          Report.getEngagementDateFormat()
+                        )}
+                      <PlanningConflictForReport report={report} largeIcon />
+                    </>
                   }
                 />
 
@@ -624,7 +628,7 @@ const ReportShow = ({ setSearchQuery, pageDispatchers }) => {
                 />
               </Fieldset>
               <Fieldset title="Meeting attendees">
-                <AttendeesTable attendees={report.attendees} disabled />
+                <AttendeesTable report={report} disabled />
               </Fieldset>
               <Fieldset title={Settings.fields.task.subLevel.longLabel}>
                 <TaskTable

--- a/client/tests/models/report.test.js
+++ b/client/tests/models/report.test.js
@@ -1,0 +1,250 @@
+import moment from "moment"
+import Settings from "../../platform/node/settings"
+import Report from "../../src/models/Report"
+
+const uuidv4 = require("uuid/v4")
+
+function tStart(report) {
+  return moment(report.engagementDate).toDate().getTime()
+}
+
+function tEnd(report) {
+  return moment(report.engagementDate)
+    .add(report.duration, "minutes")
+    .toDate()
+    .getTime()
+}
+
+describe("report model", () => {
+  it("should return empty string for blank report or blank engagementDate", () => {
+    expect(Report.getFormattedEngagementDate()).toEqual("")
+    expect(Report.getFormattedEngagementDate({})).toEqual("")
+    expect(Report.getFormattedEngagementDate({ engagementDate: null })).toEqual(
+      ""
+    )
+  })
+
+  it("should format engagement date without time when engagements do not include time and duration", () => {
+    Settings.engagementsIncludeTimeAndDuration = false
+    const d0 = new Date(1985, 5, 12, 23, 0, 0, 0)
+    const fd = Report.getFormattedEngagementDate({ engagementDate: d0 })
+    expect(fd).toEqual(moment(d0).format(Report.getEngagementDateFormat()))
+  })
+
+  it("should format engagement date as all day when duration is blank", () => {
+    Settings.engagementsIncludeTimeAndDuration = true
+    const d0 = new Date(1985, 5, 12, 23, 0, 0, 0)
+
+    expect(Report.getFormattedEngagementDate({ engagementDate: d0 })).toEqual(
+      moment(d0).format(Settings.dateFormats.forms.displayLong.date) +
+        " (all day)"
+    )
+  })
+
+  it("should show date and time range in formatted engagement date when report starts and ends within same day", () => {
+    Settings.engagementsIncludeTimeAndDuration = true
+    const d0 = new Date(1985, 5, 12, 23, 0, 0, 0)
+    const d1 = new Date(1985, 5, 12, 23, 30, 0, 0)
+
+    const fd = Report.getFormattedEngagementDate({
+      engagementDate: d0,
+      duration: 30
+    })
+    expect(fd).toEqual(
+      moment(d0).format(Report.getEngagementDateFormat()) +
+        moment(d1).format(" - HH:mm")
+    )
+  })
+
+  it("should display date and time for both start and end when report doesn't start and end within same day", () => {
+    Settings.engagementsIncludeTimeAndDuration = true
+    const d0 = new Date(1985, 5, 12, 23, 0, 0, 0)
+    const d1 = new Date(1985, 5, 13, 0, 30, 0, 0)
+
+    const fd = Report.getFormattedEngagementDate({
+      engagementDate: d0,
+      duration: 90
+    })
+    expect(fd).toEqual(
+      moment(d0).format(Report.getEngagementDateFormat()) +
+        moment(d1).format(" >>> " + Report.getEngagementDateFormat())
+    )
+  })
+
+  it("should not detect conflict for same report", () => {
+    const report = new Report({ uuid: uuidv4() })
+    expect(Report.hasConflict(report, report)).toStrictEqual(false)
+  })
+
+  it("should detect conflict when reports start at the same time", () => {
+    const report01 = new Report({
+      uuid: uuidv4(),
+      engagementDate: new Date(1985, 5, 12, 1, 0, 0, 0)
+    })
+    const report02 = new Report({
+      uuid: uuidv4(),
+      engagementDate: new Date(1985, 5, 12, 1, 0, 0, 0)
+    })
+    expect(Report.hasConflict(report01, report02)).toStrictEqual(true)
+    expect(Report.hasConflict(report02, report01)).toStrictEqual(true)
+  })
+
+  it("should detect conflict for all day reports even if reports do not start at the same time", () => {
+    const report01 = new Report({
+      uuid: uuidv4(),
+      engagementDate: new Date(1985, 5, 12, 1, 0, 0, 0)
+    })
+    const report02 = new Report({
+      uuid: uuidv4(),
+      engagementDate: new Date(1985, 5, 12, 2, 0, 0, 0)
+    })
+    expect(Report.hasConflict(report01, report02)).toStrictEqual(true)
+    expect(Report.hasConflict(report02, report01)).toStrictEqual(true)
+  })
+
+  it("should not detect conflict for all day reports when reports are on different days", () => {
+    const report01 = new Report({
+      uuid: uuidv4(),
+      engagementDate: new Date(1985, 5, 12, 1, 0, 0, 0)
+    })
+    const report02 = new Report({
+      uuid: uuidv4(),
+      engagementDate: new Date(1985, 5, 13, 1, 0, 0, 0)
+    })
+    expect(Report.hasConflict(report01, report02)).toStrictEqual(false)
+    expect(Report.hasConflict(report02, report01)).toStrictEqual(false)
+  })
+
+  // r01:  |--------|
+  // r02:              |--------|
+  it("should not detect conflict when r01.end < r02.start", () => {
+    const report01 = new Report({
+      uuid: uuidv4(),
+      duration: 30,
+      engagementDate: new Date(1985, 5, 12, 1, 0, 0, 0)
+    })
+    const report02 = new Report({
+      uuid: uuidv4(),
+      duration: 30,
+      engagementDate: new Date(1985, 5, 12, 2, 0, 0, 0)
+    })
+    expect(tEnd(report01)).toBeLessThan(tStart(report02))
+    expect(Report.hasConflict(report01, report02)).toStrictEqual(false)
+    expect(Report.hasConflict(report02, report01)).toStrictEqual(false)
+  })
+
+  // r01:  |--------|
+  // r02:           |--------|
+  it("should not detect conflict when r01.end === r02.start", () => {
+    const report01 = new Report({
+      uuid: uuidv4(),
+      duration: 30,
+      engagementDate: new Date(1985, 5, 12, 1, 0, 0, 0)
+    })
+    const report02 = new Report({
+      uuid: uuidv4(),
+      duration: 30,
+      engagementDate: new Date(1985, 5, 12, 1, 30, 0, 0)
+    })
+    expect(tEnd(report01)).toStrictEqual(tStart(report02))
+    expect(Report.hasConflict(report01, report02)).toStrictEqual(false)
+    expect(Report.hasConflict(report02, report01)).toStrictEqual(false)
+  })
+
+  // r01:  |--------|
+  // r02:       |--------|
+  it("should detect conflict when r01.end is between r02.start and r02.end && r01.start < r02.start", () => {
+    const report01 = new Report({
+      uuid: uuidv4(),
+      duration: 31,
+      engagementDate: new Date(1985, 5, 12, 1, 0, 0, 0)
+    })
+    const report02 = new Report({
+      uuid: uuidv4(),
+      duration: 30,
+      engagementDate: new Date(1985, 5, 12, 1, 30, 0, 0)
+    })
+    expect(tEnd(report01)).toBeGreaterThan(tStart(report02))
+    expect(tEnd(report01)).toBeLessThan(tEnd(report02))
+    expect(tStart(report01)).toBeLessThan(tStart(report02))
+    expect(Report.hasConflict(report01, report02)).toStrictEqual(true)
+    expect(Report.hasConflict(report02, report01)).toStrictEqual(true)
+  })
+
+  // r01:    |--------|
+  // r02:  |------------|
+  it("should detect conflict when r01.start and r01.end are between r02.start and r02.end ", () => {
+    const report01 = new Report({
+      uuid: uuidv4(),
+      duration: 30,
+      engagementDate: new Date(1985, 5, 12, 1, 0, 0, 0)
+    })
+    const report02 = new Report({
+      uuid: uuidv4(),
+      duration: 90,
+      engagementDate: new Date(1985, 5, 12, 0, 30, 0, 0)
+    })
+    expect(tEnd(report01)).toBeGreaterThan(tStart(report02))
+    expect(tEnd(report01)).toBeLessThan(tEnd(report02))
+    expect(tStart(report01)).toBeGreaterThan(tStart(report02))
+    expect(tStart(report01)).toBeLessThan(tEnd(report02))
+    expect(Report.hasConflict(report01, report02)).toStrictEqual(true)
+    expect(Report.hasConflict(report02, report01)).toStrictEqual(true)
+  })
+
+  // r01:       |--------|
+  // r02:  |--------|
+  it("should detect conflict when r01.start is between r02.start and r02.end && r01.end > r02.end ", () => {
+    const report01 = new Report({
+      uuid: uuidv4(),
+      duration: 60,
+      engagementDate: new Date(1985, 5, 12, 1, 0, 0, 0)
+    })
+    const report02 = new Report({
+      uuid: uuidv4(),
+      duration: 60,
+      engagementDate: new Date(1985, 5, 12, 0, 30, 0, 0)
+    })
+    expect(tStart(report01)).toBeGreaterThan(tStart(report02))
+    expect(tStart(report01)).toBeLessThan(tEnd(report02))
+    expect(tEnd(report01)).toBeGreaterThan(tEnd(report02))
+    expect(Report.hasConflict(report01, report02)).toStrictEqual(true)
+    expect(Report.hasConflict(report02, report01)).toStrictEqual(true)
+  })
+
+  // r01:           |--------|
+  // r02:  |--------|
+  it("should not detect conflict when r01.start === r02.end", () => {
+    const report01 = new Report({
+      uuid: uuidv4(),
+      duration: 30,
+      engagementDate: new Date(1985, 5, 12, 1, 30, 0, 0)
+    })
+    const report02 = new Report({
+      uuid: uuidv4(),
+      duration: 30,
+      engagementDate: new Date(1985, 5, 12, 1, 0, 0, 0)
+    })
+    expect(tStart(report01)).toStrictEqual(tEnd(report02))
+    expect(Report.hasConflict(report01, report02)).toStrictEqual(false)
+    expect(Report.hasConflict(report02, report01)).toStrictEqual(false)
+  })
+
+  // r01:              |--------|
+  // r02:  |--------|
+  it("should not detect conflict when r01.start > r02.end", () => {
+    const report01 = new Report({
+      uuid: uuidv4(),
+      duration: 30,
+      engagementDate: new Date(1985, 5, 12, 2, 0, 0, 0)
+    })
+    const report02 = new Report({
+      uuid: uuidv4(),
+      duration: 30,
+      engagementDate: new Date(1985, 5, 12, 1, 0, 0, 0)
+    })
+    expect(tStart(report01)).toBeGreaterThan(tEnd(report02))
+    expect(Report.hasConflict(report01, report02)).toStrictEqual(false)
+    expect(Report.hasConflict(report02, report01)).toStrictEqual(false)
+  })
+})

--- a/client/tests/webdriver/pages/report/createReport.page.js
+++ b/client/tests/webdriver/pages/report/createReport.page.js
@@ -1,0 +1,155 @@
+import moment from "moment"
+import Page from "../page"
+
+const PAGE_URL = "/reports/new"
+
+class CreateReport extends Page {
+  get form() {
+    return browser.$("form")
+  }
+
+  get title() {
+    return browser.$("h2.legend")
+  }
+
+  get intent() {
+    return browser.$("#intent")
+  }
+
+  get engagementDate() {
+    return browser.$("#engagementDate")
+  }
+
+  get today() {
+    return browser.$(".bp3-datepicker-footer > button:first-child")
+  }
+
+  get hour() {
+    return browser.$("input.bp3-timepicker-input.bp3-timepicker-hour")
+  }
+
+  get minute() {
+    return browser.$("input.bp3-timepicker-input.bp3-timepicker-minute")
+  }
+
+  get duration() {
+    return browser.$("#duration")
+  }
+
+  get attendees() {
+    return browser.$("#attendees")
+  }
+
+  get attendeesTable() {
+    return browser.$("#attendees-popover .table-responsive table")
+  }
+
+  get submitButton() {
+    return browser.$("#formBottomSubmit")
+  }
+
+  open() {
+    super.open(PAGE_URL)
+  }
+
+  getAdvisor(index) {
+    const advisor = browser.$(
+      `.advisorAttendeesTable tbody tr:nth-child(${index})`
+    )
+
+    // wait for conflict loader to disappear
+    advisor.$("td:nth-child(6) div.bp3-spinner").waitForExist({ reverse: true })
+
+    return {
+      name: advisor.$("td:nth-child(2)").getText(),
+      conflictButton: advisor.$("td:nth-child(6) > span"),
+      deleteButton: advisor.$("td:nth-child(7) > button")
+    }
+  }
+
+  getPrincipal(index) {
+    // principals table has an empty row at top
+    const principal = browser.$(
+      `.principalAttendeesTable tbody tr:nth-child(${index + 1})`
+    )
+
+    // wait for conflict loader to disappear
+    principal
+      .$("td:nth-child(6) div.bp3-spinner")
+      .waitForExist({ reverse: true })
+
+    return {
+      name: principal.$("td:nth-child(2)").getText(),
+      conflictButton: principal.$("td:nth-child(6) > span"),
+      deleteButton: principal.$("td:nth-child(7) > button")
+    }
+  }
+
+  selectAttendeeByName(name) {
+    this.attendees.click()
+    // wait for attendess table loader to disappear
+    this.attendeesTable.waitForDisplayed()
+    let searchTerm = name
+    if (searchTerm.startsWith("CIV") || searchTerm.startsWith("Maj")) {
+      searchTerm = name.substr(name.indexOf(" ") + 1)
+    }
+    browser.keys(searchTerm)
+    this.attendeesTable.waitForDisplayed()
+    const checkBox = this.attendeesTable.$(
+      "tbody tr:first-child td:first-child input.checkbox"
+    )
+    if (!checkBox.isSelected()) {
+      checkBox.click()
+    }
+    this.title.click()
+    this.attendeesTable.waitForDisplayed({ reverse: true })
+  }
+
+  fillForm(fields) {
+    this.form.waitForClickable()
+
+    if (fields.intent !== undefined) {
+      this.intent.setValue(fields.intent)
+    }
+
+    if (moment.isMoment(fields.engagementDate)) {
+      this.engagementDate.click()
+      this.today.waitForDisplayed()
+      this.today.waitForClickable()
+      this.today.click()
+      this.engagementDate.click()
+
+      this.hour.waitForDisplayed()
+      this.hour.waitForClickable()
+      this.hour.click()
+      browser.keys(fields.engagementDate.format("HH"))
+
+      this.minute.waitForDisplayed()
+      this.minute.waitForClickable()
+      this.minute.click()
+      browser.keys(fields.engagementDate.format("mm"))
+      this.engagementDate.click()
+
+      this.title.click()
+      this.today.waitForDisplayed({ reverse: true })
+    }
+
+    if (fields.duration !== undefined) {
+      this.duration.setValue(fields.duration)
+    }
+
+    if (Array.isArray(fields.advisors) && fields.advisors.length) {
+      fields.advisors.forEach(at => this.selectAttendeeByName(at))
+    }
+
+    if (Array.isArray(fields.principals) && fields.principals.length) {
+      fields.principals.forEach(at => this.selectAttendeeByName(at))
+    }
+  }
+
+  submitForm() {
+    this.submitButton.click()
+  }
+}
+
+export default new CreateReport()

--- a/client/tests/webdriver/pages/report/createReport.page.js
+++ b/client/tests/webdriver/pages/report/createReport.page.js
@@ -24,6 +24,11 @@ class CreateReport extends Page {
     return browser.$(".bp3-datepicker-footer > button:first-child")
   }
 
+  get tomorrow() {
+    const tomorrow = moment().add(1, "day").format("ddd MMM DD YYYY")
+    return browser.$(`div[aria-label="${tomorrow}"]`)
+  }
+
   get hour() {
     return browser.$("input.bp3-timepicker-input.bp3-timepicker-hour")
   }
@@ -114,16 +119,15 @@ class CreateReport extends Page {
 
     if (moment.isMoment(fields.engagementDate)) {
       this.engagementDate.click()
-      this.today.waitForDisplayed()
-      this.today.waitForClickable()
-      this.today.click()
-      this.engagementDate.click()
-
+      this.tomorrow.waitForDisplayed()
+      this.tomorrow.waitForClickable()
+      browser.pause(300) // wait for calendar popup animation
+      this.tomorrow.click()
+      browser.waitUntil(() => !!browser.$("#engagementDate").getValue())
       this.hour.waitForDisplayed()
       this.hour.waitForClickable()
       this.hour.click()
       browser.keys(fields.engagementDate.format("HH"))
-
       this.minute.waitForDisplayed()
       this.minute.waitForClickable()
       this.minute.click()
@@ -131,7 +135,7 @@ class CreateReport extends Page {
       this.engagementDate.click()
 
       this.title.click()
-      this.today.waitForDisplayed({ reverse: true })
+      this.tomorrow.waitForDisplayed({ reverse: true })
     }
 
     if (fields.duration !== undefined) {

--- a/client/tests/webdriver/pages/report/editReport.page.js
+++ b/client/tests/webdriver/pages/report/editReport.page.js
@@ -1,0 +1,56 @@
+import Page from "../page"
+
+const PAGE_URL = "/reports/:uuid/edit"
+
+class EditReport extends Page {
+  get submitButton() {
+    return browser.$("#formBottomSubmit")
+  }
+
+  get deleteButton() {
+    return browser.$(
+      "//div[@class='submit-buttons']//button[text()='Delete this report']"
+    )
+  }
+
+  get alertSuccess() {
+    return browser.$(".alert-success")
+  }
+
+  confirmDeleteButton(uuid) {
+    return browser.$(
+      `//div[@class="modal-footer"]//button[text()="Yes, I am sure that I want to delete report ${uuid}"]`
+    )
+  }
+
+  deleteReport(uuid) {
+    this.deleteButton.click()
+    this.confirmDeleteButton(uuid).waitForExist()
+    this.confirmDeleteButton(uuid).waitForDisplayed()
+    this.confirmDeleteButton(uuid).waitForClickable()
+    browser.pause(200) // wait for modal animation to finish
+    this.confirmDeleteButton(uuid).click()
+    this.waitForAlertSuccessToLoad()
+  }
+
+  open(uuid) {
+    super.open(PAGE_URL.replace(":uuid", uuid))
+    this.waitForEditReportToLoad()
+  }
+
+  waitForEditReportToLoad() {
+    if (!this.submitButton.isDisplayed()) {
+      this.submitButton.waitForExist()
+      this.submitButton.waitForDisplayed()
+    }
+  }
+
+  waitForAlertSuccessToLoad() {
+    if (!this.alertSuccess.isDisplayed()) {
+      this.alertSuccess.waitForExist()
+      this.alertSuccess.waitForDisplayed()
+    }
+  }
+}
+
+export default new EditReport()

--- a/client/tests/webdriver/pages/report/editReport.page.js
+++ b/client/tests/webdriver/pages/report/editReport.page.js
@@ -9,7 +9,7 @@ class EditReport extends Page {
 
   get deleteButton() {
     return browser.$(
-      "//div[@class='submit-buttons']//button[text()='Delete this report']"
+      "//div[@class='submit-buttons']//button[text()='Delete this planned engagement']"
     )
   }
 

--- a/client/tests/webdriver/pages/report/myReports.page.js
+++ b/client/tests/webdriver/pages/report/myReports.page.js
@@ -1,0 +1,69 @@
+import Page from "../page"
+
+const PAGE_URL = "/reports/mine"
+
+class MyReports extends Page {
+  open() {
+    super.open(PAGE_URL)
+  }
+
+  selectSummaryTab() {
+    browser.$("#draft-reports button[value='summary']").click()
+  }
+
+  selectTableTab() {
+    browser.$("#draft-reports button[value='table']").click()
+  }
+
+  // TODO Calendar and Map tabs
+
+  get reportConflictTooltipTitle() {
+    browser.pause(200)
+    return browser.$(".reportConflictTooltipContainer > div").getText()
+  }
+
+  getDraftReportByEngagementDateString(dateStr, type = "summary") {
+    let selector = `//div[@id='draft-reports']//div[contains(@class, 'report-summary') and .//span[contains(@class, 'engagement-date') and text()='${dateStr}']]`
+    if (type === "table") {
+      selector = `//div[@id='draft-reports']//div[@class= 'report-collection']//table//tbody//tr//td[.//div[1]//span[1][text()='${dateStr}']]`
+    }
+
+    const report = browser.$(selector)
+
+    if (!report.isExisting()) {
+      return null
+    }
+
+    // wait for conflict loader to disappear
+    report.$("span.reportConflictLoadingIcon").waitForExist({ reverse: true })
+
+    return {
+      reportConflictIcon: report.$(".reportConflictIcon")
+    }
+  }
+
+  waitForMyDraftReportsSummaryTabToLoad() {
+    const selector =
+      "#draft-reports .report-collection > div:first-child > div:nth-child(2)"
+    if (!browser.$(selector).isDisplayed()) {
+      browser.$(selector).waitForExist()
+      browser.$(selector).waitForDisplayed()
+    }
+    browser.waitUntil(
+      () =>
+        browser.$(selector).isExisting() &&
+        browser.$(selector).getText().startsWith("Draft")
+    )
+  }
+
+  waitForMyDraftReportsTableTabToLoad() {
+    const selector =
+      "#draft-reports .report-collection > div:first-child > div:nth-child(2) table"
+    if (!browser.$(selector).isDisplayed()) {
+      browser.$(selector).waitForExist()
+      browser.$(selector).waitForDisplayed()
+    }
+  }
+}
+
+export default new MyReports()

--- a/client/tests/webdriver/pages/report/showReport.page.js
+++ b/client/tests/webdriver/pages/report/showReport.page.js
@@ -1,0 +1,92 @@
+import Page from "../page"
+
+const PAGE_URL = "/reports/:uuid"
+
+class ShowReport extends Page {
+  get reportStatus() {
+    return browser.$("h4.text-danger")
+  }
+
+  get reportStatusText() {
+    return this.reportStatus.getText()
+  }
+
+  get uuid() {
+    const title =
+      browser
+        .$("//span[@class='title-text'][starts-with(.,'Report #')]")
+        .getText() || ""
+    return title.slice(title.lastIndexOf("#") + 1)
+  }
+
+  get intent() {
+    const text = browser.$("#intent > p:first-child").getText() || ""
+    return text.slice(text.indexOf(": ") + 2)
+  }
+
+  get engagementDate() {
+    return browser.$("div[name='engagementDate']").getText()
+  }
+
+  get reportConflictIcon() {
+    // wait for conflict loader to disappear
+    browser
+      .$("div[name='engagementDate'] > span.reportConflictLoadingIcon")
+      .waitForExist({ reverse: true })
+
+    return browser.$("div[name='engagementDate'] > span.reportConflictIcon")
+  }
+
+  get reportConflictTooltipTitle() {
+    browser.pause(200)
+    return browser.$(".reportConflictTooltipContainer > div").getText()
+  }
+
+  get duration() {
+    return browser.$("div[name='duration']").getText()
+  }
+
+  get location() {
+    return browser.$("div[name='location']").getText()
+  }
+
+  get author() {
+    return browser.$("div[name='author']").getText()
+  }
+
+  getAttendeeByName(name) {
+    const row = browser
+      .$$("#attendeesContainer tbody > tr")
+      .find(
+        r =>
+          r.$("td:nth-child(2)").isExisting() &&
+          r.$("td:nth-child(2)").getText() === name
+      )
+
+    if (!row) {
+      return null
+    }
+
+    // wait for conflict loader to disappear
+    row.$("td:nth-child(6) div.bp3-spinner").waitForExist({ reverse: true })
+
+    return {
+      name: row.$("td:nth-child(2)").getText(),
+      conflictButton: row.$("td:nth-child(6) > span"),
+      deleteButton: row.$("td:nth-child(7) > button")
+    }
+  }
+
+  open(uuid) {
+    super.open(PAGE_URL.replace(":uuid", uuid))
+  }
+
+  waitForShowReportToLoad() {
+    if (!this.reportStatus.isDisplayed()) {
+      this.reportStatus.waitForExist()
+      this.reportStatus.waitForDisplayed()
+    }
+  }
+}
+
+export default new ShowReport()

--- a/client/tests/webdriver/specs/createReportWithPlanningConflict.spec.js
+++ b/client/tests/webdriver/specs/createReportWithPlanningConflict.spec.js
@@ -1,0 +1,196 @@
+import { expect } from "chai"
+import moment from "moment"
+import CreateReport from "../pages/report/createReport.page"
+import EditReport from "../pages/report/editReport.page"
+import ShowReport from "../pages/report/showReport.page"
+
+describe("When creating a Report with conflicts", () => {
+  let firstReportUUID
+  let secondReportUUID
+  const report01 = {
+    intent: "111111111111",
+    engagementDate: moment().hours(1).minutes(0).seconds(0).milliseconds(0),
+    duration: "60",
+    advisors: ["CIV REINTON, Reina"],
+    principals: ["CIV TOPFERNESS, Christopf"]
+  }
+  const report02 = {
+    intent: "2222222222",
+    engagementDate: moment().hours(1).minutes(10).seconds(0).milliseconds(0),
+    duration: "10",
+    advisors: ["CIV REINTON, Reina", "CIV ANDERSON, Andrew"],
+    principals: ["CIV TOPFERNESS, Christopf", "Maj ROGWELL, Roger"]
+  }
+
+  it("Should create first draft report without any conflicts", () => {
+    CreateReport.open()
+    CreateReport.fillForm(report01)
+
+    expect(CreateReport.intent.getValue()).to.equal(report01.intent)
+    expect(CreateReport.engagementDate.getValue()).to.equal(
+      report01.engagementDate.format("DD-MM-YYYY HH:mm")
+    )
+    expect(CreateReport.duration.getValue()).to.equal(report01.duration)
+    const advisor01 = CreateReport.getAdvisor(1)
+    expect(advisor01.name).to.equal("CIV ERINSON, Erin")
+    expect(advisor01.conflictButton.isExisting()).to.equal(false)
+
+    const advisor02 = CreateReport.getAdvisor(2)
+    expect(advisor02.name).to.equal(report01.advisors[0])
+    expect(advisor02.conflictButton.isExisting()).to.equal(false)
+
+    const principal01 = CreateReport.getPrincipal(1)
+    expect(principal01.name).to.equal(report01.principals[0])
+    expect(principal01.conflictButton.isExisting()).to.equal(false)
+
+    CreateReport.submitForm()
+    ShowReport.waitForShowReportToLoad()
+
+    const statusText = "This is a DRAFT report and hasn't been submitted."
+    expect(ShowReport.reportStatusText).to.equal(statusText)
+    expect(ShowReport.intent).to.equal(report01.intent)
+
+    firstReportUUID = ShowReport.uuid
+    expect(firstReportUUID.length).to.equal(36)
+  })
+
+  it("Should create second draft report with conflicts", () => {
+    CreateReport.open()
+    CreateReport.fillForm(report02)
+
+    expect(CreateReport.intent.getValue()).to.equal(report02.intent)
+    expect(CreateReport.engagementDate.getValue()).to.equal(
+      report02.engagementDate.format("DD-MM-YYYY HH:mm")
+    )
+    expect(CreateReport.duration.getValue()).to.equal(report02.duration)
+    const advisor01 = CreateReport.getAdvisor(1)
+    expect(advisor01.name).to.equal("CIV ERINSON, Erin")
+    expect(advisor01.conflictButton.isExisting()).to.equal(true)
+
+    const advisor02 = CreateReport.getAdvisor(2)
+    expect(advisor02.name).to.equal(report02.advisors[0])
+    expect(advisor02.conflictButton.isExisting()).to.equal(true)
+
+    const advisor03 = CreateReport.getAdvisor(3)
+    expect(advisor03.name).to.equal(report02.advisors[1])
+    expect(advisor03.conflictButton.isExisting()).to.equal(false)
+
+    const principal01 = CreateReport.getPrincipal(1)
+    expect(principal01.name).to.equal(report02.principals[0])
+    expect(principal01.conflictButton.isExisting()).to.equal(true)
+
+    const principal02 = CreateReport.getPrincipal(2)
+    expect(principal02.name).to.equal(report02.principals[1])
+    expect(principal02.conflictButton.isExisting()).to.equal(false)
+
+    CreateReport.submitForm()
+    ShowReport.waitForShowReportToLoad()
+
+    const statusText = "This is a DRAFT report and hasn't been submitted."
+    expect(ShowReport.reportStatusText).to.equal(statusText)
+    expect(ShowReport.intent).to.equal(report02.intent)
+
+    secondReportUUID = ShowReport.uuid
+    expect(secondReportUUID.length).to.equal(36)
+  })
+
+  it("Should display first report with conflicts", () => {
+    ShowReport.open(firstReportUUID)
+    ShowReport.waitForShowReportToLoad()
+
+    expect(ShowReport.uuid.length).to.equal(36)
+
+    const statusText = "This is a DRAFT report and hasn't been submitted."
+    expect(ShowReport.reportStatusText).to.equal(statusText)
+
+    expect(ShowReport.intent).to.equal(report01.intent)
+    expect(ShowReport.engagementDate).to.equal(
+      report01.engagementDate.format("dddd, D MMMM YYYY @ HH:mm")
+    )
+    expect(ShowReport.reportConflictIcon.isExisting()).to.equal(true)
+
+    ShowReport.reportConflictIcon.moveTo()
+    expect(ShowReport.reportConflictTooltipTitle).to.equal(
+      "3 of 3 attendees are busy at the selected time!"
+    )
+
+    expect(ShowReport.duration).to.equal(report01.duration)
+    expect(ShowReport.location).to.equal("Unspecified")
+    expect(ShowReport.author).to.equal("CIV ERINSON, Erin")
+
+    const advisor01 = ShowReport.getAttendeeByName("CIV ERINSON, Erin")
+    expect(advisor01.name).to.equal("CIV ERINSON, Erin")
+    expect(advisor01.conflictButton.isExisting()).to.equal(true)
+    expect(advisor01.conflictButton.getText()).to.equal("1 conflict")
+
+    const advisor02 = ShowReport.getAttendeeByName(report01.advisors[0])
+    expect(advisor02.name).to.equal(report01.advisors[0])
+    expect(advisor02.conflictButton.isExisting()).to.equal(true)
+    expect(advisor02.conflictButton.getText()).to.equal("1 conflict")
+
+    const principal01 = ShowReport.getAttendeeByName(report01.principals[0])
+    expect(principal01.name).to.equal(report01.principals[0])
+    expect(principal01.conflictButton.isExisting()).to.equal(true)
+    expect(principal01.conflictButton.getText()).to.equal("1 conflict")
+  })
+
+  it("Should display second report with conflicts", () => {
+    ShowReport.open(secondReportUUID)
+    ShowReport.waitForShowReportToLoad()
+
+    expect(ShowReport.uuid.length).to.equal(36)
+
+    const statusText = "This is a DRAFT report and hasn't been submitted."
+    expect(ShowReport.reportStatusText).to.equal(statusText)
+
+    expect(ShowReport.intent).to.equal(report02.intent)
+    expect(ShowReport.engagementDate).to.equal(
+      report02.engagementDate.format("dddd, D MMMM YYYY @ HH:mm")
+    )
+    expect(ShowReport.reportConflictIcon.isExisting()).to.equal(true)
+
+    ShowReport.reportConflictIcon.moveTo()
+    expect(ShowReport.reportConflictTooltipTitle).to.equal(
+      "3 of 5 attendees are busy at the selected time!"
+    )
+
+    expect(ShowReport.duration).to.equal(report02.duration)
+    expect(ShowReport.location).to.equal("Unspecified")
+    expect(ShowReport.author).to.equal("CIV ERINSON, Erin")
+
+    const advisor01 = ShowReport.getAttendeeByName("CIV ERINSON, Erin")
+    expect(advisor01.name).to.equal("CIV ERINSON, Erin")
+    expect(advisor01.conflictButton.isExisting()).to.equal(true)
+    expect(advisor01.conflictButton.getText()).to.equal("1 conflict")
+
+    const advisor02 = ShowReport.getAttendeeByName("CIV ANDERSON, Andrew")
+    expect(advisor02.conflictButton.isExisting()).to.equal(false)
+
+    const advisor03 = ShowReport.getAttendeeByName("CIV REINTON, Reina")
+    expect(advisor03.conflictButton.isExisting()).to.equal(true)
+    expect(advisor03.conflictButton.getText()).to.equal("1 conflict")
+
+    const principal01 = ShowReport.getAttendeeByName(
+      "CIV TOPFERNESS, Christopf"
+    )
+    expect(principal01.conflictButton.isExisting()).to.equal(true)
+    expect(principal01.conflictButton.getText()).to.equal("1 conflict")
+
+    const principal02 = ShowReport.getAttendeeByName("Maj ROGWELL, Roger")
+    expect(principal02.conflictButton.isExisting()).to.equal(false)
+  })
+
+  it("Should delete the first report", () => {
+    EditReport.open(firstReportUUID)
+    EditReport.deleteReport(firstReportUUID)
+
+    expect(EditReport.alertSuccess.getText()).to.equal("Report deleted")
+  })
+
+  it("Should delete the second report", () => {
+    EditReport.open(secondReportUUID)
+    EditReport.deleteReport(secondReportUUID)
+
+    expect(EditReport.alertSuccess.getText()).to.equal("Report deleted")
+  })
+})

--- a/client/tests/webdriver/specs/createReportWithPlanningConflict.spec.js
+++ b/client/tests/webdriver/specs/createReportWithPlanningConflict.spec.js
@@ -9,14 +9,24 @@ describe("When creating a Report with conflicts", () => {
   let secondReportUUID
   const report01 = {
     intent: "111111111111",
-    engagementDate: moment().hours(1).minutes(0).seconds(0).milliseconds(0),
+    engagementDate: moment()
+      .add(1, "day")
+      .hours(1)
+      .minutes(0)
+      .seconds(0)
+      .milliseconds(0),
     duration: "60",
     advisors: ["CIV REINTON, Reina"],
     principals: ["CIV TOPFERNESS, Christopf"]
   }
   const report02 = {
     intent: "2222222222",
-    engagementDate: moment().hours(1).minutes(10).seconds(0).milliseconds(0),
+    engagementDate: moment()
+      .add(1, "day")
+      .hours(1)
+      .minutes(10)
+      .seconds(0)
+      .milliseconds(0),
     duration: "10",
     advisors: ["CIV REINTON, Reina", "CIV ANDERSON, Andrew"],
     principals: ["CIV TOPFERNESS, Christopf", "Maj ROGWELL, Roger"]
@@ -46,8 +56,8 @@ describe("When creating a Report with conflicts", () => {
     CreateReport.submitForm()
     ShowReport.waitForShowReportToLoad()
 
-    const statusText = "This is a DRAFT report and hasn't been submitted."
-    expect(ShowReport.reportStatusText).to.equal(statusText)
+    const text = "This is a DRAFT planned engagement and hasn't been submitted."
+    expect(ShowReport.reportStatusText).to.equal(text)
     expect(ShowReport.intent).to.equal(report01.intent)
 
     firstReportUUID = ShowReport.uuid
@@ -86,8 +96,8 @@ describe("When creating a Report with conflicts", () => {
     CreateReport.submitForm()
     ShowReport.waitForShowReportToLoad()
 
-    const statusText = "This is a DRAFT report and hasn't been submitted."
-    expect(ShowReport.reportStatusText).to.equal(statusText)
+    const text = "This is a DRAFT planned engagement and hasn't been submitted."
+    expect(ShowReport.reportStatusText).to.equal(text)
     expect(ShowReport.intent).to.equal(report02.intent)
 
     secondReportUUID = ShowReport.uuid
@@ -100,7 +110,8 @@ describe("When creating a Report with conflicts", () => {
 
     expect(ShowReport.uuid.length).to.equal(36)
 
-    const statusText = "This is a DRAFT report and hasn't been submitted."
+    const statusText =
+      "This is a DRAFT planned engagement and hasn't been submitted."
     expect(ShowReport.reportStatusText).to.equal(statusText)
 
     expect(ShowReport.intent).to.equal(report01.intent)
@@ -140,7 +151,8 @@ describe("When creating a Report with conflicts", () => {
 
     expect(ShowReport.uuid.length).to.equal(36)
 
-    const statusText = "This is a DRAFT report and hasn't been submitted."
+    const statusText =
+      "This is a DRAFT planned engagement and hasn't been submitted."
     expect(ShowReport.reportStatusText).to.equal(statusText)
 
     expect(ShowReport.intent).to.equal(report02.intent)


### PR DESCRIPTION
This PR provides changes that inform the user on reports page for conflicted engagements

### Release notes

Closes #1839 

#### User changes
- User can see on report page if attendees are included in other meetings have potential conflicts with related report
- User can see details of these conflicted engagements

#### Super User changes
- Same with user changes

#### Admin changes
- Same with user changes

#### System admin changes
- 

### Checklist
  - [X] Described the user behavior in PR body
  - [X] Referenced/updated all related issues
  - [X] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [X] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [x] Added and/or updated unit tests
  - [X] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [X] Resolved all build errors and warnings
  - [X] Opened debt issues for anything not resolved here (see #3082)
