### PR TITLE
Add all day report indicators

### DIFF
--- a/client/src/components/CustomDateInput.js
+++ b/client/src/components/CustomDateInput.js
@@ -30,18 +30,21 @@ const CustomDateInput = ({
   withTime,
   value,
   onChange,
-  onBlur
+  onBlur,
+  fullWidth,
+  allDay
 }) => {
   const inputRef = useRef()
   const rightElement = showIcon && CalendarIcon(inputRef.current)
   const width = 8 + (showIcon ? 3 : 0) + (withTime ? 3 : 0)
-  const style = { width: `${width}em`, fontSize: "1.1em" }
-  const dateFormats = withTime
-    ? Settings.dateFormats.forms.input.withTime
-    : Settings.dateFormats.forms.input.date
+  const style = { width: fullWidth ? "100%" : `${width}em`, fontSize: "1.1em" }
+  const dateFormats =
+    withTime && !allDay
+      ? Settings.dateFormats.forms.input.withTime
+      : Settings.dateFormats.forms.input.date
   const inputFormat = dateFormats[0]
   const timePickerProps = !withTime
-    ? {}
+    ? undefined
     : {
       precision: TimePrecision.MINUTE,
       selectAllOnFocus: true
@@ -70,6 +73,7 @@ const CustomDateInput = ({
       timePickerProps={timePickerProps}
       popoverProps={{ usePortal: false }}
       disabled={disabled}
+      fill={fullWidth}
     />
   )
 }
@@ -84,12 +88,16 @@ CustomDateInput.propTypes = {
     PropTypes.instanceOf(Date)
   ]),
   onChange: PropTypes.func,
-  onBlur: PropTypes.func
+  onBlur: PropTypes.func,
+  fullWidth: PropTypes.bool,
+  allDay: PropTypes.bool
 }
 CustomDateInput.defaultProps = {
   disabled: false,
   showIcon: true,
-  withTime: false
+  withTime: false,
+  fullWidth: false,
+  allDay: true
 }
 
 export default CustomDateInput

--- a/client/src/components/ReportSummary.js
+++ b/client/src/components/ReportSummary.js
@@ -245,9 +245,7 @@ const ReportSummaryRow = ({ report }) => {
         <Col md={12}>
           {report.engagementDate && (
             <Label bsStyle="default" className="engagement-date">
-              {moment(report.engagementDate).format(
-                Report.getEngagementDateFormat()
-              )}
+              {Report.getFormattedEngagementDate(report)}
             </Label>
           )}
         </Col>

--- a/client/src/components/ReportTable.js
+++ b/client/src/components/ReportTable.js
@@ -6,7 +6,6 @@ import UltimatePaginationTopDown from "components/UltimatePaginationTopDown"
 import _get from "lodash/get"
 import _isEqual from "lodash/isEqual"
 import { Report } from "models"
-import moment from "moment"
 import PropTypes from "prop-types"
 import React, { useEffect, useRef, useState } from "react"
 import { Table } from "react-bootstrap"
@@ -172,11 +171,7 @@ const ReportTable = ({
                   />
                 </td>
                 {showStatus && <td>{report.state}</td>}
-                <td>
-                  {moment(report.engagementDate).format(
-                    Report.getEngagementDateFormat()
-                  )}
-                </td>
+                <td>{Report.getFormattedEngagementDate(report)}</td>
               </tr>
             ))}
           </tbody>

--- a/client/src/components/aggregations/ReportsMapWidget.js
+++ b/client/src/components/aggregations/ReportsMapWidget.js
@@ -5,7 +5,7 @@ import {
 import Leaflet from "components/Leaflet"
 import _escape from "lodash/escape"
 import _isEmpty from "lodash/isEmpty"
-import { Location } from "models"
+import { Location, Report } from "models"
 import PropTypes from "prop-types"
 import React, { useMemo } from "react"
 
@@ -25,7 +25,9 @@ const ReportsMapWidget = ({
     values.forEach(report => {
       if (Location.hasCoordinates(report.location)) {
         let label = _escape(report.intent || "<undefined>") // escape HTML in intent!
-        label += `<br/>@ <b>${_escape(report.location.name)}</b>` // escape HTML in locationName!
+        label += `<br/>@ <b>${_escape(
+          report.location.name
+        )} ${Report.getAllDayIndicator(report)}</b>` // escape HTML in locationName!
         markerArray.push({
           id: report.uuid,
           lat: report.location.lat,

--- a/client/src/components/aggregations/utils.js
+++ b/client/src/components/aggregations/utils.js
@@ -210,9 +210,7 @@ export function reportsToEvents(reports) {
       (r.location && r.location.name) ||
       ""
     return {
-      title: `${who} @ ${where} - ${
-        Report.isEngagementAllDay(r) ? "(all day)" : ""
-      }`,
+      title: `${who} @ ${where} - ${Report.getAllDayIndicator(r)}`,
       start: moment(r.engagementDate).format("YYYY-MM-DD HH:mm"),
       end: moment(r.engagementDate)
         .add(r.duration, "minutes")

--- a/client/src/components/aggregations/utils.js
+++ b/client/src/components/aggregations/utils.js
@@ -210,7 +210,9 @@ export function reportsToEvents(reports) {
       (r.location && r.location.name) ||
       ""
     return {
-      title: who + "@" + where,
+      title: `${who} @ ${where} - ${
+        Report.isEngagementAllDay(r) ? "(all day)" : ""
+      }`,
       start: moment(r.engagementDate).format("YYYY-MM-DD HH:mm"),
       end: moment(r.engagementDate)
         .add(r.duration, "minutes")

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -148,7 +148,7 @@ fieldset.danger {
 }
 
 #duration {
-	width: 10em;
+	width: 100%;
 }
 
 .shortcut-list {

--- a/client/src/models/Report.js
+++ b/client/src/models/Report.js
@@ -111,7 +111,7 @@ export default class Report extends Model {
         .nullable()
         .test(
           "duration",
-          "Duration must be defined when engagement time is set!",
+          "You must provide duration when engagement time(hour:minute) is provided",
           function(duration) {
             const { engagementDate } = this.parent
             if (

--- a/client/src/models/Report.js
+++ b/client/src/models/Report.js
@@ -106,7 +106,26 @@ export default class Report extends Model {
         .nullable()
         .required("You must provide the Date of Engagement")
         .default(null),
-      duration: yup.number().nullable().default(null),
+      duration: yup
+        .number()
+        .nullable()
+        .test(
+          "duration",
+          "Duration must be defined when engagement time is set!",
+          function(duration) {
+            const { engagementDate } = this.parent
+            if (
+              !engagementDate ||
+              moment(engagementDate).isSame(
+                moment(engagementDate).startOf("day")
+              )
+            ) {
+              return true
+            }
+            return !!duration
+          }
+        )
+        .default(null),
       // not actually in the database, but used for validation:
       cancelled: yup
         .boolean()

--- a/client/src/models/Report.js
+++ b/client/src/models/Report.js
@@ -477,14 +477,6 @@ export default class Report extends Model {
     )
   }
 
-  static isEngagementAllDay(report) {
-    return !report.duration
-  }
-
-  static getAllDayIndicator(report) {
-    return Report.isEngagementAllDay(report) ? "(all day)" : ""
-  }
-
   static getEngagementDateFormat() {
     return Settings.engagementsIncludeTimeAndDuration
       ? Settings.dateFormats.forms.displayLong.withTime
@@ -597,6 +589,14 @@ export default class Report extends Model {
     )
   }
 
+  static isEngagementAllDay(report) {
+    return !report.duration
+  }
+
+  static getAllDayIndicator(report) {
+    return Report.isEngagementAllDay(report) ? " (all day)" : ""
+  }
+
   static getFormattedEngagementDate(report) {
     if (!report?.engagementDate) {
       return ""
@@ -606,7 +606,7 @@ export default class Report extends Model {
     if (Report.isEngagementAllDay(report)) {
       return Settings.engagementsIncludeTimeAndDuration
         ? start.format(Settings.dateFormats.forms.displayLong.date) +
-            " (all day)"
+            Report.getAllDayIndicator(report)
         : start.format(Report.getEngagementDateFormat())
     }
 

--- a/client/src/models/Report.js
+++ b/client/src/models/Report.js
@@ -477,6 +477,14 @@ export default class Report extends Model {
     )
   }
 
+  static isEngagementAllDay(report) {
+    return !report.duration
+  }
+
+  static getAllDayIndicator(report) {
+    return Report.isEngagementAllDay(report) ? "(all day)" : ""
+  }
+
   static getEngagementDateFormat() {
     return Settings.engagementsIncludeTimeAndDuration
       ? Settings.dateFormats.forms.displayLong.withTime
@@ -595,7 +603,7 @@ export default class Report extends Model {
     }
 
     const start = moment(report.engagementDate)
-    if (!report.duration) {
+    if (Report.isEngagementAllDay(report)) {
       return Settings.engagementsIncludeTimeAndDuration
         ? start.format(Settings.dateFormats.forms.displayLong.date) +
             " (all day)"

--- a/client/src/pages/reports/EngagementDateFormPartial.js
+++ b/client/src/pages/reports/EngagementDateFormPartial.js
@@ -34,10 +34,10 @@ const EngagementDatePartialFormWithDuration = ({
 
   return (
     <FormGroup>
-      <Col sm={2} componentClass={ControlLabel}>
+      <Col xsHidden sm={2} componentClass={ControlLabel}>
         Engagement planning
       </Col>
-      <Col sm={4} style={{ marginLeft: "15px" }}>
+      <Col sm={3} style={{ marginLeft: "15px" }}>
         <Field
           name="engagementDate"
           component={FieldHelper.SpecialField}
@@ -65,7 +65,7 @@ const EngagementDatePartialFormWithDuration = ({
           {Report.isFuture(values.engagementDate) && futureEngagementHint}
         </Field>
       </Col>
-      <Col sm={3} style={{ marginLeft: "15px" }}>
+      <Col sm={2} style={{ marginLeft: "15px", whiteSpace: "nowrap" }}>
         <Field
           name="duration"
           label="Duration (minutes)"
@@ -86,8 +86,14 @@ const EngagementDatePartialFormWithDuration = ({
         />
       </Col>
       <Col
-        sm={2}
-        style={{ marginTop: "2.2em", maxWidth: "max-content" }}
+        sm={1}
+        style={{
+          marginTop: "2.2em",
+          maxWidth: "max-content",
+          display: "flex",
+          alignItems: "center",
+          whiteSpace: "nowrap"
+        }}
         id="all-day-col"
       >
         <Checkbox

--- a/client/src/pages/reports/EngagementDateFormPartial.js
+++ b/client/src/pages/reports/EngagementDateFormPartial.js
@@ -84,10 +84,15 @@ const EngagementDatePartialFormWithDuration = ({
           disabled={isAllDay}
         />
       </Col>
-      <Col sm={2} style={{ marginTop: "2.2em", maxWidth: "max-content" }}>
+      <Col
+        sm={2}
+        style={{ marginTop: "2.2em", maxWidth: "max-content" }}
+        id="all-day-col"
+      >
         <Checkbox
           checked={isAllDay}
           label="All Day"
+          id="all-day"
           onChange={e => {
             setIsAllDay(e.target.checked)
             if (e.target.checked) {

--- a/client/src/pages/reports/EngagementDateFormPartial.js
+++ b/client/src/pages/reports/EngagementDateFormPartial.js
@@ -37,7 +37,7 @@ const EngagementDatePartialFormWithDuration = ({
       <Col sm={2} componentClass={ControlLabel}>
         Engagement planning
       </Col>
-      <Col lg={2} md={3} style={{ marginLeft: "15px" }}>
+      <Col sm={4} style={{ marginLeft: "15px" }}>
         <Field
           name="engagementDate"
           component={FieldHelper.SpecialField}
@@ -65,7 +65,7 @@ const EngagementDatePartialFormWithDuration = ({
           {Report.isFuture(values.engagementDate) && futureEngagementHint}
         </Field>
       </Col>
-      <Col sm={2} style={{ marginLeft: "15px" }}>
+      <Col sm={3} style={{ marginLeft: "15px" }}>
         <Field
           name="duration"
           label="Duration (minutes)"
@@ -84,7 +84,7 @@ const EngagementDatePartialFormWithDuration = ({
           disabled={isAllDay}
         />
       </Col>
-      <Col sm={2} style={{ marginTop: "2.2em" }}>
+      <Col sm={2} style={{ marginTop: "2.2em", maxWidth: "max-content" }}>
         <Checkbox
           checked={isAllDay}
           label="All Day"

--- a/client/src/pages/reports/EngagementDateFormPartial.js
+++ b/client/src/pages/reports/EngagementDateFormPartial.js
@@ -1,10 +1,12 @@
+import { Checkbox } from "@blueprintjs/core"
 import CustomDateInput from "components/CustomDateInput"
 import * as FieldHelper from "components/FieldHelper"
-import { FastField } from "formik"
+import { FastField, Field } from "formik"
 import { Report } from "models"
+import moment from "moment"
 import PropTypes from "prop-types"
-import React from "react"
-import { HelpBlock } from "react-bootstrap"
+import React, { useEffect, useState } from "react"
+import { Col, ControlLabel, FormGroup, HelpBlock } from "react-bootstrap"
 import Settings from "settings"
 import utils from "utils"
 
@@ -13,6 +15,116 @@ const futureEngagementHint = (
     <span className="text-success">This will create a planned engagement</span>
   </HelpBlock>
 )
+
+function isStartOfDay(date) {
+  return date && moment(date).isSame(moment(date).startOf("day"))
+}
+
+const EngagementDatePartialFormWithDuration = ({
+  setFieldValue,
+  setFieldTouched,
+  validateFieldDebounced,
+  initialValues,
+  edit,
+  values
+}) => {
+  const [isAllDay, setIsAllDay] = useState(true)
+  useEffect(() => {
+    if (!edit || !initialValues.engagementDate) {
+      setIsAllDay(true)
+    } else if (!isStartOfDay(initialValues.engagementDate)) {
+      setIsAllDay(false)
+    } else {
+      setIsAllDay(initialValues.duration === null)
+    }
+    // this logic should run only once when the component is mounted
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  return (
+    <FormGroup>
+      <Col sm={2} componentClass={ControlLabel}>
+        Engagement planning
+      </Col>
+      <Col lg={2} md={3} style={{ marginLeft: "15px" }}>
+        <Field
+          name="engagementDate"
+          component={FieldHelper.SpecialField}
+          onChange={value => {
+            const sval = value ? moment(value).startOf("minute").toDate() : null
+            setFieldTouched("engagementDate", true, false) // onBlur doesn't work when selecting a date
+            setFieldValue("engagementDate", sval, true)
+            if (!sval) {
+              setIsAllDay(true)
+            } else if (!isStartOfDay(sval)) {
+              setIsAllDay(false)
+            }
+          }}
+          onBlur={() => setFieldTouched("engagementDate")}
+          widget={
+            <CustomDateInput
+              id="engagementDate"
+              withTime
+              fullWidth
+              allDay={isAllDay}
+            />
+          }
+          vertical
+        >
+          {Report.isFuture(values.engagementDate) && futureEngagementHint}
+        </Field>
+      </Col>
+      <Col sm={2} style={{ marginLeft: "15px" }}>
+        <Field
+          name="duration"
+          label="Duration (minutes)"
+          component={FieldHelper.InputField}
+          inputType="number"
+          onWheelCapture={event => event.currentTarget.blur()} // Prevent scroll action on number input
+          onChange={event => {
+            const safeVal =
+              utils.preventNegativeAndLongDigits(event.target.value, 4) || null
+            setFieldTouched("duration", true, false)
+            setFieldValue("duration", safeVal, false)
+            validateFieldDebounced("duration")
+            setIsAllDay(false)
+          }}
+          vertical
+          disabled={isAllDay}
+        />
+      </Col>
+      <Col sm={2} style={{ marginTop: "2.2em" }}>
+        <Checkbox
+          checked={isAllDay}
+          label="All Day"
+          onChange={e => {
+            setIsAllDay(e.target.checked)
+            if (e.target.checked) {
+              setFieldValue("duration", null, true)
+              validateFieldDebounced("duration")
+              if (values.engagementDate) {
+                setFieldValue(
+                  "engagementDate",
+                  moment(values.engagementDate).startOf("day").toDate(),
+                  false
+                )
+              }
+            }
+          }}
+        />
+      </Col>
+    </FormGroup>
+  )
+}
+
+EngagementDatePartialFormWithDuration.propTypes = {
+  setFieldValue: PropTypes.func.isRequired,
+  setFieldTouched: PropTypes.func.isRequired,
+  validateFieldDebounced: PropTypes.func.isRequired,
+  values: PropTypes.object.isRequired,
+  initialValues: PropTypes.instanceOf(Report).isRequired,
+  edit: PropTypes.bool.isRequired
+}
 
 const EngagementDateFormPartial = ({
   setFieldValue,
@@ -28,10 +140,9 @@ const EngagementDateFormPartial = ({
         name="engagementDate"
         component={FieldHelper.SpecialField}
         onChange={value => {
-          setFieldTouched("engagementDate", true, false) // onBlur doesn't work when selecting a date
-          setFieldValue("engagementDate", value, true)
+          const val = value ? moment(value).startOf("day").toDate() : null
+          setFieldValue("engagementDate", val, true)
         }}
-        onBlur={() => setFieldTouched("engagementDate")}
         widget={<CustomDateInput id="engagementDate" />}
       >
         {Report.isFuture(values.engagementDate) && futureEngagementHint}
@@ -40,34 +151,14 @@ const EngagementDateFormPartial = ({
   }
 
   return (
-    <>
-      <FastField
-        name="engagementDate"
-        component={FieldHelper.SpecialField}
-        onChange={value => {
-          setFieldTouched("engagementDate", true, false) // onBlur doesn't work when selecting a date
-          setFieldValue("engagementDate", value, true)
-        }}
-        onBlur={() => setFieldTouched("engagementDate")}
-        widget={<CustomDateInput id="engagementDate" withTime />}
-      >
-        {Report.isFuture(values.engagementDate) && futureEngagementHint}
-      </FastField>
-      <FastField
-        name="duration"
-        label="Duration (minutes)"
-        component={FieldHelper.InputField}
-        inputType="number"
-        onWheelCapture={event => event.currentTarget.blur()} // Prevent scroll action on number input
-        onChange={event => {
-          const safeVal =
-            utils.preventNegativeAndLongDigits(event.target.value, 4) || null
-          setFieldTouched("duration", true, false)
-          setFieldValue("duration", safeVal, false)
-          validateFieldDebounced("duration")
-        }}
-      />
-    </>
+    <EngagementDatePartialFormWithDuration
+      setFieldValue={setFieldValue}
+      setFieldTouched={setFieldTouched}
+      validateFieldDebounced={validateFieldDebounced}
+      values={values}
+      initialValues={initialValues}
+      edit={edit}
+    />
   )
 }
 

--- a/client/src/pages/reports/EngagementDateFormPartial.js
+++ b/client/src/pages/reports/EngagementDateFormPartial.js
@@ -5,7 +5,7 @@ import { FastField, Field } from "formik"
 import { Report } from "models"
 import moment from "moment"
 import PropTypes from "prop-types"
-import React, { useEffect, useState } from "react"
+import React, { useState } from "react"
 import { Col, ControlLabel, FormGroup, HelpBlock } from "react-bootstrap"
 import Settings from "settings"
 import utils from "utils"
@@ -28,18 +28,9 @@ const EngagementDatePartialFormWithDuration = ({
   edit,
   values
 }) => {
-  const [isAllDay, setIsAllDay] = useState(true)
-  useEffect(() => {
-    if (!edit || !initialValues.engagementDate) {
-      setIsAllDay(true)
-    } else if (!isStartOfDay(initialValues.engagementDate)) {
-      setIsAllDay(false)
-    } else {
-      setIsAllDay(initialValues.duration === null)
-    }
-    // this logic should run only once when the component is mounted
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
+  const [isAllDay, setIsAllDay] = useState(() =>
+    getInitalAllDayState(edit, initialValues)
+  )
 
   return (
     <FormGroup>
@@ -115,6 +106,16 @@ const EngagementDatePartialFormWithDuration = ({
       </Col>
     </FormGroup>
   )
+}
+
+function getInitalAllDayState(edit, initialValues) {
+  if (!edit || !initialValues.engagementDate) {
+    return true
+  } else if (!isStartOfDay(initialValues.engagementDate)) {
+    return false
+  } else {
+    return initialValues.duration === null
+  }
 }
 
 EngagementDatePartialFormWithDuration.propTypes = {

--- a/client/src/pages/reports/EngagementDateFormPartial.js
+++ b/client/src/pages/reports/EngagementDateFormPartial.js
@@ -74,7 +74,8 @@ const EngagementDatePartialFormWithDuration = ({
           onWheelCapture={event => event.currentTarget.blur()} // Prevent scroll action on number input
           onChange={event => {
             const safeVal =
-              utils.preventNegativeAndLongDigits(event.target.value, 4) || null
+              utils.preventNonPositiveAndLongDigits(event.target.value, 4) ||
+              null
             setFieldTouched("duration", true, false)
             setFieldValue("duration", safeVal, false)
             validateFieldDebounced("duration")

--- a/client/src/pages/reports/EngagementDateFormPartial.js
+++ b/client/src/pages/reports/EngagementDateFormPartial.js
@@ -1,0 +1,83 @@
+import CustomDateInput from "components/CustomDateInput"
+import * as FieldHelper from "components/FieldHelper"
+import { FastField } from "formik"
+import { Report } from "models"
+import PropTypes from "prop-types"
+import React from "react"
+import { HelpBlock } from "react-bootstrap"
+import Settings from "settings"
+import utils from "utils"
+
+const futureEngagementHint = (
+  <HelpBlock>
+    <span className="text-success">This will create a planned engagement</span>
+  </HelpBlock>
+)
+
+const EngagementDateFormPartial = ({
+  setFieldValue,
+  setFieldTouched,
+  validateFieldDebounced,
+  initialValues,
+  edit,
+  values
+}) => {
+  if (!Settings.engagementsIncludeTimeAndDuration) {
+    return (
+      <FastField
+        name="engagementDate"
+        component={FieldHelper.SpecialField}
+        onChange={value => {
+          setFieldTouched("engagementDate", true, false) // onBlur doesn't work when selecting a date
+          setFieldValue("engagementDate", value, true)
+        }}
+        onBlur={() => setFieldTouched("engagementDate")}
+        widget={<CustomDateInput id="engagementDate" />}
+      >
+        {Report.isFuture(values.engagementDate) && futureEngagementHint}
+      </FastField>
+    )
+  }
+
+  return (
+    <>
+      <FastField
+        name="engagementDate"
+        component={FieldHelper.SpecialField}
+        onChange={value => {
+          setFieldTouched("engagementDate", true, false) // onBlur doesn't work when selecting a date
+          setFieldValue("engagementDate", value, true)
+        }}
+        onBlur={() => setFieldTouched("engagementDate")}
+        widget={<CustomDateInput id="engagementDate" withTime />}
+      >
+        {Report.isFuture(values.engagementDate) && futureEngagementHint}
+      </FastField>
+      <FastField
+        name="duration"
+        label="Duration (minutes)"
+        component={FieldHelper.InputField}
+        inputType="number"
+        onWheelCapture={event => event.currentTarget.blur()} // Prevent scroll action on number input
+        onChange={event => {
+          const safeVal =
+            utils.preventNegativeAndLongDigits(event.target.value, 4) || null
+          setFieldTouched("duration", true, false)
+          setFieldValue("duration", safeVal, false)
+          validateFieldDebounced("duration")
+        }}
+      />
+    </>
+  )
+}
+
+EngagementDateFormPartial.propTypes = {
+  setFieldValue: PropTypes.func.isRequired,
+  setFieldTouched: PropTypes.func.isRequired,
+  validateFieldDebounced: PropTypes.func.isRequired,
+  values: PropTypes.object.isRequired,
+  initialValues: PropTypes.instanceOf(Report).isRequired,
+  edit: PropTypes.bool.isRequired
+}
+
+export default EngagementDateFormPartial

--- a/client/src/pages/reports/Form.js
+++ b/client/src/pages/reports/Form.js
@@ -13,7 +13,6 @@ import AdvancedSingleSelect from "components/advancedSelectWidget/AdvancedSingle
 import AppContext from "components/AppContext"
 import InstantAssessmentsContainerField from "components/assessments/InstantAssessmentsContainerField"
 import ConfirmDelete from "components/ConfirmDelete"
-import CustomDateInput from "components/CustomDateInput"
 import {
   CustomFieldsContainer,
   customFieldsJSONString
@@ -45,11 +44,12 @@ import _isEqual from "lodash/isEqual"
 import _upperFirst from "lodash/upperFirst"
 import { AuthorizationGroup, Location, Person, Report, Tag, Task } from "models"
 import moment from "moment"
+import EngagementDateFormPartial from "pages/reports/EngagementDateFormPartial"
 import { RECURRENCE_TYPE } from "periodUtils"
 import pluralize from "pluralize"
 import PropTypes from "prop-types"
 import React, { useContext, useEffect, useRef, useState } from "react"
-import { Button, Checkbox, Collapse, HelpBlock } from "react-bootstrap"
+import { Button, Checkbox, Collapse } from "react-bootstrap"
 import { connect } from "react-redux"
 import { useHistory } from "react-router-dom"
 import { toast } from "react-toastify"
@@ -500,49 +500,14 @@ const ReportForm = ({
                   className="meeting-goal"
                 />
 
-                <FastField
-                  name="engagementDate"
-                  component={FieldHelper.SpecialField}
-                  onChange={value => {
-                    setFieldTouched("engagementDate", true, false) // onBlur doesn't work when selecting a date
-                    setFieldValue("engagementDate", value, true)
-                  }}
-                  onBlur={() => setFieldTouched("engagementDate")}
-                  widget={
-                    <CustomDateInput
-                      id="engagementDate"
-                      withTime={Settings.engagementsIncludeTimeAndDuration}
-                    />
-                  }
-                >
-                  {isFutureEngagement && (
-                    <HelpBlock>
-                      <span className="text-success">
-                        This will create a planned engagement
-                      </span>
-                    </HelpBlock>
-                  )}
-                </FastField>
-
-                {Settings.engagementsIncludeTimeAndDuration && (
-                  <FastField
-                    name="duration"
-                    label="Duration (minutes)"
-                    component={FieldHelper.InputField}
-                    inputType="number"
-                    onWheelCapture={event => event.currentTarget.blur()} // Prevent scroll action on number input
-                    onChange={event => {
-                      const safeVal =
-                        utils.preventNegativeAndLongDigits(
-                          event.target.value,
-                          4
-                        ) || null
-                      setFieldTouched("duration", true, false)
-                      setFieldValue("duration", safeVal, false)
-                      validateFieldDebounced("duration")
-                    }}
-                  />
-                )}
+                <EngagementDateFormPartial
+                  setFieldValue={setFieldValue}
+                  setFieldTouched={setFieldTouched}
+                  validateFieldDebounced={validateFieldDebounced}
+                  values={values}
+                  initialValues={initialValues}
+                  edit={edit}
+                />
 
                 <FastField
                   name="location"

--- a/client/src/pages/reports/Show.js
+++ b/client/src/pages/reports/Show.js
@@ -543,10 +543,7 @@ const ReportShow = ({ setSearchQuery, pageDispatchers }) => {
                   component={FieldHelper.ReadonlyField}
                   humanValue={
                     <>
-                      {report.engagementDate &&
-                        moment(report.engagementDate).format(
-                          Report.getEngagementDateFormat()
-                        )}
+                      {Report.getFormattedEngagementDate(report)}
                       <PlanningConflictForReport report={report} largeIcon />
                     </>
                   }

--- a/client/src/utils.js
+++ b/client/src/utils.js
@@ -199,11 +199,11 @@ export default {
     )
   },
 
-  preventNegativeAndLongDigits: function(valueStr, maxLen) {
+  preventNonPositiveAndLongDigits: function(valueStr, maxLen) {
     let safeVal
     const dangerVal = Number(valueStr)
-    if (!isNaN(dangerVal) && dangerVal < 0) {
-      safeVal = "0"
+    if (!isNaN(dangerVal) && dangerVal <= 0) {
+      safeVal = null
     } else {
       const nonDigitsRemoved = valueStr.replace(/\D/g, "")
       safeVal =

--- a/client/tests/e2e/report.js
+++ b/client/tests/e2e/report.js
@@ -35,6 +35,9 @@ test.serial("Draft and submit a report", async t => {
   const $intent = await $("#intent")
   await $intent.click() // click intent to make sure the date picker is being closed
 
+  await pageHelpers.writeInForm("#duration", "30")
+  await t.context.driver.sleep(shortWaitMs) // wait for the datepicker to pop up
+
   const $locationAdvancedSelect = await pageHelpers.chooseAdvancedSelectOption(
     "#location",
     "general hospit"

--- a/client/tests/e2e/report.js
+++ b/client/tests/e2e/report.js
@@ -32,8 +32,8 @@ test.serial("Draft and submit a report", async t => {
 
   await pageHelpers.clickTodayButton()
 
-  const $intent = await $("#intent")
-  await $intent.click() // click intent to make sure the date picker is being closed
+  const $intent = await $('label[for="intent"]')
+  await $intent.click() // click intent label to make sure the date picker is being closed
 
   await pageHelpers.writeInForm("#duration", "30")
   await t.context.driver.sleep(shortWaitMs) // wait for the datepicker to pop up
@@ -448,7 +448,7 @@ test.serial(
       )
 
       await $input.sendKeys("user input")
-      await $input.sendKeys(t.context.Key.TAB) // fire blur event
+      await $searchBarInput.click() // fire blur event
       t.false(
         _includes(await $fieldGroup.getAttribute("class"), warningClass),
         `After typing in ${fieldName} field, warning state goes away`

--- a/client/tests/webdriver/baseSpecs/createReportWithPlanningConflict.spec.js
+++ b/client/tests/webdriver/baseSpecs/createReportWithPlanningConflict.spec.js
@@ -1,20 +1,21 @@
 import { expect } from "chai"
 import moment from "moment"
-import Settings from "../../../platform/node/settings"
 import CreateReport from "../pages/report/createReport.page"
 import EditReport from "../pages/report/editReport.page"
 import ShowReport from "../pages/report/showReport.page"
 
 // NOTE: Copied Report model logic here because importing issues
 
+function getFormattedDateInput(report) {
+  return report.engagementDate.format("DD-MM-YYYY HH:mm")
+}
+
 function isEngagementAllDay(report) {
   return !report.duration
 }
 
 function getEngagementDateFormat() {
-  return Settings.engagementsIncludeTimeAndDuration
-    ? Settings.dateFormats.forms.displayLong.withTime
-    : Settings.dateFormats.forms.displayLong.date
+  return "dddd, D MMMM YYYY @ HH:mm"
 }
 
 function getAllDayIndicator(report) {
@@ -28,10 +29,7 @@ function getFormattedEngagementDate(report) {
 
   const start = moment(report.engagementDate)
   if (isEngagementAllDay(report)) {
-    return Settings.engagementsIncludeTimeAndDuration
-      ? start.format(Settings.dateFormats.forms.displayLong.date) +
-          getAllDayIndicator(report)
-      : start.format(getEngagementDateFormat())
+    return start.format("dddd, D MMMM YYYY") + getAllDayIndicator(report)
   }
 
   const end = moment(report.engagementDate).add(report.duration, "minutes")
@@ -52,7 +50,7 @@ describe("When creating a Report with conflicts", () => {
   const report01 = {
     intent: "111111111111",
     engagementDate: moment()
-      .add(1, "day")
+      .add(2, "day")
       .hours(1)
       .minutes(0)
       .seconds(0)
@@ -64,7 +62,7 @@ describe("When creating a Report with conflicts", () => {
   const report02 = {
     intent: "2222222222",
     engagementDate: moment()
-      .add(1, "day")
+      .add(2, "day")
       .hours(1)
       .minutes(10)
       .seconds(0)
@@ -80,7 +78,7 @@ describe("When creating a Report with conflicts", () => {
 
     expect(CreateReport.intent.getValue()).to.equal(report01.intent)
     expect(CreateReport.engagementDate.getValue()).to.equal(
-      getFormattedEngagementDate(report01.engagementDate)
+      getFormattedDateInput(report01)
     )
     expect(CreateReport.duration.getValue()).to.equal(report01.duration)
     const advisor01 = CreateReport.getPersonByName("CIV ERINSON, Erin")
@@ -112,7 +110,7 @@ describe("When creating a Report with conflicts", () => {
 
     expect(CreateReport.intent.getValue()).to.equal(report02.intent)
     expect(CreateReport.engagementDate.getValue()).to.equal(
-      getFormattedEngagementDate(report02.engagementDate)
+      getFormattedDateInput(report02)
     )
     expect(CreateReport.duration.getValue()).to.equal(report02.duration)
     const advisor01 = CreateReport.getPersonByName("CIV ERINSON, Erin")
@@ -158,7 +156,7 @@ describe("When creating a Report with conflicts", () => {
 
     expect(ShowReport.intent).to.equal(report01.intent)
     expect(ShowReport.engagementDate).to.equal(
-      getFormattedEngagementDate(report01.engagementDate)
+      getFormattedEngagementDate(report01)
     )
     expect(ShowReport.reportConflictIcon.isExisting()).to.equal(true)
 
@@ -199,7 +197,7 @@ describe("When creating a Report with conflicts", () => {
 
     expect(ShowReport.intent).to.equal(report02.intent)
     expect(ShowReport.engagementDate).to.equal(
-      getFormattedEngagementDate(report02.engagementDate)
+      getFormattedEngagementDate(report02)
     )
     expect(ShowReport.reportConflictIcon.isExisting()).to.equal(true)
 

--- a/client/tests/webdriver/baseSpecs/createReportWithPlanningConflict.spec.js
+++ b/client/tests/webdriver/baseSpecs/createReportWithPlanningConflict.spec.js
@@ -1,5 +1,6 @@
 import { expect } from "chai"
 import moment from "moment"
+import Report from "../../../src/models/Report"
 import CreateReport from "../pages/report/createReport.page"
 import EditReport from "../pages/report/editReport.page"
 import ShowReport from "../pages/report/showReport.page"
@@ -38,7 +39,7 @@ describe("When creating a Report with conflicts", () => {
 
     expect(CreateReport.intent.getValue()).to.equal(report01.intent)
     expect(CreateReport.engagementDate.getValue()).to.equal(
-      report01.engagementDate.format("DD-MM-YYYY HH:mm")
+      Report.getFormattedEngagementDate(report01.engagementDate)
     )
     expect(CreateReport.duration.getValue()).to.equal(report01.duration)
     const advisor01 = CreateReport.getPersonByName("CIV ERINSON, Erin")
@@ -70,7 +71,7 @@ describe("When creating a Report with conflicts", () => {
 
     expect(CreateReport.intent.getValue()).to.equal(report02.intent)
     expect(CreateReport.engagementDate.getValue()).to.equal(
-      report02.engagementDate.format("DD-MM-YYYY HH:mm")
+      Report.getFormattedEngagementDate(report02.engagementDate)
     )
     expect(CreateReport.duration.getValue()).to.equal(report02.duration)
     const advisor01 = CreateReport.getPersonByName("CIV ERINSON, Erin")
@@ -116,7 +117,7 @@ describe("When creating a Report with conflicts", () => {
 
     expect(ShowReport.intent).to.equal(report01.intent)
     expect(ShowReport.engagementDate).to.equal(
-      report01.engagementDate.format("dddd, D MMMM YYYY @ HH:mm")
+      Report.getFormattedEngagementDate(report01.engagementDate)
     )
     expect(ShowReport.reportConflictIcon.isExisting()).to.equal(true)
 
@@ -157,7 +158,7 @@ describe("When creating a Report with conflicts", () => {
 
     expect(ShowReport.intent).to.equal(report02.intent)
     expect(ShowReport.engagementDate).to.equal(
-      report02.engagementDate.format("dddd, D MMMM YYYY @ HH:mm")
+      Report.getFormattedEngagementDate(report02.engagementDate)
     )
     expect(ShowReport.reportConflictIcon.isExisting()).to.equal(true)
 

--- a/client/tests/webdriver/customFieldsSpecs/createReport.spec.js
+++ b/client/tests/webdriver/customFieldsSpecs/createReport.spec.js
@@ -36,6 +36,10 @@ describe("Create report form page", () => {
     })
 
     it("Should be able to prevent invalid duration values", () => {
+      // make it not an all day first to enable duration input
+      CreateReport.allDayCheckbox.click()
+      CreateReport.duration.waitForClickable()
+
       CreateReport.duration.setValue(INVALID_ENGAGEMENT_DURATION_1)
       browser.waitUntil(
         () => {
@@ -48,7 +52,13 @@ describe("Create report form page", () => {
           timeoutMsg: "Large positive duration value was not sliced "
         }
       )
-      CreateReport.duration.setValue(INVALID_ENGAGEMENT_DURATION_2)
+
+      // remove first value, otherwise appends the value
+      CreateReport.duration.setValue(
+        "\uE003".repeat(VALID_ENGAGEMENT_DURATION_1) +
+          INVALID_ENGAGEMENT_DURATION_2
+      )
+
       browser.waitUntil(
         () => {
           return (

--- a/client/tests/webdriver/customFieldsSpecs/createReport.spec.js
+++ b/client/tests/webdriver/customFieldsSpecs/createReport.spec.js
@@ -9,7 +9,7 @@ const INVALID_ENGAGEMENT_DURATION_1 = "123456"
 const INVALID_ENGAGEMENT_DURATION_2 = "-1"
 // positive sliced at 4th digit, negative should turn into 0
 const VALID_ENGAGEMENT_DURATION_1 = "1234"
-const VALID_ENGAGEMENT_DURATION_2 = "0"
+const VALID_ENGAGEMENT_DURATION_2 = ""
 
 const PERSON = "EF 2.1"
 const PERSON_VALUE_1 = "HENDERSON, Henry"

--- a/client/tests/webdriver/pages/createReport.page.js
+++ b/client/tests/webdriver/pages/createReport.page.js
@@ -40,6 +40,10 @@ export class CreateReport extends Page {
     return browser.$(`div[id="fg-${id}"]`)
   }
 
+  get allDayCheckbox() {
+    return browser.$("#all-day-col label")
+  }
+
   get engagementInformationTitle() {
     return browser.$('//span[text()="Engagement information"]')
   }

--- a/client/tests/webdriver/pages/report/createReport.page.js
+++ b/client/tests/webdriver/pages/report/createReport.page.js
@@ -24,13 +24,18 @@ class CreateReport extends Page {
     return browser.$("#engagementDate")
   }
 
-  get tomorrow() {
-    const tomorrow = moment().add(1, "day").format("ddd MMM DD YYYY")
-    return browser.$(`div[aria-label="${tomorrow}"]`)
+  get datePickPopover() {
+    // check the today button
+    const today = moment().format("ddd MMM DD YYYY")
+    return browser.$(`div[aria-label="${today}"]`)
   }
 
   get duration() {
     return browser.$("#duration")
+  }
+
+  get allDayCheckbox() {
+    return browser.$("#all-day-col label")
   }
 
   get reportPeople() {
@@ -91,13 +96,17 @@ class CreateReport extends Page {
     this.intentHelpBlock.waitForExist({ reverse: true })
 
     if (moment.isMoment(fields.engagementDate)) {
+      // remove all day as it would block duration adding
+      if (!this.duration.isClickable()) {
+        this.allDayCheckbox.click()
+      }
       this.engagementDate.waitForClickable()
       this.engagementDate.click()
-      this.tomorrow.waitForDisplayed()
+      this.datePickPopover.waitForDisplayed()
       browser.keys(fields.engagementDate.format("DD-MM-YYYY HH:mm"))
 
       this.title.click()
-      this.tomorrow.waitForExist({ reverse: true, timeout: 3000 })
+      this.datePickPopover.waitForExist({ reverse: true, timeout: 3000 })
     }
 
     if (fields.duration !== undefined) {


### PR DESCRIPTION
An "All day" checkbox is added to report form. Previously, reports are considered to be all-day events when duration field is left empty (specifically when duration was `null`). This behavior is preserved while giving an option (by checking all-day checkbox) to the user for explicitly setting the report as an all-day event.

When creating a new report all-day checkbox is initially checked and duration field is disabled. If user enters a time other than 00:00 in date picker, checkbox is automatically cleared and duration field is automatically enabled. At this point, entering a duration is required because time is entered (even though duration is optional initially). 

If all-day checkbox gets checked after user enters time and duration, time gets reset to 00:00 (start of day) and duration gets reset to `null` and duration field gets disabled.

### Release notes

Closes #3024 

#### User changes
- Engagement Date and Duration fields are inlined and an "All Day" checkbox is added next to Duration field in order to give users option to explicitly set a report as an all-day event.

#### Super User changes
- none

#### Admin changes
- none

#### System admin changes
- none

- [ ] anet.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [X] Described the user behavior in PR body
  - [X] Referenced/updated all related issues
  - [X] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [X] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [X] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [X] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
