### PR TITLE
Tweak PostgreSQL full-text search

### DIFF
--- a/src/main/java/mil/dds/anet/search/AbstractAuthorizationGroupSearcher.java
+++ b/src/main/java/mil/dds/anet/search/AbstractAuthorizationGroupSearcher.java
@@ -30,7 +30,7 @@ public abstract class AbstractAuthorizationGroupSearcher
     qb.addTotalCount();
     qb.addFromClause("\"authorizationGroups\"");
 
-    if (query.isTextPresent()) {
+    if (hasTextQuery(query)) {
       addTextQuery(query);
     }
 
@@ -57,8 +57,6 @@ public abstract class AbstractAuthorizationGroupSearcher
 
     addOrderByClauses(qb, query);
   }
-
-  protected abstract void addTextQuery(AuthorizationGroupSearchQuery query);
 
   protected void addOrderByClauses(AbstractSearchQueryBuilder<?, ?> qb,
       AuthorizationGroupSearchQuery query) {

--- a/src/main/java/mil/dds/anet/search/AbstractLocationSearcher.java
+++ b/src/main/java/mil/dds/anet/search/AbstractLocationSearcher.java
@@ -28,7 +28,7 @@ public abstract class AbstractLocationSearcher
     qb.addTotalCount();
     qb.addFromClause("locations");
 
-    if (query.isTextPresent()) {
+    if (hasTextQuery(query)) {
       addTextQuery(query);
     }
 
@@ -42,8 +42,6 @@ public abstract class AbstractLocationSearcher
 
     addOrderByClauses(qb, query);
   }
-
-  protected abstract void addTextQuery(LocationSearchQuery query);
 
   protected void addOrderByClauses(AbstractSearchQueryBuilder<?, ?> qb, LocationSearchQuery query) {
     switch (query.getSortBy()) {

--- a/src/main/java/mil/dds/anet/search/AbstractOrganizationSearcher.java
+++ b/src/main/java/mil/dds/anet/search/AbstractOrganizationSearcher.java
@@ -31,7 +31,7 @@ public abstract class AbstractOrganizationSearcher extends
     qb.addTotalCount();
     qb.addFromClause("organizations");
 
-    if (query.isTextPresent()) {
+    if (hasTextQuery(query)) {
       addTextQuery(query);
     }
 
@@ -56,8 +56,6 @@ public abstract class AbstractOrganizationSearcher extends
 
     addOrderByClauses(qb, query);
   }
-
-  protected abstract void addTextQuery(OrganizationSearchQuery query);
 
   @SuppressWarnings("unchecked")
   protected void addBatchClause(OrganizationSearchQuery query) {

--- a/src/main/java/mil/dds/anet/search/AbstractPersonSearcher.java
+++ b/src/main/java/mil/dds/anet/search/AbstractPersonSearcher.java
@@ -53,7 +53,7 @@ public abstract class AbstractPersonSearcher extends AbstractSearcher<Person, Pe
       qb.addFromClause("LEFT JOIN positions ON people.uuid = positions.\"currentPersonUuid\"");
     }
 
-    if (query.isTextPresent()) {
+    if (hasTextQuery(query)) {
       addTextQuery(query);
     }
 
@@ -101,8 +101,6 @@ public abstract class AbstractPersonSearcher extends AbstractSearcher<Person, Pe
 
     addOrderByClauses(qb, query);
   }
-
-  protected abstract void addTextQuery(PersonSearchQuery query);
 
   protected void addOrderByClauses(AbstractSearchQueryBuilder<?, ?> qb, PersonSearchQuery query) {
     switch (query.getSortBy()) {

--- a/src/main/java/mil/dds/anet/search/AbstractPositionSearcher.java
+++ b/src/main/java/mil/dds/anet/search/AbstractPositionSearcher.java
@@ -34,7 +34,7 @@ public abstract class AbstractPositionSearcher
       qb.addFromClause("LEFT JOIN people ON positions.\"currentPersonUuid\" = people.uuid");
     }
 
-    if (query.isTextPresent()) {
+    if (hasTextQuery(query)) {
       addTextQuery(query);
     }
 
@@ -77,8 +77,6 @@ public abstract class AbstractPositionSearcher
 
     addOrderByClauses(qb, query);
   }
-
-  protected abstract void addTextQuery(PositionSearchQuery query);
 
   @SuppressWarnings("unchecked")
   protected void addBatchClause(PositionSearchQuery query) {

--- a/src/main/java/mil/dds/anet/search/AbstractReportSearcher.java
+++ b/src/main/java/mil/dds/anet/search/AbstractReportSearcher.java
@@ -87,7 +87,7 @@ public abstract class AbstractReportSearcher extends AbstractSearcher<Report, Re
   protected void buildQuery(Set<String> subFields, ReportSearchQuery query) {
     // Base select and from clauses are added by child classes
 
-    if (query.isTextPresent()) {
+    if (hasTextQuery(query)) {
       addTextQuery(query);
     }
 
@@ -274,8 +274,6 @@ public abstract class AbstractReportSearcher extends AbstractSearcher<Report, Re
 
     addOrderByClauses(qb, query);
   }
-
-  protected abstract void addTextQuery(ReportSearchQuery query);
 
   protected abstract void addBatchClause(ReportSearchQuery query);
 

--- a/src/main/java/mil/dds/anet/search/AbstractTagSearcher.java
+++ b/src/main/java/mil/dds/anet/search/AbstractTagSearcher.java
@@ -27,14 +27,12 @@ public abstract class AbstractTagSearcher extends AbstractSearcher<Tag, TagSearc
     qb.addTotalCount();
     qb.addFromClause("tags");
 
-    if (query.isTextPresent()) {
+    if (hasTextQuery(query)) {
       addTextQuery(query);
     }
 
     addOrderByClauses(qb, query);
   }
-
-  protected abstract void addTextQuery(TagSearchQuery query);
 
   protected void addOrderByClauses(AbstractSearchQueryBuilder<?, ?> qb, TagSearchQuery query) {
     switch (query.getSortBy()) {

--- a/src/main/java/mil/dds/anet/search/AbstractTaskSearcher.java
+++ b/src/main/java/mil/dds/anet/search/AbstractTaskSearcher.java
@@ -31,7 +31,7 @@ public abstract class AbstractTaskSearcher extends AbstractSearcher<Task, TaskSe
     qb.addTotalCount();
     qb.addFromClause("tasks");
 
-    if (query.isTextPresent()) {
+    if (hasTextQuery(query)) {
       addTextQuery(query);
     }
 
@@ -78,8 +78,6 @@ public abstract class AbstractTaskSearcher extends AbstractSearcher<Task, TaskSe
 
     addOrderByClauses(qb, query);
   }
-
-  protected abstract void addTextQuery(TaskSearchQuery query);
 
   @SuppressWarnings("unchecked")
   protected void addBatchClause(TaskSearchQuery query) {

--- a/src/main/java/mil/dds/anet/search/mssql/MssqlAuthorizationGroupSearcher.java
+++ b/src/main/java/mil/dds/anet/search/mssql/MssqlAuthorizationGroupSearcher.java
@@ -38,7 +38,7 @@ public class MssqlAuthorizationGroupSearcher extends AbstractAuthorizationGroupS
   @Override
   protected void addOrderByClauses(AbstractSearchQueryBuilder<?, ?> qb,
       AuthorizationGroupSearchQuery query) {
-    if (query.isTextPresent() && !query.isSortByPresent()) {
+    if (hasTextQuery(query) && !query.isSortByPresent()) {
       // We're doing a full-text search without an explicit sort order,
       // so sort first on the search pseudo-rank.
       qb.addAllOrderByClauses(getOrderBy(SortOrder.DESC, null, "search_rank"));

--- a/src/main/java/mil/dds/anet/search/mssql/MssqlLocationSearcher.java
+++ b/src/main/java/mil/dds/anet/search/mssql/MssqlLocationSearcher.java
@@ -28,7 +28,7 @@ public class MssqlLocationSearcher extends AbstractLocationSearcher {
 
   @Override
   protected void addOrderByClauses(AbstractSearchQueryBuilder<?, ?> qb, LocationSearchQuery query) {
-    if (query.isTextPresent() && !query.isSortByPresent()) {
+    if (hasTextQuery(query) && !query.isSortByPresent()) {
       // We're doing a full-text search without an explicit sort order,
       // so sort first on the search pseudo-rank.
       qb.addAllOrderByClauses(getOrderBy(SortOrder.DESC, null, "search_rank"));

--- a/src/main/java/mil/dds/anet/search/mssql/MssqlOrganizationSearcher.java
+++ b/src/main/java/mil/dds/anet/search/mssql/MssqlOrganizationSearcher.java
@@ -38,7 +38,7 @@ public class MssqlOrganizationSearcher extends AbstractOrganizationSearcher {
   @Override
   protected void addOrderByClauses(AbstractSearchQueryBuilder<?, ?> qb,
       OrganizationSearchQuery query) {
-    if (query.isTextPresent() && !query.isSortByPresent()) {
+    if (hasTextQuery(query) && !query.isSortByPresent()) {
       // We're doing a full-text search without an explicit sort order,
       // so sort first on the search pseudo-rank.
       qb.addAllOrderByClauses(getOrderBy(SortOrder.DESC, null, "search_rank"));

--- a/src/main/java/mil/dds/anet/search/mssql/MssqlPersonSearcher.java
+++ b/src/main/java/mil/dds/anet/search/mssql/MssqlPersonSearcher.java
@@ -50,7 +50,7 @@ public class MssqlPersonSearcher extends AbstractPersonSearcher {
 
   @Override
   protected void addOrderByClauses(AbstractSearchQueryBuilder<?, ?> qb, PersonSearchQuery query) {
-    if (query.isTextPresent() && !query.isSortByPresent()) {
+    if (hasTextQuery(query) && !query.isSortByPresent()) {
       // We're doing a full-text search without an explicit sort order,
       // so sort first on the search pseudo-rank.
       qb.addAllOrderByClauses(getOrderBy(SortOrder.DESC, null, "search_rank"));

--- a/src/main/java/mil/dds/anet/search/mssql/MssqlPositionSearcher.java
+++ b/src/main/java/mil/dds/anet/search/mssql/MssqlPositionSearcher.java
@@ -41,7 +41,7 @@ public class MssqlPositionSearcher extends AbstractPositionSearcher {
 
   @Override
   protected void addOrderByClauses(AbstractSearchQueryBuilder<?, ?> qb, PositionSearchQuery query) {
-    if (query.isTextPresent() && !query.isSortByPresent()) {
+    if (hasTextQuery(query) && !query.isSortByPresent()) {
       // We're doing a full-text search without an explicit sort order,
       // so sort first on the search pseudo-rank.
       qb.addAllOrderByClauses(getOrderBy(SortOrder.DESC, null, "search_rank"));

--- a/src/main/java/mil/dds/anet/search/mssql/MssqlReportSearcher.java
+++ b/src/main/java/mil/dds/anet/search/mssql/MssqlReportSearcher.java
@@ -106,7 +106,7 @@ public class MssqlReportSearcher extends AbstractReportSearcher {
   protected void addOrderByClauses(AbstractSearchQueryBuilder<?, ?> qb, ReportSearchQuery query) {
     if (qb == outerQb) {
       // ordering must be on the outer query
-      if (query.isTextPresent() && !query.isSortByPresent()) {
+      if (hasTextQuery(query) && !query.isSortByPresent()) {
         // We're doing a full-text search without an explicit sort order,
         // so sort first on the search pseudo-rank.
         qb.addAllOrderByClauses(getOrderBy(SortOrder.DESC, null, "search_rank"));

--- a/src/main/java/mil/dds/anet/search/mssql/MssqlSearchQueryBuilder.java
+++ b/src/main/java/mil/dds/anet/search/mssql/MssqlSearchQueryBuilder.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import mil.dds.anet.beans.lists.AnetBeanList;
 import mil.dds.anet.beans.search.AbstractSearchQuery;
 import mil.dds.anet.search.AbstractSearchQueryBuilder;
+import mil.dds.anet.utils.Utils;
 import mil.dds.anet.views.AbstractAnetBean;
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.mapper.RowMapper;
@@ -23,7 +24,13 @@ public class MssqlSearchQueryBuilder<B extends AbstractAnetBean, T extends Abstr
    */
   @Override
   public String getContainsQuery(String text) {
+    if (Utils.isEmptyOrNull(text)) {
+      return null;
+    }
     String cleanText = stripWildcards(text);
+    if (Utils.isEmptyOrNull(cleanText)) {
+      return null;
+    }
     if (text.endsWith("*")) {
       cleanText = "\"" + cleanText + "*\"";
     } else {
@@ -34,6 +41,9 @@ public class MssqlSearchQueryBuilder<B extends AbstractAnetBean, T extends Abstr
 
   @Override
   public String getFullTextQuery(String text) {
+    if (Utils.isEmptyOrNull(text)) {
+      return null;
+    }
     return text;
   }
 

--- a/src/main/java/mil/dds/anet/search/mssql/MssqlTagSearcher.java
+++ b/src/main/java/mil/dds/anet/search/mssql/MssqlTagSearcher.java
@@ -33,7 +33,7 @@ public class MssqlTagSearcher extends AbstractTagSearcher {
 
   @Override
   protected void addOrderByClauses(AbstractSearchQueryBuilder<?, ?> qb, TagSearchQuery query) {
-    if (query.isTextPresent() && !query.isSortByPresent()) {
+    if (hasTextQuery(query) && !query.isSortByPresent()) {
       // We're doing a full-text search without an explicit sort order,
       // so sort first on the search pseudo-rank.
       qb.addAllOrderByClauses(getOrderBy(SortOrder.DESC, null, "search_rank"));

--- a/src/main/java/mil/dds/anet/search/mssql/MssqlTaskSearcher.java
+++ b/src/main/java/mil/dds/anet/search/mssql/MssqlTaskSearcher.java
@@ -31,7 +31,7 @@ public class MssqlTaskSearcher extends AbstractTaskSearcher {
 
   @Override
   protected void addOrderByClauses(AbstractSearchQueryBuilder<?, ?> qb, TaskSearchQuery query) {
-    if (query.isTextPresent() && !query.isSortByPresent()) {
+    if (hasTextQuery(query) && !query.isSortByPresent()) {
       // We're doing a full-text search without an explicit sort order,
       // so sort first on the search pseudo-rank.
       qb.addAllOrderByClauses(getOrderBy(SortOrder.DESC, null, "search_rank"));

--- a/src/main/java/mil/dds/anet/search/pg/PostgresqlAuthorizationGroupSearcher.java
+++ b/src/main/java/mil/dds/anet/search/pg/PostgresqlAuthorizationGroupSearcher.java
@@ -21,7 +21,7 @@ public class PostgresqlAuthorizationGroupSearcher extends AbstractAuthorizationG
   @Override
   protected void addOrderByClauses(AbstractSearchQueryBuilder<?, ?> qb,
       AuthorizationGroupSearchQuery query) {
-    if (query.isTextPresent() && !query.isSortByPresent()) {
+    if (hasTextQuery(query) && !query.isSortByPresent()) {
       // We're doing a full-text search without an explicit sort order,
       // so sort first on the search pseudo-rank.
       qb.addAllOrderByClauses(getOrderBy(SortOrder.DESC, null, "search_rank"));

--- a/src/main/java/mil/dds/anet/search/pg/PostgresqlLocationSearcher.java
+++ b/src/main/java/mil/dds/anet/search/pg/PostgresqlLocationSearcher.java
@@ -20,7 +20,7 @@ public class PostgresqlLocationSearcher extends AbstractLocationSearcher {
 
   @Override
   protected void addOrderByClauses(AbstractSearchQueryBuilder<?, ?> qb, LocationSearchQuery query) {
-    if (query.isTextPresent() && !query.isSortByPresent()) {
+    if (hasTextQuery(query) && !query.isSortByPresent()) {
       // We're doing a full-text search without an explicit sort order,
       // so sort first on the search pseudo-rank.
       qb.addAllOrderByClauses(getOrderBy(SortOrder.DESC, null, "search_rank"));

--- a/src/main/java/mil/dds/anet/search/pg/PostgresqlOrganizationSearcher.java
+++ b/src/main/java/mil/dds/anet/search/pg/PostgresqlOrganizationSearcher.java
@@ -21,7 +21,7 @@ public class PostgresqlOrganizationSearcher extends AbstractOrganizationSearcher
   @Override
   protected void addOrderByClauses(AbstractSearchQueryBuilder<?, ?> qb,
       OrganizationSearchQuery query) {
-    if (query.isTextPresent() && !query.isSortByPresent()) {
+    if (hasTextQuery(query) && !query.isSortByPresent()) {
       // We're doing a full-text search without an explicit sort order,
       // so sort first on the search pseudo-rank.
       qb.addAllOrderByClauses(getOrderBy(SortOrder.DESC, null, "search_rank"));

--- a/src/main/java/mil/dds/anet/search/pg/PostgresqlPersonSearcher.java
+++ b/src/main/java/mil/dds/anet/search/pg/PostgresqlPersonSearcher.java
@@ -19,7 +19,7 @@ public class PostgresqlPersonSearcher extends AbstractPersonSearcher {
 
   @Override
   protected void addOrderByClauses(AbstractSearchQueryBuilder<?, ?> qb, PersonSearchQuery query) {
-    if (query.isTextPresent() && !query.isSortByPresent()) {
+    if (hasTextQuery(query) && !query.isSortByPresent()) {
       // We're doing a full-text search without an explicit sort order,
       // so sort first on the search pseudo-rank.
       qb.addAllOrderByClauses(getOrderBy(SortOrder.DESC, null, "search_rank"));

--- a/src/main/java/mil/dds/anet/search/pg/PostgresqlPositionSearcher.java
+++ b/src/main/java/mil/dds/anet/search/pg/PostgresqlPositionSearcher.java
@@ -20,7 +20,7 @@ public class PostgresqlPositionSearcher extends AbstractPositionSearcher {
 
   @Override
   protected void addOrderByClauses(AbstractSearchQueryBuilder<?, ?> qb, PositionSearchQuery query) {
-    if (query.isTextPresent() && !query.isSortByPresent()) {
+    if (hasTextQuery(query) && !query.isSortByPresent()) {
       // We're doing a full-text search without an explicit sort order,
       // so sort first on the search pseudo-rank.
       qb.addAllOrderByClauses(getOrderBy(SortOrder.DESC, null, "search_rank"));

--- a/src/main/java/mil/dds/anet/search/pg/PostgresqlReportSearcher.java
+++ b/src/main/java/mil/dds/anet/search/pg/PostgresqlReportSearcher.java
@@ -78,7 +78,7 @@ public class PostgresqlReportSearcher extends AbstractReportSearcher {
 
   @Override
   protected void addOrderByClauses(AbstractSearchQueryBuilder<?, ?> qb, ReportSearchQuery query) {
-    if (query.isTextPresent() && !query.isSortByPresent()) {
+    if (hasTextQuery(query) && !query.isSortByPresent()) {
       // We're doing a full-text search without an explicit sort order,
       // so sort first on the search pseudo-rank.
       qb.addAllOrderByClauses(getOrderBy(SortOrder.DESC, null, "search_rank"));

--- a/src/main/java/mil/dds/anet/search/pg/PostgresqlTagSearcher.java
+++ b/src/main/java/mil/dds/anet/search/pg/PostgresqlTagSearcher.java
@@ -19,7 +19,7 @@ public class PostgresqlTagSearcher extends AbstractTagSearcher {
 
   @Override
   protected void addOrderByClauses(AbstractSearchQueryBuilder<?, ?> qb, TagSearchQuery query) {
-    if (query.isTextPresent() && !query.isSortByPresent()) {
+    if (hasTextQuery(query) && !query.isSortByPresent()) {
       // We're doing a full-text search without an explicit sort order,
       // so sort first on the search pseudo-rank.
       qb.addAllOrderByClauses(getOrderBy(SortOrder.DESC, null, "search_rank"));

--- a/src/main/java/mil/dds/anet/search/pg/PostgresqlTaskSearcher.java
+++ b/src/main/java/mil/dds/anet/search/pg/PostgresqlTaskSearcher.java
@@ -19,7 +19,7 @@ public class PostgresqlTaskSearcher extends AbstractTaskSearcher {
 
   @Override
   protected void addOrderByClauses(AbstractSearchQueryBuilder<?, ?> qb, TaskSearchQuery query) {
-    if (query.isTextPresent() && !query.isSortByPresent()) {
+    if (hasTextQuery(query) && !query.isSortByPresent()) {
       // We're doing a full-text search without an explicit sort order,
       // so sort first on the search pseudo-rank.
       qb.addAllOrderByClauses(getOrderBy(SortOrder.DESC, null, "search_rank"));

--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -3148,4 +3148,231 @@
 		</addColumn>
 	</changeSet>
 
+	<changeSet id="alter-postgresql-fulltext" author="gjvoosten" dbms="postgresql">
+		<sql>
+			<!-- Drop full-text materialized views (incl. indexes) -->
+			DROP MATERIALIZED VIEW "mv_fts_authorizationGroups";
+			DROP MATERIALIZED VIEW mv_fts_locations;
+			DROP MATERIALIZED VIEW mv_fts_organizations;
+			DROP MATERIALIZED VIEW mv_fts_people;
+			DROP MATERIALIZED VIEW mv_fts_positions;
+			DROP MATERIALIZED VIEW mv_fts_reports;
+			DROP MATERIALIZED VIEW mv_fts_tags;
+			DROP MATERIALIZED VIEW mv_fts_tasks;
+
+			<!-- Drop generated full-text columns -->
+			ALTER TABLE "authorizationGroups" DROP COLUMN full_text;
+			ALTER TABLE locations DROP COLUMN full_text;
+			ALTER TABLE organizations DROP COLUMN full_text;
+			ALTER TABLE notes DROP COLUMN full_text;
+			ALTER TABLE people DROP COLUMN full_text;
+			ALTER TABLE positions DROP COLUMN full_text;
+			ALTER TABLE reports DROP COLUMN full_text;
+			ALTER TABLE tags DROP COLUMN full_text;
+			ALTER TABLE tasks DROP COLUMN full_text;
+
+			<!-- Re-add generated full-text columns;
+			     use 'anet' config only for columns containing English text,
+			     use 'simple' config for all columns -->
+			ALTER TABLE "authorizationGroups"
+				ADD COLUMN full_text tsvector GENERATED ALWAYS AS (
+					setweight(to_tsvector(${fts_config}, coalesce("authorizationGroups".name, ''))
+						  || to_tsvector('simple', coalesce("authorizationGroups".name, '')), ${fts_high}) ||
+					setweight(to_tsvector(${fts_config}, coalesce("authorizationGroups".description, ''))
+						  || to_tsvector('simple', coalesce("authorizationGroups".description, '')), ${fts_low})
+				) STORED;
+
+			ALTER TABLE locations
+				ADD COLUMN full_text tsvector GENERATED ALWAYS AS (
+					setweight(to_tsvector(${fts_config}, coalesce(locations.name, ''))
+						  || to_tsvector('simple', coalesce(locations.name, '')), ${fts_high})
+				) STORED;
+
+			ALTER TABLE organizations
+				ADD COLUMN full_text tsvector GENERATED ALWAYS AS (
+					setweight(to_tsvector('simple', coalesce(organizations."identificationCode", '')), ${fts_high}) ||
+					setweight(to_tsvector('simple', coalesce(organizations."shortName", '')), ${fts_high}) ||
+					setweight(to_tsvector(${fts_config}, coalesce(organizations."longName", ''))
+						  || to_tsvector('simple', coalesce(organizations."longName", '')), ${fts_low})
+				) STORED;
+
+			ALTER TABLE notes
+				ADD COLUMN full_text tsvector GENERATED ALWAYS AS (
+					setweight(to_tsvector(${fts_config}, coalesce(notes.text, ''))
+						  || to_tsvector('simple', coalesce(notes.text, '')), ${fts_low})
+				) STORED;
+
+			ALTER TABLE people
+				ADD COLUMN full_text tsvector GENERATED ALWAYS AS (
+					setweight(to_tsvector('simple', coalesce(people.name, '')), ${fts_high}) ||
+					setweight(to_tsvector('simple', coalesce(people.code, '')), ${fts_high}) ||
+					setweight(to_tsvector('simple', coalesce(people."domainUsername", '')), ${fts_high}) ||
+					setweight(to_tsvector('simple', coalesce(people."emailAddress", '')), ${fts_high}) ||
+					setweight(to_tsvector('simple', coalesce(people."phoneNumber", '')), ${fts_high}) ||
+					setweight(to_tsvector(${fts_config}, coalesce(people.biography, ''))
+						  || to_tsvector('simple', coalesce(people.biography, '')), ${fts_low})
+				) STORED;
+
+			ALTER TABLE positions
+				ADD COLUMN full_text tsvector GENERATED ALWAYS AS (
+					setweight(to_tsvector('simple', coalesce(positions.code, '')), ${fts_high}) ||
+					setweight(to_tsvector(${fts_config}, coalesce(positions.name, ''))
+						  || to_tsvector('simple', coalesce(positions.name, '')), ${fts_high})
+				) STORED;
+
+			ALTER TABLE reports
+				ADD COLUMN full_text tsvector GENERATED ALWAYS AS (
+					setweight(to_tsvector(${fts_config}, coalesce(reports.intent, ''))
+						  || to_tsvector('simple', coalesce(reports.intent, '')), ${fts_high}) ||
+					setweight(to_tsvector(${fts_config}, coalesce(reports."keyOutcomes", ''))
+						  || to_tsvector('simple', coalesce(reports."keyOutcomes", '')), ${fts_high}) ||
+					setweight(to_tsvector(${fts_config}, coalesce(reports."nextSteps", ''))
+						  || to_tsvector('simple', coalesce(reports."nextSteps", '')), ${fts_high}) ||
+					setweight(to_tsvector(${fts_config}, coalesce(reports.text, ''))
+						  || to_tsvector('simple', coalesce(reports.text, '')), ${fts_low})
+				) STORED;
+
+			ALTER TABLE tags
+				ADD COLUMN full_text tsvector GENERATED ALWAYS AS (
+					setweight(to_tsvector(${fts_config}, coalesce(tags.name, ''))
+						  || to_tsvector('simple', coalesce(tags.name, '')), ${fts_high}) ||
+					setweight(to_tsvector(${fts_config}, coalesce(tags.description, ''))
+						  || to_tsvector('simple', coalesce(tags.description, '')), ${fts_low})
+				) STORED;
+
+			ALTER TABLE tasks
+				ADD COLUMN full_text tsvector GENERATED ALWAYS AS (
+					setweight(to_tsvector('simple', coalesce(tasks."shortName", '')), ${fts_high}) ||
+					setweight(to_tsvector(${fts_config}, coalesce(tasks."longName", ''))
+						  || to_tsvector('simple', coalesce(tasks."longName", '')), ${fts_high})
+				) STORED;
+
+			<!-- Re-create full-text materialized views and indexes -->
+			CREATE MATERIALIZED VIEW IF NOT EXISTS "mv_fts_authorizationGroups"(uuid, full_text) AS
+				SELECT
+					"authorizationGroups".uuid,
+					"authorizationGroups".full_text
+					|| coalesce(tsvector_agg(notes.full_text), ''::tsvector)
+				FROM "authorizationGroups"
+				LEFT JOIN "noteRelatedObjects" ON "noteRelatedObjects"."relatedObjectType" = 'authorizationGroups'
+					AND "noteRelatedObjects"."relatedObjectUuid" = "authorizationGroups".uuid
+				LEFT JOIN notes ON notes.uuid = "noteRelatedObjects"."noteUuid"
+				GROUP BY "authorizationGroups".uuid
+				WITH DATA;
+			CREATE UNIQUE INDEX "UQ_mv_fts_authorizationGroups_uuid" ON "mv_fts_authorizationGroups"(uuid);
+			CREATE INDEX "FT_mv_fts_authorizationGroups" ON "mv_fts_authorizationGroups" USING gin(full_text);
+			CREATE INDEX "TR_authorizationGroups_uuid" ON "mv_fts_authorizationGroups" USING gin(uuid gin_trgm_ops);
+
+			CREATE MATERIALIZED VIEW IF NOT EXISTS mv_fts_locations(uuid, full_text) AS
+				SELECT
+					locations.uuid,
+					locations.full_text
+					|| coalesce(tsvector_agg(notes.full_text), ''::tsvector)
+				FROM locations
+				LEFT JOIN "noteRelatedObjects" ON "noteRelatedObjects"."relatedObjectType" = 'locations'
+					AND "noteRelatedObjects"."relatedObjectUuid" = locations.uuid
+				LEFT JOIN notes ON notes.uuid = "noteRelatedObjects"."noteUuid"
+				GROUP BY locations.uuid
+				WITH DATA;
+			CREATE UNIQUE INDEX "UQ_mv_fts_locations_uuid" ON mv_fts_locations(uuid);
+			CREATE INDEX "FT_mv_fts_locations" ON mv_fts_locations USING gin(full_text);
+			CREATE INDEX "TR_locations_uuid" ON mv_fts_locations USING gin(uuid gin_trgm_ops);
+
+			CREATE MATERIALIZED VIEW IF NOT EXISTS mv_fts_organizations(uuid, full_text) AS
+				SELECT
+					organizations.uuid,
+					organizations.full_text
+					|| coalesce(tsvector_agg(notes.full_text), ''::tsvector)
+				FROM organizations
+				LEFT JOIN "noteRelatedObjects" ON "noteRelatedObjects"."relatedObjectType" = 'organizations'
+					AND "noteRelatedObjects"."relatedObjectUuid" = organizations.uuid
+				LEFT JOIN notes ON notes.uuid = "noteRelatedObjects"."noteUuid"
+				GROUP BY organizations.uuid
+				WITH DATA;
+			CREATE UNIQUE INDEX "UQ_mv_fts_organizations_uuid" ON mv_fts_organizations(uuid);
+			CREATE INDEX "FT_mv_fts_organizations" ON mv_fts_organizations USING gin(full_text);
+			CREATE INDEX "TR_organizations_uuid" ON mv_fts_organizations USING gin(uuid gin_trgm_ops);
+
+			CREATE MATERIALIZED VIEW IF NOT EXISTS mv_fts_people(uuid, full_text) AS
+				SELECT
+					people.uuid,
+					people.full_text
+					|| coalesce(tsvector_agg(positions.full_text), ''::tsvector)
+					|| coalesce(tsvector_agg(organizations.full_text), ''::tsvector)
+					|| coalesce(tsvector_agg(notes.full_text), ''::tsvector)
+				FROM people
+				LEFT JOIN positions ON positions."currentPersonUuid" = people.uuid
+				LEFT JOIN organizations ON organizations.uuid = positions."organizationUuid"
+				LEFT JOIN "noteRelatedObjects" ON "noteRelatedObjects"."relatedObjectType" = 'people'
+					AND "noteRelatedObjects"."relatedObjectUuid" = people.uuid
+				LEFT JOIN notes ON notes.uuid = "noteRelatedObjects"."noteUuid"
+				GROUP BY people.uuid
+				WITH DATA;
+			CREATE UNIQUE INDEX "UQ_mv_fts_people_uuid" ON mv_fts_people(uuid);
+			CREATE INDEX "FT_mv_fts_people" ON mv_fts_people USING gin(full_text);
+			CREATE INDEX "TR_people_uuid" ON mv_fts_people USING gin(uuid gin_trgm_ops);
+
+			CREATE MATERIALIZED VIEW IF NOT EXISTS mv_fts_positions(uuid, full_text) AS
+				SELECT
+					positions.uuid,
+					positions.full_text
+					|| coalesce(tsvector_agg(people.full_text), ''::tsvector)
+					|| coalesce(tsvector_agg(organizations.full_text), ''::tsvector)
+					|| coalesce(tsvector_agg(notes.full_text), ''::tsvector)
+				FROM positions
+				LEFT JOIN people ON people.uuid = positions."currentPersonUuid"
+				LEFT JOIN organizations ON organizations.uuid = positions."organizationUuid"
+				LEFT JOIN "noteRelatedObjects" ON "noteRelatedObjects"."relatedObjectType" = 'positions'
+					AND "noteRelatedObjects"."relatedObjectUuid" = positions.uuid
+				LEFT JOIN notes ON notes.uuid = "noteRelatedObjects"."noteUuid"
+				GROUP BY positions.uuid
+				WITH DATA;
+			CREATE UNIQUE INDEX "UQ_mv_fts_positions" ON mv_fts_positions(uuid);
+			CREATE INDEX "FT_mv_fts_positions" ON mv_fts_positions USING gin(full_text);
+			CREATE INDEX "TR_positions_uuid" ON mv_fts_positions USING gin(uuid gin_trgm_ops);
+
+			CREATE MATERIALIZED VIEW IF NOT EXISTS mv_fts_reports(uuid, full_text) AS
+				SELECT
+					reports.uuid,
+					reports.full_text
+					|| coalesce(tsvector_agg(notes.full_text), ''::tsvector)
+				FROM reports
+				LEFT JOIN "noteRelatedObjects" ON "noteRelatedObjects"."relatedObjectType" = 'reports'
+					AND "noteRelatedObjects"."relatedObjectUuid" = reports.uuid
+				LEFT JOIN notes ON notes.uuid = "noteRelatedObjects"."noteUuid"
+				GROUP BY reports.uuid
+				WITH DATA;
+			CREATE UNIQUE INDEX "UQ_mv_fts_reports_uuid" ON mv_fts_reports(uuid);
+			CREATE INDEX "FT_mv_fts_reports" ON mv_fts_reports USING gin(full_text);
+			CREATE INDEX "TR_reports_uuid" ON mv_fts_reports USING gin(uuid gin_trgm_ops);
+
+			CREATE MATERIALIZED VIEW IF NOT EXISTS mv_fts_tags(uuid, full_text) AS
+				SELECT
+					tags.uuid,
+					tags.full_text
+				FROM tags
+				GROUP BY tags.uuid
+				WITH DATA;
+			CREATE UNIQUE INDEX "UQ_mv_fts_tags" ON mv_fts_tags(uuid);
+			CREATE INDEX "FT_mv_fts_tags" ON mv_fts_tags USING gin(full_text);
+			CREATE INDEX "TR_tags_uuid" ON mv_fts_tags USING gin(uuid gin_trgm_ops);
+
+			CREATE MATERIALIZED VIEW IF NOT EXISTS mv_fts_tasks(uuid, full_text) AS
+				SELECT
+					tasks.uuid,
+					tasks.full_text
+					|| coalesce(tsvector_agg(notes.full_text), ''::tsvector)
+				FROM tasks
+				LEFT JOIN "noteRelatedObjects" ON "noteRelatedObjects"."relatedObjectType" = 'tasks'
+					AND "noteRelatedObjects"."relatedObjectUuid" = tasks.uuid
+				LEFT JOIN notes ON notes.uuid = "noteRelatedObjects"."noteUuid"
+				GROUP BY tasks.uuid
+				WITH DATA;
+			CREATE UNIQUE INDEX "UQ_mv_fts_tasks" ON mv_fts_tasks(uuid);
+			CREATE INDEX "FT_mv_fts_tasks" ON mv_fts_tasks USING gin(full_text);
+			CREATE INDEX "TR_tasks_uuid" ON mv_fts_tasks USING gin(uuid gin_trgm_ops);
+		</sql>
+		<!-- Rolling back is not useful anymore -->
+	</changeSet>
+
 </databaseChangeLog>

--- a/src/test/java/mil/dds/anet/test/resources/PersonResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/PersonResourceTest.java
@@ -226,8 +226,7 @@ public class PersonResourceTest extends AbstractResourceTest {
         .findFirst()).isNotEmpty();
 
     final OrganizationSearchQuery queryOrgs = new OrganizationSearchQuery();
-    // FIXME: decide what the search should do in both cases
-    queryOrgs.setText(DaoUtils.isPostgresql() ? "\"EF 1\" or \"EF 1.1\"" : "EF 1");
+    queryOrgs.setText("EF 1");
     queryOrgs.setType(OrganizationType.ADVISOR_ORG);
     final AnetBeanList<Organization> orgs = graphQLHelper.searchObjects(jack, "organizationList",
         "query", "OrganizationSearchQueryInput", "uuid shortName", queryOrgs,

--- a/src/test/java/mil/dds/anet/test/resources/PositionResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/PositionResourceTest.java
@@ -34,7 +34,6 @@ import mil.dds.anet.beans.search.PositionSearchSortBy;
 import mil.dds.anet.test.beans.OrganizationTest;
 import mil.dds.anet.test.beans.PositionTest;
 import mil.dds.anet.test.resources.utils.GraphQlResponse;
-import mil.dds.anet.utils.DaoUtils;
 import org.junit.jupiter.api.Test;
 
 public class PositionResourceTest extends AbstractResourceTest {
@@ -395,8 +394,7 @@ public class PositionResourceTest extends AbstractResourceTest {
 
     // Search by organization
     final OrganizationSearchQuery queryOrgs = new OrganizationSearchQuery();
-    // FIXME: decide what the search should do in both cases
-    queryOrgs.setText(DaoUtils.isPostgresql() ? "\"ef 1\" or \"ef 1.1\"" : "ef 1");
+    queryOrgs.setText("ef 1");
     queryOrgs.setType(OrganizationType.ADVISOR_ORG);
     final AnetBeanList<Organization> orgs = graphQLHelper.searchObjects(jack, "organizationList",
         "query", "OrganizationSearchQueryInput", ORGANIZATION_FIELDS, queryOrgs,

--- a/src/test/java/mil/dds/anet/test/resources/ReportsResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/ReportsResourceTest.java
@@ -627,8 +627,7 @@ public class ReportsResourceTest extends AbstractResourceTest {
 
     // Put billet in EF 1.1
     final OrganizationSearchQuery queryOrgs = new OrganizationSearchQuery();
-    // FIXME: decide what the search should do in both cases
-    queryOrgs.setText(DaoUtils.isPostgresql() ? "\"EF 1\" or \"EF 1.1\"" : "EF 1");
+    queryOrgs.setText("EF 1");
     queryOrgs.setType(OrganizationType.ADVISOR_ORG);
     final AnetBeanList<Organization> results = graphQLHelper.searchObjects(admin,
         "organizationList", "query", "OrganizationSearchQueryInput", ORGANIZATION_FIELDS, queryOrgs,
@@ -886,8 +885,7 @@ public class ReportsResourceTest extends AbstractResourceTest {
 
     // Search by direct organization
     OrganizationSearchQuery queryOrgs = new OrganizationSearchQuery();
-    // FIXME: decide what the search should do in both cases
-    queryOrgs.setText(DaoUtils.isPostgresql() ? "\"EF 1\" or \"EF 1.1\"" : "EF 1");
+    queryOrgs.setText("EF 1");
     queryOrgs.setType(OrganizationType.ADVISOR_ORG);
     AnetBeanList<Organization> orgs = graphQLHelper.searchObjects(jack, "organizationList", "query",
         "OrganizationSearchQueryInput", ORGANIZATION_FIELDS, queryOrgs,


### PR DESCRIPTION
Do so simple-minded preprocessing of the text input to turn it into word-prefixes AND'ed together.
Store English both stemmed ('anet' FTS config) and plain ('simple' FTS config) in the full-text index, non-English text only plain ('simple' FTS config), and search with both configs.
Also make sure full-text search clause is only added if there actually is something to search for (both for PostgreSQL and MS SQL).

### Release notes

Partially addresses NCI-Agency/anet#1969

#### User changes
- Full-text search against a server back-end using a PostgreSQL database should return more meaningful results.

#### Super User changes
- none

#### Admin changes
- none

#### System admin changes
- [ ] anet.yml needs change
- [x] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [x] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [x] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
