### PR TITLE
Make `jar` and `run` depend on buildClient

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -430,7 +430,8 @@ task dbMaintenance(dependsOn: 'compileJava', type: JavaExec) {
 	args cmdline
 }
 
-classes.dependsOn buildClient
+jar.dependsOn buildClient
+run.dependsOn buildClient
 
 //Configure the Java Checkstyle settings. Run with ./gradlew check
 checkstyle {


### PR DESCRIPTION
If `classes` depends on it, the CodeQL build action will also process all JS from our dependencies, which takes a long time and isn't helpful.