### PR TITLE
GH 3042 Add MGRS coordinate format

### DIFF
--- a/anet.yml
+++ b/anet.yml
@@ -641,6 +641,9 @@ dictionary:
               helpText: Help text for object date field
               visibleWhen: $[?(@.colourOptions === 'GREEN')]
 
+    location:
+      format: LAT_LON
+      
     position:
       name: 'Position Name'
 

--- a/client/package.json
+++ b/client/package.json
@@ -138,6 +138,7 @@
     "locale-compare-polyfill": "0.0.2",
     "lodash": "4.17.20",
     "mathjs": "7.2.0",
+    "mgrs": "1.0.0",
     "milsymbol": "2.0.0",
     "ml-matrix": "6.5.1",
     "moment": "2.27.0",

--- a/client/src/geoUtils.js
+++ b/client/src/geoUtils.js
@@ -1,0 +1,54 @@
+import { forward, toPoint } from "mgrs"
+
+export function parseCoordinate(latLng) {
+  const value = parseFloat(latLng)
+  if (!value && value !== 0) {
+    return null
+  }
+
+  /*
+   * We use 5 decimal point (~110cm) precision because MGRS has
+   * a minimum of 1 meter precision.
+   * Please see;
+   * https://stackoverflow.com/a/16743805/1209097
+   * https://en.wikipedia.org/wiki/Military_Grid_Reference_System
+   */
+  const precision = 5
+  /*
+   * for the purpose of rounding below please see:
+   * https://stackoverflow.com/questions/1458633/how-to-deal-with-floating-point-number-precision-in-javascript
+   * https://floating-point-gui.de/
+   */
+  const safeRoundedValue = Math.round(value * 10 ** precision * 10) / 10
+  /*
+   * Also, coordinates are truncated instead of rounding when changing
+   * precision level in order to aviod inconsistencies during (MGRS <--> Lat/Lon) conversion.
+   */
+  return Math.trunc(safeRoundedValue) / 10 ** precision
+}
+
+export function convertLatLngToMGRS(lat, lng) {
+  const parsedLat = parseCoordinate(lat)
+  const parsedLng = parseCoordinate(lng)
+
+  let mgrs = ""
+  try {
+    if ((parsedLat || parsedLat === 0) && (parsedLng || parsedLng === 0)) {
+      mgrs = forward([parsedLng, parsedLat])
+    }
+  } catch (e) {
+    mgrs = ""
+  }
+  return mgrs
+}
+
+export function convertMGRSToLatLng(mgrs) {
+  let latLng
+  try {
+    // toPoint returns an array of [lon, lat]
+    latLng = mgrs ? toPoint(mgrs) : ["", ""]
+  } catch (e) {
+    latLng = ["", ""]
+  }
+  return [parseCoordinate(latLng[1]), parseCoordinate(latLng[0])]
+}

--- a/client/src/pages/locations/Form.js
+++ b/client/src/pages/locations/Form.js
@@ -9,6 +9,7 @@ import Messages from "components/Messages"
 import NavigationWarning from "components/NavigationWarning"
 import { jumpToTop } from "components/Page"
 import { FastField, Form, Formik } from "formik"
+import { parseCoordinate } from "geoUtils"
 import _escape from "lodash/escape"
 import { Location, Position } from "models"
 import PropTypes from "prop-types"
@@ -97,8 +98,8 @@ const LocationForm = ({ edit, title, initialValues }) => {
             const latLng = map.wrapLatLng(event.target.getLatLng())
             setValues({
               ...values,
-              lat: Location.parseCoordinate(latLng.lat),
-              lng: Location.parseCoordinate(latLng.lng)
+              lat: parseCoordinate(latLng.lat),
+              lng: parseCoordinate(latLng.lng)
             })
           }
         }
@@ -158,8 +159,8 @@ const LocationForm = ({ edit, title, initialValues }) => {
                   const latLng = map.wrapLatLng(event.latlng)
                   setValues({
                     ...values,
-                    lat: Location.parseCoordinate(latLng.lat),
-                    lng: Location.parseCoordinate(latLng.lng)
+                    lat: parseCoordinate(latLng.lat),
+                    lng: parseCoordinate(latLng.lng)
                   })
                 }}
               />
@@ -240,7 +241,11 @@ const LocationForm = ({ edit, title, initialValues }) => {
   }
 
   function save(values) {
-    const location = Object.without(new Location(values), "notes")
+    const location = Object.without(
+      new Location(values),
+      "notes",
+      "displayedCoordinate"
+    )
     return API.mutation(edit ? GQL_UPDATE_LOCATION : GQL_CREATE_LOCATION, {
       location
     })

--- a/client/src/pages/locations/Form.js
+++ b/client/src/pages/locations/Form.js
@@ -80,12 +80,11 @@ const LocationForm = ({ edit, title, initialValues }) => {
       initialValues={initialValues}
     >
       {({
-        handleSubmit,
         isSubmitting,
         dirty,
-        errors,
         setFieldTouched,
         setFieldValue,
+        setValues,
         values,
         submitForm
       }) => {
@@ -94,7 +93,14 @@ const LocationForm = ({ edit, title, initialValues }) => {
           name: _escape(values.name) || "", // escape HTML in location name!
           draggable: true,
           autoPan: true,
-          onMove: (event, map) => onMarkerMove(event, map, setFieldValue)
+          onMove: (event, map) => {
+            const latLng = map.wrapLatLng(event.target.getLatLng())
+            setValues({
+              ...values,
+              lat: Location.parseCoordinate(latLng.lat),
+              lng: Location.parseCoordinate(latLng.lng)
+            })
+          }
         }
         if (Location.hasCoordinates(values)) {
           Object.assign(marker, {
@@ -140,7 +146,7 @@ const LocationForm = ({ edit, title, initialValues }) => {
                   lat={values.lat}
                   lng={values.lng}
                   isSubmitting={isSubmitting}
-                  setFieldValue={setFieldValue}
+                  setValues={vals => setValues({ ...values, ...vals })}
                   setFieldTouched={setFieldTouched}
                 />
               </Fieldset>
@@ -149,7 +155,12 @@ const LocationForm = ({ edit, title, initialValues }) => {
               <Leaflet
                 markers={[marker]}
                 onMapClick={(event, map) => {
-                  onMarkerMapClick(event, map, setFieldValue)
+                  const latLng = map.wrapLatLng(event.latlng)
+                  setValues({
+                    ...values,
+                    lat: Location.parseCoordinate(latLng.lat),
+                    lng: Location.parseCoordinate(latLng.lng)
+                  })
                 }}
               />
 
@@ -196,24 +207,12 @@ const LocationForm = ({ edit, title, initialValues }) => {
     </Formik>
   )
 
-  function onMarkerMove(event, map, setFieldValue) {
-    const latLng = map.wrapLatLng(event.target.getLatLng())
-    setFieldValue("lat", Location.parseCoordinate(latLng.lat))
-    setFieldValue("lng", Location.parseCoordinate(latLng.lng))
-  }
-
-  function onMarkerMapClick(event, map, setFieldValue) {
-    const latLng = map.wrapLatLng(event.latlng)
-    setFieldValue("lat", Location.parseCoordinate(latLng.lat))
-    setFieldValue("lng", Location.parseCoordinate(latLng.lng))
-  }
-
   function onCancel() {
     history.goBack()
   }
 
   function onSubmit(values, form) {
-    return save(values, form)
+    return save(values)
       .then(response => onSubmitSuccess(response, values, form))
       .catch(error => {
         setError(error)
@@ -240,7 +239,7 @@ const LocationForm = ({ edit, title, initialValues }) => {
     })
   }
 
-  function save(values, form) {
+  function save(values) {
     const location = Object.without(new Location(values), "notes")
     return API.mutation(edit ? GQL_UPDATE_LOCATION : GQL_CREATE_LOCATION, {
       location

--- a/client/src/pages/locations/GeoLocation.js
+++ b/client/src/pages/locations/GeoLocation.js
@@ -1,41 +1,62 @@
-import RemoveButton from "components/RemoveButton"
-import React from "react"
-import PropTypes from "prop-types"
-import { Col, ControlLabel, FormGroup } from "react-bootstrap"
-import { Field } from "formik"
-import { Location } from "models"
+import {
+  AnchorButton,
+  Popover,
+  PopoverInteractionKind,
+  Position,
+  Tooltip
+} from "@blueprintjs/core"
 import * as FieldHelper from "components/FieldHelper"
+import { Field } from "formik"
+import {
+  convertLatLngToMGRS,
+  convertMGRSToLatLng,
+  parseCoordinate
+} from "geoUtils"
+import PropTypes from "prop-types"
+import React, { useEffect, useState } from "react"
+import { Col, ControlLabel, FormGroup, Table } from "react-bootstrap"
+import Settings from "settings"
 
 export const GEO_LOCATION_DISPLAY_TYPE = {
   FORM_FIELD: "FORM_FIELD",
   GENERIC: "GENERIC"
 }
 
+const MGRS_LABEL = "MGRS Coordinate"
+const LAT_LON_LABEL = "Latitude, Longitude"
+
 const GeoLocation = ({
   lat,
   lng,
-  setFieldTouched,
-  setValues,
-  isSubmitting,
   editable,
+  setValues,
+  setFieldTouched,
+  isSubmitting,
   displayType
 }) => {
+  let label = LAT_LON_LABEL
+  let CoordinatesFormField = LatLonFormField
+  if (Settings?.fields?.location?.format === "MGRS") {
+    label = MGRS_LABEL
+    CoordinatesFormField = MGRSFormField
+  }
+
   if (!editable) {
     const humanValue = (
-      <>
-        <span>{Location.parseCoordinate(lat) || "?"}</span>
-        <span>,&nbsp;</span>
-        <span>{Location.parseCoordinate(lng) || "?"}</span>
-      </>
+      <div style={{ display: "flex", alignItems: "center" }}>
+        <CoordinatesFormField lat={lat} lng={lng} />
+        <AllFormatsInfo lat={lat} lng={lng} />
+      </div>
     )
 
     if (displayType === GEO_LOCATION_DISPLAY_TYPE.FORM_FIELD) {
       return (
         <Field
           name="location"
-          label="Latitude, Longitude"
+          label={label}
           component={FieldHelper.ReadonlyField}
           humanValue={humanValue}
+          style={{ paddingTop: "2px" }}
         />
       )
     }
@@ -43,60 +64,15 @@ const GeoLocation = ({
     return humanValue
   }
 
-  const setTouched = touched => {
-    setFieldTouched("lat", touched, false)
-    setFieldTouched("lng", touched, false)
-  }
-
   return (
-    <FormGroup style={{ marginBottom: 0 }}>
-      <Col sm={2} componentClass={ControlLabel} htmlFor="lat">
-        Latitude, Longitude
-      </Col>
-
-      <Col sm={7}>
-        <Col sm={3} style={{ marginRight: "8px" }}>
-          <Field
-            name="lat"
-            component={FieldHelper.InputFieldNoLabel}
-            onBlur={() => {
-              setTouched(true)
-              setValues({
-                lat: Location.parseCoordinate(lat),
-                lng: Location.parseCoordinate(lng)
-              })
-            }}
-          />
-        </Col>
-        <Col sm={3}>
-          <Field
-            name="lng"
-            component={FieldHelper.InputFieldNoLabel}
-            onBlur={() => {
-              setTouched(true)
-              setValues({
-                lat: Location.parseCoordinate(lat),
-                lng: Location.parseCoordinate(lng)
-              })
-            }}
-          />
-        </Col>
-        {(lat || lng) && (
-          <Col sm={1}>
-            <RemoveButton
-              title="Clear Location"
-              altText="Clear Location"
-              buttonStyle="link"
-              onClick={() => {
-                setTouched(false) // prevent validation since lat, lng can be null together
-                setValues({ lat: null, lng: null })
-              }}
-              disabled={isSubmitting}
-            />
-          </Col>
-        )}
-      </Col>
-    </FormGroup>
+    <CoordinatesFormField
+      lat={lat}
+      lng={lng}
+      editable
+      setValues={setValues}
+      setFieldTouched={setFieldTouched}
+      isSubmitting={isSubmitting}
+    />
   )
 }
 
@@ -111,10 +87,10 @@ function fnRequiredWhenEditable(props, propName, componentName) {
 GeoLocation.propTypes = {
   lat: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   lng: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-  setFieldTouched: fnRequiredWhenEditable,
-  setValues: fnRequiredWhenEditable,
-  isSubmitting: PropTypes.bool,
   editable: PropTypes.bool,
+  setValues: fnRequiredWhenEditable,
+  setFieldTouched: fnRequiredWhenEditable,
+  isSubmitting: PropTypes.bool,
   displayType: PropTypes.oneOf([
     GEO_LOCATION_DISPLAY_TYPE.FORM_FIELD,
     GEO_LOCATION_DISPLAY_TYPE.GENERIC
@@ -124,9 +100,290 @@ GeoLocation.propTypes = {
 GeoLocation.defaultProps = {
   lat: null,
   lng: null,
-  isSubmitting: false,
   editable: false,
+  isSubmitting: false,
   displayType: GEO_LOCATION_DISPLAY_TYPE.GENERIC
 }
 
 export default GeoLocation
+
+/* =========================== MGRSFormField ================================ */
+
+const MGRSFormField = ({
+  lat,
+  lng,
+  editable,
+  setValues,
+  setFieldTouched,
+  isSubmitting
+}) => {
+  const [mgrs, setMgrs] = useState("")
+
+  useEffect(() => {
+    if (!editable && lat === null && lng === null) {
+      setMgrs("")
+    } else {
+      const mgrsValue = convertLatLngToMGRS(lat, lng)
+      if (mgrsValue) {
+        setMgrs(mgrsValue)
+        if (editable) {
+          setValues({ displayedCoordinate: mgrsValue, lat: lat, lng: lng })
+        }
+      }
+    }
+  }, [editable, lat, lng, setValues])
+
+  if (!editable) {
+    return <span>{mgrs || "?"}</span>
+  }
+
+  return (
+    <FormGroup style={{ marginBottom: 0 }}>
+      <Col sm={2} componentClass={ControlLabel} htmlFor="displayedCoordinate">
+        {MGRS_LABEL}
+      </Col>
+
+      <Col sm={7}>
+        <Col sm={4}>
+          <Field
+            name="displayedCoordinate"
+            component={FieldHelper.InputFieldNoLabel}
+            value={mgrs}
+            onChange={e => setMgrs(e.target.value)}
+            onBlur={e => {
+              const newLatLng = convertMGRSToLatLng(mgrs)
+              setValues({
+                displayedCoordinate: e.target.value,
+                lat: newLatLng[0],
+                lng: newLatLng[1]
+              })
+              setFieldTouched("displayedCoordinate", true, false)
+            }}
+          />
+        </Col>
+        <CoordinateActionButtons
+          lat={lat}
+          lng={lng}
+          isSubmitting={isSubmitting}
+          disabled={!mgrs}
+          onClear={() => {
+            setValues({ lat: null, lng: null, displayedCoordinate: null })
+            setMgrs("")
+          }}
+        />
+      </Col>
+    </FormGroup>
+  )
+}
+
+MGRSFormField.propTypes = {
+  lat: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  lng: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  editable: PropTypes.bool,
+  setValues: fnRequiredWhenEditable,
+  setFieldTouched: fnRequiredWhenEditable,
+  isSubmitting: PropTypes.bool
+}
+
+MGRSFormField.defaultProps = {
+  lat: null,
+  lng: null,
+  editable: false,
+  isSubmitting: false
+}
+
+/* ========================= LatLonFormField ================================ */
+
+const LatLonFormField = ({
+  lat,
+  lng,
+  editable,
+  setValues,
+  setFieldTouched,
+  isSubmitting
+}) => {
+  if (!editable) {
+    const lt = parseCoordinate(lat)
+    const ln = parseCoordinate(lng)
+    return (
+      <>
+        <span>{lt || lt === 0 ? lt : "?"}</span>
+        <span>,&nbsp;</span>
+        <span>{ln || ln === 0 ? ln : "?"}</span>
+      </>
+    )
+  }
+
+  return (
+    <FormGroup style={{ marginBottom: 0 }}>
+      <Col sm={2} componentClass={ControlLabel} htmlFor="lat">
+        {LAT_LON_LABEL}
+      </Col>
+
+      <Col sm={7}>
+        <Col sm={3} style={{ marginRight: "8px" }}>
+          <Field
+            name="lat"
+            component={FieldHelper.InputFieldNoLabel}
+            onBlur={() => {
+              setFieldTouched("lat", true, false)
+              setFieldTouched("lng", true, false)
+              setValues({
+                lat: parseCoordinate(lat),
+                lng: parseCoordinate(lng)
+              })
+            }}
+          />
+        </Col>
+        <Col sm={3}>
+          <Field
+            name="lng"
+            component={FieldHelper.InputFieldNoLabel}
+            onBlur={() => {
+              setFieldTouched("lat", true, false)
+              setFieldTouched("lng", true, false)
+              setValues({
+                lat: parseCoordinate(lat),
+                lng: parseCoordinate(lng)
+              })
+            }}
+          />
+        </Col>
+        <CoordinateActionButtons
+          lat={lat}
+          lng={lng}
+          isSubmitting={isSubmitting}
+          disabled={!lat && lat !== 0 && !lng && lng !== 0}
+          onClear={() => {
+            // setting second param to false prevents validation since lat, lng can be null together
+            setFieldTouched("lat", false, false)
+            setFieldTouched("lng", false, false)
+            setValues({ lat: null, lng: null })
+          }}
+        />
+      </Col>
+    </FormGroup>
+  )
+}
+
+LatLonFormField.propTypes = {
+  lat: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  lng: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  editable: PropTypes.bool,
+  setValues: fnRequiredWhenEditable,
+  setFieldTouched: fnRequiredWhenEditable,
+  isSubmitting: PropTypes.bool
+}
+
+LatLonFormField.defaultProps = {
+  lat: null,
+  lng: null,
+  editable: false,
+  isSubmitting: false
+}
+
+/* ======================= CoordinateActionButtons ============================ */
+
+const CoordinateActionButtons = ({
+  lat,
+  lng,
+  onClear,
+  isSubmitting,
+  disabled
+}) => {
+  return (
+    <Col sm={2} style={{ padding: "4px 8px" }}>
+      <Tooltip content="Clear coordinates">
+        <AnchorButton
+          minimal
+          icon="delete"
+          outlined
+          intent="danger"
+          onClick={onClear}
+          disabled={isSubmitting || disabled}
+        />
+      </Tooltip>
+      <AllFormatsInfo lat={lat} lng={lng} inForm />
+    </Col>
+  )
+}
+
+CoordinateActionButtons.propTypes = {
+  lat: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  lng: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  onClear: PropTypes.func.isRequired,
+  isSubmitting: PropTypes.bool.isRequired,
+  disabled: PropTypes.bool
+}
+
+CoordinateActionButtons.defaultProps = {
+  lat: null,
+  lng: null,
+  disabled: true
+}
+
+/* ======================= AllFormatsInfo ============================ */
+
+const AllFormatsInfo = ({ lat, lng, inForm }) => {
+  if (!inForm && ((!lat && lat !== 0) || (!lng && lng !== 0))) {
+    return null
+  }
+  return (
+    <Popover
+      content={
+        <div style={{ padding: "8px" }}>
+          <Table style={{ margin: 0 }}>
+            <thead>
+              <tr>
+                <th colSpan="2" className="text-center">
+                  All Coordinate Formats
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td style={{ whiteSpace: "nowrap" }}>{LAT_LON_LABEL}</td>
+                <td>
+                  <LatLonFormField lat={lat} lng={lng} />
+                </td>
+              </tr>
+              <tr>
+                <td style={{ whiteSpace: "nowrap" }}>{MGRS_LABEL}</td>
+                <td>
+                  <MGRSFormField lat={lat} lng={lng} />
+                </td>
+              </tr>
+            </tbody>
+          </Table>
+        </div>
+      }
+      target={
+        <Tooltip content="Display all coordinate formats">
+          <AnchorButton
+            style={{ marginLeft: "8px" }}
+            id="gloc-info-btn"
+            minimal
+            icon="info-sign"
+            intent="primary"
+            outlined={inForm}
+          />
+        </Tooltip>
+      }
+      position={Position.RIGHT}
+      interactionKind={PopoverInteractionKind.CLICK_TARGET_ONLY}
+      usePortal={false}
+    />
+  )
+}
+
+AllFormatsInfo.propTypes = {
+  lat: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  lng: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  inForm: PropTypes.bool
+}
+
+AllFormatsInfo.defaultProps = {
+  lat: null,
+  lng: null,
+  inForm: false
+}

--- a/client/src/pages/locations/GeoLocation.js
+++ b/client/src/pages/locations/GeoLocation.js
@@ -15,7 +15,7 @@ const GeoLocation = ({
   lat,
   lng,
   setFieldTouched,
-  setFieldValue,
+  setValues,
   isSubmitting,
   editable,
   displayType
@@ -61,7 +61,10 @@ const GeoLocation = ({
             component={FieldHelper.InputFieldNoLabel}
             onBlur={() => {
               setTouched(true)
-              setFieldValue("lat", Location.parseCoordinate(lat))
+              setValues({
+                lat: Location.parseCoordinate(lat),
+                lng: Location.parseCoordinate(lng)
+              })
             }}
           />
         </Col>
@@ -71,7 +74,10 @@ const GeoLocation = ({
             component={FieldHelper.InputFieldNoLabel}
             onBlur={() => {
               setTouched(true)
-              setFieldValue("lng", Location.parseCoordinate(lng))
+              setValues({
+                lat: Location.parseCoordinate(lat),
+                lng: Location.parseCoordinate(lng)
+              })
             }}
           />
         </Col>
@@ -83,8 +89,7 @@ const GeoLocation = ({
               buttonStyle="link"
               onClick={() => {
                 setTouched(false) // prevent validation since lat, lng can be null together
-                setFieldValue("lat", null)
-                setFieldValue("lng", null)
+                setValues({ lat: null, lng: null })
               }}
               disabled={isSubmitting}
             />
@@ -107,7 +112,7 @@ GeoLocation.propTypes = {
   lat: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   lng: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   setFieldTouched: fnRequiredWhenEditable,
-  setFieldValue: fnRequiredWhenEditable,
+  setValues: fnRequiredWhenEditable,
   isSubmitting: PropTypes.bool,
   editable: PropTypes.bool,
   displayType: PropTypes.oneOf([

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -10834,6 +10834,11 @@ methods@~1.1.2:
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
   integrity sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=
 
+mgrs@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/mgrs/-/mgrs-1.0.0.tgz#fb91588e78c90025672395cb40b25f7cd6ad1829"
+  integrity sha1-+5FYjnjJACVnI5XLQLJffNatGCk=
+
 microevent.ts@~0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/microevent.ts/-/microevent.ts-0.1.1.tgz#70b09b83f43df5172d0205a63025bce0f7357fa0"

--- a/src/main/resources/anet-schema.yml
+++ b/src/main/resources/anet-schema.yml
@@ -516,6 +516,17 @@ properties:
             additionalProperties:
               "$ref": "#/$defs/customField"
 
+      location:
+        type: object
+        additionalProperties: false
+        required: [format]
+        properties:
+          format:
+            type: string
+            enum: [LAT_LON, MGRS]
+            title: Coordinate format for location
+            description: Used in the UI where a location's coordinate is shown. Defaults to LAT_LON.
+
       position:
         type: object
         additionalProperties: false


### PR DESCRIPTION
Added MGRS coordinate format support. System admin can define which format to use through the dictionary. Currently two formats are supported: **MGRS** and **LAT_LON**. **LAT_LON** is the default when no format is specified or an unknown format is defined in the dictionary.

Coordinates are still stored as lat,lon values. However, when displaying/editing locations we will convert between lat,lon and the specified format behind the scenes.

### Release notes

Closes #3042 and 1st and 2nd items from #244 

#### User changes
- Users will see coordinates in specified format

#### Super User changes
- none

#### Admin changes
- While editing/creating a location, admin will see form field(s) for coordinates according to the format defined in anet.yml.

#### System admin changes
- System admin can define which coordinate format to be used throughout the UI in anet.yml.

- [X] anet.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [X] Described the user behavior in PR body
  - [X] Referenced/updated all related issues
  - [X] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [X] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [X] Resolved all build errors and warnings
  - [X] Opened debt issues for anything not resolved here #3085 
