### PR TITLE
Send back e2e test results to BrowserStack

### DIFF
--- a/client/tests/util/test.js
+++ b/client/tests/util/test.js
@@ -7,6 +7,7 @@ const moment = require("moment")
 const _includes = require("lodash/includes")
 const _isRegExp = require("lodash/isRegExp")
 const chalk = require("chalk")
+const fetch = require("cross-fetch")
 
 let capabilities = {}
 const testEnv =
@@ -370,6 +371,27 @@ test.beforeEach(t => {
 // Shut down the browser when we are done.
 test.afterEach.always(async t => {
   if (t.context.driver) {
+    if (testEnv !== "local") {
+      // Send back test result to BrowserStack
+      const session = await t.context.driver.getSession()
+      const url = `https://api.browserstack.com/automate/sessions/${session.getId()}.json`
+      const options = {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization:
+            "Basic " +
+            Buffer.from(
+              `${capabilities["browserstack.user"]}:${capabilities["browserstack.key"]}`
+            ).toString("base64")
+        },
+        body: JSON.stringify({
+          status: t.passed ? "passed" : "failed"
+        })
+      }
+      await fetch(url, options)
+    }
+
     await t.context.driver.quit()
   }
 })


### PR DESCRIPTION
Changes (current behaviour on `candidate` when running client-side tests against BrowserStack):

![Screenshot from 2020-08-19 15-48-36](https://user-images.githubusercontent.com/445238/90643106-7b6a6080-e233-11ea-9aaa-89d3e550d93b.png)

with details:

![Screenshot from 2020-08-19 15-50-36](https://user-images.githubusercontent.com/445238/90643312-bff5fc00-e233-11ea-8839-dcd266c610e7.png)

To (this branch when running client-side tests against BrowserStack):

![Screenshot from 2020-08-19 15-53-39](https://user-images.githubusercontent.com/445238/90643852-51656e00-e234-11ea-8c63-22691ecfc357.png)

with details:

![Screenshot from 2020-08-19 15-54-38](https://user-images.githubusercontent.com/445238/90643883-5b876c80-e234-11ea-975e-13385d156fda.png)

As can be seen from the screenshots, the wdio tests already posted back the test result; this PR adds similar functionality to the e2e tests. The test result can be **PASSED** or **FAILED**.