### PR TITLE
NCI-Agency/anet#3035: Add principal organizations navigation item

### DIFF
--- a/anet.yml
+++ b/anet.yml
@@ -657,6 +657,7 @@ dictionary:
 
       org:
         name: Afghan Government Organization
+        allOrgName: Principal Organizations
         longName:
           label: Official Organization Name
           placeholder: e.g. Afghan Ministry of Defense

--- a/client/src/components/Nav.js
+++ b/client/src/components/Nav.js
@@ -63,7 +63,8 @@ SidebarLink.propTypes = {
 
 const BaseNav = ({
   currentUser,
-  organizations,
+  advisorOrganizations,
+  principalOrganizations,
   appSettings,
   resetPages,
   clearSearchQuery
@@ -87,6 +88,9 @@ const BaseNav = ({
     orgUuid = path.split("/")[2]
     myOrgUuid = myOrg && myOrg.uuid
   }
+
+  const advisorOrganizationUuids = advisorOrganizations.map(o => o.uuid)
+  const principalOrganizationUuids = principalOrganizations.map(o => o.uuid)
 
   return (
     <BSNav bsStyle="pills" stacked id="leftNav" className="hide-for-print">
@@ -123,9 +127,33 @@ const BaseNav = ({
       <NavDropdown
         title={Settings.fields.advisor.org.allOrgName}
         id="advisor-organizations"
-        active={inOrg && orgUuid !== myOrgUuid}
+        active={
+          inOrg &&
+          advisorOrganizationUuids.includes(orgUuid) &&
+          orgUuid !== myOrgUuid
+        }
       >
-        {Organization.map(organizations, org => (
+        {Organization.map(advisorOrganizations, org => (
+          <Link
+            to={Organization.pathFor(org)}
+            key={org.uuid}
+            onClick={clearSearchQuery}
+          >
+            <MenuItem>{org.shortName}</MenuItem>
+          </Link>
+        ))}
+      </NavDropdown>
+
+      <NavDropdown
+        title={Settings.fields.principal.org.allOrgName}
+        id="principal-organizations"
+        active={
+          inOrg &&
+          principalOrganizationUuids.includes(orgUuid) &&
+          orgUuid !== myOrgUuid
+        }
+      >
+        {Organization.map(principalOrganizations, org => (
           <Link
             to={Organization.pathFor(org)}
             key={org.uuid}
@@ -208,14 +236,16 @@ const BaseNav = ({
 BaseNav.propTypes = {
   currentUser: PropTypes.instanceOf(Person),
   appSettings: PropTypes.object,
-  organizations: PropTypes.array,
+  advisorOrganizations: PropTypes.array,
+  principalOrganizations: PropTypes.array,
   clearSearchQuery: PropTypes.func.isRequired,
   resetPages: PropTypes.func.isRequired
 }
 
 BaseNav.defaultProps = {
   appSettings: {},
-  organizations: []
+  advisorOrganizations: [],
+  principalOrganizations: []
 }
 
 const mapDispatchToProps = (dispatch, ownProps) =>

--- a/client/src/components/Nav.js
+++ b/client/src/components/Nav.js
@@ -144,6 +144,8 @@ const BaseNav = ({
         ))}
       </NavDropdown>
 
+      <BSNav id="advisor-org-nav" />
+
       <NavDropdown
         title={Settings.fields.principal.org.allOrgName}
         id="principal-organizations"
@@ -164,7 +166,8 @@ const BaseNav = ({
         ))}
       </NavDropdown>
 
-      <BSNav id="org-nav" />
+      <BSNav id="principal-org-nav" />
+
       <SidebarLink linkTo="/rollup" handleOnClick={resetPages}>
         Daily rollup
       </SidebarLink>

--- a/client/src/components/ResponsiveLayout.js
+++ b/client/src/components/ResponsiveLayout.js
@@ -109,7 +109,7 @@ const ResponsiveLayout = ({ pageProps, sidebarData, children }) => {
               className={`main-sidebar ${sidebarClass}`}
             >
               <div style={sidebar}>
-                <Nav organizations={sidebarData} />
+                <Nav {...sidebarData} />
               </div>
             </div>
           )}
@@ -144,7 +144,10 @@ ResponsiveLayout.propTypes = {
     minimalHeader: PropTypes.bool,
     useNavigation: PropTypes.bool
   }).isRequired,
-  sidebarData: PropTypes.array,
+  sidebarData: PropTypes.shape({
+    advisorOrganizations: PropTypes.array,
+    principalOrganizations: PropTypes.array
+  }),
   children: PropTypes.node
 }
 

--- a/client/src/pages/App.js
+++ b/client/src/pages/App.js
@@ -167,22 +167,25 @@ const App = ({ pageDispatchers, pageProps }) => {
     </AppContext.Provider>
   )
 
-  function sortOrganizations(organizations) {
-    organizations.sort((a, b) => a.shortName.localeCompare(b.shortName))
-  }
   function processData(data) {
+    function sortOrganizations(organizations) {
+      organizations.sort((a, b) => a.shortName.localeCompare(b.shortName))
+    }
+
+    function getSortedOrganizationsFromData(organizationsData) {
+      let organizations = (organizationsData && organizationsData.list) || []
+      organizations = Organization.fromArray(organizations)
+      sortOrganizations(organizations)
+      return organizations
+    }
+
     const currentUser = new Person(data.me)
-
-    let advisorOrganizations =
-      (data.topLevelAdvisorOrgs && data.topLevelAdvisorOrgs.list) || []
-    advisorOrganizations = Organization.fromArray(advisorOrganizations)
-    sortOrganizations(advisorOrganizations)
-
-    let principalOrganizations =
-      (data.topLevelPrincipalOrgs && data.topLevelPrincipalOrgs.list) || []
-    principalOrganizations = Organization.fromArray(principalOrganizations)
-    sortOrganizations(principalOrganizations)
-
+    const advisorOrganizations = getSortedOrganizationsFromData(
+      data.topLevelAdvisorOrgs
+    )
+    const principalOrganizations = getSortedOrganizationsFromData(
+      data.topLevelPrincipalOrgs
+    )
     const settings = {}
     data.adminSettings.forEach(
       setting => (settings[setting.key] = setting.value)

--- a/client/src/pages/App.js
+++ b/client/src/pages/App.js
@@ -85,12 +85,26 @@ const GQL_GET_APP_DATA = gql`
       value
     }
 
-    organizationTopLevelOrgs: organizationList(
+    topLevelAdvisorOrgs: organizationList(
       query: {
         pageSize: 0
         hasParentOrg: false
         status: ACTIVE
         type: ADVISOR_ORG
+      }
+    ) {
+      list {
+        uuid
+        shortName
+      }
+    }
+
+    topLevelPrincipalOrgs: organizationList(
+      query: {
+        pageSize: 0
+        hasParentOrg: false
+        status: ACTIVE
+        type: PRINCIPAL_ORG
       }
     ) {
       list {
@@ -141,7 +155,10 @@ const App = ({ pageDispatchers, pageProps }) => {
         pageProps={pageProps}
         pageHistory={history}
         location={routerLocation}
-        sidebarData={appState.organizations}
+        sidebarData={{
+          advisorOrganizations: appState.advisorOrganizations,
+          principalOrganizations: appState.principalOrganizations
+        }}
       >
         <ToastContainer />
         <ReactTooltip id="tooltip-top" place="top" className="tooltip-top" />
@@ -150,20 +167,33 @@ const App = ({ pageDispatchers, pageProps }) => {
     </AppContext.Provider>
   )
 
+  function sortOrganizations(organizations) {
+    organizations.sort((a, b) => a.shortName.localeCompare(b.shortName))
+  }
   function processData(data) {
     const currentUser = new Person(data.me)
-    let organizations =
-      (data.organizationTopLevelOrgs && data.organizationTopLevelOrgs.list) ||
-      []
-    organizations = Organization.fromArray(organizations)
-    organizations.sort((a, b) => a.shortName.localeCompare(b.shortName))
+
+    let advisorOrganizations =
+      (data.topLevelAdvisorOrgs && data.topLevelAdvisorOrgs.list) || []
+    advisorOrganizations = Organization.fromArray(advisorOrganizations)
+    sortOrganizations(advisorOrganizations)
+
+    let principalOrganizations =
+      (data.topLevelPrincipalOrgs && data.topLevelPrincipalOrgs.list) || []
+    principalOrganizations = Organization.fromArray(principalOrganizations)
+    sortOrganizations(principalOrganizations)
 
     const settings = {}
     data.adminSettings.forEach(
       setting => (settings[setting.key] = setting.value)
     )
 
-    return { currentUser, settings, organizations }
+    return {
+      currentUser,
+      settings,
+      advisorOrganizations,
+      principalOrganizations
+    }
   }
 }
 

--- a/client/src/pages/organizations/Show.js
+++ b/client/src/pages/organizations/Show.js
@@ -225,7 +225,13 @@ const BaseOrganizationShow = ({ pageDispatchers, currentUser }) => {
           <div>
             <SubNav subnavElemId="myorg-nav">{isMyOrg && orgSubNav}</SubNav>
 
-            <SubNav subnavElemId="org-nav">{!isMyOrg && orgSubNav}</SubNav>
+            <SubNav subnavElemId="advisor-org-nav">
+              {!isMyOrg && isAdvisorOrg && orgSubNav}
+            </SubNav>
+
+            <SubNav subnavElemId="principal-org-nav">
+              {!isMyOrg && isPrincipalOrg && orgSubNav}
+            </SubNav>
 
             {currentUser.isSuperUser() && (
               <div className="pull-right">

--- a/src/main/resources/anet-schema.yml
+++ b/src/main/resources/anet-schema.yml
@@ -555,8 +555,8 @@ properties:
                 description: Used in the UI where an advisor organization is shown.
               allOrgName:
                 type: string
-                title: The name used to represent 'all organizations'
-                description: Used in the UI to refer to all organizations collectively.
+                title: The name used to represent 'all advisor organizations'
+                description: Used in the UI to refer to all advisor organizations collectively.
               longName:
                 "$ref": "#/definitions/inputField"
               identificationCode:
@@ -640,12 +640,16 @@ properties:
           org:
             type: object
             additionalProperties: false
-            required: [name, longName]
+            required: [name, allOrgName, longName]
             properties:
               name:
                 type: string
                 title: The name of this field
                 description: Used in the UI where a principal organization is shown.
+              allOrgName:
+                type: string
+                title: The name used to represent 'all principal organizations'
+                description: Used in the UI to refer to all principal organizations collectively.
               longName:
                 "$ref": "#/definitions/inputField"
               identificationCode:


### PR DESCRIPTION
This adds an extra item to the navigation: principal organizations.

This functionality makes it possible to select an active top level principal
organization from the navigation, similar to how advisor organizations
navigation works.

Closes #3035 

#### User changes
- Users can now use the navigation in order to get to one of the top level principal organizations.

#### Super User changes
- See user changes

#### Admin changes
- See user changes

#### System admin changes
- See user changes

- [x] anet.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [ ] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [ ] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
