### PR TITLE
Fix Uncaught TypeError: First argument must be a string

### DIFF
--- a/client/src/utils_links.js
+++ b/client/src/utils_links.js
@@ -112,7 +112,10 @@ export function getEntityInfoFromUrl(url) {
 }
 
 // Enhanced HTML so that links will be converted to LinkTo components
-export function parseHtmlWithLinkTo(html, report) {
+export function parseHtmlWithLinkTo(html) {
+  if (!html) {
+    return null
+  }
   return parse(html, {
     replace: domNode => {
       if (domNode.attribs && domNode.attribs.href) {


### PR DESCRIPTION
Error happened when parseHtmlWithLinkTo() was called with `undefined`.