### PR TITLE
Improve and extend merge for positions object

### DIFF
--- a/client/src/components/CustomFields.js
+++ b/client/src/components/CustomFields.js
@@ -897,7 +897,7 @@ CustomFields.defaultProps = {
   vertical: false
 }
 
-export const READONLY_FIELD_COMPONENTS = {
+const READONLY_FIELD_COMPONENTS = {
   [CUSTOM_FIELD_TYPE.TEXT]: ReadonlyTextField,
   [CUSTOM_FIELD_TYPE.NUMBER]: ReadonlyTextField,
   [CUSTOM_FIELD_TYPE.DATE]: ReadonlyDateField,

--- a/client/src/components/CustomFields.js
+++ b/client/src/components/CustomFields.js
@@ -897,7 +897,7 @@ CustomFields.defaultProps = {
   vertical: false
 }
 
-const READONLY_FIELD_COMPONENTS = {
+export const READONLY_FIELD_COMPONENTS = {
   [CUSTOM_FIELD_TYPE.TEXT]: ReadonlyTextField,
   [CUSTOM_FIELD_TYPE.NUMBER]: ReadonlyTextField,
   [CUSTOM_FIELD_TYPE.DATE]: ReadonlyDateField,

--- a/client/src/components/EditHistory.css
+++ b/client/src/components/EditHistory.css
@@ -1,0 +1,3 @@
+.edit-history-dialog {
+  width: 90vw;
+}

--- a/client/src/components/EditHistory.js
+++ b/client/src/components/EditHistory.js
@@ -8,6 +8,7 @@ import PropTypes from "prop-types"
 import React, { useState } from "react"
 import { Col, Grid, Modal, Row } from "react-bootstrap"
 import Settings from "settings"
+import uuidv4 from "uuid/v4"
 import "./EditHistory.css"
 
 function EditHistory({
@@ -20,7 +21,9 @@ function EditHistory({
   title
 }) {
   const [showModal, setShowModal] = useState(false)
-  const [finalHistory, setFinalHistory] = useState(initialHistory || history1)
+  const [finalHistory, setFinalHistory] = useState(() =>
+    giveEachItemUuid(initialHistory || history1)
+  )
 
   return (
     <div
@@ -106,7 +109,7 @@ function EditHistory({
                           const endTimeFieldName = `history[${idx}].endTime`
 
                           return (
-                            <div key={`${item.startTime}-${item.endTime}`}>
+                            <div key={item.uuid}>
                               <Fieldset
                                 title={`${idx + 1}-) ${item[entityType].name}`}
                                 action={
@@ -212,7 +215,9 @@ function EditHistory({
               }
 
               function addItem(item) {
-                setValues({ history: [...values.history, item] })
+                setValues({
+                  history: [...values.history, { ...item, uuid: uuidv4() }]
+                })
               }
             }}
           </Formik>
@@ -224,11 +229,16 @@ function EditHistory({
   function onHide() {
     setShowModal(false)
     // Set the state to initial value
-    setFinalHistory(initialHistory || history1)
+    setFinalHistory(giveEachItemUuid(initialHistory || history1))
   }
 
   function onSave(values) {
-    setHistory(values.history)
+    // Shouldn't have uuid, that was for item listing
+    const savedHistory = values.history.map(item =>
+      Object.without(item, "uuid")
+    )
+    setHistory(savedHistory)
+    setFinalHistory(giveEachItemUuid(savedHistory))
     setShowModal(false)
   }
 }
@@ -281,4 +291,11 @@ function getStyle(index, overlapSet, invalidDatesSet) {
   } else if (overlapSet.has(index) && !invalidDatesSet.size) {
     return getOverlapWarningStyle()
   }
+}
+
+function giveEachItemUuid(history) {
+  return history.map(item => {
+    const newItem = { ...item, uuid: uuidv4() }
+    return newItem
+  })
 }

--- a/client/src/components/EditHistory.js
+++ b/client/src/components/EditHistory.js
@@ -1,0 +1,284 @@
+import { Button } from "@blueprintjs/core"
+import CustomDateInput from "components/CustomDateInput"
+import * as FieldHelper from "components/FieldHelper"
+import Fieldset from "components/Fieldset"
+import { Field, Form, Formik } from "formik"
+import { getOverlappingPeriodIndexes } from "periodUtils"
+import PropTypes from "prop-types"
+import React, { useState } from "react"
+import { Col, Grid, Modal, Row } from "react-bootstrap"
+import Settings from "settings"
+import "./EditHistory.css"
+
+function EditHistory({
+  history1,
+  history2,
+  initialHistory,
+  setHistory,
+  entityType,
+  historyComp: HistoryComp,
+  title
+}) {
+  const [showModal, setShowModal] = useState(false)
+  const [finalHistory, setFinalHistory] = useState(initialHistory || history1)
+
+  return (
+    <div
+      className="edit-history"
+      style={{ display: "flex", flexDirection: "column" }}
+    >
+      <Button intent="primary" onClick={() => setShowModal(true)}>
+        Edit History Manually
+      </Button>
+      <Modal
+        show={showModal}
+        onHide={onHide}
+        bsSize="lg"
+        dialogClassName="edit-history-dialog"
+      >
+        <Modal.Header closeButton>
+          <Modal.Title>{title}</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          <Formik
+            enableReinitialize
+            initialValues={{
+              history: finalHistory
+            }}
+          >
+            {({ values, setFieldValue, setValues }) => {
+              const overlapArrays = getOverlappingDateIndexes(values.history)
+              const uniqueOverlappingIndexes = new Set(overlapArrays.flat())
+              const invalidDateIndexes = new Set(
+                getInvalidDateIndexes(values.history)
+              )
+              return (
+                <Grid fluid>
+                  <Row>
+                    <Col sm={4}>
+                      <HistoryComp
+                        history={history1}
+                        action={(item, index) => (
+                          <Button
+                            onClick={() => addItem(item)}
+                            intent="primary"
+                          >
+                            Insert To End
+                          </Button>
+                        )}
+                      />
+                    </Col>
+                    <Col sm={history2 ? 4 : 8}>
+                      <Form className="form-horizontal">
+                        <div>
+                          {invalidDateIndexes.size ? (
+                            <fieldset style={getIvalidDateStyle()}>
+                              <legend>Invalid Date Ranges</legend>
+                              <ul>
+                                {Array.from(invalidDateIndexes).map(val => (
+                                  <li key={val}>
+                                    Item #{val + 1}'s start time is later than
+                                    end time
+                                  </li>
+                                ))}
+                              </ul>
+                            </fieldset>
+                          ) : null}
+                          {/* Don't even show overlaps if there are invalid date ranges */}
+                          {!invalidDateIndexes.size && overlapArrays.length ? (
+                            <fieldset style={getOverlapWarningStyle()}>
+                              <legend>Overlapping Items:</legend>
+                              <ul>
+                                {overlapArrays.map(o => (
+                                  <li key={`${o[0]}-${o[1]}`}>
+                                    Item #{o[0] + 1} overlaps with Item #
+                                    {o[1] + 1}
+                                  </li>
+                                ))}
+                              </ul>
+                            </fieldset>
+                          ) : null}
+                        </div>
+                        <h2 style={{ textAlign: "center" }}>Merged History</h2>
+                        {values.history.map((item, idx) => {
+                          // To be able to set fields inside the array state
+                          const startTimeFieldName = `history[${idx}].startTime`
+                          const endTimeFieldName = `history[${idx}].endTime`
+
+                          return (
+                            <div key={`${item.startTime}-${item.endTime}`}>
+                              <Fieldset
+                                title={`${idx + 1}-) ${item[entityType].name}`}
+                                action={
+                                  <Button
+                                    intent="danger"
+                                    onClick={() => removeItemFromHistory(idx)}
+                                  >
+                                    Remove From History
+                                  </Button>
+                                }
+                              />
+                              <div
+                                style={getStyle(
+                                  idx,
+                                  uniqueOverlappingIndexes,
+                                  invalidDateIndexes
+                                )}
+                              >
+                                <Field
+                                  name={startTimeFieldName}
+                                  label="Start Time"
+                                  value={values.history[idx].startTime}
+                                  onChange={value =>
+                                    setFieldValue(
+                                      startTimeFieldName,
+                                      value?.valueOf()
+                                    )
+                                  }
+                                  component={FieldHelper.SpecialField}
+                                  widget={
+                                    <CustomDateInput
+                                      id={startTimeFieldName}
+                                      withTime={
+                                        Settings.engagementsIncludeTimeAndDuration
+                                      }
+                                    />
+                                  }
+                                />
+                                <Field
+                                  name={endTimeFieldName}
+                                  label="End Time"
+                                  value={values.history[idx].endTime}
+                                  onChange={value =>
+                                    setFieldValue(
+                                      endTimeFieldName,
+                                      value?.valueOf()
+                                    )
+                                  }
+                                  component={FieldHelper.SpecialField}
+                                  widget={
+                                    <CustomDateInput
+                                      id={endTimeFieldName}
+                                      withTime={
+                                        Settings.engagementsIncludeTimeAndDuration
+                                      }
+                                    />
+                                  }
+                                />
+                              </div>
+                            </div>
+                          )
+                        })}
+                        <div className="submit-buttons">
+                          <div>
+                            <Button
+                              id="saveSearchModalSubmitButton"
+                              intent="primary"
+                              large
+                              onClick={() => onSave(values)}
+                              disabled={
+                                invalidDateIndexes.size || overlapArrays.length
+                              }
+                            >
+                              Save
+                            </Button>
+                          </div>
+                        </div>
+                      </Form>
+                    </Col>
+                    {history2 && (
+                      <Col sm={4}>
+                        <HistoryComp
+                          history={history2}
+                          action={(item, index) => (
+                            <Button
+                              onClick={() => addItem(item)}
+                              intent="primary"
+                            >
+                              Insert To End
+                            </Button>
+                          )}
+                        />
+                      </Col>
+                    )}
+                  </Row>
+                </Grid>
+              )
+
+              function removeItemFromHistory(idx) {
+                setValues({
+                  history: values.history.filter((item, index) => index !== idx)
+                })
+              }
+
+              function addItem(item) {
+                setValues({ history: [...values.history, item] })
+              }
+            }}
+          </Formik>
+        </Modal.Body>
+      </Modal>
+    </div>
+  )
+
+  function onHide() {
+    setShowModal(false)
+    // Set the state to initial value
+    setFinalHistory(initialHistory || history1)
+  }
+
+  function onSave(values) {
+    setHistory(values.history)
+    setShowModal(false)
+  }
+}
+
+EditHistory.propTypes = {
+  history1: PropTypes.array,
+  history2: PropTypes.array,
+  initialHistory: PropTypes.array,
+  setHistory: PropTypes.func,
+  entityType: PropTypes.string,
+  historyComp: PropTypes.func,
+  title: PropTypes.string
+}
+
+export default EditHistory
+
+// Returns indexes of the overlapping items
+function getOverlappingDateIndexes(history) {
+  // one of them falsy, we don't have overlapping
+  if (!history) {
+    return null
+  }
+
+  return getOverlappingPeriodIndexes(history)
+}
+
+function getInvalidDateIndexes(history) {
+  const invalidIndexes = []
+  history.forEach((item, index) => {
+    const endTime = item.endTime || Infinity
+    if (item.startTime >= endTime) {
+      invalidIndexes.push(index)
+    }
+  })
+
+  return invalidIndexes
+}
+
+function getOverlapWarningStyle() {
+  return { outline: "2px dashed orange" }
+}
+
+function getIvalidDateStyle() {
+  return { outline: "2px dashed red" }
+}
+
+function getStyle(index, overlapSet, invalidDatesSet) {
+  if (invalidDatesSet.has(index)) {
+    return getIvalidDateStyle()
+  } else if (overlapSet.has(index) && !invalidDatesSet.size) {
+    return getOverlapWarningStyle()
+  }
+}

--- a/client/src/components/MergeField.js
+++ b/client/src/components/MergeField.js
@@ -18,16 +18,15 @@ const MergeField = ({ label, value, align, action }) => {
 const MergeFieldBox = styled.div`
   display: flex;
   flex-direction: ${props => props.fDir};
-  justtify-content: space-between;
+  justify-content: space-between;
   align-items: center;
   padding: 8px 0;
-  height: 46px;
 `
 
 const LabelBox = styled.div`
   text-align: ${props => props.align};
   font-weight: bold;
-  text-decoratiın: underline;
+  text-decoration: underline;
 `
 
 MergeField.propTypes = {

--- a/client/src/components/MergeField.js
+++ b/client/src/components/MergeField.js
@@ -1,32 +1,34 @@
+import styled from "@emotion/styled"
 import PropTypes from "prop-types"
 import React from "react"
 
 const MergeField = ({ label, value, align, action }) => {
-  const flexDir = align === "right" ? "row-reverse" : "row"
+  const fDir = align === "right" ? "row-reverse" : "row"
   return (
-    <div style={{ ...FIELD_STYLE, flexDirection: flexDir }}>
+    <MergeFieldBox fDir={fDir}>
       <div style={{ flex: "1 1 auto" }}>
-        <div style={{ ...LABEL_STYLE, textAlign: align }}>{label}</div>
+        <LabelBox align={align}>{label}</LabelBox>
         <div style={{ textAlign: align }}>{value}</div>
       </div>
       {action}
-    </div>
+    </MergeFieldBox>
   )
 }
 
-const FIELD_STYLE = {
-  borderBottom: "1px solid #CCCCCC",
-  display: "flex",
-  justifyContent: "space-between",
-  alignItems: "center",
-  padding: "8px 0",
-  height: "46px"
-}
+const MergeFieldBox = styled.div`
+  display: flex;
+  flex-direction: ${props => props.fDir};
+  justtify-content: space-between;
+  align-items: center;
+  padding: 8px 0;
+  height: 46px;
+`
 
-const LABEL_STYLE = {
-  fontWeight: "bold",
-  textDecoration: "underline"
-}
+const LabelBox = styled.div`
+  text-align: ${props => props.align};
+  font-weight: bold;
+  text-decoratiın: underline;
+`
 
 MergeField.propTypes = {
   label: PropTypes.string.isRequired,

--- a/client/src/components/MergeField.js
+++ b/client/src/components/MergeField.js
@@ -1,0 +1,38 @@
+import PropTypes from "prop-types"
+import React from "react"
+
+const MergeField = ({ label, value, align, action }) => {
+  const flexDir = align === "right" ? "row-reverse" : "row"
+  return (
+    <div style={{ ...FIELD_STYLE, flexDirection: flexDir }}>
+      <div style={{ flex: "1 1 auto" }}>
+        <div style={{ ...LABEL_STYLE, textAlign: align }}>{label}</div>
+        <div style={{ textAlign: align }}>{value}</div>
+      </div>
+      {action}
+    </div>
+  )
+}
+
+const FIELD_STYLE = {
+  borderBottom: "1px solid #CCCCCC",
+  display: "flex",
+  justifyContent: "space-between",
+  alignItems: "center",
+  padding: "8px 0",
+  height: "46px"
+}
+
+const LABEL_STYLE = {
+  fontWeight: "bold",
+  textDecoration: "underline"
+}
+
+MergeField.propTypes = {
+  label: PropTypes.string.isRequired,
+  value: PropTypes.node,
+  align: PropTypes.string.isRequired,
+  action: PropTypes.node
+}
+
+export default MergeField

--- a/client/src/components/MergeField.js
+++ b/client/src/components/MergeField.js
@@ -8,7 +8,7 @@ const MergeField = ({ label, value, align, action }) => {
     <MergeFieldBox fDir={fDir}>
       <div style={{ flex: "1 1 auto" }}>
         <LabelBox align={align}>{label}</LabelBox>
-        <div style={{ textAlign: align }}>{value}</div>
+        <ValueBox align={align}>{value}</ValueBox>
       </div>
       {action}
     </MergeFieldBox>
@@ -21,6 +21,7 @@ const MergeFieldBox = styled.div`
   justify-content: space-between;
   align-items: center;
   padding: 8px 0;
+  height: 50px;
 `
 
 const LabelBox = styled.div`
@@ -28,11 +29,23 @@ const LabelBox = styled.div`
   font-weight: bold;
   text-decoration: underline;
 `
+const ALIGN_TO_JUSTIFY = {
+  center: "center",
+  left: "flex-start",
+  right: "flex-end"
+}
+
+const ValueBox = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: ${props => ALIGN_TO_JUSTIFY[props.align]};
+  align-items: center;
+`
 
 MergeField.propTypes = {
   label: PropTypes.string.isRequired,
   value: PropTypes.node,
-  align: PropTypes.string.isRequired,
+  align: PropTypes.oneOf(["left", "right", "center"]).isRequired,
   action: PropTypes.node
 }
 

--- a/client/src/components/MergeField.js
+++ b/client/src/components/MergeField.js
@@ -2,10 +2,10 @@ import styled from "@emotion/styled"
 import PropTypes from "prop-types"
 import React from "react"
 
-const MergeField = ({ label, value, align, action }) => {
+const MergeField = ({ label, value, align, action, customStyle }) => {
   const fDir = align === "right" ? "row-reverse" : "row"
   return (
-    <MergeFieldBox fDir={fDir}>
+    <MergeFieldBox fDir={fDir} customStyle={customStyle}>
       <div style={{ flex: "1 1 auto" }}>
         <LabelBox align={align}>{label}</LabelBox>
         <ValueBox align={align}>{value}</ValueBox>
@@ -22,6 +22,7 @@ const MergeFieldBox = styled.div`
   align-items: center;
   padding: 8px 0;
   height: 50px;
+  ${props => props.customStyle};
 `
 
 const LabelBox = styled.div`
@@ -46,7 +47,8 @@ MergeField.propTypes = {
   label: PropTypes.string.isRequired,
   value: PropTypes.node,
   align: PropTypes.oneOf(["left", "right", "center"]).isRequired,
-  action: PropTypes.node
+  action: PropTypes.node,
+  customStyle: PropTypes.string
 }
 
 export default MergeField

--- a/client/src/components/MergeField.js
+++ b/client/src/components/MergeField.js
@@ -13,7 +13,7 @@ const MergeField = ({
   dispatchMergeActions
 }) => {
   const fieldRef = useRef(null)
-  const [updated, setUpdated] = useState(false)
+  const [height, setSetHeight] = useState("auto")
 
   useEffect(() => {
     // We have more than one columns of fields, each field should have same height
@@ -23,9 +23,10 @@ const MergeField = ({
       const savedHeight = mergeState.heightMap?.[fieldName] || 0
       if (savedHeight < currentHeight) {
         dispatchMergeActions(setHeightOfAField(fieldName, currentHeight))
+        setSetHeight("auto")
       } else if (savedHeight > currentHeight) {
         // if some other column field height is bigger, we update small ui
-        setUpdated(true)
+        setSetHeight(`${savedHeight}px`)
       }
     }
     return () => {}
@@ -38,7 +39,7 @@ const MergeField = ({
       /* We first let its height be auto to get the natural height */
       /* If it is bigger than already existing one's height in the other column */
       /* we set other field to this height in useEffect */
-      fieldHeight={updated ? `${mergeState.heightMap[fieldName]}px` : "auto"}
+      fieldHeight={`${height}`}
     >
       <div style={{ flex: "1 1 auto" }}>
         <LabelBox align={align}>{label}</LabelBox>

--- a/client/src/components/MergeField.js
+++ b/client/src/components/MergeField.js
@@ -31,10 +31,9 @@ const MergeField = ({
     return () => {}
   }, [fieldName, mergeState, dispatchMergeActions])
 
-  const fDir = align === "right" ? "row-reverse" : "row"
   return (
     <MergeFieldBox
-      fDir={fDir}
+      align={align}
       ref={fieldRef}
       /* We first let its height be auto to get the natural height */
       /* If it is bigger than already existing one's height in the other column */
@@ -50,9 +49,30 @@ const MergeField = ({
   )
 }
 
+const ROW_DIRECTION = {
+  column: "row",
+  right: "row-reverse",
+  left: "row",
+  center: "row"
+}
+
+const FLEX_DIRECTION = {
+  column: "column",
+  right: "row",
+  left: "row",
+  center: "row"
+}
+
+const TEXT_ALIGN = {
+  right: "right",
+  left: "left",
+  center: "center",
+  column: "center"
+}
+
 const MergeFieldBox = styled.div`
   display: flex;
-  flex-direction: ${props => props.fDir};
+  flex-direction: ${props => ROW_DIRECTION[props.align]};
   justify-content: space-between;
   align-items: center;
   padding: 8px 0;
@@ -60,7 +80,7 @@ const MergeFieldBox = styled.div`
 `
 
 const LabelBox = styled.div`
-  text-align: ${props => props.align};
+  text-align: ${props => TEXT_ALIGN[props.align]};
   font-weight: bold;
   text-decoration: underline;
 `
@@ -72,7 +92,7 @@ const ALIGN_TO_JUSTIFY = {
 
 const ValueBox = styled.div`
   display: flex;
-  flex-direction: row;
+  flex-direction: ${props => FLEX_DIRECTION[props.align]};
   justify-content: ${props => ALIGN_TO_JUSTIFY[props.align]};
   align-items: center;
 `
@@ -81,7 +101,7 @@ MergeField.propTypes = {
   label: PropTypes.string.isRequired,
   fieldName: PropTypes.string.isRequired,
   value: PropTypes.node,
-  align: PropTypes.oneOf(["left", "right", "center"]).isRequired,
+  align: PropTypes.oneOf(["left", "right", "center", "column"]).isRequired,
   action: PropTypes.node,
   mergeState: PropTypes.object,
   dispatchMergeActions: PropTypes.func

--- a/client/src/components/MergeField.js
+++ b/client/src/components/MergeField.js
@@ -1,33 +1,35 @@
 import styled from "@emotion/styled"
+import { setHeightOfAField } from "mergeUtils"
 import PropTypes from "prop-types"
 import React, { useEffect, useRef, useState } from "react"
 
 const MergeField = ({
   label,
+  fieldName,
   value,
   align,
   action,
-  mergeFieldHeights,
-  setMergeFieldHeights
+  mergeState,
+  dispatchMergeActions
 }) => {
   const fieldRef = useRef(null)
   const [updated, setUpdated] = useState(false)
 
   useEffect(() => {
-    // We have more than one columns of fields, each field should have same height, we use label to search for previously set value
+    // We have more than one columns of fields, each field should have same height
     // if a column has bigger height, that height wins
     if (fieldRef.current) {
       const currentHeight = fieldRef.current.clientHeight
-      const savedHeight = mergeFieldHeights?.[label] || 0
+      const savedHeight = mergeState.heightMap?.[fieldName] || 0
       if (savedHeight < currentHeight) {
-        setMergeFieldHeights({ ...mergeFieldHeights, [label]: currentHeight })
+        dispatchMergeActions(setHeightOfAField(fieldName, currentHeight))
       } else if (savedHeight > currentHeight) {
         // if some other column field height is bigger, we update small ui
         setUpdated(true)
       }
     }
     return () => {}
-  }, [label, mergeFieldHeights, setMergeFieldHeights])
+  }, [fieldName, mergeState, dispatchMergeActions])
 
   const fDir = align === "right" ? "row-reverse" : "row"
   return (
@@ -35,7 +37,9 @@ const MergeField = ({
       fDir={fDir}
       ref={fieldRef}
       /* We first let its height be auto to get the natural height */
-      fieldHeight={updated ? `${mergeFieldHeights[label]}px` : "auto"}
+      /* If it is bigger than already existing one's height in the other column */
+      /* we set other field to this height in useEffect */
+      fieldHeight={updated ? `${mergeState.heightMap[fieldName]}px` : "auto"}
     >
       <div style={{ flex: "1 1 auto" }}>
         <LabelBox align={align}>{label}</LabelBox>
@@ -75,11 +79,12 @@ const ValueBox = styled.div`
 
 MergeField.propTypes = {
   label: PropTypes.string.isRequired,
+  fieldName: PropTypes.string.isRequired,
   value: PropTypes.node,
   align: PropTypes.oneOf(["left", "right", "center"]).isRequired,
   action: PropTypes.node,
-  mergeFieldHeights: PropTypes.object,
-  setMergeFieldHeights: PropTypes.func
+  mergeState: PropTypes.object,
+  dispatchMergeActions: PropTypes.func
 }
 
 export default MergeField

--- a/client/src/components/MergeField.js
+++ b/client/src/components/MergeField.js
@@ -14,7 +14,7 @@ const MergeField = ({
   const [updated, setUpdated] = useState(false)
 
   useEffect(() => {
-    // We have 3 columns of fields, each field should have same height, we use label to search for previously set value
+    // We have more than one columns of fields, each field should have same height, we use label to search for previously set value
     // if a column has bigger height, that height wins
     if (fieldRef.current) {
       const currentHeight = fieldRef.current.clientHeight

--- a/client/src/components/Model.js
+++ b/client/src/components/Model.js
@@ -153,14 +153,39 @@ export const CUSTOM_FIELD_TYPE = {
   ARRAY_OF_ANET_OBJECTS: "array_of_anet_objects"
 }
 
+export const CUSTOM_FIELD_TYPE_DEFAULTS = {
+  [CUSTOM_FIELD_TYPE.TEXT]: "",
+  [CUSTOM_FIELD_TYPE.NUMBER]: null,
+  [CUSTOM_FIELD_TYPE.DATE]: null,
+  [CUSTOM_FIELD_TYPE.DATETIME]: null,
+  [CUSTOM_FIELD_TYPE.JSON]: null,
+  [CUSTOM_FIELD_TYPE.ENUM]: "",
+  [CUSTOM_FIELD_TYPE.ENUMSET]: [],
+  [CUSTOM_FIELD_TYPE.ARRAY_OF_OBJECTS]: [],
+  [CUSTOM_FIELD_TYPE.SPECIAL_FIELD]: null,
+  [CUSTOM_FIELD_TYPE.ANET_OBJECT]: null,
+  [CUSTOM_FIELD_TYPE.ARRAY_OF_ANET_OBJECTS]: []
+}
+
 const CUSTOM_FIELD_TYPE_SCHEMA = {
-  [CUSTOM_FIELD_TYPE.TEXT]: yup.string().nullable().default(""),
-  [CUSTOM_FIELD_TYPE.NUMBER]: yup.number().nullable().default(null).typeError(
-    // eslint-disable-next-line no-template-curly-in-string
-    "${path} must be a ${type} type, but the final value was ${originalValue}"
-  ),
-  [CUSTOM_FIELD_TYPE.DATE]: yupDate.nullable().default(null),
-  [CUSTOM_FIELD_TYPE.DATETIME]: yupDate.nullable().default(null),
+  [CUSTOM_FIELD_TYPE.TEXT]: yup
+    .string()
+    .nullable()
+    .default(CUSTOM_FIELD_TYPE_DEFAULTS[CUSTOM_FIELD_TYPE.TEXT]),
+  [CUSTOM_FIELD_TYPE.NUMBER]: yup
+    .number()
+    .nullable()
+    .default(CUSTOM_FIELD_TYPE_DEFAULTS[CUSTOM_FIELD_TYPE.NUMBER])
+    .typeError(
+      // eslint-disable-next-line no-template-curly-in-string
+      "${path} must be a ${type} type, but the final value was ${originalValue}"
+    ),
+  [CUSTOM_FIELD_TYPE.DATE]: yupDate
+    .nullable()
+    .default(CUSTOM_FIELD_TYPE_DEFAULTS[CUSTOM_FIELD_TYPE.DATE]),
+  [CUSTOM_FIELD_TYPE.DATETIME]: yupDate
+    .nullable()
+    .default(CUSTOM_FIELD_TYPE_DEFAULTS[CUSTOM_FIELD_TYPE.DATETIME]),
   [CUSTOM_FIELD_TYPE.JSON]: yup
     .mixed()
     .nullable()
@@ -174,13 +199,33 @@ const CUSTOM_FIELD_TYPE_SCHEMA = {
           : this.createError({ message: "Invalid JSON" })
       }
     )
-    .default(null),
-  [CUSTOM_FIELD_TYPE.ENUM]: yup.string().nullable().default(""),
-  [CUSTOM_FIELD_TYPE.ENUMSET]: yup.array().nullable().default([]),
-  [CUSTOM_FIELD_TYPE.ARRAY_OF_OBJECTS]: yup.array().nullable().default([]),
-  [CUSTOM_FIELD_TYPE.SPECIAL_FIELD]: yup.mixed().nullable().default(null),
-  [CUSTOM_FIELD_TYPE.ANET_OBJECT]: yup.mixed().nullable().default(null),
-  [CUSTOM_FIELD_TYPE.ARRAY_OF_ANET_OBJECTS]: yup.array().nullable().default([])
+    .default(CUSTOM_FIELD_TYPE_DEFAULTS[CUSTOM_FIELD_TYPE.JSON]),
+  [CUSTOM_FIELD_TYPE.ENUM]: yup
+    .string()
+    .nullable()
+    .default(CUSTOM_FIELD_TYPE_DEFAULTS[CUSTOM_FIELD_TYPE.ENUM]),
+  [CUSTOM_FIELD_TYPE.ENUMSET]: yup
+    .array()
+    .nullable()
+    .default(CUSTOM_FIELD_TYPE_DEFAULTS[CUSTOM_FIELD_TYPE.ENUMSET]),
+  [CUSTOM_FIELD_TYPE.ARRAY_OF_OBJECTS]: yup
+    .array()
+    .nullable()
+    .default(CUSTOM_FIELD_TYPE_DEFAULTS[CUSTOM_FIELD_TYPE.ARRAY_OF_OBJECTS]),
+  [CUSTOM_FIELD_TYPE.SPECIAL_FIELD]: yup
+    .mixed()
+    .nullable()
+    .default(CUSTOM_FIELD_TYPE_DEFAULTS[CUSTOM_FIELD_TYPE.SPECIAL_FIELD]),
+  [CUSTOM_FIELD_TYPE.ANET_OBJECT]: yup
+    .mixed()
+    .nullable()
+    .default(CUSTOM_FIELD_TYPE_DEFAULTS[CUSTOM_FIELD_TYPE.ANET_OBJECT]),
+  [CUSTOM_FIELD_TYPE.ARRAY_OF_ANET_OBJECTS]: yup
+    .array()
+    .nullable()
+    .default(
+      CUSTOM_FIELD_TYPE_DEFAULTS[CUSTOM_FIELD_TYPE.ARRAY_OF_ANET_OBJECTS]
+    )
 }
 
 const createFieldYupSchema = (fieldKey, fieldConfig, parentFieldName) => {

--- a/client/src/components/Nav.js
+++ b/client/src/components/Nav.js
@@ -222,6 +222,9 @@ const Nav = ({
           <LinkContainer to="/admin/mergePeople" onClick={resetPages}>
             <NavItem>Merge people</NavItem>
           </LinkContainer>
+          <LinkContainer to="/admin/mergePositions" onClick={resetPages}>
+            <NavItem>Merge positions</NavItem>
+          </LinkContainer>
           <LinkContainer to="/admin/authorizationGroups" onClick={resetPages}>
             <NavItem>Authorization groups</NavItem>
           </LinkContainer>

--- a/client/src/mergeUtils.js
+++ b/client/src/mergeUtils.js
@@ -127,7 +127,12 @@ export function unassignedPerson(position1, position2, mergedPosition) {
 }
 
 export function areAllSet(...args) {
-  return args.every(item => item && !_isEmpty(item))
+  return args.every(item => {
+    if (typeof item === "boolean") {
+      return item
+    }
+    return !_isEmpty(item)
+  })
 }
 
 export function getInfoButton(infoText) {

--- a/client/src/mergeUtils.js
+++ b/client/src/mergeUtils.js
@@ -1,0 +1,176 @@
+import { Button, Tooltip } from "@blueprintjs/core"
+import Leaflet from "components/Leaflet"
+import * as L from "leaflet"
+import _escape from "lodash/escape"
+import { Location } from "models"
+import React, { useState } from "react"
+import { toast } from "react-toastify"
+
+const useMergeValidation = (
+  initMergeable1 = null,
+  initMergeable2 = null,
+  initMergedState = null,
+  mergeableType = "value"
+) => {
+  const [mergeable1, setMergeable1] = useState(initMergeable1)
+  const [mergeable2, setMergeable2] = useState(initMergeable2)
+  const [merged, setMerged] = useState(initMergedState)
+
+  function createStateSetter(mergeableNumber) {
+    let other
+    let setMergeable
+
+    if (mergeableNumber === 1) {
+      other = mergeable2
+      setMergeable = setMergeable1
+    } else if (mergeableNumber === 2) {
+      other = mergeable1
+      setMergeable = setMergeable2
+    } else {
+      throw new Error("Pass a valid mergeable number")
+    }
+
+    return function setValidState(newMergeable) {
+      // One of them being nullish means first time selecting or removing of a selection (which should always happen)
+      // Only validate if both set
+      if (other && newMergeable) {
+        // Validations applicable to all types
+        if (sameMergeable(other, newMergeable)) {
+          toast(`Please select a different ${mergeableType}`)
+          return
+        }
+        // Type specific validations
+        if (mergeableType === "position") {
+          if (!validPositions(other, newMergeable)) {
+            return
+          }
+        }
+      }
+      setMergeable(newMergeable)
+      setMerged(initMergedState) // merged state should reset when a mergeable changes
+    }
+  }
+
+  return [
+    [mergeable1, mergeable2, merged],
+    [createStateSetter(1), createStateSetter(2), setMerged]
+  ]
+}
+
+function validPositions(otherPos, newPos) {
+  if (!sameOrganization(otherPos, newPos)) {
+    toast("Please select two positions with the same organization")
+    return false
+  }
+  if (bothPosOccupied(otherPos, newPos)) {
+    toast("Please select at least one unoccupied position")
+    return false
+  }
+  return true
+}
+
+function sameMergeable(otherMergeable, newMergeable) {
+  return otherMergeable.uuid === newMergeable.uuid
+}
+
+function sameOrganization(otherMergeable, newMergeable) {
+  return otherMergeable.organization.uuid === newMergeable.organization.uuid
+}
+
+function bothPosOccupied(otherPos, newPos) {
+  return otherPos.person.uuid && newPos.person.uuid
+}
+
+export function areAllSet(...args) {
+  return args.every(item => item)
+}
+
+export function getInfoButton(infoText) {
+  return (
+    <Tooltip content={infoText} intent="primary">
+      <Button minimal icon="info-sign" intent="primary" />
+    </Tooltip>
+  )
+}
+
+export function getClearButton(onClear) {
+  return (
+    <Tooltip content="Clear field value" intent="danger">
+      <Button icon="delete" outlined intent="danger" onClick={onClear} />
+    </Tooltip>
+  )
+}
+
+export function getActivationButton(
+  isActive,
+  onClickAction,
+  mergeableType = "value"
+) {
+  return (
+    <Tooltip
+      content={
+        isActive ? `Deactivate ${mergeableType}` : `Activate ${mergeableType}`
+      }
+      intent={isActive ? "danger" : "success"}
+    >
+      <Button
+        icon={isActive ? "stop" : "play"}
+        outlined
+        intent={isActive ? "danger" : "success"}
+        onClick={onClickAction}
+      />
+    </Tooltip>
+  )
+}
+
+export function getActionButton(
+  onClickAction,
+  align,
+  disabled = false,
+  text = "Use value"
+) {
+  const icon = align === "right" ? "double-chevron-left" : ""
+  const rightIcon = align === "right" ? "" : "double-chevron-right"
+  return (
+    <small>
+      <Button
+        icon={icon}
+        rightIcon={rightIcon}
+        intent="primary"
+        text={text}
+        onClick={onClickAction}
+        disabled={disabled}
+        style={{ textAlign: "center" }}
+      />
+    </small>
+  )
+}
+// A workaround for "Map container is already initialized" error
+// Don't wait leaflet to set its id to null, do it here
+// FIXME: is there a better way?
+export function removePrevMapEarly(mapId) {
+  mapId = "map-" + mapId // to get map's real id, extra "map-" is added in the Leaflet
+  const map = L.DomUtil.get(mapId)
+  if (map) {
+    map._leaflet_id = null
+  }
+}
+
+export function getLeafletMap(mapId, location) {
+  removePrevMapEarly(mapId)
+  return (
+    <Leaflet
+      mapId={mapId}
+      markers={[
+        {
+          id: "marker-" + mapId,
+          name: _escape(location.name) || "", // escape HTML in location name!
+          lat: Location.hasCoordinates(location) ? location.lat : null,
+          lng: Location.hasCoordinates(location) ? location.lng : null
+        }
+      ]}
+    />
+  )
+}
+
+export default useMergeValidation

--- a/client/src/mergeUtils.js
+++ b/client/src/mergeUtils.js
@@ -101,6 +101,31 @@ function bothPosOccupied(otherPos, newPos) {
   return otherPos.person.uuid && newPos.person.uuid
 }
 
+export function unassignedPerson(position1, position2, mergedPosition) {
+  const msg = "You can't merge if a person is left unassigned"
+  // both positions having a person is validated in useMergeValidation, can't happen
+  // warn when one of them has it and merged doesn't
+  if (
+    // only position1 has it
+    !mergedPosition?.person?.uuid &&
+    position1?.person?.uuid &&
+    !position2?.person?.uuid
+  ) {
+    toast(msg)
+    return true
+  } else if (
+    // only position2 has it
+    !mergedPosition?.person?.uuid &&
+    !position1?.person?.uuid &&
+    position2?.person?.uuid
+  ) {
+    toast(msg)
+    return true
+  } else {
+    return false
+  }
+}
+
 export function areAllSet(...args) {
   return args.every(item => item && !_isEmpty(item))
 }

--- a/client/src/mergeUtils.js
+++ b/client/src/mergeUtils.js
@@ -66,7 +66,7 @@ const OBJECT_TYPE_TO_VALIDATOR = {
   [MODEL_TO_OBJECT_TYPE.Person]: null,
   [MODEL_TO_OBJECT_TYPE.Position]: validPositions,
   [MODEL_TO_OBJECT_TYPE.Report]: null,
-  [MODEL_TO_OBJECT_TYPE.Task]: null
+  [MODEL_TO_OBJECT_TYPE.Task]: validTasks
 }
 // validations for every type of objects
 function validForGeneral(otherMergeable, newMergeable, mergeableType) {
@@ -74,6 +74,10 @@ function validForGeneral(otherMergeable, newMergeable, mergeableType) {
     toast(`Please select different ${mergeableType}`)
     return false
   }
+  return true
+}
+// FIXME: validation steps for tasks
+function validTasks() {
   return true
 }
 
@@ -151,15 +155,11 @@ export function getClearButton(onClear) {
   )
 }
 
-export function getActivationButton(
-  isActive,
-  onClickAction,
-  mergeableType = "value"
-) {
+export function getActivationButton(isActive, onClickAction, instanceName) {
   return (
     <Tooltip
       content={
-        isActive ? `Deactivate ${mergeableType}` : `Activate ${mergeableType}`
+        isActive ? `Deactivate ${instanceName}` : `Activate ${instanceName}`
       }
       intent={isActive ? "danger" : "success"}
     >

--- a/client/src/mergeUtils.js
+++ b/client/src/mergeUtils.js
@@ -1,7 +1,6 @@
 import { Button, Tooltip } from "@blueprintjs/core"
 import Leaflet from "components/Leaflet"
 import { MODEL_TO_OBJECT_TYPE } from "components/Model"
-import * as L from "leaflet"
 import _escape from "lodash/escape"
 import _isEmpty from "lodash/isEmpty"
 import { Location } from "models"
@@ -132,7 +131,7 @@ export function unassignedPerson(position1, position2, mergedPosition) {
 
 export function areAllSet(...args) {
   return args.every(item => {
-    if (typeof item === "boolean") {
+    if (typeof item !== "object") {
       return item
     }
     return !_isEmpty(item)
@@ -195,19 +194,8 @@ export function getActionButton(
     </small>
   )
 }
-// A workaround for "Map container is already initialized" error
-// Don't wait leaflet to set its id to null, do it here
-// FIXME: is there a better way?
-export function removePrevMapEarly(mapId) {
-  mapId = "map-" + mapId // to get map's real id, extra "map-" is added in the Leaflet
-  const map = L.DomUtil.get(mapId)
-  if (map) {
-    map._leaflet_id = null
-  }
-}
 
 export function getLeafletMap(mapId, location) {
-  removePrevMapEarly(mapId)
   return (
     <Leaflet
       mapId={mapId}

--- a/client/src/mergeUtils.js
+++ b/client/src/mergeUtils.js
@@ -15,6 +15,9 @@ import { toast } from "react-toastify"
 
 const MERGE_SIDES = ["left", "right"]
 
+export const getOtherSide = side =>
+  side === MERGE_SIDES[0] ? MERGE_SIDES[1] : MERGE_SIDES[0]
+
 const ACTIONS = {
   SET_MERGEABLE: 1,
   SELECT_ALL_FIELDS: 2,
@@ -281,7 +284,7 @@ export function getActionButton(
   mergeState,
   fieldName,
   disabled = false,
-  text = "Use value"
+  text = ""
 ) {
   const intent =
     mergeState?.selectedMap?.[fieldName] === align ? "success" : "primary"
@@ -330,12 +333,17 @@ function getInitialMapOfFieldNames(obj) {
     }
   }, {})
 
-  Object.keys(obj[DEFAULT_CUSTOM_FIELDS_PARENT]).reduce((accum, fieldName) => {
-    const combinedFieldName = `${DEFAULT_CUSTOM_FIELDS_PARENT}.${fieldName}`
-    accum[combinedFieldName] = null
-    return accum
-  }, map)
-
+  // if it has custom fields, we should initialize those as well
+  if (obj[DEFAULT_CUSTOM_FIELDS_PARENT]) {
+    Object.keys(obj[DEFAULT_CUSTOM_FIELDS_PARENT]).reduce(
+      (accum, fieldName) => {
+        const combinedFieldName = `${DEFAULT_CUSTOM_FIELDS_PARENT}.${fieldName}`
+        accum[combinedFieldName] = null
+        return accum
+      },
+      map
+    )
+  }
   return map
 }
 

--- a/client/src/mergeUtils.js
+++ b/client/src/mergeUtils.js
@@ -92,7 +92,6 @@ function reducer(state, action) {
     case ACTIONS.SELECT_ALL_FIELDS: {
       const newState = { ...state, merged: action.payload.data }
       if (state.selectedMap) {
-        console.log(state.selectedMap)
         // Since we selected everything from one side, selectedMap should point to that side
         Object.keys(state.selectedMap).forEach(fieldName => {
           newState.selectedMap[fieldName] = action.payload.side

--- a/client/src/mergeUtils.js
+++ b/client/src/mergeUtils.js
@@ -1,4 +1,5 @@
-import { Button, Tooltip } from "@blueprintjs/core"
+import { Button } from "@blueprintjs/core"
+import { Tooltip2 } from "@blueprintjs/popover2"
 import Leaflet from "components/Leaflet"
 import { MODEL_TO_OBJECT_TYPE } from "components/Model"
 import _escape from "lodash/escape"
@@ -6,7 +7,6 @@ import _isEmpty from "lodash/isEmpty"
 import { Location } from "models"
 import React, { useState } from "react"
 import { toast } from "react-toastify"
-
 const useMergeValidation = (
   initMergeable1 = {},
   initMergeable2 = {},
@@ -140,23 +140,23 @@ export function areAllSet(...args) {
 
 export function getInfoButton(infoText) {
   return (
-    <Tooltip content={infoText} intent="primary">
+    <Tooltip2 content={infoText} intent="primary">
       <Button minimal icon="info-sign" intent="primary" />
-    </Tooltip>
+    </Tooltip2>
   )
 }
 
 export function getClearButton(onClear) {
   return (
-    <Tooltip content="Clear field value" intent="danger">
+    <Tooltip2 content="Clear field value" intent="danger">
       <Button icon="delete" outlined intent="danger" onClick={onClear} />
-    </Tooltip>
+    </Tooltip2>
   )
 }
 
 export function getActivationButton(isActive, onClickAction, instanceName) {
   return (
-    <Tooltip
+    <Tooltip2
       content={
         isActive ? `Deactivate ${instanceName}` : `Activate ${instanceName}`
       }
@@ -168,7 +168,7 @@ export function getActivationButton(isActive, onClickAction, instanceName) {
         intent={isActive ? "danger" : "success"}
         onClick={onClickAction}
       />
-    </Tooltip>
+    </Tooltip2>
   )
 }
 

--- a/client/src/mergeUtils.js
+++ b/client/src/mergeUtils.js
@@ -211,4 +211,21 @@ export function getLeafletMap(mapId, location) {
   )
 }
 
+export function customStyleForLargeFields(fieldConfig) {
+  switch (fieldConfig?.type) {
+    case "array":
+      return "height: 100px;"
+    case "array_of_anet_objects":
+      return "height: 120px;"
+    case "array_of_objects":
+      return "height: 120px;"
+    case "enumset":
+      return "height: 80px;"
+    case "json":
+      return "height: 120px;"
+    default:
+      return ""
+  }
+}
+
 export default useMergeValidation

--- a/client/src/mergeUtils.js
+++ b/client/src/mergeUtils.js
@@ -107,7 +107,7 @@ function reducer(state, action) {
     }
     case ACTIONS.SET_A_MERGED_FIELD: {
       const newState = { ...state }
-      newState.merged = _cloneDeep(state.merged)
+      newState.merged = { ..._cloneDeep(state.merged) }
       _set(newState.merged, action.payload.fieldName, action.payload.data)
       newState.selectedMap = {
         ...state.selectedMap,
@@ -312,7 +312,7 @@ export function getLeafletMap(mapId, location) {
       markers={[
         {
           id: "marker-" + mapId,
-          name: _escape(location.name) || "", // escape HTML in location name!
+          name: _escape(location?.name) || "", // escape HTML in location name!
           lat: Location.hasCoordinates(location) ? location.lat : null,
           lng: Location.hasCoordinates(location) ? location.lng : null
         }

--- a/client/src/mergeUtils.js
+++ b/client/src/mergeUtils.js
@@ -7,7 +7,7 @@ import _isEmpty from "lodash/isEmpty"
 import { Location } from "models"
 import React, { useState } from "react"
 import { toast } from "react-toastify"
-const useMergeValidation = (
+const useMergeObjects = (
   initMergeable1 = {},
   initMergeable2 = {},
   initMergedState = {},
@@ -16,6 +16,7 @@ const useMergeValidation = (
   const [mergeable1, setMergeable1] = useState(initMergeable1)
   const [mergeable2, setMergeable2] = useState(initMergeable2)
   const [merged, setMerged] = useState(initMergedState)
+  const [mergeFieldHeights, setMergeFieldHeights] = useState({})
 
   const validForThatType = OBJECT_TYPE_TO_VALIDATOR[mergeableType]
   if (!validForThatType) {
@@ -54,7 +55,8 @@ const useMergeValidation = (
 
   return [
     [mergeable1, mergeable2, merged],
-    [createStateSetter(1), createStateSetter(2), setMerged]
+    [createStateSetter(1), createStateSetter(2), setMerged],
+    [mergeFieldHeights, setMergeFieldHeights]
   ]
 }
 // FIXME: Fill when ready
@@ -106,7 +108,7 @@ function bothPosOccupied(otherPos, newPos) {
 
 export function unassignedPerson(position1, position2, mergedPosition) {
   const msg = "You can't merge if a person is left unassigned"
-  // both positions having a person is validated in useMergeValidation, can't happen
+  // both positions having a person is validated in useMergeObjects, can't happen
   // warn when one of them has it and merged doesn't
   if (
     // only position1 has it
@@ -211,21 +213,4 @@ export function getLeafletMap(mapId, location) {
   )
 }
 
-export function customStyleForLargeFields(fieldConfig) {
-  switch (fieldConfig?.type) {
-    case "array":
-      return "height: 100px;"
-    case "array_of_anet_objects":
-      return "height: 120px;"
-    case "array_of_objects":
-      return "height: 120px;"
-    case "enumset":
-      return "height: 80px;"
-    case "json":
-      return "height: 120px;"
-    default:
-      return ""
-  }
-}
-
-export default useMergeValidation
+export default useMergeObjects

--- a/client/src/mergeUtils.js
+++ b/client/src/mergeUtils.js
@@ -7,6 +7,7 @@ import _isEmpty from "lodash/isEmpty"
 import { Location } from "models"
 import React, { useState } from "react"
 import { toast } from "react-toastify"
+
 const useMergeObjects = (
   initMergeable1 = {},
   initMergeable2 = {},

--- a/client/src/models/Position.js
+++ b/client/src/models/Position.js
@@ -106,6 +106,10 @@ export default class Position extends Model {
     return this.type === Position.TYPE.PRINCIPAL
   }
 
+  isActive() {
+    return this.status === Position.STATUS.ACTIVE
+  }
+
   toString() {
     return this.name
   }

--- a/client/src/models/Position.js
+++ b/client/src/models/Position.js
@@ -74,6 +74,60 @@ export default class Position extends Model {
 
   static autocompleteQueryWithNotes = `${this.autocompleteQuery} ${GRAPHQL_NOTES_FIELDS}`
 
+  static allFieldsQuery = `
+    uuid
+    name
+    type
+    status
+    code
+    organization {
+      uuid
+      shortName
+      longName
+      identificationCode
+    }
+    person {
+      uuid
+      name
+      rank
+      role
+      avatar(size: 32)
+    }
+    associatedPositions {
+      uuid
+      name
+      type
+      person {
+        uuid
+        name
+        rank
+        role
+        avatar(size: 32)
+      }
+      organization {
+        uuid
+        shortName
+      }
+    }
+    previousPeople {
+      startTime
+      endTime
+      person {
+        uuid
+        name
+        rank
+        role
+        avatar(size: 32)
+      }
+    }
+    location {
+      uuid
+      name
+    }
+    customFields
+    ${GRAPHQL_NOTES_FIELDS}
+  `
+
   static humanNameOfStatus(status) {
     return utils.sentenceCase(status)
   }

--- a/client/src/models/Position.js
+++ b/client/src/models/Position.js
@@ -161,7 +161,11 @@ export default class Position extends Model {
   }
 
   isActive() {
-    return this.status === Position.STATUS.ACTIVE
+    return Position.isActive(this)
+  }
+
+  static isActive(pos) {
+    return pos.status === Position.STATUS.ACTIVE
   }
 
   toString() {

--- a/client/src/pages/Routing.js
+++ b/client/src/pages/Routing.js
@@ -5,6 +5,7 @@ import AuthorizationGroupShow from "pages/admin/authorizationgroup/Show"
 import AuthorizationGroups from "pages/admin/AuthorizationGroups"
 import AdminIndex from "pages/admin/Index"
 import MergePeople from "pages/admin/MergePeople"
+import MergePositions from "pages/admin/MergePositions"
 import BoardDashboard from "pages/dashboards/BoardDashboard"
 import DecisivesDashboard from "pages/dashboards/DecisivesDashboard"
 import KanbanDashboard from "pages/dashboards/KanbanDashboard"
@@ -130,6 +131,10 @@ const Routing = () => {
             <Switch>
               <Route exact path={`${url}/`} component={AdminIndex} />
               <Route path={`${url}/mergePeople`} component={MergePeople} />
+              <Route
+                path={`${url}/mergePositions`}
+                component={MergePositions}
+              />
               <Route
                 exact
                 path={`${url}/authorizationGroups`}

--- a/client/src/pages/admin/MergePositions.js
+++ b/client/src/pages/admin/MergePositions.js
@@ -202,7 +202,7 @@ const MergePositions = ({ pageDispatchers }) => {
                         : Position.STATUS.ACTIVE
                     )
                   },
-                  "position"
+                  Position.getInstanceName
                 )}
               />
               <PositionField

--- a/client/src/pages/admin/MergePositions.js
+++ b/client/src/pages/admin/MergePositions.js
@@ -157,14 +157,14 @@ const MergePositions = ({ pageDispatchers }) => {
               </Callout>
             </div>
           )}
-          {areAllSet(position1, position2, !mergedPosition?.name) && (
+          {areAllSet(position1, position2, !mergedPosition.name) && (
             <div style={{ padding: "16px 5%" }}>
               <Callout intent="primary">
                 Please choose a <strong>name</strong> to proceed...
               </Callout>
             </div>
           )}
-          {areAllSet(position1, position2, mergedPosition?.name) && (
+          {areAllSet(position1, position2, mergedPosition.name) && (
             <>
               <PositionField
                 label="Name"

--- a/client/src/pages/admin/MergePositions.js
+++ b/client/src/pages/admin/MergePositions.js
@@ -1,7 +1,8 @@
-import { gql } from "@apollo/client"
 import { Button, Callout } from "@blueprintjs/core"
+import styled from "@emotion/styled"
 import { DEFAULT_PAGE_PROPS, DEFAULT_SEARCH_PROPS } from "actions"
 import API from "api"
+import { gql } from "apollo-boost"
 import { PositionOverlayRow } from "components/advancedSelectWidget/AdvancedSelectOverlayRow"
 import AdvancedSingleSelect from "components/advancedSelectWidget/AdvancedSingleSelect"
 import PositionField from "components/MergeField"
@@ -37,6 +38,34 @@ const GQL_MERGE_POSITION = gql`
     }
   }
 `
+const POSITION_FIELDS = `
+  uuid,
+  name,
+  code,
+  type,
+  organization {
+    uuid,
+    shortName,
+    longName,
+    identificationCode
+  },
+  person {
+    uuid,
+    name,
+    rank,
+    role,
+    avatar(size: 32)
+  }
+`
+
+const positionsFilters = {
+  allAdvisorPositions: {
+    label: "All",
+    queryVars: {
+      status: Position.STATUS.ACTIVE
+    }
+  }
+}
 
 const MergePositions = ({ pageDispatchers }) => {
   const history = useHistory()
@@ -64,13 +93,12 @@ const MergePositions = ({ pageDispatchers }) => {
             position={position1}
             setPosition={setPosition1}
             setFieldValue={setFieldValue}
-            style={COLUMN_DIV_STYLE}
             align="left"
             label="Position 1"
           />
         </Col>
         <Col md={4}>
-          <div style={MID_COLUMN_TITLE_STYLE}>
+          <MidColTitle>
             {getActionButton(
               () => setAllFields(position1),
               "left",
@@ -84,7 +112,7 @@ const MergePositions = ({ pageDispatchers }) => {
               !areAllSet(position1, position2),
               "Use All"
             )}
-          </div>
+          </MidColTitle>
           {!areAllSet(position1, position2) && (
             <div style={{ padding: "16px 5%" }}>
               <Callout intent="warning">
@@ -194,7 +222,6 @@ const MergePositions = ({ pageDispatchers }) => {
             position={position2}
             setPosition={setPosition2}
             setFieldValue={setFieldValue}
-            style={COLUMN_DIV_STYLE}
             align="right"
             label="Position 2"
           />
@@ -282,42 +309,25 @@ MergePositions.propTypes = {
   pageDispatchers: PageDispatchersPropType
 }
 
-const COLUMN_DIV_STYLE = {
-  display: "flex",
-  flexDirection: "column",
-  justifyContent: "flex-start",
-  width: "100%"
-}
-
-const MID_COLUMN_TITLE_STYLE = {
-  height: "39px",
-  marginTop: "25px",
-  borderBottom: "1px solid #CCCCCC",
-  borderTop: "1px solid #CCCCCC",
-  display: "flex",
-  justifyContent: "space-between",
-  alignItems: "center"
-}
-
-const positionsFilters = {
-  allAdvisorPositions: {
-    label: "All",
-    queryVars: {
-      status: Position.STATUS.ACTIVE
-    }
-  }
-}
+const MidColTitle = styled.div`
+  display: flex;
+  height: 39px;
+  margin-top: 25px;
+  border-bottom: 1px solid #cccccc;
+  border-top: 1px solid #cccccc;
+  justify-content: space-between;
+  align-items: center;
+`
 
 const PositionColumn = ({
   position,
   setPosition,
   setFieldValue,
   align,
-  style,
   label
 }) => {
   return (
-    <div style={style}>
+    <PositionCol>
       {/* FIXME: label hmtlFor needs AdvancedSingleSelect id, no prop in AdvSelect to set id */}
       <label style={{ textAlign: align }}>{label}</label>
       <AdvancedSingleSelect
@@ -431,19 +441,21 @@ const PositionColumn = ({
           {getLeafletMap(position.uuid, position.location)}
         </>
       )}
-    </div>
+    </PositionCol>
   )
 }
-
-const POSITION_FIELDS =
-  "uuid, name, code, type, organization { uuid, shortName, longName, identificationCode}, person { uuid, name, rank, role, avatar(size: 32) }"
+const PositionCol = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+`
 
 PositionColumn.propTypes = {
   position: PropTypes.instanceOf(Position),
   setPosition: PropTypes.func.isRequired,
   setFieldValue: PropTypes.func.isRequired,
   align: PropTypes.string.isRequired,
-  style: PropTypes.object,
   label: PropTypes.string.isRequired
 }
 

--- a/client/src/pages/admin/MergePositions.js
+++ b/client/src/pages/admin/MergePositions.js
@@ -7,6 +7,7 @@ import { PositionOverlayRow } from "components/advancedSelectWidget/AdvancedSele
 import AdvancedSingleSelect from "components/advancedSelectWidget/AdvancedSingleSelect"
 import PositionField from "components/MergeField"
 import Messages from "components/Messages"
+import { MODEL_TO_OBJECT_TYPE } from "components/Model"
 import {
   jumpToTop,
   mapPageDispatchersToProps,
@@ -25,7 +26,7 @@ import { Position } from "models"
 import GeoLocation from "pages/locations/GeoLocation"
 import PropTypes from "prop-types"
 import React, { useState } from "react"
-import { Col, Grid, Row } from "react-bootstrap"
+import { Col, FormGroup, Grid, Row } from "react-bootstrap"
 import { connect } from "react-redux"
 import { useHistory } from "react-router-dom"
 import { toast } from "react-toastify"
@@ -73,7 +74,7 @@ const MergePositions = ({ pageDispatchers }) => {
   const [
     [position1, position2, mergedPosition],
     [setPosition1, setPosition2, setMergedPosition]
-  ] = useMergeValidation(null, null, new Position(), "position")
+  ] = useMergeValidation({}, {}, new Position(), MODEL_TO_OBJECT_TYPE.Position)
 
   useBoilerplate({
     pageProps: DEFAULT_PAGE_PROPS,
@@ -328,26 +329,29 @@ const PositionColumn = ({
 }) => {
   return (
     <PositionCol>
-      {/* FIXME: label hmtlFor needs AdvancedSingleSelect id, no prop in AdvSelect to set id */}
-      <label style={{ textAlign: align }}>{label}</label>
-      <AdvancedSingleSelect
-        fieldName="position"
-        fieldLabel="Select a position"
-        placeholder="Select a position to merge"
-        value={position}
-        overlayColumns={["Position", "Organization", "Current Occupant"]}
-        overlayRenderRow={PositionOverlayRow}
-        filterDefs={positionsFilters}
-        onChange={value => {
-          return setPosition(value)
-        }}
-        objectType={Position}
-        valueKey="name"
-        fields={POSITION_FIELDS}
-        addon={POSITIONS_ICON}
-        vertical
-      />
-      {position && (
+      <label htmlFor={label.replace(/ /g, "")} style={{ textAlign: align }}>
+        {label}
+      </label>
+      <FormGroup controlId={label.replace(/ /g, "")}>
+        <AdvancedSingleSelect
+          fieldName="position"
+          fieldLabel="Select a position"
+          placeholder="Select a position to merge"
+          value={position}
+          overlayColumns={["Position", "Organization", "Current Occupant"]}
+          overlayRenderRow={PositionOverlayRow}
+          filterDefs={positionsFilters}
+          onChange={value => {
+            return setPosition(value)
+          }}
+          objectType={Position}
+          valueKey="name"
+          fields={POSITION_FIELDS}
+          addon={POSITIONS_ICON}
+          vertical
+        />
+      </FormGroup>
+      {areAllSet(position) && (
         <>
           <PositionField
             label="Name"
@@ -408,7 +412,7 @@ const PositionColumn = ({
           />
           <PositionField
             label="Organization"
-            value={position.organization.shortName}
+            value={position.organization?.shortName}
             align={align}
             action={getActionButton(
               () => setFieldValue("organization", position.organization),
@@ -417,7 +421,7 @@ const PositionColumn = ({
           />
           <PositionField
             label="Person"
-            value={position.person.name}
+            value={position.person?.name}
             align={align}
             action={getActionButton(() => {
               setFieldValue("person", position.person)
@@ -429,8 +433,8 @@ const PositionColumn = ({
             label="Location"
             value={
               <GeoLocation
-                lat={position.location.lat}
-                lng={position.location.lng}
+                lat={position.location?.lat}
+                lng={position.location?.lng}
               />
             }
             align={align}
@@ -452,7 +456,7 @@ const PositionCol = styled.div`
 `
 
 PositionColumn.propTypes = {
-  position: PropTypes.instanceOf(Position),
+  position: PropTypes.object,
   setPosition: PropTypes.func.isRequired,
   setFieldValue: PropTypes.func.isRequired,
   align: PropTypes.string.isRequired,

--- a/client/src/pages/admin/MergePositions.js
+++ b/client/src/pages/admin/MergePositions.js
@@ -1,0 +1,450 @@
+import { gql } from "@apollo/client"
+import { Button, Callout } from "@blueprintjs/core"
+import { DEFAULT_PAGE_PROPS, DEFAULT_SEARCH_PROPS } from "actions"
+import API from "api"
+import { PositionOverlayRow } from "components/advancedSelectWidget/AdvancedSelectOverlayRow"
+import AdvancedSingleSelect from "components/advancedSelectWidget/AdvancedSingleSelect"
+import PositionField from "components/MergeField"
+import Messages from "components/Messages"
+import {
+  jumpToTop,
+  mapPageDispatchersToProps,
+  PageDispatchersPropType,
+  useBoilerplate
+} from "components/Page"
+import useMergeValidation, {
+  areAllSet,
+  getActionButton,
+  getActivationButton,
+  getClearButton,
+  getInfoButton,
+  getLeafletMap
+} from "mergeUtils"
+import { Position } from "models"
+import GeoLocation from "pages/locations/GeoLocation"
+import PropTypes from "prop-types"
+import React, { useState } from "react"
+import { Col, Grid, Row } from "react-bootstrap"
+import { connect } from "react-redux"
+import { useHistory } from "react-router-dom"
+import { toast } from "react-toastify"
+import POSITIONS_ICON from "resources/positions.png"
+
+const GQL_MERGE_POSITION = gql`
+  mutation($loserUuid: String!, $winnerPosition: PositionInput!) {
+    mergePosition(loserUuid: $loserUuid, winnerPosition: $winnerPosition) {
+      uuid
+    }
+  }
+`
+
+const MergePositions = ({ pageDispatchers }) => {
+  const history = useHistory()
+  const [saveError, setSaveError] = useState(null)
+  const [
+    [position1, position2, mergedPosition],
+    [setPosition1, setPosition2, setMergedPosition]
+  ] = useMergeValidation(null, null, new Position(), "position")
+
+  useBoilerplate({
+    pageProps: DEFAULT_PAGE_PROPS,
+    searchProps: DEFAULT_SEARCH_PROPS,
+    pageDispatchers
+  })
+
+  return (
+    <Grid fluid>
+      <Row>
+        <Messages error={saveError} />
+        <h2>Merge Positions Tool</h2>
+      </Row>
+      <Row>
+        <Col md={4}>
+          <PositionColumn
+            position={position1}
+            setPosition={setPosition1}
+            setFieldValue={setFieldValue}
+            style={COLUMN_DIV_STYLE}
+            align="left"
+            label="Position 1"
+          />
+        </Col>
+        <Col md={4}>
+          <div style={MID_COLUMN_TITLE_STYLE}>
+            {getActionButton(
+              () => setAllFields(position1),
+              "left",
+              !areAllSet(position1, position2),
+              "Use All"
+            )}
+            <h4 style={{ margin: "0" }}>Merged Position</h4>
+            {getActionButton(
+              () => setAllFields(position2),
+              "right",
+              !areAllSet(position1, position2),
+              "Use All"
+            )}
+          </div>
+          {!areAllSet(position1, position2) && (
+            <div style={{ padding: "16px 5%" }}>
+              <Callout intent="warning">
+                Please select <strong>both</strong> positions to proceed...
+              </Callout>
+            </div>
+          )}
+          {areAllSet(position1, position2, !mergedPosition?.name) && (
+            <div style={{ padding: "16px 5%" }}>
+              <Callout intent="primary">
+                Please choose a <strong>name</strong> to proceed...
+              </Callout>
+            </div>
+          )}
+          {areAllSet(position1, position2, mergedPosition?.name) && (
+            <>
+              <PositionField
+                label="Name"
+                value={mergedPosition.name}
+                align="center"
+                action={getInfoButton("Name is required.")}
+              />
+              <PositionField
+                label="Type"
+                value={mergedPosition.type}
+                align="center"
+                action={getClearButton(() => {
+                  setFieldValue("type", Position.TYPE.ADVISOR)
+                })}
+              />
+              <PositionField
+                label="Code"
+                value={mergedPosition.code}
+                align="center"
+                action={getClearButton(() => {
+                  setFieldValue("code", "")
+                })}
+              />
+              <PositionField
+                label="Status"
+                value={mergedPosition.status}
+                align="center"
+                action={getActivationButton(
+                  mergedPosition.isActive(),
+                  () => {
+                    setFieldValue(
+                      "status",
+                      mergedPosition.isActive()
+                        ? Position.STATUS.INACTIVE
+                        : Position.STATUS.ACTIVE
+                    )
+                  },
+                  "position"
+                )}
+              />
+              <PositionField
+                label="Associated Positions"
+                value={mergedPosition.associatedPositions}
+                align="center"
+                action={getClearButton(() => {
+                  setFieldValue("associatedPositions", "")
+                })}
+              />
+              <PositionField
+                label="Previous People"
+                value={mergedPosition.previousPeople}
+                align="center"
+                action={getClearButton(() => {
+                  setFieldValue("previousPeople", "")
+                })}
+              />
+              <PositionField
+                label="Organization"
+                value={mergedPosition.organization.shortName}
+                align="center"
+                action={getClearButton(() => {
+                  setFieldValue("organization", {})
+                })}
+              />
+              <PositionField
+                label="Person"
+                value={mergedPosition.person.name}
+                align="center"
+                action={getClearButton(() => {
+                  setFieldValue("person", "")
+                })}
+              />
+              <PositionField
+                label="Location"
+                value={
+                  <GeoLocation
+                    lat={mergedPosition.location.lat}
+                    lng={mergedPosition.location.lng}
+                  />
+                }
+                align="center"
+                action={getClearButton(() => {
+                  setFieldValue("location", "")
+                })}
+              />
+              {getLeafletMap("merged-location", mergedPosition.location)}
+            </>
+          )}
+        </Col>
+        <Col md={4}>
+          <PositionColumn
+            position={position2}
+            setPosition={setPosition2}
+            setFieldValue={setFieldValue}
+            style={COLUMN_DIV_STYLE}
+            align="right"
+            label="Position 2"
+          />
+        </Col>
+      </Row>
+      <Row>
+        <Button
+          style={{ width: "98%", margin: "16px 1%" }}
+          large
+          intent="primary"
+          text="Merge Positions"
+          onClick={mergePosition}
+          disabled={!areAllSet(position1, position2, mergedPosition?.name)}
+        />
+      </Row>
+    </Grid>
+  )
+
+  function mergePosition() {
+    if (unassignedPerson()) {
+      return
+    }
+    let loser
+    if (mergedPosition.uuid) {
+      // uuid only gets set by person field, loser must be the position with different uuid
+      loser = mergedPosition.uuid === position1.uuid ? position2 : position1
+    } else {
+      // if not set, means no person in both positions, doesn't matter which one is loser
+      mergedPosition.uuid = position1.uuid
+      loser = position2
+    }
+
+    API.mutation(GQL_MERGE_POSITION, {
+      loserUuid: loser.uuid,
+      winnerPosition: mergedPosition
+    })
+      .then(res => {
+        if (res.mergePosition) {
+          history.push(Position.pathFor({ uuid: res.mergePosition.uuid }), {
+            success: "Positions merged. Displaying merged Position below."
+          })
+        }
+      })
+      .catch(error => {
+        setSaveError(error)
+        jumpToTop()
+      })
+  }
+
+  function setFieldValue(field, value) {
+    setMergedPosition(oldState => new Position({ ...oldState, [field]: value }))
+  }
+
+  function setAllFields(pos) {
+    setMergedPosition(new Position({ ...pos }))
+  }
+
+  function unassignedPerson() {
+    const msg = "You can't merge if a person is left unassigned"
+    // both positions having a person is validated in useMergeValidation, can't happen
+    // warn when one of them has it and merged doesn't
+    if (
+      // only position1 has it
+      !mergedPosition.person.uuid &&
+      position1.person.uuid &&
+      !position2.person.uuid
+    ) {
+      toast(msg)
+      return true
+    } else if (
+      // only position2 has it
+      !mergedPosition.person.uuid &&
+      !position1.person.uuid &&
+      position2.person.uuid
+    ) {
+      toast(msg)
+      return true
+    } else {
+      return false
+    }
+  }
+}
+
+MergePositions.propTypes = {
+  pageDispatchers: PageDispatchersPropType
+}
+
+const COLUMN_DIV_STYLE = {
+  display: "flex",
+  flexDirection: "column",
+  justifyContent: "flex-start",
+  width: "100%"
+}
+
+const MID_COLUMN_TITLE_STYLE = {
+  height: "39px",
+  marginTop: "25px",
+  borderBottom: "1px solid #CCCCCC",
+  borderTop: "1px solid #CCCCCC",
+  display: "flex",
+  justifyContent: "space-between",
+  alignItems: "center"
+}
+
+const positionsFilters = {
+  allAdvisorPositions: {
+    label: "All",
+    queryVars: {
+      status: Position.STATUS.ACTIVE
+    }
+  }
+}
+
+const PositionColumn = ({
+  position,
+  setPosition,
+  setFieldValue,
+  align,
+  style,
+  label
+}) => {
+  return (
+    <div style={style}>
+      {/* FIXME: label hmtlFor needs AdvancedSingleSelect id, no prop in AdvSelect to set id */}
+      <label style={{ textAlign: align }}>{label}</label>
+      <AdvancedSingleSelect
+        fieldName="position"
+        fieldLabel="Select a position"
+        placeholder="Select a position to merge"
+        value={position}
+        overlayColumns={["Position", "Organization", "Current Occupant"]}
+        overlayRenderRow={PositionOverlayRow}
+        filterDefs={positionsFilters}
+        onChange={value => {
+          return setPosition(value)
+        }}
+        objectType={Position}
+        valueKey="name"
+        fields={POSITION_FIELDS}
+        addon={POSITIONS_ICON}
+        vertical
+      />
+      {position && (
+        <>
+          <PositionField
+            label="Name"
+            value={position.name}
+            align={align}
+            action={getActionButton(() => {
+              setFieldValue("name", position.name)
+            }, align)}
+          />
+          <PositionField
+            label="Type"
+            value={position.type}
+            align={align}
+            action={getActionButton(
+              () => setFieldValue("type", position.type),
+              align
+            )}
+          />
+          <PositionField
+            label="Code"
+            value={position.code}
+            align={align}
+            action={getActionButton(
+              () => setFieldValue("code", position.code),
+              align
+            )}
+          />
+          <PositionField
+            label="Status"
+            value={position.status}
+            align={align}
+            action={getActionButton(
+              () => setFieldValue("status", position.status),
+              align
+            )}
+          />
+          <PositionField
+            label="Associated Positions"
+            value={position.associatedPositions}
+            align={align}
+            action={getActionButton(
+              () =>
+                setFieldValue(
+                  "associatedPositions",
+                  position.associatedPositions
+                ),
+              align
+            )}
+          />
+          <PositionField
+            label="Previous People"
+            value={position.previousPeople}
+            align={align}
+            action={getActionButton(
+              () => setFieldValue("previousPeople", position.previousPeople),
+              align
+            )}
+          />
+          <PositionField
+            label="Organization"
+            value={position.organization.shortName}
+            align={align}
+            action={getActionButton(
+              () => setFieldValue("organization", position.organization),
+              align
+            )}
+          />
+          <PositionField
+            label="Person"
+            value={position.person.name}
+            align={align}
+            action={getActionButton(() => {
+              setFieldValue("person", position.person)
+              // setting person should also set uuid
+              setFieldValue("uuid", position.uuid)
+            }, align)}
+          />
+          <PositionField
+            label="Location"
+            value={
+              <GeoLocation
+                lat={position.location.lat}
+                lng={position.location.lng}
+              />
+            }
+            align={align}
+            action={getActionButton(() => {
+              setFieldValue("location", position.location)
+            }, align)}
+          />
+          {getLeafletMap(position.uuid, position.location)}
+        </>
+      )}
+    </div>
+  )
+}
+
+const POSITION_FIELDS =
+  "uuid, name, code, type, organization { uuid, shortName, longName, identificationCode}, person { uuid, name, rank, role, avatar(size: 32) }"
+
+PositionColumn.propTypes = {
+  position: PropTypes.instanceOf(Position),
+  setPosition: PropTypes.func.isRequired,
+  setFieldValue: PropTypes.func.isRequired,
+  align: PropTypes.string.isRequired,
+  style: PropTypes.object,
+  label: PropTypes.string.isRequired
+}
+
+export default connect(null, mapPageDispatchersToProps)(MergePositions)

--- a/client/src/pages/admin/MergePositions.js
+++ b/client/src/pages/admin/MergePositions.js
@@ -26,7 +26,6 @@ import useMergeValidation, {
   unassignedPerson
 } from "mergeUtils"
 import { Position } from "models"
-import GeoLocation from "pages/locations/GeoLocation"
 import PropTypes from "prop-types"
 import React, { useState } from "react"
 import { Col, FormGroup, Grid, Row } from "react-bootstrap"
@@ -173,12 +172,21 @@ const MergePositions = ({ pageDispatchers }) => {
                 action={getInfoButton("Name is required.")}
               />
               <PositionField
+                label="Organization"
+                value={
+                  <LinkTo
+                    modelType="Organization"
+                    model={mergedPosition.organization}
+                  />
+                }
+                align="center"
+                action={getInfoButton("Organization is required.")}
+              />
+              <PositionField
                 label="Type"
                 value={mergedPosition.type}
                 align="center"
-                action={getClearButton(() => {
-                  setFieldValue("type", Position.TYPE.ADVISOR)
-                })}
+                action={getInfoButton("Type is required.")}
               />
               <PositionField
                 label="Code"
@@ -225,29 +233,25 @@ const MergePositions = ({ pageDispatchers }) => {
                 label="Previous People"
                 value={
                   <>
-                    {mergedPosition.previousPeople.map(person => (
-                      <React.Fragment key={`${person.uuid}`}>
-                        <LinkTo modelType="Person" model={person} />{" "}
+                    {mergedPosition.previousPeople.map((pp, idx) => (
+                      // can be same people, uuid not enough
+                      <React.Fragment key={`${pp.person.uuid}-${idx}`}>
+                        <LinkTo modelType="Person" model={pp.person} />{" "}
                       </React.Fragment>
                     ))}
                   </>
                 }
                 align="center"
+                customStyle="height: 100px;"
                 action={getClearButton(() => {
                   setFieldValue("previousPeople", "")
                 })}
               />
               <PositionField
-                label="Organization"
-                value={mergedPosition.organization.shortName}
-                align="center"
-                action={getClearButton(() => {
-                  setFieldValue("organization", {})
-                })}
-              />
-              <PositionField
                 label="Person"
-                value={mergedPosition.person.name}
+                value={
+                  <LinkTo modelType="Person" model={mergedPosition.person} />
+                }
                 align="center"
                 action={getClearButton(() => {
                   setFieldValue("person", "")
@@ -256,9 +260,9 @@ const MergePositions = ({ pageDispatchers }) => {
               <PositionField
                 label="Location"
                 value={
-                  <GeoLocation
-                    lat={mergedPosition.location.lat}
-                    lng={mergedPosition.location.lng}
+                  <LinkTo
+                    modelType="Location"
+                    model={mergedPosition.location}
                   />
                 }
                 align="center"
@@ -388,6 +392,17 @@ const PositionColumn = ({
             }, align)}
           />
           <PositionField
+            label="Organization"
+            value={
+              <LinkTo modelType="Organization" model={position.organization} />
+            }
+            align={align}
+            action={getActionButton(
+              () => setFieldValue("organization", position.organization),
+              align
+            )}
+          />
+          <PositionField
             label="Type"
             value={position.type}
             align={align}
@@ -416,6 +431,7 @@ const PositionColumn = ({
           />
           <PositionField
             label="Associated Positions"
+            customStyle="height: 80px;"
             value={
               <>
                 {position.associatedPositions.map(pos => (
@@ -437,11 +453,12 @@ const PositionColumn = ({
           />
           <PositionField
             label="Previous People"
+            customStyle="height: 80px;"
             value={
               <>
-                {position.previousPeople.map(person => (
-                  <React.Fragment key={`${person.uuid}`}>
-                    <LinkTo modelType="Person" model={person} />{" "}
+                {position.previousPeople.map((pp, idx) => (
+                  <React.Fragment key={`${pp.person.uuid}-${idx}`}>
+                    <LinkTo modelType="Person" model={pp.person} />{" "}
                   </React.Fragment>
                 ))}
               </>
@@ -453,17 +470,9 @@ const PositionColumn = ({
             )}
           />
           <PositionField
-            label="Organization"
-            value={position.organization?.shortName}
-            align={align}
-            action={getActionButton(
-              () => setFieldValue("organization", position.organization),
-              align
-            )}
-          />
-          <PositionField
             label="Person"
-            value={position.person?.name}
+            customStyle="height: 80px;"
+            value={<LinkTo modelType="Person" model={position.person} />}
             align={align}
             action={getActionButton(() => {
               setFieldValue("person", position.person)
@@ -473,18 +482,13 @@ const PositionColumn = ({
           />
           <PositionField
             label="Location"
-            value={
-              <GeoLocation
-                lat={position.location?.lat}
-                lng={position.location?.lng}
-              />
-            }
+            value={<LinkTo modelType="Location" model={position.location} />}
             align={align}
             action={getActionButton(() => {
               setFieldValue("location", position.location)
             }, align)}
           />
-          {getLeafletMap(`merge-positions-map-${align}`, position.location)}
+          {getLeafletMap(`merge-position-map-${align}`, position.location)}
         </>
       )}
     </PositionCol>

--- a/client/src/pages/admin/MergePositions.js
+++ b/client/src/pages/admin/MergePositions.js
@@ -341,6 +341,7 @@ const MidColTitle = styled.div`
   display: flex;
   height: 39px;
   margin-top: 25px;
+  margin-bottom: 15px;
   border-bottom: 1px solid #cccccc;
   border-top: 1px solid #cccccc;
   justify-content: space-between;
@@ -356,10 +357,10 @@ const PositionColumn = ({
 }) => {
   return (
     <PositionCol>
-      <label htmlFor={label.replace(/ /g, "")} style={{ textAlign: align }}>
+      <label htmlFor={label.replace(/\s+/g, "")} style={{ textAlign: align }}>
         {label}
       </label>
-      <FormGroup controlId={label.replace(/ /g, "")}>
+      <FormGroup controlId={label.replace(/\s+/g, "")}>
         <AdvancedSingleSelect
           fieldName="position"
           fieldLabel="Select a position"
@@ -368,9 +369,7 @@ const PositionColumn = ({
           overlayColumns={["Position", "Organization", "Current Occupant"]}
           overlayRenderRow={PositionOverlayRow}
           filterDefs={positionsFilters}
-          onChange={value => {
-            return setPosition(value)
-          }}
+          onChange={value => setPosition(value)}
           objectType={Position}
           valueKey="name"
           fields={POSITION_FIELDS}
@@ -485,7 +484,7 @@ const PositionColumn = ({
               setFieldValue("location", position.location)
             }, align)}
           />
-          {getLeafletMap(position.uuid, position.location)}
+          {getLeafletMap(`merge-positions-map-${align}`, position.location)}
         </>
       )}
     </PositionCol>
@@ -502,7 +501,7 @@ PositionColumn.propTypes = {
   position: PropTypes.object,
   setPosition: PropTypes.func.isRequired,
   setFieldValue: PropTypes.func.isRequired,
-  align: PropTypes.string.isRequired,
+  align: PropTypes.oneOf(["left", "right", "center"]).isRequired,
   label: PropTypes.string.isRequired
 }
 

--- a/client/src/pages/admin/MergePositions.js
+++ b/client/src/pages/admin/MergePositions.js
@@ -6,6 +6,7 @@ import { gql } from "apollo-boost"
 import { PositionOverlayRow } from "components/advancedSelectWidget/AdvancedSelectOverlayRow"
 import AdvancedSingleSelect from "components/advancedSelectWidget/AdvancedSingleSelect"
 import { customFieldsJSONString } from "components/CustomFields"
+import EditHistory from "components/EditHistory"
 import LinkTo from "components/LinkTo"
 import PositionField from "components/MergeField"
 import Messages from "components/Messages"
@@ -77,7 +78,7 @@ const MergePositions = ({ pageDispatchers }) => {
         <h2>Merge Positions Tool</h2>
       </Row>
       <Row>
-        <Col md={4}>
+        <Col md={4} id="left-merge-pos-col">
           <PositionColumn
             mergeState={mergeState}
             dispatchMergeActions={dispatchMergeActions}
@@ -85,7 +86,7 @@ const MergePositions = ({ pageDispatchers }) => {
             label="Position 1"
           />
         </Col>
-        <Col md={4}>
+        <Col md={4} id="mid-merge-pos-col">
           <MidColTitle>
             {getActionButton(
               () =>
@@ -191,13 +192,9 @@ const MergePositions = ({ pageDispatchers }) => {
               <PositionField
                 label="Associated Positions"
                 value={
-                  <>
-                    {mergedPosition.associatedPositions.map(pos => (
-                      <React.Fragment key={`${pos.uuid}`}>
-                        <LinkTo modelType="Position" model={pos} />{" "}
-                      </React.Fragment>
-                    ))}
-                  </>
+                  <AssociatedPositions
+                    associatedPositions={mergedPosition.associatedPositions}
+                  />
                 }
                 align="center"
                 action={getClearButton(() =>
@@ -213,15 +210,23 @@ const MergePositions = ({ pageDispatchers }) => {
                 label="Previous People"
                 value={
                   <>
-                    {mergedPosition.previousPeople.map((pp, idx) => (
-                      // can be same people, uuid not enough
-                      <React.Fragment key={`${pp.person.uuid}-${idx}`}>
-                        <LinkTo modelType="Person" model={pp.person} />{" "}
-                      </React.Fragment>
-                    ))}
+                    <PreviousPeople history={mergedPosition.previousPeople} />
+                    <EditHistory
+                      history1={position1.previousPeople}
+                      history2={position2.previousPeople}
+                      initialHistory={mergedPosition.previousPeople}
+                      entityType="person"
+                      historyComp={PreviousPeople}
+                      title="Pick and Choose people and dates for People History"
+                      setHistory={history =>
+                        dispatchMergeActions(
+                          setAMergedField("previousPeople", history, null)
+                        )
+                      }
+                    />
                   </>
                 }
-                align="center"
+                align="column"
                 action={getClearButton(() =>
                   dispatchMergeActions(
                     setAMergedField("previousPeople", [], null)
@@ -291,7 +296,7 @@ const MergePositions = ({ pageDispatchers }) => {
             </>
           )}
         </Col>
-        <Col md={4}>
+        <Col md={4} id="right-merge-pos-col">
           <PositionColumn
             align={mergeSides[1]}
             label="Position 2"
@@ -536,7 +541,7 @@ const PositionColumn = ({ align, label, mergeState, dispatchMergeActions }) => {
           <PositionField
             label="Previous People"
             fieldName="previousPeople"
-            value={<PreviousPeople previousPeople={position.previousPeople} />}
+            value={<PreviousPeople history={position.previousPeople} />}
             align={align}
             action={getActionButton(
               () =>

--- a/client/src/pages/admin/MergePositions.js
+++ b/client/src/pages/admin/MergePositions.js
@@ -262,7 +262,7 @@ const MergePositions = ({ pageDispatchers }) => {
                 align="center"
                 action={getClearButton(() =>
                   dispatchMergeActions(
-                    setAMergedField("associatedPositions", "", null)
+                    setAMergedField("associatedPositions", [], null)
                   )
                 )}
                 fieldName="associatedPositions"
@@ -284,7 +284,7 @@ const MergePositions = ({ pageDispatchers }) => {
                 align="center"
                 action={getClearButton(() =>
                   dispatchMergeActions(
-                    setAMergedField("previousPeople", "", null)
+                    setAMergedField("previousPeople", [], null)
                   )
                 )}
                 fieldName="previousPeople"

--- a/client/src/pages/admin/MergePositions.js
+++ b/client/src/pages/admin/MergePositions.js
@@ -396,6 +396,8 @@ const PositionColumn = ({
             align={align}
             action={getActionButton(() => {
               setFieldValue("name", position.name)
+              setFieldValue("organization", position.organization)
+              setFieldValue("type", position.type)
             }, align)}
           />
           <PositionField

--- a/client/src/pages/admin/MergePositions.js
+++ b/client/src/pages/admin/MergePositions.js
@@ -43,7 +43,7 @@ import utils from "utils"
 
 const GQL_MERGE_POSITION = gql`
   mutation($loserUuid: String!, $winnerPosition: PositionInput!) {
-    mergePosition(loserUuid: $loserUuid, winnerPosition: $winnerPosition) {
+    mergePositions(loserUuid: $loserUuid, winnerPosition: $winnerPosition) {
       uuid
     }
   }
@@ -321,14 +321,14 @@ const MergePositions = ({ pageDispatchers }) => {
           large
           intent="primary"
           text="Merge Positions"
-          onClick={mergePosition}
+          onClick={mergePositions}
           disabled={!areAllSet(position1, position2, mergedPosition?.name)}
         />
       </Row>
     </Grid>
   )
 
-  function mergePosition() {
+  function mergePositions() {
     if (unassignedPerson(position1, position2, mergedPosition)) {
       return
     }
@@ -343,6 +343,7 @@ const MergePositions = ({ pageDispatchers }) => {
     }
     // serialize form custom fields before query, and remove unserialized field
     mergedPosition.customFields = customFieldsJSONString(mergedPosition)
+
     const winnerPosition = Object.without(
       mergedPosition,
       DEFAULT_CUSTOM_FIELDS_PARENT
@@ -352,8 +353,8 @@ const MergePositions = ({ pageDispatchers }) => {
       winnerPosition
     })
       .then(res => {
-        if (res.mergePosition) {
-          history.push(Position.pathFor({ uuid: res.mergePosition.uuid }), {
+        if (res.mergePositions) {
+          history.push(Position.pathFor({ uuid: res.mergePositions.uuid }), {
             success: "Positions merged. Displaying merged Position below."
           })
         }

--- a/client/src/pages/admin/MergePositions.js
+++ b/client/src/pages/admin/MergePositions.js
@@ -20,7 +20,6 @@ import {
   PageDispatchersPropType,
   useBoilerplate
 } from "components/Page"
-import { GRAPHQL_NOTES_FIELDS } from "components/RelatedObjectNotes"
 import useMergeObjects, {
   areAllSet,
   getActionButton,
@@ -42,6 +41,8 @@ import { useHistory } from "react-router-dom"
 import POSITIONS_ICON from "resources/positions.png"
 import Settings from "settings"
 import utils from "utils"
+import AssociatedPositions from "../positions/AssociatedPositions"
+import PreviousPeople from "../positions/PreviousPeople"
 
 const GQL_MERGE_POSITION = gql`
   mutation($loserUuid: String!, $winnerPosition: PositionInput!) {
@@ -49,59 +50,6 @@ const GQL_MERGE_POSITION = gql`
       uuid
     }
   }
-`
-const POSITION_FIELDS = `
-  uuid
-  name
-  type
-  status
-  code
-  organization {
-    uuid
-    shortName
-    longName
-    identificationCode
-  }
-  person {
-    uuid
-    name
-    rank
-    role
-    avatar(size: 32)
-  }
-  associatedPositions {
-    uuid
-    name
-    type
-    person {
-      uuid
-      name
-      rank
-      role
-      avatar(size: 32)
-    }
-    organization {
-      uuid
-      shortName
-    }
-  }
-  previousPeople {
-    startTime
-    endTime
-    person {
-      uuid
-      name
-      rank
-      role
-      avatar(size: 32)
-    }
-  }
-  location {
-    uuid
-    name
-  }
-  ${GRAPHQL_NOTES_FIELDS}
-  customFields
 `
 
 const positionsFilters = {
@@ -454,7 +402,7 @@ const PositionColumn = ({ align, label, mergeState, dispatchMergeActions }) => {
           }}
           objectType={Position}
           valueKey="name"
-          fields={POSITION_FIELDS}
+          fields={Position.allFieldsQuery}
           addon={POSITIONS_ICON}
           vertical
         />
@@ -559,13 +507,9 @@ const PositionColumn = ({ align, label, mergeState, dispatchMergeActions }) => {
             label="Associated Positions"
             fieldName="associatedPositions"
             value={
-              <>
-                {position.associatedPositions.map(pos => (
-                  <React.Fragment key={`${pos.uuid}`}>
-                    <LinkTo modelType="Position" model={pos} />{" "}
-                  </React.Fragment>
-                ))}
-              </>
+              <AssociatedPositions
+                associatedPositions={position.associatedPositions}
+              />
             }
             align={align}
             action={getActionButton(
@@ -587,15 +531,7 @@ const PositionColumn = ({ align, label, mergeState, dispatchMergeActions }) => {
           <PositionField
             label="Previous People"
             fieldName="previousPeople"
-            value={
-              <>
-                {position.previousPeople.map((pp, idx) => (
-                  <React.Fragment key={`${pp.person.uuid}-${idx}`}>
-                    <LinkTo modelType="Person" model={pp.person} />{" "}
-                  </React.Fragment>
-                ))}
-              </>
-            }
+            value={<PreviousPeople previousPeople={position.previousPeople} />}
             align={align}
             action={getActionButton(
               () =>

--- a/client/src/pages/admin/MergePositions.js
+++ b/client/src/pages/admin/MergePositions.js
@@ -172,12 +172,12 @@ const MergePositions = ({ pageDispatchers }) => {
                 value={mergedPosition.status}
                 align="center"
                 action={getActivationButton(
-                  mergedPosition.isActive(),
+                  Position.isActive(mergedPosition),
                   () =>
                     dispatchMergeActions(
                       setAMergedField(
                         "status",
-                        mergedPosition.isActive()
+                        Position.isActive(mergedPosition)
                           ? Position.STATUS.INACTIVE
                           : Position.STATUS.ACTIVE,
                         null
@@ -215,7 +215,6 @@ const MergePositions = ({ pageDispatchers }) => {
                       history1={position1.previousPeople}
                       history2={position2.previousPeople}
                       initialHistory={mergedPosition.previousPeople}
-                      entityType="person"
                       historyComp={PreviousPeople}
                       currentlyOccupyingEntity={mergedPosition.person}
                       title="Pick and Choose people and dates for People History"
@@ -254,7 +253,9 @@ const MergePositions = ({ pageDispatchers }) => {
                 Object.entries(Settings.fields.position.customFields).map(
                   ([fieldName, fieldConfig]) => {
                     const fieldValue =
-                      mergedPosition[DEFAULT_CUSTOM_FIELDS_PARENT][fieldName]
+                      mergedPosition?.[DEFAULT_CUSTOM_FIELDS_PARENT]?.[
+                        fieldName
+                      ]
                     return (
                       <PositionField
                         key={fieldName}

--- a/client/src/pages/admin/MergePositions.js
+++ b/client/src/pages/admin/MergePositions.js
@@ -8,7 +8,10 @@ import AdvancedSingleSelect from "components/advancedSelectWidget/AdvancedSingle
 import LinkTo from "components/LinkTo"
 import PositionField from "components/MergeField"
 import Messages from "components/Messages"
-import { MODEL_TO_OBJECT_TYPE } from "components/Model"
+import {
+  DEFAULT_CUSTOM_FIELDS_PARENT,
+  MODEL_TO_OBJECT_TYPE
+} from "components/Model"
 import {
   jumpToTop,
   mapPageDispatchersToProps,
@@ -225,6 +228,7 @@ const MergePositions = ({ pageDispatchers }) => {
                   </>
                 }
                 align="center"
+                customStyle="height: 100px;"
                 action={getClearButton(() => {
                   setFieldValue("associatedPositions", "")
                 })}
@@ -313,7 +317,10 @@ const MergePositions = ({ pageDispatchers }) => {
 
     API.mutation(GQL_MERGE_POSITION, {
       loserUuid: loser.uuid,
-      winnerPosition: mergedPosition
+      winnerPosition: Object.without(
+        mergedPosition,
+        DEFAULT_CUSTOM_FIELDS_PARENT
+      )
     })
       .then(res => {
         if (res.mergePosition) {
@@ -431,7 +438,7 @@ const PositionColumn = ({
           />
           <PositionField
             label="Associated Positions"
-            customStyle="height: 80px;"
+            customStyle="height: 100px;"
             value={
               <>
                 {position.associatedPositions.map(pos => (
@@ -453,7 +460,7 @@ const PositionColumn = ({
           />
           <PositionField
             label="Previous People"
-            customStyle="height: 80px;"
+            customStyle="height: 100px;"
             value={
               <>
                 {position.previousPeople.map((pp, idx) => (
@@ -471,7 +478,6 @@ const PositionColumn = ({
           />
           <PositionField
             label="Person"
-            customStyle="height: 80px;"
             value={<LinkTo modelType="Person" model={position.person} />}
             align={align}
             action={getActionButton(() => {

--- a/client/src/pages/admin/MergePositions.js
+++ b/client/src/pages/admin/MergePositions.js
@@ -217,6 +217,7 @@ const MergePositions = ({ pageDispatchers }) => {
                       initialHistory={mergedPosition.previousPeople}
                       entityType="person"
                       historyComp={PreviousPeople}
+                      currentlyOccupyingEntity={mergedPosition.person}
                       title="Pick and Choose people and dates for People History"
                       setHistory={history =>
                         dispatchMergeActions(

--- a/client/src/pages/admin/MergePositions.js
+++ b/client/src/pages/admin/MergePositions.js
@@ -21,9 +21,8 @@ import {
 } from "components/Page"
 import { GRAPHQL_NOTES_FIELDS } from "components/RelatedObjectNotes"
 import _set from "lodash/set"
-import useMergeValidation, {
+import useMergeObjects, {
   areAllSet,
-  customStyleForLargeFields,
   getActionButton,
   getActivationButton,
   getClearButton,
@@ -116,8 +115,9 @@ const MergePositions = ({ pageDispatchers }) => {
   const [saveError, setSaveError] = useState(null)
   const [
     [position1, position2, mergedPosition],
-    [setPosition1, setPosition2, setMergedPosition]
-  ] = useMergeValidation({}, {}, new Position(), MODEL_TO_OBJECT_TYPE.Position)
+    [setPosition1, setPosition2, setMergedPosition],
+    [mergeFieldHeights, setMergeFieldHeights]
+  ] = useMergeObjects({}, {}, new Position(), MODEL_TO_OBJECT_TYPE.Position)
 
   useBoilerplate({
     pageProps: PAGE_PROPS_NO_NAV,
@@ -139,6 +139,8 @@ const MergePositions = ({ pageDispatchers }) => {
             setFieldValue={setFieldValue}
             align="left"
             label="Position 1"
+            mergeFieldHeights={mergeFieldHeights}
+            setMergeFieldHeights={setMergeFieldHeights}
           />
         </Col>
         <Col md={4}>
@@ -178,6 +180,8 @@ const MergePositions = ({ pageDispatchers }) => {
                 value={mergedPosition.name}
                 align="center"
                 action={getInfoButton("Name is required.")}
+                mergeFieldHeights={mergeFieldHeights}
+                setMergeFieldHeights={setMergeFieldHeights}
               />
               <PositionField
                 label="Organization"
@@ -189,12 +193,16 @@ const MergePositions = ({ pageDispatchers }) => {
                 }
                 align="center"
                 action={getInfoButton("Organization is required.")}
+                mergeFieldHeights={mergeFieldHeights}
+                setMergeFieldHeights={setMergeFieldHeights}
               />
               <PositionField
                 label="Type"
                 value={mergedPosition.type}
                 align="center"
                 action={getInfoButton("Type is required.")}
+                mergeFieldHeights={mergeFieldHeights}
+                setMergeFieldHeights={setMergeFieldHeights}
               />
               <PositionField
                 label="Code"
@@ -203,6 +211,8 @@ const MergePositions = ({ pageDispatchers }) => {
                 action={getClearButton(() => {
                   setFieldValue("code", "")
                 })}
+                mergeFieldHeights={mergeFieldHeights}
+                setMergeFieldHeights={setMergeFieldHeights}
               />
               <PositionField
                 label="Status"
@@ -220,6 +230,8 @@ const MergePositions = ({ pageDispatchers }) => {
                   },
                   Position.getInstanceName
                 )}
+                mergeFieldHeights={mergeFieldHeights}
+                setMergeFieldHeights={setMergeFieldHeights}
               />
               <PositionField
                 label="Associated Positions"
@@ -233,10 +245,11 @@ const MergePositions = ({ pageDispatchers }) => {
                   </>
                 }
                 align="center"
-                customStyle={customStyleForLargeFields({ type: "array" })}
                 action={getClearButton(() => {
                   setFieldValue("associatedPositions", "")
                 })}
+                mergeFieldHeights={mergeFieldHeights}
+                setMergeFieldHeights={setMergeFieldHeights}
               />
               <PositionField
                 label="Previous People"
@@ -251,10 +264,11 @@ const MergePositions = ({ pageDispatchers }) => {
                   </>
                 }
                 align="center"
-                customStyle={customStyleForLargeFields({ type: "array" })}
                 action={getClearButton(() => {
                   setFieldValue("previousPeople", "")
                 })}
+                mergeFieldHeights={mergeFieldHeights}
+                setMergeFieldHeights={setMergeFieldHeights}
               />
               <PositionField
                 label="Person"
@@ -265,6 +279,8 @@ const MergePositions = ({ pageDispatchers }) => {
                 action={getClearButton(() => {
                   setFieldValue("person", "")
                 })}
+                mergeFieldHeights={mergeFieldHeights}
+                setMergeFieldHeights={setMergeFieldHeights}
               />
               {Settings.fields.position.customFields &&
                 Object.entries(Settings.fields.position.customFields).map(
@@ -276,7 +292,6 @@ const MergePositions = ({ pageDispatchers }) => {
                         key={fieldName}
                         label={fieldConfig.label || fieldName}
                         value={JSON.stringify(fieldValue)}
-                        customStyle={customStyleForLargeFields(fieldConfig)}
                         align="center"
                         action={getClearButton(() => {
                           setFieldValue(
@@ -284,6 +299,8 @@ const MergePositions = ({ pageDispatchers }) => {
                             ""
                           )
                         })}
+                        mergeFieldHeights={mergeFieldHeights}
+                        setMergeFieldHeights={setMergeFieldHeights}
                       />
                     )
                   }
@@ -300,6 +317,8 @@ const MergePositions = ({ pageDispatchers }) => {
                 action={getClearButton(() => {
                   setFieldValue("location", "")
                 })}
+                mergeFieldHeights={mergeFieldHeights}
+                setMergeFieldHeights={setMergeFieldHeights}
               />
               {getLeafletMap("merged-location", mergedPosition.location)}
             </>
@@ -312,6 +331,8 @@ const MergePositions = ({ pageDispatchers }) => {
             setFieldValue={setFieldValue}
             align="right"
             label="Position 2"
+            mergeFieldHeights={mergeFieldHeights}
+            setMergeFieldHeights={setMergeFieldHeights}
           />
         </Col>
       </Row>
@@ -398,7 +419,9 @@ const PositionColumn = ({
   setPosition,
   setFieldValue,
   align,
-  label
+  label,
+  mergeFieldHeights,
+  setMergeFieldHeights
 }) => {
   return (
     <PositionCol>
@@ -441,6 +464,8 @@ const PositionColumn = ({
               setFieldValue("organization", position.organization)
               setFieldValue("type", position.type)
             }, align)}
+            mergeFieldHeights={mergeFieldHeights}
+            setMergeFieldHeights={setMergeFieldHeights}
           />
           <PositionField
             label="Organization"
@@ -452,6 +477,8 @@ const PositionColumn = ({
               () => setFieldValue("organization", position.organization),
               align
             )}
+            mergeFieldHeights={mergeFieldHeights}
+            setMergeFieldHeights={setMergeFieldHeights}
           />
           <PositionField
             label="Type"
@@ -461,6 +488,8 @@ const PositionColumn = ({
               () => setFieldValue("type", position.type),
               align
             )}
+            mergeFieldHeights={mergeFieldHeights}
+            setMergeFieldHeights={setMergeFieldHeights}
           />
           <PositionField
             label="Code"
@@ -470,6 +499,8 @@ const PositionColumn = ({
               () => setFieldValue("code", position.code),
               align
             )}
+            mergeFieldHeights={mergeFieldHeights}
+            setMergeFieldHeights={setMergeFieldHeights}
           />
           <PositionField
             label="Status"
@@ -479,10 +510,11 @@ const PositionColumn = ({
               () => setFieldValue("status", position.status),
               align
             )}
+            mergeFieldHeights={mergeFieldHeights}
+            setMergeFieldHeights={setMergeFieldHeights}
           />
           <PositionField
             label="Associated Positions"
-            customStyle={customStyleForLargeFields({ type: "array" })}
             value={
               <>
                 {position.associatedPositions.map(pos => (
@@ -501,10 +533,11 @@ const PositionColumn = ({
                 ),
               align
             )}
+            mergeFieldHeights={mergeFieldHeights}
+            setMergeFieldHeights={setMergeFieldHeights}
           />
           <PositionField
             label="Previous People"
-            customStyle={customStyleForLargeFields({ type: "array" })}
             value={
               <>
                 {position.previousPeople.map((pp, idx) => (
@@ -519,6 +552,8 @@ const PositionColumn = ({
               () => setFieldValue("previousPeople", position.previousPeople),
               align
             )}
+            mergeFieldHeights={mergeFieldHeights}
+            setMergeFieldHeights={setMergeFieldHeights}
           />
           <PositionField
             label="Person"
@@ -529,6 +564,8 @@ const PositionColumn = ({
               // setting person should also set uuid
               setFieldValue("uuid", position.uuid)
             }, align)}
+            mergeFieldHeights={mergeFieldHeights}
+            setMergeFieldHeights={setMergeFieldHeights}
           />
           {Settings.fields.position.customFields &&
             Object.entries(Settings.fields.position.customFields).map(
@@ -540,7 +577,6 @@ const PositionColumn = ({
                   <PositionField
                     key={fieldName}
                     label={fieldConfig.label || fieldName}
-                    customStyle={customStyleForLargeFields(fieldConfig)}
                     // To be able to see arrays and ojects
                     value={JSON.stringify(fieldValue)}
                     align={align}
@@ -550,6 +586,8 @@ const PositionColumn = ({
                         fieldValue
                       )
                     }, align)}
+                    mergeFieldHeights={mergeFieldHeights}
+                    setMergeFieldHeights={setMergeFieldHeights}
                   />
                 )
               }
@@ -561,6 +599,8 @@ const PositionColumn = ({
             action={getActionButton(() => {
               setFieldValue("location", position.location)
             }, align)}
+            mergeFieldHeights={mergeFieldHeights}
+            setMergeFieldHeights={setMergeFieldHeights}
           />
           {getLeafletMap(`merge-position-map-${align}`, position.location)}
         </>
@@ -580,7 +620,9 @@ PositionColumn.propTypes = {
   setPosition: PropTypes.func.isRequired,
   setFieldValue: PropTypes.func.isRequired,
   align: PropTypes.oneOf(["left", "right", "center"]).isRequired,
-  label: PropTypes.string.isRequired
+  label: PropTypes.string.isRequired,
+  mergeFieldHeights: PropTypes.object,
+  setMergeFieldHeights: PropTypes.func
 }
 
 export default connect(null, mapPageDispatchersToProps)(MergePositions)

--- a/client/src/pages/admin/MergePositions.js
+++ b/client/src/pages/admin/MergePositions.js
@@ -27,6 +27,7 @@ import useMergeObjects, {
   getClearButton,
   getInfoButton,
   getLeafletMap,
+  getOtherSide,
   selectAllFields,
   setAMergedField,
   setMergeable,
@@ -51,15 +52,6 @@ const GQL_MERGE_POSITION = gql`
     }
   }
 `
-
-const positionsFilters = {
-  allAdvisorPositions: {
-    label: "All",
-    queryVars: {
-      status: Position.STATUS.ACTIVE
-    }
-  }
-}
 
 const MergePositions = ({ pageDispatchers }) => {
   const history = useHistory()
@@ -374,6 +366,19 @@ const MidColTitle = styled.div`
   align-items: center;
 `
 
+function getPositionFilters(mergeState, align) {
+  const positionsFilters = {
+    allAdvisorPositions: {
+      label: "All",
+      queryVars: {
+        status: Position.STATUS.ACTIVE,
+        organizationUuid: mergeState[getOtherSide(align)]?.organization?.uuid
+      }
+    }
+  }
+  return positionsFilters
+}
+
 const PositionColumn = ({ align, label, mergeState, dispatchMergeActions }) => {
   const position = mergeState[align]
   const idForPosition = label.replace(/\s+/g, "")
@@ -390,7 +395,7 @@ const PositionColumn = ({ align, label, mergeState, dispatchMergeActions }) => {
           value={position}
           overlayColumns={["Position", "Organization", "Current Occupant"]}
           overlayRenderRow={PositionOverlayRow}
-          filterDefs={positionsFilters}
+          filterDefs={getPositionFilters(mergeState, align)}
           onChange={value => {
             const newValue = value
             if (newValue?.customFields) {

--- a/client/src/pages/admin/MergePositions.js
+++ b/client/src/pages/admin/MergePositions.js
@@ -115,14 +115,17 @@ const MergePositions = ({ pageDispatchers }) => {
               </Callout>
             </div>
           )}
-          {areAllSet(position1, position2, !mergedPosition?.name) && (
+          {areAllSet(position1, position2, !mergedPosition) && (
             <div style={{ padding: "16px 5%" }}>
               <Callout intent="primary">
-                Please choose a <strong>name</strong> to proceed...
+                - You must choose a <strong>name</strong> field. It
+                automatically fills organization and type
+                <br />- You also need to select the person from the filled
+                position
               </Callout>
             </div>
           )}
-          {areAllSet(position1, position2, mergedPosition?.name) && (
+          {areAllSet(position1, position2, mergedPosition) && (
             <>
               <PositionField
                 label="Name"
@@ -452,15 +455,6 @@ const PositionColumn = ({ align, label, mergeState, dispatchMergeActions }) => {
               <LinkTo modelType="Organization" model={position.organization} />
             }
             align={align}
-            action={getActionButton(
-              () =>
-                dispatchMergeActions(
-                  setAMergedField("organization", position.organization, align)
-                ),
-              align,
-              mergeState,
-              "organization"
-            )}
             mergeState={mergeState}
             dispatchMergeActions={dispatchMergeActions}
           />
@@ -469,15 +463,6 @@ const PositionColumn = ({ align, label, mergeState, dispatchMergeActions }) => {
             fieldName="type"
             value={position.type}
             align={align}
-            action={getActionButton(
-              () =>
-                dispatchMergeActions(
-                  setAMergedField("type", position.type, align)
-                ),
-              align,
-              mergeState,
-              "type"
-            )}
             mergeState={mergeState}
             dispatchMergeActions={dispatchMergeActions}
           />

--- a/client/src/pages/admin/MergePositions.js
+++ b/client/src/pages/admin/MergePositions.js
@@ -1,6 +1,6 @@
 import { Button, Callout } from "@blueprintjs/core"
 import styled from "@emotion/styled"
-import { DEFAULT_PAGE_PROPS, DEFAULT_SEARCH_PROPS } from "actions"
+import { DEFAULT_SEARCH_PROPS, PAGE_PROPS_NO_NAV } from "actions"
 import API from "api"
 import { gql } from "apollo-boost"
 import { PositionOverlayRow } from "components/advancedSelectWidget/AdvancedSelectOverlayRow"
@@ -120,7 +120,7 @@ const MergePositions = ({ pageDispatchers }) => {
   ] = useMergeValidation({}, {}, new Position(), MODEL_TO_OBJECT_TYPE.Position)
 
   useBoilerplate({
-    pageProps: DEFAULT_PAGE_PROPS,
+    pageProps: PAGE_PROPS_NO_NAV,
     searchProps: DEFAULT_SEARCH_PROPS,
     pageDispatchers
   })

--- a/client/src/pages/admin/MergePositions.js
+++ b/client/src/pages/admin/MergePositions.js
@@ -10,6 +10,7 @@ import LinkTo from "components/LinkTo"
 import PositionField from "components/MergeField"
 import Messages from "components/Messages"
 import {
+  CUSTOM_FIELD_TYPE_DEFAULTS,
   DEFAULT_CUSTOM_FIELDS_PARENT,
   MODEL_TO_OBJECT_TYPE
 } from "components/Model"
@@ -296,7 +297,7 @@ const MergePositions = ({ pageDispatchers }) => {
                         action={getClearButton(() => {
                           setFieldValue(
                             `${DEFAULT_CUSTOM_FIELDS_PARENT}.${fieldName}`,
-                            ""
+                            CUSTOM_FIELD_TYPE_DEFAULTS[fieldConfig.type]
                           )
                         })}
                         mergeFieldHeights={mergeFieldHeights}

--- a/client/src/pages/positions/AssociatedPositions.js
+++ b/client/src/pages/positions/AssociatedPositions.js
@@ -42,4 +42,8 @@ AssociatedPositions.propTypes = {
   associatedPositions: PropTypes.array
 }
 
+AssociatedPositions.defaultProps = {
+  associatedPositions: []
+}
+
 export default AssociatedPositions

--- a/client/src/pages/positions/AssociatedPositions.js
+++ b/client/src/pages/positions/AssociatedPositions.js
@@ -1,0 +1,45 @@
+import LinkTo from "components/LinkTo"
+import PropTypes from "prop-types"
+import React from "react"
+import { Table } from "react-bootstrap"
+
+function AssociatedPositions({ associatedPositions }) {
+  return (
+    <Table>
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Position</th>
+        </tr>
+      </thead>
+      <tbody>
+        {associatedPositions.map((pos, idx) =>
+          renderAssociatedPositionRow(pos, idx)
+        )}
+      </tbody>
+    </Table>
+  )
+
+  function renderAssociatedPositionRow(pos, idx) {
+    let personName
+    if (!pos.person) {
+      personName = "Unfilled"
+    } else {
+      personName = <LinkTo modelType="Person" model={pos.person} />
+    }
+    return (
+      <tr key={pos.uuid} id={`associatedPosition_${idx}`}>
+        <td>{personName}</td>
+        <td>
+          <LinkTo modelType="Position" model={pos} />
+        </td>
+      </tr>
+    )
+  }
+}
+
+AssociatedPositions.propTypes = {
+  associatedPositions: PropTypes.array
+}
+
+export default AssociatedPositions

--- a/client/src/pages/positions/PreviousPeople.js
+++ b/client/src/pages/positions/PreviousPeople.js
@@ -5,13 +5,14 @@ import React from "react"
 import { Table } from "react-bootstrap"
 import Settings from "settings"
 
-function PreviousPeople({ previousPeople }) {
+function PreviousPeople({ history: previousPeople, action }) {
   return (
     <Table>
       <thead>
         <tr>
           <th>Name</th>
           <th>Dates</th>
+          {action && <th>Action</th>}
         </tr>
       </thead>
       <tbody>
@@ -30,6 +31,7 @@ function PreviousPeople({ previousPeople }) {
                   Settings.dateFormats.forms.displayShort.date
                 )}
             </td>
+            {action && <td>{action(pp, idx)}</td>}
           </tr>
         ))}
       </tbody>
@@ -38,7 +40,8 @@ function PreviousPeople({ previousPeople }) {
 }
 
 PreviousPeople.propTypes = {
-  previousPeople: PropTypes.array
+  history: PropTypes.array,
+  action: PropTypes.func
 }
 
 export default PreviousPeople

--- a/client/src/pages/positions/PreviousPeople.js
+++ b/client/src/pages/positions/PreviousPeople.js
@@ -1,0 +1,44 @@
+import LinkTo from "components/LinkTo"
+import moment from "moment"
+import PropTypes from "prop-types"
+import React from "react"
+import { Table } from "react-bootstrap"
+import Settings from "settings"
+
+function PreviousPeople({ previousPeople }) {
+  return (
+    <Table>
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Dates</th>
+        </tr>
+      </thead>
+      <tbody>
+        {previousPeople.map((pp, idx) => (
+          <tr key={idx} id={`previousPerson_${idx}`}>
+            <td>
+              <LinkTo modelType="Person" model={pp.person} />
+            </td>
+            <td>
+              {moment(pp.startTime).format(
+                Settings.dateFormats.forms.displayShort.date
+              )}{" "}
+              - &nbsp;
+              {pp.endTime &&
+                moment(pp.endTime).format(
+                  Settings.dateFormats.forms.displayShort.date
+                )}
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </Table>
+  )
+}
+
+PreviousPeople.propTypes = {
+  previousPeople: PropTypes.array
+}
+
+export default PreviousPeople

--- a/client/src/pages/positions/PreviousPeople.js
+++ b/client/src/pages/positions/PreviousPeople.js
@@ -44,4 +44,8 @@ PreviousPeople.propTypes = {
   action: PropTypes.func
 }
 
+PreviousPeople.defaultProps = {
+  history: []
+}
+
 export default PreviousPeople

--- a/client/src/pages/positions/Show.js
+++ b/client/src/pages/positions/Show.js
@@ -18,76 +18,24 @@ import {
   PageDispatchersPropType,
   useBoilerplate
 } from "components/Page"
-import RelatedObjectNotes, {
-  GRAPHQL_NOTES_FIELDS
-} from "components/RelatedObjectNotes"
+import RelatedObjectNotes from "components/RelatedObjectNotes"
 import { Field, Form, Formik } from "formik"
 import DictionaryField from "HOC/DictionaryField"
 import { Position } from "models"
-import moment from "moment"
 import { positionTour } from "pages/HopscotchTour"
 import React, { useContext, useState } from "react"
-import { Button, Table } from "react-bootstrap"
+import { Button } from "react-bootstrap"
 import { connect } from "react-redux"
 import { useHistory, useLocation, useParams } from "react-router-dom"
 import Settings from "settings"
 import utils from "utils"
+import AssociatedPositions from "./AssociatedPositions"
+import PreviousPeople from "./PreviousPeople"
 
 const GQL_GET_POSITION = gql`
   query($uuid: String!) {
     position(uuid: $uuid) {
-      uuid
-      name
-      type
-      status
-      code
-      organization {
-        uuid
-        shortName
-        longName
-        identificationCode
-      }
-      person {
-        uuid
-        name
-        rank
-        role
-        avatar(size: 32)
-      }
-      associatedPositions {
-        uuid
-        name
-        type
-        person {
-          uuid
-          name
-          rank
-          role
-          avatar(size: 32)
-        }
-        organization {
-          uuid
-          shortName
-        }
-      }
-      previousPeople {
-        startTime
-        endTime
-        person {
-          uuid
-          name
-          rank
-          role
-          avatar(size: 32)
-        }
-      }
-      location {
-        uuid
-        name
-      }
-      customFields
-      ${GRAPHQL_NOTES_FIELDS}
-
+      ${Position.allFieldsQuery}
     }
   }
 `
@@ -319,20 +267,9 @@ const PositionShow = ({ pageDispatchers }) => {
                   )
                 }
               >
-                <Table>
-                  <thead>
-                    <tr>
-                      <th>Name</th>
-                      <th>Position</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {Position.map(position.associatedPositions, (pos, idx) =>
-                      renderAssociatedPositionRow(pos, idx)
-                    )}
-                  </tbody>
-                </Table>
-
+                <AssociatedPositions
+                  associatedPositions={position.associatedPositions}
+                />
                 {position.associatedPositions.length === 0 && (
                   <em>
                     {position.name} has no associated {assignedRole}
@@ -350,33 +287,7 @@ const PositionShow = ({ pageDispatchers }) => {
               </Fieldset>
 
               <Fieldset title="Previous position holders" id="previous-people">
-                <Table>
-                  <thead>
-                    <tr>
-                      <th>Name</th>
-                      <th>Dates</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {position.previousPeople.map((pp, idx) => (
-                      <tr key={idx} id={`previousPerson_${idx}`}>
-                        <td>
-                          <LinkTo modelType="Person" model={pp.person} />
-                        </td>
-                        <td>
-                          {moment(pp.startTime).format(
-                            Settings.dateFormats.forms.displayShort.date
-                          )}{" "}
-                          - &nbsp;
-                          {pp.endTime &&
-                            moment(pp.endTime).format(
-                              Settings.dateFormats.forms.displayShort.date
-                            )}
-                        </td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </Table>
+                <PreviousPeople previousPeople={position.previousPeople} />
               </Fieldset>
               {Settings.fields.position.customFields && (
                 <Fieldset title="Position information" id="custom-fields">
@@ -407,23 +318,6 @@ const PositionShow = ({ pageDispatchers }) => {
       }}
     </Formik>
   )
-
-  function renderAssociatedPositionRow(pos, idx) {
-    let personName
-    if (!pos.person) {
-      personName = "Unfilled"
-    } else {
-      personName = <LinkTo modelType="Person" model={pos.person} />
-    }
-    return (
-      <tr key={pos.uuid} id={`associatedPosition_${idx}`}>
-        <td>{personName}</td>
-        <td>
-          <LinkTo modelType="Position" model={pos} />
-        </td>
-      </tr>
-    )
-  }
 
   function hideAssignPersonModal(success) {
     setShowAssignPersonModal(false)

--- a/client/src/pages/positions/Show.js
+++ b/client/src/pages/positions/Show.js
@@ -287,7 +287,7 @@ const PositionShow = ({ pageDispatchers }) => {
               </Fieldset>
 
               <Fieldset title="Previous position holders" id="previous-people">
-                <PreviousPeople previousPeople={position.previousPeople} />
+                <PreviousPeople history={position.previousPeople} />
               </Fieldset>
               {Settings.fields.position.customFields && (
                 <Fieldset title="Position information" id="custom-fields">

--- a/client/src/periodUtils.js
+++ b/client/src/periodUtils.js
@@ -234,3 +234,21 @@ PeriodsTableHeader.propTypes = {
     PeriodsConfigPropType
   ])
 }
+
+export function getOverlappingPeriodIndexes(periods) {
+  const overlappingDateIndexes = []
+
+  for (let i = 0; i < periods.length; i++) {
+    // end time being null means it is still continuing, might as well pick a large number for it
+    const endTime1 = periods[i].endTime || Infinity
+    // Search against other periods
+    for (let j = i + 1; j < periods.length; j++) {
+      const endTime2 = periods[j].endTime || Infinity
+      if (periods[i].startTime < endTime2 && endTime1 > periods[j].startTime) {
+        overlappingDateIndexes.push([i, j])
+      }
+    }
+  }
+
+  return overlappingDateIndexes
+}

--- a/client/src/periodUtils.js
+++ b/client/src/periodUtils.js
@@ -235,8 +235,9 @@ PeriodsTableHeader.propTypes = {
   ])
 }
 
-export function getOverlappingPeriodIndexes(periods) {
+export function getOverlappingPeriodIndexes(inputPeriods) {
   const overlappingDateIndexes = []
+  const periods = inputPeriods || []
 
   for (let i = 0; i < periods.length; i++) {
     // end time being null means it is still continuing, might as well pick a large number for it

--- a/client/tests/webdriver/baseSpecs/mergePositions.spec.js
+++ b/client/tests/webdriver/baseSpecs/mergePositions.spec.js
@@ -1,0 +1,77 @@
+import { expect } from "chai"
+import MergePositions from "../pages/mergePositions.page"
+
+const EXAMPLE_POSITIONS = {
+  left: {
+    search: "cost",
+    fullName: "Cost Adder - MoD"
+  },
+  right: {
+    search: "Director",
+    fullName: "Director of Budgeting - MoD"
+  }
+}
+
+describe("Merge positions page", () => {
+  it("Should be able to select to positions to merge", () => {
+    MergePositions.open()
+    MergePositions.title.waitForExist()
+    MergePositions.title.waitForDisplayed()
+
+    MergePositions.leftPositionField.setValue(EXAMPLE_POSITIONS.left.search)
+    MergePositions.waitForAdvancedSelectLoading(EXAMPLE_POSITIONS.left.fullName)
+    MergePositions.firstItemFromAdvancedSelect.click()
+    MergePositions.waitForColumnToChange(
+      EXAMPLE_POSITIONS.left.fullName,
+      "left"
+    )
+
+    expect(MergePositions.getColumnPositionName("left").getText()).to.eq(
+      EXAMPLE_POSITIONS.left.fullName
+    )
+
+    MergePositions.rightPositionField.setValue(EXAMPLE_POSITIONS.right.search)
+    MergePositions.waitForAdvancedSelectLoading(
+      EXAMPLE_POSITIONS.right.fullName
+    )
+    MergePositions.firstItemFromAdvancedSelect.click()
+    MergePositions.waitForColumnToChange(
+      EXAMPLE_POSITIONS.right.fullName,
+      "right"
+    )
+
+    expect(MergePositions.getColumnPositionName("right").getText()).to.eq(
+      EXAMPLE_POSITIONS.right.fullName
+    )
+  })
+
+  it("Should be able to select all fields from left position", () => {
+    MergePositions.getUseAllButton("left").click()
+    MergePositions.waitForColumnToChange(EXAMPLE_POSITIONS.left.fullName, "mid")
+
+    expect(MergePositions.getColumnPositionName("mid").getText()).to.eq(
+      EXAMPLE_POSITIONS.left.fullName
+    )
+  })
+
+  it("Should be able to select all fields from right position", () => {
+    MergePositions.getUseAllButton("right").click()
+    MergePositions.waitForColumnToChange(
+      EXAMPLE_POSITIONS.right.fullName,
+      "mid"
+    )
+
+    expect(MergePositions.getColumnPositionName("mid").getText()).to.eq(
+      EXAMPLE_POSITIONS.right.fullName
+    )
+  })
+
+  it("Should be able to merge both positions when winner is left position", () => {
+    MergePositions.getUseAllButton("left").click()
+    MergePositions.waitForColumnToChange(EXAMPLE_POSITIONS.left.fullName, "mid")
+
+    MergePositions.mergePositionsButton.click()
+
+    MergePositions.waitForSuccessAlert()
+  })
+})

--- a/client/tests/webdriver/pages/mergePositions.page.js
+++ b/client/tests/webdriver/pages/mergePositions.page.js
@@ -1,0 +1,96 @@
+import Page from "./page"
+
+const PATH = "/admin/mergePositions"
+
+class MergePositions extends Page {
+  open() {
+    super.openAsAdminUser(PATH)
+  }
+
+  get title() {
+    return browser.$('//h2[contains(text(),"Merge Positions")]')
+  }
+
+  get leftPositionField() {
+    return browser.$("#Position1")
+  }
+
+  get rightPositionField() {
+    return browser.$("#Position2")
+  }
+
+  get advancedSelectPopover() {
+    return browser.$(".bp3-popover2-content")
+  }
+
+  get positionHeaderFromPopover() {
+    return browser.$('//table//th[contains(text(), "Position")]')
+  }
+
+  get firstItemFromAdvancedSelect() {
+    return browser.$("table > tbody > tr:first-child > td:nth-child(2) > span")
+  }
+
+  get mergePositionsButton() {
+    return browser.$('//button//span[text()="Merge Positions"]')
+  }
+
+  getUseAllButton(side) {
+    const button = side === "left" ? "small:first-child" : "small:last-child"
+    return browser.$(`#mid-merge-pos-col ${button} > button`)
+  }
+
+  getColumnPositionName(side) {
+    return browser.$(
+      `//div[@id="${side}-merge-pos-col"]//div[text()="Name"]/following-sibling::div`
+    )
+  }
+
+  waitForAdvancedSelectLoading(compareStr) {
+    this.advancedSelectPopover.waitForExist()
+    this.advancedSelectPopover.waitForDisplayed()
+    this.positionHeaderFromPopover.waitForExist()
+    this.positionHeaderFromPopover.waitForDisplayed()
+
+    browser.waitUntil(
+      () => {
+        return this.firstItemFromAdvancedSelect.getText() === compareStr
+      },
+      {
+        timeout: 5000,
+        timeoutMsg: "Couldn't find the searched position in time"
+      }
+    )
+  }
+
+  waitForColumnToChange(compareStr, side) {
+    const field = this.getColumnPositionName(side)
+
+    browser.waitUntil(
+      () => {
+        return field.getText() === compareStr
+      },
+      {
+        timeout: 5000,
+        timeoutMsg: "Couldn't set the position in time"
+      }
+    )
+  }
+
+  waitForSuccessAlert() {
+    browser.waitUntil(
+      () => {
+        return (
+          browser.$(".alert-success").getText() ===
+          "Positions merged. Displaying merged Position below."
+        )
+      },
+      {
+        timeout: 5000,
+        timeoutMsg: "Couldn't see the success alert in time"
+      }
+    )
+  }
+}
+
+export default new MergePositions()

--- a/src/main/java/mil/dds/anet/database/AnetBaseDao.java
+++ b/src/main/java/mil/dds/anet/database/AnetBaseDao.java
@@ -54,4 +54,34 @@ public abstract class AnetBaseDao<T extends AbstractAnetBean, S extends Abstract
     throw new UnsupportedOperationException();
   }
 
+  // Some convenience functions for merging objects
+
+  protected void updateForMerge(String tableName, String fieldName, String winnerUuid,
+      String loserUuid) {
+    final String sqlUpdateFormat =
+        "UPDATE \"%1$s\" SET \"%2$s\" = :winnerUuid WHERE \"%2$s\" = :loserUuid";
+    getDbHandle().createUpdate(String.format(sqlUpdateFormat, tableName, fieldName))
+        .bind("winnerUuid", winnerUuid).bind("loserUuid", loserUuid).execute();
+  }
+
+  protected void updateM2mForMerge(String tableName, String mainObjectFieldName,
+      String relatedObjectFieldName, String winnerUuid, String loserUuid) {
+    // update m2m objects where we don't already have the same object for the winnerUuid
+    final String sqlUpdateFormat = "UPDATE \"%1$s\" SET \"%3$s\" = :winnerUuid"
+        + " WHERE \"%3$s\" = :loserUuid AND \"%2$s\" NOT IN ("
+        + "SELECT \"%2$s\" FROM \"%1$s\" WHERE \"%3$s\" = :winnerUuid" + ")";
+    getDbHandle()
+        .createUpdate(
+            String.format(sqlUpdateFormat, tableName, mainObjectFieldName, relatedObjectFieldName))
+        .bind("winnerUuid", winnerUuid).bind("loserUuid", loserUuid).execute();
+
+    // now delete obsolete m2m objects for the loserUuid
+    deleteForMerge(tableName, relatedObjectFieldName, loserUuid);
+  }
+
+  protected int deleteForMerge(String tableName, String fieldName, String loserUuid) {
+    final String sqlDeleteFormat = "DELETE FROM \"%1$s\" WHERE \"%2$s\" = :loserUuid";
+    return getDbHandle().createUpdate(String.format(sqlDeleteFormat, tableName, fieldName))
+        .bind("loserUuid", loserUuid).execute();
+  }
 }

--- a/src/main/java/mil/dds/anet/database/PositionDao.java
+++ b/src/main/java/mil/dds/anet/database/PositionDao.java
@@ -479,7 +479,7 @@ public class PositionDao extends AnetBaseDao<Position, PositionSearchQuery> {
   @InTransaction
   public int mergePositions(Position existingPos, Position mergedPosition) {
     getDbHandle().createUpdate(
-        "/* updatePeoplePositionsAfterMergePosition */ UPDATE \"peoplePositions\" set \"positionUuid\" = :mergedPositionUuid "
+        "/* updatePeoplePositionsAfterMergePositions */ UPDATE \"peoplePositions\" set \"positionUuid\" = :mergedPositionUuid "
             + "WHERE \"positionUuid\" = :existingPosUuid")
         .bind("mergedPositionUuid", mergedPosition.getUuid())
         .bind("existingPosUuid", existingPos.getUuid()).execute();
@@ -490,21 +490,21 @@ public class PositionDao extends AnetBaseDao<Position, PositionSearchQuery> {
 
     // Update notes of existing position's with merged position info
     getDbHandle().createUpdate(
-        "/* updateNoteRelatedObjectsAfterMergePosition */ UPDATE \"noteRelatedObjects\" set \"relatedObjectUuid\" = :mergedPositionUuid "
+        "/* updateNoteRelatedObjectsAfterMergePositions */ UPDATE \"noteRelatedObjects\" set \"relatedObjectUuid\" = :mergedPositionUuid "
             + "WHERE \"relatedObjectUuid\" = :existingPosUuid")
         .bind("mergedPositionUuid", mergedPosition.getUuid())
         .bind("existingPosUuid", existingPos.getUuid()).execute();
 
     // Update approvers position info with merged position info
     getDbHandle().createUpdate(
-        "/* updateApproversAfterMergePosition */ UPDATE \"approvers\" set \"positionUuid\" = :mergedPositionUuid "
+        "/* updateApproversAfterMergePositions */ UPDATE \"approvers\" set \"positionUuid\" = :mergedPositionUuid "
             + "WHERE \"positionUuid\" = :existingPosUuid")
         .bind("mergedPositionUuid", mergedPosition.getUuid())
         .bind("existingPosUuid", existingPos.getUuid()).execute();
 
     // Update task Responsible Position info with merged position info
     getDbHandle().createUpdate(
-        "/* updateTaskResponsiblePositionsAfterMergePosition */ UPDATE \"taskResponsiblePositions\" set \"positionUuid\" = :mergedPositionUuid "
+        "/* updateTaskResponsiblePositionsAfterMergePositions */ UPDATE \"taskResponsiblePositions\" set \"positionUuid\" = :mergedPositionUuid "
             + "WHERE \"positionUuid\" = :existingPosUuid")
         .bind("mergedPositionUuid", mergedPosition.getUuid())
         .bind("existingPosUuid", existingPos.getUuid()).execute();

--- a/src/main/java/mil/dds/anet/database/PositionDao.java
+++ b/src/main/java/mil/dds/anet/database/PositionDao.java
@@ -254,7 +254,7 @@ public class PositionDao extends AnetBaseDao<Position, PositionSearchQuery> {
         .createUpdate("/* positionRemovePerson.update */ UPDATE positions "
             + "SET \"currentPersonUuid\" = :personUuid, \"updatedAt\" = :updatedAt "
             + "WHERE uuid = :positionUuid")
-        .bind("personUuid", (Integer) null).bind("updatedAt", DaoUtils.asLocalDateTime(now))
+        .bind("personUuid", (String) null).bind("updatedAt", DaoUtils.asLocalDateTime(now))
         .bind("positionUuid", positionUuid).execute();
 
     final String updateSql;
@@ -376,7 +376,6 @@ public class PositionDao extends AnetBaseDao<Position, PositionSearchQuery> {
         .bind("deleted", true).bind("positionUuid_a", uuids.get(0))
         .bind("positionUuid_b", uuids.get(1))
         .bind("updatedAt", DaoUtils.asLocalDateTime(Instant.now())).execute();
-
   }
 
   @InTransaction

--- a/src/main/java/mil/dds/anet/database/PositionDao.java
+++ b/src/main/java/mil/dds/anet/database/PositionDao.java
@@ -476,7 +476,6 @@ public class PositionDao extends AnetBaseDao<Position, PositionSearchQuery> {
         .bind("loserUuid", loserUuid).execute();
   }
 
-
   @InTransaction
   public int mergePositions(Position existingPos, Position mergedPosition) {
     getDbHandle().createUpdate(

--- a/src/main/java/mil/dds/anet/resources/PersonResource.java
+++ b/src/main/java/mil/dds/anet/resources/PersonResource.java
@@ -241,7 +241,7 @@ public class PersonResource {
     }
 
     int merged = dao.mergePeople(winner, loser);
-    AnetAuditLogger.log("Person {} merged into WINNER: {}  by {}", loser, winner, user);
+    AnetAuditLogger.log("Person {} merged into {} by {}", loser, winner, user);
 
     if (loserPosition != null && copyPosition) {
       AnetObjectEngine.getInstance().getPositionDao().setPersonInPosition(winner.getUuid(),

--- a/src/main/java/mil/dds/anet/resources/PositionResource.java
+++ b/src/main/java/mil/dds/anet/resources/PositionResource.java
@@ -237,16 +237,7 @@ public class PositionResource {
     final Position existingPos = dao.getByUuid(loserUuid);
 
     // Check that given two position can mergeable
-    canPositionsMergeable(existingPos, winnerPosition);
-    if ((Objects.nonNull(existingPos.getPersonUuid())
-        || Objects.nonNull(winnerPosition.getPersonUuid()))
-        && Objects.isNull(winnerPosition.getPersonUuid())) {
-      throw new WebApplicationException(
-          "If There is a person assigned to one of the combined Positions, "
-              + "This person must be in the position which is merged",
-          Status.BAD_REQUEST);
-    }
-
+    arePositionsMergeable(existingPos, winnerPosition);
     assertCanUpdatePosition(user, winnerPosition);
     validatePosition(user, winnerPosition);
 
@@ -273,7 +264,7 @@ public class PositionResource {
     return position;
   }
 
-  private void canPositionsMergeable(Position existingPos, Position existingPos2) {
+  private void arePositionsMergeable(Position existingPos, Position existingPos2) {
     if (existingPos.getUuid().equals(existingPos2.getUuid())) {
       throw new WebApplicationException("Cannot merge same Positions.", Status.BAD_REQUEST);
     }
@@ -286,6 +277,15 @@ public class PositionResource {
 
     if (!existingPos.getOrganizationUuid().equals(existingPos2.getOrganizationUuid())) {
       throw new WebApplicationException("Positions to be merged must be in the same organization.",
+          Status.BAD_REQUEST);
+    }
+
+    if ((Objects.nonNull(existingPos.getPersonUuid())
+        || Objects.nonNull(existingPos2.getPersonUuid()))
+        && Objects.isNull(existingPos2.getPersonUuid())) {
+      throw new WebApplicationException(
+          "If There is a person assigned to one of the combined Positions, "
+              + "This person must be in the position which is merged",
           Status.BAD_REQUEST);
     }
   }

--- a/src/main/java/mil/dds/anet/resources/PositionResource.java
+++ b/src/main/java/mil/dds/anet/resources/PositionResource.java
@@ -229,8 +229,8 @@ public class PositionResource {
     return dao.delete(positionUuid);
   }
 
-  @GraphQLMutation(name = "mergePosition")
-  public Position mergePosition(@GraphQLRootContext Map<String, Object> context,
+  @GraphQLMutation(name = "mergePositions")
+  public Position mergePositions(@GraphQLRootContext Map<String, Object> context,
       @GraphQLArgument(name = "loserUuid") String loserUuid,
       @GraphQLArgument(name = "winnerPosition") Position winnerPosition) {
     final Person user = DaoUtils.getUserFromContext(context);

--- a/src/main/java/mil/dds/anet/resources/PositionResource.java
+++ b/src/main/java/mil/dds/anet/resources/PositionResource.java
@@ -236,7 +236,7 @@ public class PositionResource {
     final Person user = DaoUtils.getUserFromContext(context);
     final Position existingPos = dao.getByUuid(loserUuid);
 
-    // Check that given two position can mergeable
+    // Check that given two position can be merged
     arePositionsMergeable(existingPos, winnerPosition);
     assertCanUpdatePosition(user, winnerPosition);
     validatePosition(user, winnerPosition);

--- a/src/main/java/mil/dds/anet/resources/PositionResource.java
+++ b/src/main/java/mil/dds/anet/resources/PositionResource.java
@@ -236,9 +236,9 @@ public class PositionResource {
     final Person user = DaoUtils.getUserFromContext(context);
     final Position existingPos = dao.getByUuid(loserUuid);
 
+    assertCanUpdatePosition(user, winnerPosition);
     // Check that given two position can be merged
     arePositionsMergeable(existingPos, winnerPosition);
-    assertCanUpdatePosition(user, winnerPosition);
     validatePosition(user, winnerPosition);
 
     // Delete loser position's code information
@@ -271,22 +271,21 @@ public class PositionResource {
 
   private void arePositionsMergeable(Position existingPos, Position existingPos2) {
     if (existingPos.getUuid().equals(existingPos2.getUuid())) {
-      throw new WebApplicationException("Cannot merge same Positions.", Status.BAD_REQUEST);
+      throw new WebApplicationException("Cannot merge identical positions.", Status.BAD_REQUEST);
     }
 
     if (Objects.nonNull(existingPos.getPersonUuid())
         && Objects.nonNull(existingPos2.getPersonUuid())) {
-      throw new WebApplicationException("There are assigned person in both Position.",
+      throw new WebApplicationException("Cannot merge positions when both have assigned person.",
           Status.BAD_REQUEST);
     }
 
     if (!existingPos.getOrganizationUuid().equals(existingPos2.getOrganizationUuid())) {
-      throw new WebApplicationException("Positions to be merged must be in the same organization.",
+      throw new WebApplicationException("Cannot merge positions from different organizations.",
           Status.BAD_REQUEST);
     }
 
-    if ((Objects.nonNull(existingPos.getPersonUuid())
-        || Objects.nonNull(existingPos2.getPersonUuid()))
+    if (Objects.nonNull(existingPos.getPersonUuid())
         && Objects.isNull(existingPos2.getPersonUuid())) {
       throw new WebApplicationException(
           "If There is a person assigned to one of the combined Positions, "

--- a/src/main/java/mil/dds/anet/resources/PositionResource.java
+++ b/src/main/java/mil/dds/anet/resources/PositionResource.java
@@ -244,13 +244,16 @@ public class PositionResource {
     // Delete loser position's code information
     int rowNums = dao.cleanLoserPositionCode(loserUuid);
     if (rowNums == 0) {
-      throw new WebApplicationException("Couldn't process merge operation", Status.NOT_FOUND);
+      throw new WebApplicationException(
+          "Couldn't process merge operation, loser position code cannot be deleted.",
+          Status.NOT_FOUND);
     }
 
     // Update winner position.
     final int nr = dao.update(winnerPosition);
     if (nr == 0) {
-      throw new WebApplicationException("Couldn't process merge operation", Status.NOT_FOUND);
+      throw new WebApplicationException(
+          "Couldn't process merge operation, winner position update failed.", Status.NOT_FOUND);
     }
     final Position position = dao.getByUuid(winnerPosition.getUuid());
     if (winnerPosition.getPersonUuid() != null) {
@@ -258,7 +261,9 @@ public class PositionResource {
     }
     int numRows = dao.mergePositions(existingPos, position);
     if (numRows == 0) {
-      throw new WebApplicationException("Couldn't process merge operation", Status.NOT_FOUND);
+      throw new WebApplicationException(
+          "Couldn't process merge operation, error occurred while updating merged position relation information.",
+          Status.NOT_FOUND);
     }
     AnetAuditLogger.log("Position {} merged on {} by {}", existingPos, position, user);
     return position;

--- a/src/test/java/mil/dds/anet/test/resources/PositionResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/PositionResourceTest.java
@@ -778,7 +778,7 @@ public class PositionResourceTest extends AbstractResourceTest {
     testPerson.setRole(Role.PRINCIPAL);
     testPerson.setStatus(Person.Status.ACTIVE);
 
-    String testPersonUuid = graphQLHelper.createObject(admin, "createPerson", "person",
+    final String testPersonUuid = graphQLHelper.createObject(admin, "createPerson", "person",
         "PersonInput", testPerson, new TypeReference<GraphQlResponse<Person>>() {});
     assertThat(testPersonUuid).isNotNull();
     testPerson = graphQLHelper.getObjectById(admin, "person", PERSON_FIELDS, testPersonUuid,
@@ -800,7 +800,7 @@ public class PositionResourceTest extends AbstractResourceTest {
     firstPosition.setStatus(Position.Status.ACTIVE);
     firstPosition.setPerson(testPerson);
 
-    String firstPositionUuid = graphQLHelper.createObject(admin, "createPosition", "position",
+    final String firstPositionUuid = graphQLHelper.createObject(admin, "createPosition", "position",
         "PositionInput", firstPosition, new TypeReference<GraphQlResponse<Position>>() {});
     assertThat(firstPositionUuid).isNotNull();
     firstPosition = graphQLHelper.getObjectById(admin, "position", FIELDS, firstPositionUuid,
@@ -813,8 +813,9 @@ public class PositionResourceTest extends AbstractResourceTest {
     secondPosition.setOrganization(orgs.getList().get(0));
     secondPosition.setStatus(Position.Status.ACTIVE);
 
-    String secondPositionUuid = graphQLHelper.createObject(admin, "createPosition", "position",
-        "PositionInput", secondPosition, new TypeReference<GraphQlResponse<Position>>() {});
+    final String secondPositionUuid =
+        graphQLHelper.createObject(admin, "createPosition", "position", "PositionInput",
+            secondPosition, new TypeReference<GraphQlResponse<Position>>() {});
     assertThat(secondPositionUuid).isNotNull();
     secondPosition = graphQLHelper.getObjectById(admin, "position", FIELDS, secondPositionUuid,
         new TypeReference<GraphQlResponse<Position>>() {});

--- a/src/test/java/mil/dds/anet/test/resources/PositionResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/PositionResourceTest.java
@@ -776,7 +776,7 @@ public class PositionResourceTest extends AbstractResourceTest {
     Person testPerson = new Person();
     testPerson.setName("MergePositionTest Person");
     testPerson.setRole(Role.PRINCIPAL);
-    testPerson.setStatus(PersonStatus.ACTIVE);
+    testPerson.setStatus(Person.Status.ACTIVE);
 
     String testPersonUuid = graphQLHelper.createObject(admin, "createPerson", "person",
         "PersonInput", testPerson, new TypeReference<GraphQlResponse<Person>>() {});
@@ -797,7 +797,7 @@ public class PositionResourceTest extends AbstractResourceTest {
     firstPosition.setName("MergePositionTest First Position");
     firstPosition.setType(PositionType.PRINCIPAL);
     firstPosition.setOrganization(orgs.getList().get(0));
-    firstPosition.setStatus(PositionStatus.ACTIVE);
+    firstPosition.setStatus(Position.Status.ACTIVE);
     firstPosition.setPerson(testPerson);
 
     String firstPositionUuid = graphQLHelper.createObject(admin, "createPosition", "position",
@@ -811,7 +811,7 @@ public class PositionResourceTest extends AbstractResourceTest {
     secondPosition.setName("MergePositionTest Second Position");
     secondPosition.setType(PositionType.PRINCIPAL);
     secondPosition.setOrganization(orgs.getList().get(0));
-    secondPosition.setStatus(PositionStatus.ACTIVE);
+    secondPosition.setStatus(Position.Status.ACTIVE);
 
     String secondPositionUuid = graphQLHelper.createObject(admin, "createPosition", "position",
         "PositionInput", secondPosition, new TypeReference<GraphQlResponse<Position>>() {});

--- a/src/test/java/mil/dds/anet/test/resources/PositionResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/PositionResourceTest.java
@@ -774,7 +774,7 @@ public class PositionResourceTest extends AbstractResourceTest {
   public void mergePositionsTest() {
     // Create a new position and designate the person upfront
     Person testPerson = new Person();
-    testPerson.setName("MergePositionTest Person");
+    testPerson.setName("MergePositionsTest Person");
     testPerson.setRole(Role.PRINCIPAL);
     testPerson.setStatus(Person.Status.ACTIVE);
 
@@ -794,7 +794,7 @@ public class PositionResourceTest extends AbstractResourceTest {
     assertThat(orgs.getList().size()).isGreaterThan(0);
 
     Position firstPosition = new Position();
-    firstPosition.setName("MergePositionTest First Position");
+    firstPosition.setName("MergePositionsTest First Position");
     firstPosition.setType(PositionType.PRINCIPAL);
     firstPosition.setOrganization(orgs.getList().get(0));
     firstPosition.setStatus(Position.Status.ACTIVE);
@@ -808,7 +808,7 @@ public class PositionResourceTest extends AbstractResourceTest {
     assertThat(firstPosition.getUuid()).isNotNull();
 
     Position secondPosition = new Position();
-    secondPosition.setName("MergePositionTest Second Position");
+    secondPosition.setName("MergePositionsTest Second Position");
     secondPosition.setType(PositionType.PRINCIPAL);
     secondPosition.setOrganization(orgs.getList().get(0));
     secondPosition.setStatus(Position.Status.ACTIVE);
@@ -830,7 +830,7 @@ public class PositionResourceTest extends AbstractResourceTest {
     variables.put("winnerPosition", firstPosition);
     Position position = graphQLHelper.updateObject(admin,
         "mutation ($loserUuid: String!, $winnerPosition: PositionInput!) "
-            + "{ payload: mergePosition (loserUuid: $loserUuid, winnerPosition: $winnerPosition) { uuid }}",
+            + "{ payload: mergePositions (loserUuid: $loserUuid, winnerPosition: $winnerPosition) { uuid }}",
         variables, new TypeReference<GraphQlResponse<Position>>() {});
     assertThat(position).isNotNull();
     assertThat(position.getUuid()).isNotNull();

--- a/src/test/java/mil/dds/anet/test/resources/PositionResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/PositionResourceTest.java
@@ -769,4 +769,77 @@ public class PositionResourceTest extends AbstractResourceTest {
       }
     }
   }
+
+  @Test
+  public void mergePositionsTest() {
+    // Create a new position and designate the person upfront
+    Person testPerson = new Person();
+    testPerson.setName("MergePositionTest Person");
+    testPerson.setRole(Role.PRINCIPAL);
+    testPerson.setStatus(PersonStatus.ACTIVE);
+
+    String testPersonUuid = graphQLHelper.createObject(admin, "createPerson", "person",
+        "PersonInput", testPerson, new TypeReference<GraphQlResponse<Person>>() {});
+    assertThat(testPersonUuid).isNotNull();
+    testPerson = graphQLHelper.getObjectById(admin, "person", PERSON_FIELDS, testPersonUuid,
+        new TypeReference<GraphQlResponse<Person>>() {});
+    assertThat(testPerson.getUuid()).isNotNull();
+
+    final OrganizationSearchQuery queryOrgs = new OrganizationSearchQuery();
+    queryOrgs.setText("Ministry");
+    queryOrgs.setType(OrganizationType.PRINCIPAL_ORG);
+    final AnetBeanList<Organization> orgs = graphQLHelper.searchObjects(admin, "organizationList",
+        "query", "OrganizationSearchQueryInput", ORGANIZATION_FIELDS, queryOrgs,
+        new TypeReference<GraphQlResponse<AnetBeanList<Organization>>>() {});
+    assertThat(orgs.getList().size()).isGreaterThan(0);
+
+    Position firstPosition = new Position();
+    firstPosition.setName("MergePositionTest First Position");
+    firstPosition.setType(PositionType.PRINCIPAL);
+    firstPosition.setOrganization(orgs.getList().get(0));
+    firstPosition.setStatus(PositionStatus.ACTIVE);
+    firstPosition.setPerson(testPerson);
+
+    String firstPositionUuid = graphQLHelper.createObject(admin, "createPosition", "position",
+        "PositionInput", firstPosition, new TypeReference<GraphQlResponse<Position>>() {});
+    assertThat(firstPositionUuid).isNotNull();
+    firstPosition = graphQLHelper.getObjectById(admin, "position", FIELDS, firstPositionUuid,
+        new TypeReference<GraphQlResponse<Position>>() {});
+    assertThat(firstPosition.getUuid()).isNotNull();
+
+    Position secondPosition = new Position();
+    secondPosition.setName("MergePositionTest Second Position");
+    secondPosition.setType(PositionType.PRINCIPAL);
+    secondPosition.setOrganization(orgs.getList().get(0));
+    secondPosition.setStatus(PositionStatus.ACTIVE);
+
+    String secondPositionUuid = graphQLHelper.createObject(admin, "createPosition", "position",
+        "PositionInput", secondPosition, new TypeReference<GraphQlResponse<Position>>() {});
+    assertThat(secondPositionUuid).isNotNull();
+    secondPosition = graphQLHelper.getObjectById(admin, "position", FIELDS, secondPositionUuid,
+        new TypeReference<GraphQlResponse<Position>>() {});
+    assertThat(secondPosition.getUuid()).isNotNull();
+
+    firstPosition.setStatus(secondPosition.getStatus());
+    firstPosition.setType(secondPosition.getType());
+    firstPosition.setUuid(firstPositionUuid);
+
+    Map<String, Object> variables = new HashMap<>();
+    variables.put("loserUuid", secondPosition.getUuid());
+    variables.put("winnerPosition", firstPosition);
+    Position position = graphQLHelper.updateObject(admin,
+        "mutation ($loserUuid: String!, $winnerPosition: PositionInput!) "
+            + "{ payload: mergePosition (loserUuid: $loserUuid, winnerPosition: $winnerPosition) { uuid }}",
+        variables, new TypeReference<GraphQlResponse<Position>>() {});
+    assertThat(position).isNotNull();
+    assertThat(position.getUuid()).isNotNull();
+
+    // Assert that loser is gone.
+    try {
+      graphQLHelper.getObjectById(admin, "position", FIELDS, secondPosition.getUuid(),
+          new TypeReference<GraphQlResponse<Position>>() {});
+      fail("Expected NotFoundException");
+    } catch (NotFoundException expectedException) {
+    }
+  }
 }


### PR DESCRIPTION
Added an admin page to merge duplicate positions. Admins can choose two position objects and can merge these positions by picking each field as they wish. These are the validation steps before merging:

- The positions must be different
- The positions must be in the same organization
- At least one of the positions must be empty
- If one of the positions is occupied by a person, the uuid and person fields must match with merged position

### Release notes

Closes #2995
Fixes #2258

#### User changes
- None

#### Super User changes
- None

#### Admin changes
- Add merge positions page

#### System admin changes
-
- [ ] anet.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [X] graphql schema has changed

### Checklist
  - [X] Described the user behavior in PR body
  - [X] Referenced/updated all related issues
  - [X] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [X] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [X] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [X] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
