### PR TITLE
Fix duration field errors in Report from

### DIFF
--- a/client/src/pages/reports/Form.js
+++ b/client/src/pages/reports/Form.js
@@ -596,8 +596,11 @@ const BaseReportForm = ({
                     label="Duration (minutes)"
                     component={FieldHelper.InputField}
                     onChange={event => {
+                      const safeVal =
+                        (event.target.value || "").replace(/[^0-9]+/g, "") ||
+                        null
                       setFieldTouched("duration", true, false)
-                      setFieldValue("duration", event.target.value, false)
+                      setFieldValue("duration", safeVal, false)
                       validateFieldDebounced("duration")
                     }}
                   />


### PR DESCRIPTION
When user clears duration input in Report form null value is assigned to duration field on Report model instead of empty string. Also duration input now accepts only digits. Therefore negative and decimal point numbers cannot be entered in the input.

### Release notes

Closes nci-agency/anet#3021
Closes nci-agency/anet#3022
Closes nci-agency/anet#3023

#### User changes
- Users can now only type digits into duration field in Report form.

#### System admin changes
- [ ] anet.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [X] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [ ] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
