### PR TITLE
Improve and extend merge for locations object

### DIFF
--- a/client/src/components/Nav.js
+++ b/client/src/components/Nav.js
@@ -222,6 +222,9 @@ const Nav = ({
           <LinkContainer to="/admin/mergePeople" onClick={resetPages}>
             <NavItem>Merge people</NavItem>
           </LinkContainer>
+          <LinkContainer to="/admin/mergeLocations" onClick={resetPages}>
+            <NavItem>Merge locations</NavItem>
+          </LinkContainer>
           <LinkContainer to="/admin/authorizationGroups" onClick={resetPages}>
             <NavItem>Authorization groups</NavItem>
           </LinkContainer>

--- a/client/src/components/approvals/ApprovalSteps.js
+++ b/client/src/components/approvals/ApprovalSteps.js
@@ -1,0 +1,77 @@
+import Fieldset from "components/Fieldset"
+import LinkTo from "components/LinkTo"
+import PropTypes from "prop-types"
+import React from "react"
+import { Checkbox, Table } from "react-bootstrap"
+
+export const PLANNING_APPROVAL = {
+  fsId: "planningApprovals",
+  fsTitle: "Engagement planning approval process",
+  noStepsMsg: "This object doesn't have any engagement planning approval steps"
+}
+
+export const PUBLICATION_APPROVAL = {
+  fsId: "approvals",
+  fsTitle: "Report publication approval process",
+  noStepsMsg: "This object doesn't have any report publication approval steps"
+}
+
+const ApprovalSteps = ({
+  type,
+  steps,
+  restrictedApprovalLabel,
+  fieldSetAction
+}) => {
+  return (
+    <Fieldset id={type.fsId} title={type.fsTitle} action={fieldSetAction}>
+      {!steps?.length && <em>{type.noStepsMsg}</em>}
+      {steps?.length > 0 &&
+        steps.map((step, idx) => (
+          <Fieldset title={`Step ${idx + 1}: ${step.name}`} key={"step_" + idx}>
+            {restrictedApprovalLabel && (
+              <Checkbox inline checked={step.restrictedApproval} readOnly>
+                {restrictedApprovalLabel}
+              </Checkbox>
+            )}
+            <Table>
+              <thead>
+                <tr>
+                  <th>Name</th>
+                  <th>Position</th>
+                </tr>
+              </thead>
+
+              <tbody>
+                {step.approvers.map((position, approverIdx) => (
+                  <tr
+                    key={`${step.uuid}_${position.uuid}`}
+                    id={`step_${idx}_approver_${approverIdx}`}
+                  >
+                    {position.person && position.person.uuid ? (
+                      <td>
+                        <LinkTo modelType="Person" model={position.person} />
+                      </td>
+                    ) : (
+                      <td className="text-danger">Unfilled</td>
+                    )}
+                    <td>
+                      <LinkTo modelType="Position" model={position} />
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </Table>
+          </Fieldset>
+        ))}
+    </Fieldset>
+  )
+}
+
+ApprovalSteps.propTypes = {
+  type: PropTypes.oneOf([PLANNING_APPROVAL, PUBLICATION_APPROVAL]).isRequired,
+  steps: PropTypes.arrayOf(PropTypes.object),
+  restrictedApprovalLabel: PropTypes.string,
+  fieldSetAction: PropTypes.node
+}
+
+export default ApprovalSteps

--- a/client/src/components/approvals/Approvals.js
+++ b/client/src/components/approvals/Approvals.js
@@ -1,109 +1,24 @@
-import Fieldset from "components/Fieldset"
-import LinkTo from "components/LinkTo"
+import ApprovalSteps, {
+  PLANNING_APPROVAL,
+  PUBLICATION_APPROVAL
+} from "components/approvals/ApprovalSteps"
 import { Location, Organization, Task } from "models"
 import PropTypes from "prop-types"
 import React from "react"
-import { Checkbox, Table } from "react-bootstrap"
 
 const Approvals = ({ restrictedApprovalLabel, relatedObject }) => {
-  const approvalSteps = relatedObject.approvalSteps
-  const planningApprovalSteps = relatedObject.planningApprovalSteps
-
   return (
     <div>
-      <Fieldset
-        id="planningApprovals"
-        title="Engagement planning approval process"
-      >
-        {planningApprovalSteps.map((step, idx) => (
-          <Fieldset title={`Step ${idx + 1}: ${step.name}`} key={"step_" + idx}>
-            {restrictedApprovalLabel && (
-              <Checkbox inline checked={step.restrictedApproval} readOnly>
-                {restrictedApprovalLabel}
-              </Checkbox>
-            )}
-            <Table>
-              <thead>
-                <tr>
-                  <th>Name</th>
-                  <th>Position</th>
-                </tr>
-              </thead>
-
-              <tbody>
-                {step.approvers.map((position, approverIdx) => (
-                  <tr
-                    key={`${step.uuid}_${position.uuid}`}
-                    id={`step_${idx}_approver_${approverIdx}`}
-                  >
-                    {position.person && position.person.uuid ? (
-                      <td>
-                        <LinkTo modelType="Person" model={position.person} />
-                      </td>
-                    ) : (
-                      <td className="text-danger">Unfilled</td>
-                    )}
-                    <td>
-                      <LinkTo modelType="Position" model={position} />
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </Table>
-          </Fieldset>
-        ))}
-
-        {planningApprovalSteps.length === 0 && (
-          <em>
-            This object doesn't have any engagement planning approval steps
-          </em>
-        )}
-      </Fieldset>
-      <Fieldset id="approvals" title="Report publication approval process">
-        {approvalSteps.map((step, idx) => (
-          <Fieldset title={`Step ${idx + 1}: ${step.name}`} key={"step_" + idx}>
-            {restrictedApprovalLabel && (
-              <Checkbox inline checked={step.restrictedApproval} readOnly>
-                {restrictedApprovalLabel}
-              </Checkbox>
-            )}
-            <Table>
-              <thead>
-                <tr>
-                  <th>Name</th>
-                  <th>Position</th>
-                </tr>
-              </thead>
-
-              <tbody>
-                {step.approvers.map((position, approverIdx) => (
-                  <tr
-                    key={`${step.uuid}_${position.uuid}`}
-                    id={`step_${idx}_approver_${approverIdx}`}
-                  >
-                    {position.person && position.person.uuid ? (
-                      <td>
-                        <LinkTo modelType="Person" model={position.person} />
-                      </td>
-                    ) : (
-                      <td className="text-danger">Unfilled</td>
-                    )}
-                    <td>
-                      <LinkTo modelType="Position" model={position} />
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </Table>
-          </Fieldset>
-        ))}
-
-        {approvalSteps.length === 0 && (
-          <em>
-            This object doesn't have any report publication approval steps
-          </em>
-        )}
-      </Fieldset>
+      <ApprovalSteps
+        type={PLANNING_APPROVAL}
+        steps={relatedObject.planningApprovalSteps}
+        restrictedApprovalLabel={restrictedApprovalLabel}
+      />
+      <ApprovalSteps
+        type={PUBLICATION_APPROVAL}
+        steps={relatedObject.approvalSteps}
+        restrictedApprovalLabel={restrictedApprovalLabel}
+      />
     </div>
   )
 }

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1106,3 +1106,24 @@ header.searchPagination {
 		display: none;
 	}
 }
+
+.merge-loc-fset .legend {
+    float: none;
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.merge-loc-fset.reversed .legend {
+	flex-direction: row-reverse;
+}
+
+.merge-loc-fset .legend small {
+    float: none;
+    margin: 0;
+}
+
+.merge-loc-fset small > button {
+    margin: 0;
+}

--- a/client/src/models/Location.js
+++ b/client/src/models/Location.js
@@ -152,4 +152,8 @@ export default class Location extends Model {
     }
     return this.name
   }
+
+  isActive() {
+    return this.status === Location.STATUS.ACTIVE
+  }
 }

--- a/client/src/pages/Routing.js
+++ b/client/src/pages/Routing.js
@@ -4,6 +4,7 @@ import AuthorizationGroupNew from "pages/admin/authorizationgroup/New"
 import AuthorizationGroupShow from "pages/admin/authorizationgroup/Show"
 import AuthorizationGroups from "pages/admin/AuthorizationGroups"
 import AdminIndex from "pages/admin/Index"
+import MergeLocations from "pages/admin/MergeLocations"
 import MergePeople from "pages/admin/MergePeople"
 import BoardDashboard from "pages/dashboards/BoardDashboard"
 import DecisivesDashboard from "pages/dashboards/DecisivesDashboard"
@@ -130,6 +131,10 @@ const Routing = () => {
             <Switch>
               <Route exact path={`${url}/`} component={AdminIndex} />
               <Route path={`${url}/mergePeople`} component={MergePeople} />
+              <Route
+                path={`${url}/mergeLocations`}
+                component={MergeLocations}
+              />
               <Route
                 exact
                 path={`${url}/authorizationGroups`}

--- a/client/src/pages/admin/MergeLocations.js
+++ b/client/src/pages/admin/MergeLocations.js
@@ -1,17 +1,457 @@
+import { Button, Callout, Tooltip } from "@blueprintjs/core"
 import { DEFAULT_PAGE_PROPS, DEFAULT_SEARCH_PROPS } from "actions"
+import { LocationOverlayRow } from "components/advancedSelectWidget/AdvancedSelectOverlayRow"
+import AdvancedSingleSelect from "components/advancedSelectWidget/AdvancedSingleSelect"
+import ApprovalSteps, {
+  PLANNING_APPROVAL,
+  PUBLICATION_APPROVAL
+} from "components/approvals/ApprovalSteps"
+import Leaflet from "components/Leaflet"
+import { GRAPHQL_NOTES_FIELDS } from "components/Model"
 import {
   mapPageDispatchersToProps,
   PageDispatchersPropType,
   useBoilerplate
 } from "components/Page"
+import _escape from "lodash/escape"
+import { Location } from "models"
+import GeoLocation from "pages/locations/GeoLocation"
+import PropTypes from "prop-types"
+import React, { useState } from "react"
 import { connect } from "react-redux"
+import { toast } from "react-toastify"
+import LOCATIONS_ICON from "resources/locations.png"
+
+const locationFilters = {
+  allLocations: {
+    label: "All locations",
+    queryVars: {}
+  }
+}
+
+const selectFields = `
+  uuid
+  name
+  lat
+  lng
+  status
+  planningApprovalSteps {
+    uuid
+    name
+    approvers {
+      uuid
+      name
+      person {
+        uuid
+        name
+        rank
+        role
+        avatar(size: 32)
+      }
+    }
+  }
+  approvalSteps {
+    uuid
+    name
+    approvers {
+      uuid
+      name
+      person {
+        uuid
+        name
+        rank
+        role
+        avatar(size: 32)
+      }
+    }
+  }
+  ${GRAPHQL_NOTES_FIELDS}
+`
+
+const LocationColumn = ({
+  location,
+  setLocation,
+  setFieldValue,
+  reversed,
+  style
+}) => {
+  return (
+    <div style={style}>
+      <AdvancedSingleSelect
+        fieldName="location"
+        placeholder="Select location to merge..."
+        value={location}
+        overlayColumns={["Name"]}
+        overlayRenderRow={LocationOverlayRow}
+        filterDefs={locationFilters}
+        objectType={Location}
+        fields={selectFields}
+        valueKey="name"
+        addon={LOCATIONS_ICON}
+        onChange={setLocation}
+      />
+      {location && (
+        <>
+          <LocationField
+            label="Name"
+            value={location.name}
+            align={reversed ? "right" : "left"}
+            reversed={reversed}
+            action={getActionButton(() => setFieldValue("name", location.name))}
+          />
+          <LocationField
+            label="Status"
+            value={location.status}
+            align={reversed ? "right" : "left"}
+            reversed={reversed}
+            action={getActionButton(() =>
+              setFieldValue("status", location.status)
+            )}
+          />
+          <LocationField
+            label="Location"
+            value={<GeoLocation lat={location.lat} lng={location.lng} />}
+            align={reversed ? "right" : "left"}
+            reversed={reversed}
+            action={getActionButton(() => {
+              setFieldValue("lat", location.lat)
+              setFieldValue("lng", location.lng)
+            })}
+          />
+          <Leaflet
+            mapId={"map-" + location.uuid}
+            markers={[
+              {
+                id: "marker-" + location.uuid,
+                name: _escape(location.name) || "", // escape HTML in location name!
+                lat: Location.hasCoordinates(location) ? location.lat : null,
+                lng: Location.hasCoordinates(location) ? location.lng : null
+              }
+            ]}
+          />
+          <div className={"merge-loc-fset" + (reversed ? " reversed" : "")}>
+            <ApprovalSteps
+              type={PLANNING_APPROVAL}
+              steps={location.planningApprovalSteps}
+              fieldSetAction={getActionButton(() =>
+                setFieldValue(
+                  "planningApprovalSteps",
+                  location.planningApprovalSteps
+                )
+              )}
+            />
+          </div>
+
+          <div className={"merge-loc-fset" + (reversed ? " reversed" : "")}>
+            <ApprovalSteps
+              type={PUBLICATION_APPROVAL}
+              steps={location.approvalSteps}
+              fieldSetAction={getActionButton(() =>
+                setFieldValue("approvalSteps", location.approvalSteps)
+              )}
+            />
+          </div>
+        </>
+      )}
+    </div>
+  )
+
+  function getActionButton(onClickAction) {
+    return (
+      <small>
+        <Button
+          icon={reversed ? "double-chevron-left" : ""}
+          rightIcon={reversed ? "" : "double-chevron-right"}
+          intent="primary"
+          text="Use value"
+          onClick={onClickAction}
+        />
+      </small>
+    )
+  }
+}
+
+LocationColumn.propTypes = {
+  location: PropTypes.instanceOf(Location),
+  setLocation: PropTypes.func.isRequired,
+  setFieldValue: PropTypes.func.isRequired,
+  reversed: PropTypes.bool,
+  style: PropTypes.object
+}
+
+LocationColumn.defaultProps = {
+  reversed: false
+}
+
+const LocationField = ({ label, value, align, reversed, action }) => {
+  return (
+    <div
+      style={{
+        borderBottom: "1px solid #CCCCCC",
+        display: "flex",
+        flexDirection: reversed ? "row-reverse" : "row",
+        justifyContent: "space-between",
+        alignItems: "center",
+        padding: "8px 0"
+      }}
+    >
+      <div style={{ flex: "1 1 auto" }}>
+        <div
+          style={{
+            fontWeight: "bold",
+            textAlign: align || "center",
+            textDecoration: "underline"
+          }}
+        >
+          {label}
+        </div>
+        <div style={{ textAlign: align || "center" }}>{value}</div>
+      </div>
+      {action}
+    </div>
+  )
+}
+
+LocationField.propTypes = {
+  label: PropTypes.string.isRequired,
+  value: PropTypes.node,
+  align: PropTypes.string,
+  reversed: PropTypes.bool,
+  action: PropTypes.node
+}
 
 const MergeLocations = ({ pageDispatchers }) => {
+  const [mergedLocation, setMergedLocation] = useState(new Location())
+  const [location01, setLocation01] = useState()
+  const [location02, setLocation02] = useState()
+
+  const setLocationFn01 = value => {
+    if (location02?.uuid && value?.uuid && location02.uuid === value.uuid) {
+      toast.warning("Please select a different location!")
+    } else {
+      setMergedLocation(new Location())
+      setLocation01(null) // workaround for map already initialized error
+      if (value) {
+        setTimeout(() => setLocation01(new Location(value)))
+      }
+    }
+  }
+
+  const setLocationFn02 = value => {
+    if (location01?.uuid && value?.uuid && location01.uuid === value.uuid) {
+      toast.warning("Please select a different location!")
+    } else {
+      setMergedLocation(new Location())
+      setLocation02(null) // workaround for map already initialized error
+      if (value) {
+        setTimeout(() => setLocation02(new Location(value)))
+      }
+    }
+  }
+
   useBoilerplate({
     pageProps: DEFAULT_PAGE_PROPS,
     searchProps: DEFAULT_SEARCH_PROPS,
     pageDispatchers
   })
+
+  return (
+    <div>
+      <h2 className="form-header">Merge Locations Tool</h2>
+      <div style={{ display: "flex" }}>
+        <LocationColumn
+          location={location01}
+          setLocation={setLocationFn01}
+          setFieldValue={setFieldValue}
+          style={{ flex: "0 0 33%" }}
+        />
+        <div style={{ margin: "0 0.5%", flex: "0 0 33%" }}>
+          <h4
+            style={{
+              height: "39px",
+              margin: 0,
+              borderBottom: "1px solid #CCCCCC",
+              borderTop: "1px solid #CCCCCC",
+              display: "flex",
+              justifyContent: "space-between",
+              alignItems: "center"
+            }}
+          >
+            <small>
+              <Button
+                rightIcon="double-chevron-right"
+                intent="primary"
+                text="Use All"
+                onClick={() => setAllFields(location01)}
+                disabled={!location01 || !location02}
+              />
+            </small>
+            <span>Merged Location</span>
+            <small>
+              <Button
+                icon="double-chevron-left"
+                intent="primary"
+                text="Use All"
+                onClick={() => setAllFields(location02)}
+                disabled={!location01 || !location02}
+              />
+            </small>
+          </h4>
+          {(!location01 || !location02) && (
+            <div style={{ padding: "16px 5%" }}>
+              <Callout intent="warning">
+                Please select both locations to proceed...
+              </Callout>
+            </div>
+          )}
+          {location01 && location02 && !mergedLocation.name && (
+            <div style={{ padding: "16px 5%" }}>
+              <Callout intent="primary">
+                Please choose name to proceed...
+              </Callout>
+            </div>
+          )}
+          {location01 && location02 && mergedLocation?.name && (
+            <>
+              <LocationField
+                label="Name"
+                value={mergedLocation.name}
+                action={
+                  <Tooltip content="Name is required." intent="primary">
+                    <Button minimal icon="info-sign" intent="primary" />
+                  </Tooltip>
+                }
+              />
+              <LocationField
+                label="Status"
+                value={mergedLocation.status}
+                action={
+                  <Tooltip
+                    content={
+                      mergedLocation.isActive()
+                        ? "Deactivate location"
+                        : "Activate location"
+                    }
+                    intent={mergedLocation.isActive() ? "danger" : "success"}
+                  >
+                    <Button
+                      icon={mergedLocation.isActive() ? "stop" : "play"}
+                      outlined
+                      intent={mergedLocation.isActive() ? "danger" : "success"}
+                      onClick={() => {
+                        setFieldValue(
+                          "status",
+                          mergedLocation.isActive()
+                            ? Location.STATUS.INACTIVE
+                            : Location.STATUS.ACTIVE
+                        )
+                      }}
+                    />
+                  </Tooltip>
+                }
+              />
+              <LocationField
+                label="Location"
+                value={
+                  <GeoLocation
+                    lat={mergedLocation.lat}
+                    lng={mergedLocation.lng}
+                  />
+                }
+                action={getClearButton(() => {
+                  setFieldValue("lat", null)
+                  setFieldValue("lng", null)
+                })}
+              />
+              <Leaflet
+                mapId="merged-location"
+                markers={[
+                  {
+                    id: "marker-merged-location",
+                    name: _escape(mergedLocation.name) || "", // escape HTML in location name!
+                    lat: Location.hasCoordinates(mergedLocation)
+                      ? mergedLocation.lat
+                      : null,
+                    lng: Location.hasCoordinates(mergedLocation)
+                      ? mergedLocation.lng
+                      : null
+                  }
+                ]}
+              />
+              <div className="merge-loc-fset">
+                <ApprovalSteps
+                  type={PLANNING_APPROVAL}
+                  steps={mergedLocation.planningApprovalSteps}
+                  fieldSetAction={getClearButton("planningApprovalSteps", [])}
+                />
+              </div>
+
+              <div className="merge-loc-fset">
+                <ApprovalSteps
+                  type={PUBLICATION_APPROVAL}
+                  steps={mergedLocation.approvalSteps}
+                  fieldSetAction={getClearButton("approvalSteps", [])}
+                />
+              </div>
+            </>
+          )}
+        </div>
+        <LocationColumn
+          location={location02}
+          setLocation={setLocationFn02}
+          setFieldValue={setFieldValue}
+          style={{ flex: "0 0 33%" }}
+          reversed
+        />
+      </div>
+      <Button
+        style={{ width: "98%", margin: "16px 1%" }}
+        large
+        intent="primary"
+        text="Merge Locations"
+        onClick={() => mergeLocation(location01, location02, mergedLocation)}
+        disabled={!location01 || !location02 || !mergedLocation?.name}
+      />
+    </div>
+  )
+
+  function mergeLocation(location01, location02, mergedLocation) {
+    console.log(location01)
+    console.log(location02)
+    console.log(mergedLocation)
+  }
+
+  function setFieldValue(field, value) {
+    mergedLocation[field] = value
+    setMergedLocation(new Location(mergedLocation))
+  }
+
+  function setAllFields(old) {
+    const { name, status, lat, lng, approvalSteps, planningApprovalSteps } = old
+    const nw = { name, status, lat, lng, approvalSteps, planningApprovalSteps }
+    setMergedLocation(new Location(nw))
+  }
+
+  function getClearButton(field, value = null) {
+    return (
+      <Tooltip content="Clear field value" intent="danger">
+        <Button
+          icon="delete"
+          outlined
+          intent="danger"
+          onClick={() => {
+            if (typeof field === "string") {
+              setFieldValue(field, value)
+            } else if (typeof field === "function") {
+              field()
+            } else {
+              throw new Error("Unexpected onClick handler!")
+            }
+          }}
+        />
+      </Tooltip>
+    )
+  }
 }
 
 MergeLocations.propTypes = {

--- a/client/src/pages/admin/MergeLocations.js
+++ b/client/src/pages/admin/MergeLocations.js
@@ -1,0 +1,21 @@
+import { DEFAULT_PAGE_PROPS, DEFAULT_SEARCH_PROPS } from "actions"
+import {
+  mapPageDispatchersToProps,
+  PageDispatchersPropType,
+  useBoilerplate
+} from "components/Page"
+import { connect } from "react-redux"
+
+const MergeLocations = ({ pageDispatchers }) => {
+  useBoilerplate({
+    pageProps: DEFAULT_PAGE_PROPS,
+    searchProps: DEFAULT_SEARCH_PROPS,
+    pageDispatchers
+  })
+}
+
+MergeLocations.propTypes = {
+  pageDispatchers: PageDispatchersPropType
+}
+
+export default connect(null, mapPageDispatchersToProps)(MergeLocations)

--- a/client/src/pages/admin/MergeLocations.js
+++ b/client/src/pages/admin/MergeLocations.js
@@ -35,8 +35,8 @@ const locationFilters = {
 }
 
 const GQL_MERGE_LOCATION = gql`
-  mutation($looserUuid: String!, $winnerLocation: LocationInput!) {
-    mergeLocation(looserUuid: $looserUuid, winnerLocation: $winnerLocation) {
+  mutation($loserUuid: String!, $winnerLocation: LocationInput!) {
+    mergeLocation(loserUuid: $loserUuid, winnerLocation: $winnerLocation) {
       uuid
     }
   }
@@ -434,7 +434,7 @@ const MergeLocations = ({ pageDispatchers }) => {
   function mergeLocation(location01, location02, mergedLocation) {
     mergedLocation.uuid = location01.uuid
     API.mutation(GQL_MERGE_LOCATION, {
-      looserUuid: location02.uuid,
+      loserUuid: location02.uuid,
       winnerLocation: mergedLocation
     })
       .then(res => {

--- a/client/src/pages/admin/MergeLocations.js
+++ b/client/src/pages/admin/MergeLocations.js
@@ -433,9 +433,15 @@ const MergeLocations = ({ pageDispatchers }) => {
 
   function mergeLocation(location01, location02, mergedLocation) {
     mergedLocation.uuid = location01.uuid
+
+    const mergedFiltered = Object.without(
+      new Location(mergedLocation),
+      "notes",
+      "displayedCoordinate"
+    )
     API.mutation(GQL_MERGE_LOCATION, {
       loserUuid: location02.uuid,
-      winnerLocation: mergedLocation
+      winnerLocation: mergedFiltered
     })
       .then(res => {
         if (res.mergeLocation) {

--- a/src/main/java/mil/dds/anet/resources/LocationResource.java
+++ b/src/main/java/mil/dds/anet/resources/LocationResource.java
@@ -99,4 +99,40 @@ public class LocationResource {
     return numRows;
   }
 
+  @GraphQLMutation(name = "mergeLocation")
+  public Location mergeLocation(@GraphQLRootContext Map<String, Object> context,
+      @GraphQLArgument(name = "looserUuid") String looserUuid,
+      @GraphQLArgument(name = "winnerLocation") Location winnerLocation) {
+    final Person user = DaoUtils.getUserFromContext(context);
+    AuthUtils.assertSuperUser(user);
+    final Location existing = dao.getByUuid(looserUuid);
+
+    // update the merged location and update approval steps.
+    final int nr = dao.update(winnerLocation);
+    if (nr == 0) {
+      throw new WebApplicationException("Couldn't process location merge", Status.NOT_FOUND);
+    }
+    final Location mergedLocation = dao.getByUuid(looserUuid);
+    final List<ApprovalStep> existingPlanningApprovalSteps =
+        existing.loadPlanningApprovalSteps(engine.getContext()).join();
+    final List<ApprovalStep> existing2PlanningApprovalSteps =
+        winnerLocation.loadPlanningApprovalSteps(engine.getContext()).join();
+    existingPlanningApprovalSteps.addAll(existing2PlanningApprovalSteps);
+    final List<ApprovalStep> existingApprovalSteps =
+        existing.loadApprovalSteps(engine.getContext()).join();
+    final List<ApprovalStep> existingApprovalSteps2 =
+        winnerLocation.loadApprovalSteps(engine.getContext()).join();
+    existingApprovalSteps.addAll(existingApprovalSteps2);
+    Utils.updateApprovalSteps(mergedLocation, mergedLocation.getPlanningApprovalSteps(),
+        existingPlanningApprovalSteps, mergedLocation.getApprovalSteps(), existingApprovalSteps);
+
+    final int numRow = dao.mergeLocation(existing, mergedLocation);
+    if (numRow == 0) {
+      throw new WebApplicationException("Couldn't process location merge", Status.NOT_FOUND);
+    }
+    AnetAuditLogger.log("Location {} merged on {} by {}", existing, mergedLocation, user);
+    // Return merged location uuid because of navigate that location.
+    return mergedLocation;
+  }
+
 }

--- a/src/main/java/mil/dds/anet/resources/LocationResource.java
+++ b/src/main/java/mil/dds/anet/resources/LocationResource.java
@@ -112,27 +112,27 @@ public class LocationResource {
     if (nr == 0) {
       throw new WebApplicationException("Couldn't process location merge", Status.NOT_FOUND);
     }
-    final Location mergedLocation = dao.getByUuid(loserUuid);
+    final Location locationBeforeMerge = dao.getByUuid(winnerLocation.getUuid());
     final List<ApprovalStep> existingPlanningApprovalSteps =
         existing.loadPlanningApprovalSteps(engine.getContext()).join();
     final List<ApprovalStep> existing2PlanningApprovalSteps =
-        winnerLocation.loadPlanningApprovalSteps(engine.getContext()).join();
+        locationBeforeMerge.loadPlanningApprovalSteps(engine.getContext()).join();
     existingPlanningApprovalSteps.addAll(existing2PlanningApprovalSteps);
     final List<ApprovalStep> existingApprovalSteps =
         existing.loadApprovalSteps(engine.getContext()).join();
     final List<ApprovalStep> existingApprovalSteps2 =
-        winnerLocation.loadApprovalSteps(engine.getContext()).join();
+        locationBeforeMerge.loadApprovalSteps(engine.getContext()).join();
     existingApprovalSteps.addAll(existingApprovalSteps2);
-    Utils.updateApprovalSteps(mergedLocation, mergedLocation.getPlanningApprovalSteps(),
-        existingPlanningApprovalSteps, mergedLocation.getApprovalSteps(), existingApprovalSteps);
+    Utils.updateApprovalSteps(winnerLocation, winnerLocation.getPlanningApprovalSteps(),
+        existingPlanningApprovalSteps, winnerLocation.getApprovalSteps(), existingApprovalSteps);
 
-    final int numRow = dao.mergeLocation(existing, mergedLocation);
+    final int numRow = dao.mergeLocation(existing, winnerLocation);
     if (numRow == 0) {
       throw new WebApplicationException("Couldn't process location merge", Status.NOT_FOUND);
     }
-    AnetAuditLogger.log("Location {} merged on {} by {}", existing, mergedLocation, user);
+    AnetAuditLogger.log("Location {} merged on {} by {}", existing, winnerLocation, user);
     // Return merged location uuid because of navigate that location.
-    return mergedLocation;
+    return winnerLocation;
   }
 
 }

--- a/src/main/java/mil/dds/anet/resources/LocationResource.java
+++ b/src/main/java/mil/dds/anet/resources/LocationResource.java
@@ -101,18 +101,18 @@ public class LocationResource {
 
   @GraphQLMutation(name = "mergeLocation")
   public Location mergeLocation(@GraphQLRootContext Map<String, Object> context,
-      @GraphQLArgument(name = "looserUuid") String looserUuid,
+      @GraphQLArgument(name = "loserUuid") String loserUuid,
       @GraphQLArgument(name = "winnerLocation") Location winnerLocation) {
     final Person user = DaoUtils.getUserFromContext(context);
     AuthUtils.assertSuperUser(user);
-    final Location existing = dao.getByUuid(looserUuid);
+    final Location existing = dao.getByUuid(loserUuid);
 
     // update the merged location and update approval steps.
     final int nr = dao.update(winnerLocation);
     if (nr == 0) {
       throw new WebApplicationException("Couldn't process location merge", Status.NOT_FOUND);
     }
-    final Location mergedLocation = dao.getByUuid(looserUuid);
+    final Location mergedLocation = dao.getByUuid(loserUuid);
     final List<ApprovalStep> existingPlanningApprovalSteps =
         existing.loadPlanningApprovalSteps(engine.getContext()).join();
     final List<ApprovalStep> existing2PlanningApprovalSteps =

--- a/src/test/java/mil/dds/anet/test/resources/LocationResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/LocationResourceTest.java
@@ -144,7 +144,7 @@ public class LocationResourceTest extends AbstractResourceTest {
     mergedLocation.setUuid(firstLocationUuid);
     mergedLocation.setLat(firstCreatedLocation.getLat());
     mergedLocation.setLng(firstCreatedLocation.getLng());
-    mergedLocation.setStatus(Location.LocationStatus.ACTIVE);
+    mergedLocation.setStatus(Location.Status.ACTIVE);
     mergedLocation.setName(secondCreatedLocation.getName());
 
     Map<String, Object> variables = new HashMap<>();

--- a/src/test/java/mil/dds/anet/test/resources/LocationResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/LocationResourceTest.java
@@ -148,11 +148,11 @@ public class LocationResourceTest extends AbstractResourceTest {
     mergedLocation.setName(secondCreatedLocation.getName());
 
     Map<String, Object> variables = new HashMap<>();
-    variables.put("looserUuid", secondCreatedLocation.getUuid());
+    variables.put("loserUuid", secondCreatedLocation.getUuid());
     variables.put("winnerLocation", mergedLocation);
     final Location createdLocation = graphQLHelper.updateObject(admin,
-        "mutation ($looserUuid: String!, $winnerLocation: LocationInput!) { payload: mergeLocation "
-            + "(looserUuid: $looserUuid, winnerLocation: $winnerLocation) { uuid } }",
+        "mutation ($loserUuid: String!, $winnerLocation: LocationInput!) { payload: mergeLocation "
+            + "(loserUuid: $loserUuid, winnerLocation: $winnerLocation) { uuid } }",
         variables, new TypeReference<GraphQlResponse<Location>>() {});
 
     assertThat(createdLocation).isNotNull();


### PR DESCRIPTION
Added an admin page for merging duplicate locations. The page is accessible by admins only. Admin can choose two locations and cherry-pick particular fields from each location. Then a new location is created with a new uuid and all relations of previous two locations are migrated to newly created location object.

### Release notes

Closes #2994 

#### User changes
- none

#### Super User changes
- none

#### Admin changes
- Added Merge Locations feature 

#### System admin changes
-
- [ ] anet.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [X] Described the user behavior in PR body
  - [X] Referenced/updated all related issues
  - [X] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [X] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [X] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [X] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
