### PR TITLE
Log only the uuid for Person objects

### DIFF
--- a/src/main/java/mil/dds/anet/InitializationCommand.java
+++ b/src/main/java/mil/dds/anet/InitializationCommand.java
@@ -95,7 +95,7 @@ public class InitializationCommand extends EnvironmentCommand<AnetConfiguration>
     admin.setStatus(PersonStatus.ACTIVE);
     admin = engine.getPersonDao().insert(admin);
     engine.getPositionDao().setPersonInPosition(admin.getUuid(), adminPos.getUuid());
-    System.out.println("... Person " + admin.getUuid() + " Saved!");
+    System.out.println("... Person " + admin + " Saved!");
 
     // Set Default Approval Chain.
     System.out.println("Setting you as the default approver...");

--- a/src/main/java/mil/dds/anet/beans/Person.java
+++ b/src/main/java/mil/dds/anet/beans/Person.java
@@ -337,7 +337,8 @@ public class Person extends AbstractCustomizableAnetBean implements Principal, R
 
   @Override
   public String toString() {
-    return String.format("[uuid:%s, name:%s, emailAddress:%s]", uuid, name, emailAddress);
+    // Only use the uuid, no personal information
+    return String.format("[uuid:%s]", uuid);
   }
 
   public static Person createWithUuid(String uuid) {

--- a/src/main/java/mil/dds/anet/resources/LoggingResource.java
+++ b/src/main/java/mil/dds/anet/resources/LoggingResource.java
@@ -52,7 +52,7 @@ public class LoggingResource {
       final List<LogEntry> logEntries) {
     for (final LogEntry logEntry : logEntries) {
 
-      final String message = String.format("%1$s %2$s %3$s %4$s %5$s", user.getUuid(),
+      final String message = String.format("%1$s %2$s %3$s %4$s %5$s", user,
           requestContext.getRemoteAddr(), logEntry.url, logEntry.lineNr, logEntry.message);
 
       switch (logEntry.severity) {

--- a/src/main/java/mil/dds/anet/resources/PersonResource.java
+++ b/src/main/java/mil/dds/anet/resources/PersonResource.java
@@ -137,20 +137,20 @@ public class PersonResource {
         AuthUtils.assertSuperUser(user);
         AnetObjectEngine.getInstance().getPositionDao().setPersonInPosition(DaoUtils.getUuid(p),
             p.getPosition().getUuid());
-        AnetAuditLogger.log("Person {} put in position {}  by {}", p, p.getPosition(), user);
+        AnetAuditLogger.log("Person {} put in position {} by {}", p, p.getPosition(), user);
       } else if (existingPos != null
           && existingPos.getUuid().equals(p.getPosition().getUuid()) == false) {
         // Update the position for this person.
         AuthUtils.assertSuperUser(user);
         AnetObjectEngine.getInstance().getPositionDao().setPersonInPosition(DaoUtils.getUuid(p),
             p.getPosition().getUuid());
-        AnetAuditLogger.log("Person {} put in position {}  by {}", p, p.getPosition(), user);
+        AnetAuditLogger.log("Person {} put in position {} by {}", p, p.getPosition(), user);
       } else if (existingPos != null && p.getPosition().getUuid() == null) {
         // Remove this person from their position.
         AuthUtils.assertSuperUser(user);
         AnetObjectEngine.getInstance().getPositionDao()
             .removePersonFromPosition(existingPos.getUuid());
-        AnetAuditLogger.log("Person {} removed from position   by {}", p, user);
+        AnetAuditLogger.log("Person {} removed from position by {}", p, user);
       }
     }
 

--- a/src/main/java/mil/dds/anet/resources/PositionResource.java
+++ b/src/main/java/mil/dds/anet/resources/PositionResource.java
@@ -216,8 +216,7 @@ public class PositionResource {
       throw new WebApplicationException("Cannot delete an active position", Status.BAD_REQUEST);
     }
 
-    AnetAuditLogger.log("Position {} deleted by {} (uuid: {})", positionUuid, user.getName(),
-        user.getUuid());
+    AnetAuditLogger.log("Position {} deleted by {}", positionUuid, user);
 
     // if this position has any history, we'll just delete it
     // if this position is in an approval chain, we just delete it

--- a/src/main/java/mil/dds/anet/resources/ReportResource.java
+++ b/src/main/java/mil/dds/anet/resources/ReportResource.java
@@ -362,9 +362,8 @@ public class ReportResource {
         }
         break;
       case PUBLISHED:
-        AnetAuditLogger.log(
-            "attempt to edit published report {} by editor {} (uuid: {}) was forbidden",
-            report.getUuid(), editor.getName(), editor.getUuid());
+        AnetAuditLogger.log("attempt to edit published report {} by editor {} was forbidden",
+            report.getUuid(), editor);
         throw new WebApplicationException("Cannot edit a published report", Status.FORBIDDEN);
       default:
         throw new WebApplicationException("Unknown report state", Status.FORBIDDEN);
@@ -450,8 +449,7 @@ public class ReportResource {
       logger.info("Putting report {} into step {}", r.getUuid(), steps.get(0).getUuid());
     }
 
-    AnetAuditLogger.log("report {} submitted by author {} (uuid: {})", r.getUuid(),
-        r.loadAuthor(engine.getContext()).join(), r.getAuthorUuid());
+    AnetAuditLogger.log("report {} submitted by author {}", r.getUuid(), r.getAuthorUuid());
     // GraphQL mutations *have* to return something, we return the report
     return r;
   }
@@ -487,8 +485,8 @@ public class ReportResource {
         .canUserApproveStep(engine.getContext(), approver.getUuid(), step, r.getAdvisorOrgUuid())
         .join();
     if (!canApprove) {
-      logger.info("User UUID {} cannot approve report UUID {} for step UUID {}", approver.getUuid(),
-          r.getUuid(), step.getUuid());
+      logger.info("User {} cannot approve report UUID {} for step UUID {}", approver, r.getUuid(),
+          step.getUuid());
       throw new WebApplicationException("User cannot approve report", Status.FORBIDDEN);
     }
 
@@ -505,8 +503,7 @@ public class ReportResource {
       engine.getCommentDao().insert(comment1);
     }
 
-    AnetAuditLogger.log("Report {} approved by {} (uuid: {})", r.getUuid(), approver.getName(),
-        approver.getUuid());
+    AnetAuditLogger.log("Report {} approved by {}", r.getUuid(), approver);
     // GraphQL mutations *have* to return something
     return r;
   }
@@ -533,8 +530,8 @@ public class ReportResource {
           .canUserRejectStep(engine.getContext(), approver.getUuid(), step, r.getAdvisorOrgUuid())
           .join();
       if (!canReject) {
-        logger.info("User UUID {} cannot request changes to report UUID {} for step UUID {}",
-            approver.getUuid(), r.getUuid(), step.getUuid());
+        logger.info("User {} cannot request changes to report UUID {} for step UUID {}", approver,
+            r.getUuid(), step.getUuid());
         throw new WebApplicationException("User cannot request changes to report",
             Status.FORBIDDEN);
       }
@@ -566,8 +563,7 @@ public class ReportResource {
     engine.getCommentDao().insert(reason1);
 
     sendReportRejectEmail(r, approver, reason1);
-    AnetAuditLogger.log("report {} has requested changes by {} (uuid: {})", r.getUuid(),
-        approver.getName(), approver.getUuid());
+    AnetAuditLogger.log("report {} has requested changes by {}", r.getUuid(), approver);
     // GraphQL mutations *have* to return something
     return r;
   }
@@ -596,7 +592,7 @@ public class ReportResource {
 
     // Only admin may publish a report, and only for non future engagements
     if (!AuthUtils.isAdmin(user) || r.isFutureEngagement()) {
-      logger.info("User {} cannot publish report UUID {}", user.getUuid(), r.getUuid());
+      logger.info("User {} cannot publish report UUID {}", user, r.getUuid());
       throw new WebApplicationException("You cannot publish this report", Status.FORBIDDEN);
     }
 
@@ -605,7 +601,7 @@ public class ReportResource {
       throw new WebApplicationException("Couldn't process report publication", Status.NOT_FOUND);
     }
 
-    AnetAuditLogger.log("report {} published by admin UUID {}", r.getUuid(), user.getUuid());
+    AnetAuditLogger.log("report {} published by admin {}", r.getUuid(), user);
     // GraphQL mutations *have* to return something
     return r;
   }
@@ -670,8 +666,7 @@ public class ReportResource {
     }
 
     assertCanDeleteReport(report, user);
-    AnetAuditLogger.log("report {} deleted by {} (uuid: {})", reportUuid, user.getName(),
-        user.getUuid());
+    AnetAuditLogger.log("report {} deleted by {}", reportUuid, user);
 
     return dao.delete(reportUuid);
   }

--- a/src/test/java/mil/dds/anet/test/resources/ReportsResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/ReportsResourceTest.java
@@ -341,8 +341,8 @@ public class ReportsResourceTest extends AbstractResourceTest {
     } catch (BadRequestException expectedException) {
     }
 
-    logger.debug("Expecting report {} in step {} because of org {} on author {}", new Object[] {
-        returned.getUuid(), approval.getUuid(), advisorOrg.getUuid(), author.getUuid()});
+    logger.debug("Expecting report {} in step {} because of org {} on author {}",
+        new Object[] {returned.getUuid(), approval.getUuid(), advisorOrg.getUuid(), author});
     assertThat(returned.getApprovalStepUuid()).isEqualTo(approval.getUuid());
 
     // verify the location on this report


### PR DESCRIPTION
Prevent logging personally identifiable information by logging only the uuid for Person objects.

### Release notes

Closes NCI-Agency/anet#3140

#### User changes
- none

#### Super User changes
- none

#### Admin changes
- none

#### System admin changes
- (audit) logs will no longer contain name or email address when a Person is logged
- [ ] anet.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
