### PR TITLE
Make JSON parsing more robust

### DIFF
--- a/client/src/components/RelatedObjectNoteModal.js
+++ b/client/src/components/RelatedObjectNoteModal.js
@@ -11,6 +11,7 @@ import { Field, Form, Formik } from "formik"
 import PropTypes from "prop-types"
 import React, { useState } from "react"
 import { Button, Modal } from "react-bootstrap"
+import utils from "utils"
 import * as yup from "yup"
 
 const RelatedObjectNoteModal = ({
@@ -44,7 +45,8 @@ const RelatedObjectNoteModal = ({
           submitForm
         }) => {
           const isJson = note.type !== NOTE_TYPE.FREE_TEXT
-          const jsonFields = isJson && note.text ? JSON.parse(note.text) : {}
+          const jsonFields =
+            isJson && note.text ? utils.parseJsonSafe(note.text) : {}
           const noteText = isJson ? jsonFields.text : note.text
           const typeName =
             note.type === NOTE_TYPE.PARTNER_ASSESSMENT ||

--- a/client/src/components/RelatedObjectNotes.js
+++ b/client/src/components/RelatedObjectNotes.js
@@ -88,7 +88,7 @@ const RelatedObjectNotes = ({
     )
     const partnerAssessmentsSummary = partnerAssessments.reduce(
       (counters, assessment) => {
-        const assessmentJson = JSON.parse(assessment.text)
+        const assessmentJson = utils.parseJsonSafe(assessment.text)
 
         questions.forEach(question => {
           if (!counters[question.id]) {
@@ -245,7 +245,8 @@ const RelatedObjectNotes = ({
               note.type !== NOTE_TYPE.ASSESSMENT &&
               (byMe || currentUser.isAdmin())
             const isJson = note.type !== NOTE_TYPE.FREE_TEXT
-            const jsonFields = isJson && note.text ? JSON.parse(note.text) : {}
+            const jsonFields =
+              isJson && note.text ? utils.parseJsonSafe(note.text) : {}
             const noteText = isJson
               ? jsonFields.text
               : parseHtmlWithLinkTo(note.text)

--- a/client/src/components/SavedSearchTable.js
+++ b/client/src/components/SavedSearchTable.js
@@ -2,6 +2,7 @@ import { SEARCH_OBJECT_TYPES } from "actions"
 import ReportCollection from "components/ReportCollection"
 import PropTypes from "prop-types"
 import React from "react"
+import utils from "utils"
 
 const SavedSearchTable = props => {
   const objType =
@@ -11,7 +12,7 @@ const SavedSearchTable = props => {
     return <em>No reports found</em>
   }
 
-  const query = JSON.parse(props.search.query)
+  const query = utils.parseJsonSafe(props.search.query)
   // Add default sorting (if not specified/saved in the query); see SEARCH_CONFIG in pages/Search.js
   query.sortBy = query.sortBy || "ENGAGEMENT_DATE"
   query.sortOrder = query.sortOrder || "DESC"

--- a/client/src/components/assessments/AssessmentResultsTable.js
+++ b/client/src/components/assessments/AssessmentResultsTable.js
@@ -11,6 +11,7 @@ import _isEmpty from "lodash/isEmpty"
 import PropTypes from "prop-types"
 import React, { useState } from "react"
 import { Button, Table } from "react-bootstrap"
+import utils from "utils"
 import "components/assessments/AssessmentResultsTable.css"
 
 /* The AssessmentResultsTable component displays the results of two types of
@@ -213,8 +214,8 @@ const EntityAssessmentResults = ({
   if (!entity) {
     return null
   }
-  const assessmentDefinition = JSON.parse(
-    JSON.parse(entity.customFields || "{}").assessmentDefinition || "{}"
+  const assessmentDefinition = utils.parseJsonSafe(
+    utils.parseJsonSafe(entity.customFields).assessmentDefinition
   )
   return (
     <>

--- a/client/src/models/Report.js
+++ b/client/src/models/Report.js
@@ -398,7 +398,7 @@ export default class Report extends Model {
           )[0].relatedObjectUuid
         ],
         assessmentUuid: ta.uuid,
-        assessment: JSON.parse(ta.text)
+        assessment: utils.parseJsonSafe(ta.text)
       }))
     // When updating the assessments, we need for each task the uuid of the related assessment
     const taskToAssessmentUuid = {}

--- a/client/src/models/Task.js
+++ b/client/src/models/Task.js
@@ -223,7 +223,7 @@ export default class Task extends Model {
           (!dateRange ||
             (n.createdAt <= dateRange.end && n.createdAt >= dateRange.start))
       )
-      .map(ta => JSON.parse(ta.text))
+      .map(ta => utils.parseJsonSafe(ta.text))
     const assessmentResults = {}
     taskAssessmentNotes.forEach(o =>
       Object.keys(o).forEach(k => {
@@ -249,7 +249,7 @@ export default class Task extends Model {
       .sort((a, b) => b.createdAt - a.createdAt) // desc sorted
       .map(ta => ({
         uuid: ta.uuid,
-        assessment: JSON.parse(ta.text)
+        assessment: utils.parseJsonSafe(ta.text)
       }))
     return notesToAssessments.length ? notesToAssessments[0].assessment : null
   }

--- a/client/src/pages/Home.js
+++ b/client/src/pages/Home.js
@@ -37,6 +37,7 @@ import { connect } from "react-redux"
 import { useHistory, useLocation } from "react-router-dom"
 import { deserializeQueryParams } from "searchUtils"
 import Settings from "settings"
+import utils from "utils"
 
 const GQL_GET_SAVED_SEARCHES = gql`
   query {
@@ -369,7 +370,7 @@ const SavedSearches = ({ setSearchQuery, pageDispatchers }) => {
   function showSearch() {
     if (selectedSearch) {
       const objType = SEARCH_OBJECT_TYPES[selectedSearch.objectType]
-      const queryParams = JSON.parse(selectedSearch.query)
+      const queryParams = utils.parseJsonSafe(selectedSearch.query)
       deserializeQueryParams(objType, queryParams, deserializeCallback)
     }
   }

--- a/client/src/pages/people/Edit.js
+++ b/client/src/pages/people/Edit.js
@@ -14,6 +14,7 @@ import moment from "moment"
 import React from "react"
 import { connect } from "react-redux"
 import { useParams } from "react-router-dom"
+import utils from "utils"
 import PersonForm from "./Form"
 
 const GQL_GET_PERSON = gql`
@@ -74,7 +75,7 @@ const PersonEdit = ({ pageDispatchers }) => {
     const parsedFullName = Person.parseFullName(data.person.name)
     data.person.firstName = parsedFullName.firstName
     data.person.lastName = parsedFullName.lastName
-    data.person.formCustomFields = JSON.parse(data.person.customFields)
+    data.person.formCustomFields = utils.parseJsonSafe(data.person.customFields)
   }
   const person = new Person(data ? data.person : {})
   const legendText = person.isNewUser()

--- a/client/src/pages/people/Show.js
+++ b/client/src/pages/people/Show.js
@@ -35,6 +35,7 @@ import { Button, Col, ControlLabel, FormGroup, Table } from "react-bootstrap"
 import { connect } from "react-redux"
 import { useLocation, useParams } from "react-router-dom"
 import Settings from "settings"
+import utils from "utils"
 import { parseHtmlWithLinkTo } from "utils_links"
 
 const GQL_GET_PERSON = gql`
@@ -119,7 +120,7 @@ const PersonShow = ({ pageDispatchers }) => {
     return result
   }
   if (data) {
-    data.person.formCustomFields = JSON.parse(data.person.customFields)
+    data.person.formCustomFields = utils.parseJsonSafe(data.person.customFields)
   }
   const person = new Person(data ? data.person : {})
   const stateSuccess = routerLocation.state && routerLocation.state.success

--- a/client/src/pages/reports/Edit.js
+++ b/client/src/pages/reports/Edit.js
@@ -13,6 +13,7 @@ import { Report } from "models"
 import React from "react"
 import { connect } from "react-redux"
 import { useParams } from "react-router-dom"
+import utils from "utils"
 import ReportForm from "./Form"
 
 const GQL_GET_REPORT = gql`
@@ -119,7 +120,7 @@ const ReportEdit = ({ pageDispatchers }) => {
       id: tag.uuid.toString(),
       text: tag.name
     }))
-    data.report.formCustomFields = JSON.parse(data.report.customFields)
+    data.report.formCustomFields = utils.parseJsonSafe(data.report.customFields)
   }
   const report = new Report(data ? data.report : {})
   const reportInitialValues = Object.assign(report, report.getTaskAssessments())

--- a/client/src/pages/reports/Form.js
+++ b/client/src/pages/reports/Form.js
@@ -334,10 +334,10 @@ const ReportForm = ({
   reportTasks
     .filter(t => t.customFields)
     .forEach(t => {
-      const taskCustomFields = JSON.parse(t.customFields)
+      const taskCustomFields = utils.parseJsonSafe(t.customFields)
       if (taskCustomFields?.assessmentDefinition) {
         taskAssessmentsSchemaShape[t.uuid] = createYupObjectShape(
-          JSON.parse(taskCustomFields.assessmentDefinition),
+          utils.parseJsonSafe(taskCustomFields.assessmentDefinition),
           `taskAssessments.${t.uuid}`
         )
       }
@@ -1075,11 +1075,13 @@ const ReportForm = ({
                   if (!task.customFields) {
                     return null
                   }
-                  const taskCustomFields = JSON.parse(task.customFields)
+                  const taskCustomFields = utils.parseJsonSafe(
+                    task.customFields
+                  )
                   if (!taskCustomFields?.assessmentDefinition) {
                     return null
                   }
-                  const taskAssessmentDefinition = JSON.parse(
+                  const taskAssessmentDefinition = utils.parseJsonSafe(
                     taskCustomFields.assessmentDefinition
                   )
                   return (

--- a/client/src/pages/reports/Show.js
+++ b/client/src/pages/reports/Show.js
@@ -301,7 +301,7 @@ const ReportShow = ({ setSearchQuery, pageDispatchers }) => {
       text: tag.name
     }))
     data.report.to = ""
-    data.report.formCustomFields = JSON.parse(data.report.customFields)
+    data.report.formCustomFields = utils.parseJsonSafe(data.report.customFields)
     report = new Report(data.report)
     try {
       Report.yupSchema.validateSync(report, { abortEarly: false })
@@ -662,11 +662,13 @@ const ReportShow = ({ setSearchQuery, pageDispatchers }) => {
                   if (!task.customFields) {
                     return null
                   }
-                  const taskCustomFields = JSON.parse(task.customFields)
+                  const taskCustomFields = utils.parseJsonSafe(
+                    task.customFields
+                  )
                   if (!taskCustomFields?.assessmentDefinition) {
                     return null
                   }
-                  const taskAssessmentDefinition = JSON.parse(
+                  const taskAssessmentDefinition = utils.parseJsonSafe(
                     taskCustomFields.assessmentDefinition
                   )
                   return (

--- a/client/src/pages/tasks/Edit.js
+++ b/client/src/pages/tasks/Edit.js
@@ -14,6 +14,7 @@ import React from "react"
 import { connect } from "react-redux"
 import { useParams } from "react-router-dom"
 import Settings from "settings"
+import utils from "utils"
 import TaskForm from "./Form"
 
 const GQL_GET_TASK = gql`
@@ -113,7 +114,7 @@ const TaskEdit = ({ pageDispatchers }) => {
     return result
   }
   if (data) {
-    data.task.formCustomFields = JSON.parse(data.task.customFields)
+    data.task.formCustomFields = utils.parseJsonSafe(data.task.customFields)
   }
   const task = new Task(data ? data.task : {})
 

--- a/client/src/pages/tasks/Show.js
+++ b/client/src/pages/tasks/Show.js
@@ -27,6 +27,7 @@ import React, { useContext } from "react"
 import { connect } from "react-redux"
 import { useLocation, useParams } from "react-router-dom"
 import Settings from "settings"
+import utils from "utils"
 import DictionaryField from "../../HOC/DictionaryField"
 
 const GQL_GET_TASK = gql`
@@ -160,11 +161,11 @@ const TaskShow = ({ pageDispatchers }) => {
   }
 
   if (data) {
-    data.task.formCustomFields = JSON.parse(data.task.customFields) // TODO: Maybe move this code to Task()
+    data.task.formCustomFields = utils.parseJsonSafe(data.task.customFields) // TODO: Maybe move this code to Task()
     data.task.notes.forEach(
       note =>
         note.type !== NOTE_TYPE.FREE_TEXT &&
-        (note.customFields = JSON.parse(note.text))
+        (note.customFields = utils.parseJsonSafe(note.text))
     ) // TODO: Maybe move this code to Task()
   }
   const task = new Task(data ? data.task : {})
@@ -175,7 +176,7 @@ const TaskShow = ({ pageDispatchers }) => {
       subTask.notes.forEach(
         note =>
           note.type !== NOTE_TYPE.FREE_TEXT &&
-          (note.customFields = JSON.parse(note.text))
+          (note.customFields = utils.parseJsonSafe(note.text))
       ) // TODO: Maybe move this code to Task()
       subTasks.push(new Task(subTask))
     })

--- a/client/src/utils.js
+++ b/client/src/utils.js
@@ -151,6 +151,17 @@ export default {
     } else {
       location.hash = hash
     }
+  },
+
+  parseJsonSafe: function(jsonString) {
+    // TODO: Improve error handling so that consuming widgets can display an error w/o crashing
+    let result
+    try {
+      result = JSON.parse(jsonString || "{}")
+    } catch (error) {
+      console.error(`unable to parse JSON: ${jsonString}`)
+    }
+    return typeof result === "object" ? result : {}
   }
 }
 


### PR DESCRIPTION
Log invalid JSON errors on the console, and always return either a parsed object (for correct JSON) or an empty object (for incorrect or absent JSON).