### PR TITLE
Remove unused headers from wdio test config

### DIFF
--- a/client/config/wdio.config.js
+++ b/client/config/wdio.config.js
@@ -100,9 +100,7 @@ const config = {
   //
   // A key-value store of headers to be added to every selenium request. Values must be strings. Type: Object
   // Default: None
-  headers: {
-    Authorization: "Basic ZXJpbjplcmlu"
-  },
+  // headers: {},
   //
   // Default timeout for all waitFor* commands.
   waitforTimeout: 10000,


### PR DESCRIPTION
Authorization during the wdio tests does not use the headers from the wdio config.