### PR TITLE
Make sure we keep our initial admin

### DIFF
--- a/client/tests/sim/simutils.js
+++ b/client/tests/sim/simutils.js
@@ -235,7 +235,8 @@ function populate(instance, scheme, context) {
   return populator
 }
 
-const specialUser = { name: "erin", password: "erin" }
+// Our initial admin, should always be there
+const specialUser = { name: "arthur", password: "arthur" }
 
 export {
   runGQL,

--- a/client/tests/sim/stories/NoteStories.js
+++ b/client/tests/sim/stories/NoteStories.js
@@ -30,7 +30,7 @@ export async function getRandomObject(
   type,
   variables,
   fields = "uuid",
-  ignoredUuids = []
+  ignoreCallback = randomObject => false
 ) {
   const [listEndpoint, queryType] = getListEndpoint(type)
   const objectQuery = Object.assign({}, variables, {
@@ -77,7 +77,7 @@ export async function getRandomObject(
       return null
     }
     const randomObject = list[0]
-    if (ignoredUuids.includes(randomObject?.uuid)) {
+    if (ignoreCallback(randomObject)) {
       attempt++
     } else {
       return randomObject

--- a/client/tests/sim/stories/PositionStories.js
+++ b/client/tests/sim/stories/PositionStories.js
@@ -197,7 +197,9 @@ const _createPosition = async function(user) {
       role: getPersonRole(organization.type)
     },
     "uuid",
-    [user.uuid]
+    randomObject =>
+      randomObject?.uuid === user.uuid ||
+      randomObject?.domainUsername === specialUser.name
   )
   const location = await getRandomObject(user, "locations")
   const template = {


### PR DESCRIPTION
Sometimes the sim would assign 'arthur' to a newly created position, after which he was no longer admin and subsequent calls started failing.
Fix this by:
• making 'arthur' the special user
• changing the ignored uuid's into a callback so the caller can more flexibly decide which random objects should not be returned

### Release notes

Partially addresses NCI-Agency/anet#2347