### PR TITLE
Correct pendingApprovalsOf

### DIFF
--- a/src/main/java/mil/dds/anet/search/AbstractReportSearcher.java
+++ b/src/main/java/mil/dds/anet/search/AbstractReportSearcher.java
@@ -162,7 +162,6 @@ public abstract class AbstractReportSearcher extends AbstractSearcher<Report, Re
     }
 
     if (query.getPendingApprovalOf() != null) {
-      qb.addWhereClause("reports.\"authorUuid\" != :approverUuid");
       qb.addWhereClause("reports.\"approvalStepUuid\" IN"
           + " (SELECT \"approvalStepUuid\" FROM approvers WHERE \"positionUuid\" IN"
           + " (SELECT uuid FROM positions WHERE \"currentPersonUuid\" = :approverUuid))");


### PR DESCRIPTION
### Release notes
Fix a bug that was not showing the reports of authors that are their own approvers in dashboard/search

related to #2901 and a remake of the prematurely closed #2988

#### User changes
- Approvers now see own reports pending their approvers in dashboard

#### System admin changes
- [ ] anet.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [ ] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
