### PR TITLE
Add ANET object to custom fields

### DIFF
--- a/anet.yml
+++ b/anet.yml
@@ -372,6 +372,18 @@ dictionary:
       keyOutcomes: Key outcomes
       reportText: Key details
       customFields:
+        relatedReport:
+          type: anet_object
+          label: Related report
+          types:
+            - Report
+        additionalEngagementNeeded:
+          type: array_of_anet_objects
+          label: Additional engagement needed for
+          types:
+            - Person
+            - Position
+            - Organization
         multipleButtons:
           type: enumset
           label: Engagement types

--- a/anet.yml
+++ b/anet.yml
@@ -321,6 +321,7 @@ dictionary:
         assessments:
           type: array_of_objects
           label: Assessments definition
+          helpText: Here you can add as many assessments as needed
           addButtonLabel: Add an assessment
           objectLabel: Assessment
           objectFields:
@@ -375,11 +376,13 @@ dictionary:
         relatedReport:
           type: anet_object
           label: Related report
+          helpText: Here you can link to a related report
           types:
             - Report
         additionalEngagementNeeded:
           type: array_of_anet_objects
           label: Additional engagement needed for
+          helpText: Here you can link to people, positions and organizations that need an additional engagement
           types:
             - Person
             - Position
@@ -387,7 +390,7 @@ dictionary:
         multipleButtons:
           type: enumset
           label: Engagement types
-          helpText: Choose one or more of the engagement purposess
+          helpText: Choose one or more of the engagement purposes
           choices:
             train:
               label: Train
@@ -456,6 +459,7 @@ dictionary:
         itemsAgreed:
           type: array_of_objects
           label: Items Agreed To
+          helpText: Here you can add as many agreed-to items as needed
           addButtonLabel: Add an item
           objectLabel: Item agreed
           objectFields:
@@ -473,6 +477,7 @@ dictionary:
         assetsUsed:
           type: array_of_objects
           label: Assets used to assist
+          helpText: Here you can add all assets that were used
           addButtonLabel: Add an asset
           objectLabel: Asset used
           objectFields:
@@ -621,6 +626,7 @@ dictionary:
         arrayFieldName:
           type: array_of_objects
           label: Array of objects
+          helpText: Here you can add as many objects as needed
           addButtonLabel: Add an object
           objectLabel: Object
           objectFields:

--- a/client/package.json
+++ b/client/package.json
@@ -57,6 +57,7 @@
     "eslint-config-standard": "14.1.1",
     "eslint-config-standard-react": "9.2.0",
     "eslint-loader": "4.0.2",
+    "eslint-plugin-chai-expect": "2.2.0",
     "eslint-plugin-flowtype": "5.2.0",
     "eslint-plugin-import": "2.22.0",
     "eslint-plugin-jsx-a11y": "6.3.1",
@@ -252,6 +253,7 @@
       "jquery": true
     },
     "extends": [
+      "plugin:chai-expect/recommended",
       "react-app",
       "standard",
       "standard-react"
@@ -261,6 +263,7 @@
     },
     "parser": "@babel/eslint-parser",
     "plugins": [
+      "chai-expect",
       "flowtype",
       "import",
       "jsx-a11y",

--- a/client/src/components/AdvancedSearch.js
+++ b/client/src/components/AdvancedSearch.js
@@ -8,6 +8,7 @@ import {
 } from "@blueprintjs/core"
 import { resetPagination, SEARCH_OBJECT_LABELS, setSearchQuery } from "actions"
 import ButtonToggleGroup from "components/ButtonToggleGroup"
+import RemoveButton from "components/RemoveButton"
 import searchFilters, {
   POSTITION_POSITION_TYPE_FILTER_KEY,
   SearchQueryPropType
@@ -26,7 +27,6 @@ import {
 } from "react-bootstrap"
 import { connect } from "react-redux"
 import { useHistory } from "react-router-dom"
-import REMOVE_ICON from "resources/delete.png"
 
 const ORG_QUERY_PARAM_TYPES = {
   NONE: {},
@@ -124,9 +124,7 @@ const AdvancedSearch = ({
                   ))}
                 </ButtonToggleGroup>
 
-                <Button
-                  bsStyle="link"
-                  onClick={clearObjectType}
+                <div
                   style={{
                     visibility:
                       possibleFilterTypes.length > 1 && objectType
@@ -134,8 +132,13 @@ const AdvancedSearch = ({
                         : "hidden"
                   }}
                 >
-                  <img src={REMOVE_ICON} height={14} alt="Clear type" />
-                </Button>
+                  <RemoveButton
+                    title="Clear type"
+                    altText="Clear type"
+                    onClick={clearObjectType}
+                    buttonStyle="link"
+                  />
+                </div>
               </div>
             </FormGroup>
 
@@ -333,9 +336,12 @@ const SearchFilter = ({
         </div>
       </Col>
       <Col sm={1} lg={1}>
-        <Button bsStyle="link" onClick={() => onRemove(filter)}>
-          <img src={REMOVE_ICON} height={14} alt="Remove this filter" />
-        </Button>
+        <RemoveButton
+          title="Remove this filter"
+          altText="Remove this filter"
+          onClick={() => onRemove(filter)}
+          buttonStyle="link"
+        />
       </Col>
     </FormGroup>
   )

--- a/client/src/components/CustomFields.js
+++ b/client/src/components/CustomFields.js
@@ -219,7 +219,8 @@ const ArrayOfObjectsField = fieldProps => {
     formikProps,
     invisibleFields,
     updateInvisibleFields,
-    vertical
+    vertical,
+    children
   } = fieldProps
   const value = useMemo(() => getArrayObjectValue(formikProps.values, name), [
     formikProps.values,
@@ -234,6 +235,7 @@ const ArrayOfObjectsField = fieldProps => {
   const addButtonLabel = fieldConfig.addButtonLabel || "Add a new item"
   return (
     <Fieldset title={fieldsetTitle}>
+      {children}
       <FieldArray
         name={name}
         render={arrayHelpers => (
@@ -364,7 +366,13 @@ ReadonlyArrayObject.propTypes = {
   index: PropTypes.number.isRequired
 }
 
-const AnetObjectField = ({ name, types, formikProps, ...otherFieldProps }) => {
+const AnetObjectField = ({
+  name,
+  types,
+  formikProps,
+  children,
+  ...otherFieldProps
+}) => {
   const { values, setFieldValue } = formikProps
   const fieldValue = Object.get(values, name) || {}
   return (
@@ -385,6 +393,7 @@ const AnetObjectField = ({ name, types, formikProps, ...otherFieldProps }) => {
       }
       {...otherFieldProps}
     >
+      {children}
       {fieldValue.type && fieldValue.uuid && (
         <Table id={`${name}-value`} striped condensed hover responsive>
           <tbody>
@@ -409,7 +418,8 @@ const AnetObjectField = ({ name, types, formikProps, ...otherFieldProps }) => {
 AnetObjectField.propTypes = {
   name: PropTypes.string.isRequired,
   types: PropTypes.arrayOf(PropTypes.string),
-  formikProps: PropTypes.object
+  formikProps: PropTypes.object,
+  children: PropTypes.node
 }
 
 const ReadonlyAnetObjectField = ({ name, label, values }) => {
@@ -446,6 +456,7 @@ const ArrayOfAnetObjectsField = ({
   name,
   types,
   formikProps,
+  children,
   ...otherFieldProps
 }) => {
   const { values, setFieldValue } = formikProps
@@ -475,6 +486,7 @@ const ArrayOfAnetObjectsField = ({
       }
       {...otherFieldProps}
     >
+      {children}
       {!_isEmpty(fieldValue) && (
         <Table id={`${name}-value`} striped condensed hover responsive>
           <tbody>
@@ -513,7 +525,8 @@ const ArrayOfAnetObjectsField = ({
 ArrayOfAnetObjectsField.propTypes = {
   name: PropTypes.string.isRequired,
   types: PropTypes.arrayOf(PropTypes.string),
-  formikProps: PropTypes.object
+  formikProps: PropTypes.object,
+  children: PropTypes.node
 }
 
 const ReadonlyArrayOfAnetObjectsField = ({ name, label, values }) => {

--- a/client/src/components/CustomFields.js
+++ b/client/src/components/CustomFields.js
@@ -388,7 +388,7 @@ const AnetObjectField = ({ name, types, formikProps, ...otherFieldProps }) => {
       {...otherFieldProps}
     >
       {fieldValue.type && fieldValue.uuid && (
-        <>
+        <div id={`${name}-value`}>
           <span
             style={{ cursor: "pointer" }}
             onClick={() => setFieldValue(name, null)}
@@ -396,7 +396,7 @@ const AnetObjectField = ({ name, types, formikProps, ...otherFieldProps }) => {
             <img src={REMOVE_ICON} height={14} alt="Unlink object" />
           </span>
           <LinkAnetEntity type={fieldValue.type} uuid={fieldValue.uuid} />
-        </>
+        </div>
       )}
     </FastField>
   )
@@ -414,7 +414,14 @@ const ReadonlyAnetObjectField = ({ name, label, values }) => {
       name={name}
       label={label}
       component={FieldHelper.ReadonlyField}
-      humanValue={type && uuid && <LinkAnetEntity type={type} uuid={uuid} />}
+      humanValue={
+        type &&
+        uuid && (
+          <div id={`${name}-value`}>
+            <LinkAnetEntity type={type} uuid={uuid} />
+          </div>
+        )
+      }
     />
   )
 }
@@ -458,7 +465,7 @@ const ArrayOfAnetObjectsField = ({
       {...otherFieldProps}
     >
       {!_isEmpty(fieldValue) && (
-        <Table striped condensed hover responsive>
+        <Table id={`${name}-value`} striped condensed hover responsive>
           <tbody>
             {fieldValue.map(entity => (
               <tr key={entity.uuid}>
@@ -506,7 +513,7 @@ const ReadonlyArrayOfAnetObjectsField = ({ name, label, values }) => {
       component={FieldHelper.ReadonlyField}
       humanValue={
         !_isEmpty(fieldValue) && (
-          <Table striped condensed hover responsive>
+          <Table id={`${name}-value`} striped condensed hover responsive>
             <tbody>
               {fieldValue.map(entity => (
                 <tr key={entity.uuid}>

--- a/client/src/components/CustomFields.js
+++ b/client/src/components/CustomFields.js
@@ -10,6 +10,7 @@ import Model, {
   DEFAULT_CUSTOM_FIELDS_PARENT,
   INVISIBLE_CUSTOM_FIELDS_FIELD
 } from "components/Model"
+import RemoveButton from "components/RemoveButton"
 import RichTextEditor from "components/RichTextEditor"
 import { FastField, FieldArray } from "formik"
 import { JSONPath } from "jsonpath-plus"
@@ -23,7 +24,6 @@ import moment from "moment"
 import PropTypes from "prop-types"
 import React, { useEffect, useMemo, useRef, useState } from "react"
 import { Button, HelpBlock, Table } from "react-bootstrap"
-import REMOVE_ICON from "resources/delete.png"
 import Settings from "settings"
 import { useDebouncedCallback } from "use-debounce"
 import utils from "utils"
@@ -279,13 +279,11 @@ const ArrayObject = ({
   const objLabel = _upperFirst(fieldConfig.objectLabel || "item")
   return (
     <Fieldset title={`${objLabel} ${index + 1}`}>
-      <Button
-        className="pull-right"
+      <RemoveButton
         title={`Remove this ${objLabel}`}
+        altText={`Remove this ${objLabel}`}
         onClick={() => arrayHelpers.remove(index)}
-      >
-        <img src={REMOVE_ICON} height={14} alt={`Remove this ${objLabel}`} />
-      </Button>
+      />
       <CustomFields
         fieldsConfig={fieldConfig.objectFields}
         formikProps={formikProps}
@@ -388,15 +386,22 @@ const AnetObjectField = ({ name, types, formikProps, ...otherFieldProps }) => {
       {...otherFieldProps}
     >
       {fieldValue.type && fieldValue.uuid && (
-        <div id={`${name}-value`}>
-          <span
-            style={{ cursor: "pointer" }}
-            onClick={() => setFieldValue(name, null)}
-          >
-            <img src={REMOVE_ICON} height={14} alt="Unlink object" />
-          </span>
-          <LinkAnetEntity type={fieldValue.type} uuid={fieldValue.uuid} />
-        </div>
+        <Table id={`${name}-value`} striped condensed hover responsive>
+          <tbody>
+            <tr>
+              <td>
+                <LinkAnetEntity type={fieldValue.type} uuid={fieldValue.uuid} />
+              </td>
+              <td className="col-xs-1">
+                <RemoveButton
+                  title={`Unlink this ${fieldValue.type}`}
+                  altText={`Unlink this ${fieldValue.type}`}
+                  onClick={() => setFieldValue(name, null)}
+                />
+              </td>
+            </tr>
+          </tbody>
+        </Table>
       )}
     </FastField>
   )
@@ -417,9 +422,15 @@ const ReadonlyAnetObjectField = ({ name, label, values }) => {
       humanValue={
         type &&
         uuid && (
-          <div id={`${name}-value`}>
-            <LinkAnetEntity type={type} uuid={uuid} />
-          </div>
+          <Table id={`${name}-value`} striped condensed hover responsive>
+            <tbody>
+              <tr>
+                <td>
+                  <LinkAnetEntity type={type} uuid={uuid} />
+                </td>
+              </tr>
+            </tbody>
+          </Table>
         )
       }
     />
@@ -470,8 +481,12 @@ const ArrayOfAnetObjectsField = ({
             {fieldValue.map(entity => (
               <tr key={entity.uuid}>
                 <td>
-                  <span
-                    style={{ cursor: "pointer" }}
+                  <LinkAnetEntity type={entity.type} uuid={entity.uuid} />
+                </td>
+                <td className="col-xs-1">
+                  <RemoveButton
+                    title={`Unlink this ${entity.type}`}
+                    altText={`Unlink this ${entity.type}`}
                     onClick={() => {
                       let found = false
                       const newValue = fieldValue.filter(e => {
@@ -485,10 +500,7 @@ const ArrayOfAnetObjectsField = ({
                         setFieldValue(name, newValue)
                       }
                     }}
-                  >
-                    <img src={REMOVE_ICON} height={14} alt="Unlink object" />
-                  </span>
-                  <LinkAnetEntity type={entity.type} uuid={entity.uuid} />
+                  />
                 </td>
               </tr>
             ))}

--- a/client/src/components/FieldHelper.js
+++ b/client/src/components/FieldHelper.js
@@ -46,7 +46,7 @@ const FieldNoLabel = ({ field, form, widgetElem, children }) => {
   const id = getFieldId(field)
   const validationState = getFormGroupValidationState(field, form)
   return (
-    <FormGroup controlId={id} validationState={validationState}>
+    <FormGroup id={`fg-${id}`} controlId={id} validationState={validationState}>
       {widgetElem}
       {getHelpBlock(field, form)}
       {children}
@@ -95,7 +95,7 @@ const Field = ({
     12 - (label === null ? 0 : 2) - (extraColElem === null ? 0 : 3)
   // controlId prop of the FormGroup sets the id of the control element
   return (
-    <FormGroup controlId={id} validationState={validationState}>
+    <FormGroup id={`fg-${id}`} controlId={id} validationState={validationState}>
       {vertical ? (
         <>
           <div>{label !== null && <ControlLabel>{label}</ControlLabel>}</div>

--- a/client/src/components/Model.js
+++ b/client/src/components/Model.js
@@ -133,7 +133,9 @@ export const CUSTOM_FIELD_TYPE = {
   ENUM: "enum",
   ENUMSET: "enumset",
   ARRAY_OF_OBJECTS: "array_of_objects",
-  SPECIAL_FIELD: "special_field"
+  SPECIAL_FIELD: "special_field",
+  ANET_OBJECT: "anet_object",
+  ARRAY_OF_ANET_OBJECTS: "array_of_anet_objects"
 }
 
 const CUSTOM_FIELD_TYPE_SCHEMA = {
@@ -147,7 +149,9 @@ const CUSTOM_FIELD_TYPE_SCHEMA = {
   [CUSTOM_FIELD_TYPE.ENUM]: yup.string().nullable().default(""),
   [CUSTOM_FIELD_TYPE.ENUMSET]: yup.array().nullable().default([]),
   [CUSTOM_FIELD_TYPE.ARRAY_OF_OBJECTS]: yup.array().nullable().default([]),
-  [CUSTOM_FIELD_TYPE.SPECIAL_FIELD]: yup.mixed().nullable().default(null)
+  [CUSTOM_FIELD_TYPE.SPECIAL_FIELD]: yup.mixed().nullable().default(null),
+  [CUSTOM_FIELD_TYPE.ANET_OBJECT]: yup.mixed().nullable().default(null),
+  [CUSTOM_FIELD_TYPE.ARRAY_OF_ANET_OBJECTS]: yup.array().nullable().default([])
 }
 
 const createFieldYupSchema = (fieldKey, fieldConfig, parentFieldName) => {

--- a/client/src/components/OrganizationTable.js
+++ b/client/src/components/OrganizationTable.js
@@ -6,6 +6,7 @@ import {
   mapPageDispatchersToProps,
   useBoilerplate
 } from "components/Page"
+import RemoveButton from "components/RemoveButton"
 import UltimatePaginationTopDown from "components/UltimatePaginationTopDown"
 import _get from "lodash/get"
 import { Organization } from "models"
@@ -13,7 +14,6 @@ import PropTypes from "prop-types"
 import React, { useState } from "react"
 import { Table } from "react-bootstrap"
 import { connect } from "react-redux"
-import REMOVE_ICON from "resources/delete.png"
 import Settings from "settings"
 
 const GQL_GET_ORGANIZATION_LIST = gql`
@@ -142,17 +142,12 @@ const BaseOrganizationTable = ({
                     <td>{org.identificationCode}</td>
                   )}
                   {showDelete && (
-                    <td
-                      onClick={() => onDelete(org)}
-                      id={"organizationDelete_" + org.uuid}
-                    >
-                      <span style={{ cursor: "pointer" }}>
-                        <img
-                          src={REMOVE_ICON}
-                          height={14}
-                          alt="Remove organization"
-                        />
-                      </span>
+                    <td id={"organizationDelete_" + org.uuid}>
+                      <RemoveButton
+                        title="Remove organization"
+                        altText="Remove organization"
+                        onClick={() => onDelete(org)}
+                      />
                     </td>
                   )}
                 </tr>

--- a/client/src/components/PositionTable.js
+++ b/client/src/components/PositionTable.js
@@ -6,6 +6,7 @@ import {
   mapPageDispatchersToProps,
   useBoilerplate
 } from "components/Page"
+import RemoveButton from "components/RemoveButton"
 import UltimatePaginationTopDown from "components/UltimatePaginationTopDown"
 import _get from "lodash/get"
 import { Position } from "models"
@@ -13,7 +14,6 @@ import PropTypes from "prop-types"
 import React, { useState } from "react"
 import { Table } from "react-bootstrap"
 import { connect } from "react-redux"
-import REMOVE_ICON from "resources/delete.png"
 import utils from "utils"
 
 const GQL_GET_POSITION_LIST = gql`
@@ -171,17 +171,12 @@ const BasePositionTable = ({
                   </td>
                   <td>{utils.sentenceCase(pos.status)}</td>
                   {showDelete && (
-                    <td
-                      onClick={() => onDelete(pos)}
-                      id={"positionDelete_" + pos.uuid}
-                    >
-                      <span style={{ cursor: "pointer" }}>
-                        <img
-                          src={REMOVE_ICON}
-                          height={14}
-                          alt="Remove position"
-                        />
-                      </span>
+                    <td id={"positionDelete_" + pos.uuid}>
+                      <RemoveButton
+                        title="Remove position"
+                        altText="Remove position"
+                        onClick={() => onDelete(pos)}
+                      />
                     </td>
                   )}
                 </tr>

--- a/client/src/components/RelatedObjectsTable.js
+++ b/client/src/components/RelatedObjectsTable.js
@@ -1,11 +1,11 @@
 import LinkTo from "components/LinkTo"
 import Model from "components/Model"
 import MultiTypeAdvancedSelectComponent from "components/advancedSelectWidget/MultiTypeAdvancedSelectComponent"
+import RemoveButton from "components/RemoveButton"
 import _get from "lodash/get"
 import PropTypes from "prop-types"
 import React from "react"
 import { Table } from "react-bootstrap"
-import REMOVE_ICON from "resources/delete.png"
 import utils from "utils"
 
 const RelatedObjectsTable = ({
@@ -55,17 +55,12 @@ const RelatedObjectsTable = ({
                   currentObject?.relatedObjectUuid === nro.relatedObjectUuid ? (
                     <td />
                     ) : (
-                      <td
-                        onClick={() => onDelete(nro)}
-                        id={"relatedObjectsDelete_" + nro.relatedObjectUuid}
-                      >
-                        <span style={{ cursor: "pointer" }}>
-                          <img
-                            src={REMOVE_ICON}
-                            height={14}
-                            alt="Unlink object"
-                          />
-                        </span>
+                      <td id={"relatedObjectsDelete_" + nro.relatedObjectUuid}>
+                        <RemoveButton
+                          title="Unlink object"
+                          altText="Unlink object"
+                          onClick={() => onDelete(nro)}
+                        />
                       </td>
                     ))}
               </tr>

--- a/client/src/components/RemoveButton.js
+++ b/client/src/components/RemoveButton.js
@@ -3,14 +3,30 @@ import React from "react"
 import { Button } from "react-bootstrap"
 import REMOVE_ICON from "resources/delete.png"
 
-const RemoveButton = ({ title, handleOnClick, ...props }) => (
-  <Button {...props} bsStyle="link" title={title} onClick={handleOnClick}>
-    <img src={REMOVE_ICON} height={14} alt="Remove attendee" />
+const RemoveButton = ({
+  title,
+  altText,
+  onClick,
+  buttonStyle = "default",
+  disabled = false
+}) => (
+  <Button
+    className="pull-right"
+    bsStyle={buttonStyle}
+    title={title}
+    onClick={onClick}
+    disabled={disabled}
+  >
+    <img src={REMOVE_ICON} height={14} alt={altText} />
   </Button>
 )
+
 RemoveButton.propTypes = {
   title: PropTypes.string,
-  handleOnClick: PropTypes.func
+  altText: PropTypes.string,
+  onClick: PropTypes.func,
+  buttonStyle: PropTypes.string,
+  disabled: PropTypes.bool
 }
 
 export default RemoveButton

--- a/client/src/components/TaskTable.js
+++ b/client/src/components/TaskTable.js
@@ -1,10 +1,10 @@
 import LinkTo from "components/LinkTo"
+import RemoveButton from "components/RemoveButton"
 import _get from "lodash/get"
 import { Task } from "models"
 import PropTypes from "prop-types"
 import React from "react"
 import { Table } from "react-bootstrap"
-import REMOVE_ICON from "resources/delete.png"
 import Settings from "settings"
 
 const TaskTable = ({
@@ -70,17 +70,12 @@ const TaskTable = ({
                     </td>
                   )}
                   {showDelete && (
-                    <td
-                      onClick={() => onDelete(task)}
-                      id={"taskDelete_" + task.uuid}
-                    >
-                      <span style={{ cursor: "pointer" }}>
-                        <img
-                          src={REMOVE_ICON}
-                          height={14}
-                          alt={`Remove ${fieldSettings.shortLabel}`}
-                        />
-                      </span>
+                    <td id={"taskDelete_" + task.uuid}>
+                      <RemoveButton
+                        title={`Remove ${fieldSettings.shortLabel}`}
+                        altText={`Remove ${fieldSettings.shortLabel}`}
+                        onClick={() => onDelete(task)}
+                      />
                     </td>
                   )}
                 </tr>

--- a/client/src/components/advancedSelectWidget/AdvancedSelect.js
+++ b/client/src/components/advancedSelectWidget/AdvancedSelect.js
@@ -368,6 +368,7 @@ const AdvancedSelect = ({
                   value={searchTerms || ""}
                   placeholder={placeholder}
                   onChange={changeSearchTerms}
+                  onFocus={event => handleInteraction(true, event)}
                   inputRef={ref => {
                     searchInput.current = ref
                   }}

--- a/client/src/components/advancedSelectWidget/AdvancedSingleSelect.js
+++ b/client/src/components/advancedSelectWidget/AdvancedSingleSelect.js
@@ -21,6 +21,7 @@ const AdvancedSingleSelect = props => {
       extraAddon={
         props.showRemoveButton && !_isEmpty(props.value) ? (
           <img
+            style={{ cursor: "pointer" }}
             src={REMOVE_ICON}
             height={16}
             alt=""

--- a/client/src/components/advancedSelectWidget/AdvancedSingleSelect.js
+++ b/client/src/components/advancedSelectWidget/AdvancedSingleSelect.js
@@ -41,10 +41,11 @@ const AdvancedSingleSelect = props => {
 }
 AdvancedSingleSelect.propTypes = {
   ...advancedSelectPropTypes,
-  value: PropTypes.object,
+  value: PropTypes.object.isRequired,
   valueKey: PropTypes.string
 }
 AdvancedSingleSelect.defaultProps = {
+  value: {},
   overlayTable: AdvancedSingleSelectOverlayTable,
   showRemoveButton: true // whether to display a remove button in the input field to allow removing the selected value
 }

--- a/client/src/components/advancedSelectWidget/MultiTypeAdvancedSelectComponent.js
+++ b/client/src/components/advancedSelectWidget/MultiTypeAdvancedSelectComponent.js
@@ -140,6 +140,10 @@ const MultiTypeAdvancedSelectComponent = ({
     const entityLabel = SEARCH_OBJECT_LABELS[SEARCH_OBJECT_TYPES[key]]
     return "Find " + entityLabel.toLowerCase()
   }, [entityType])
+  const SelectComponent = isMultiSelect
+    ? AdvancedMultiSelect
+    : AdvancedSingleSelect
+  const extraSelectProps = isMultiSelect ? {} : { showRemoveButton: false }
   return (
     <>
       {entityTypes.length > 1 && (
@@ -157,42 +161,23 @@ const MultiTypeAdvancedSelectComponent = ({
         </ButtonToggleGroup>
       )}
 
-      {isMultiSelect ? (
-        <AdvancedMultiSelect
-          autofocus="true"
-          fieldName={fieldName}
-          fieldLabel="Search in ANET:"
-          placeholder={searchPlaceholder}
-          value={value}
-          showEmbedded
-          overlayColumns={advancedSelectProps.overlayColumns}
-          overlayRenderRow={advancedSelectProps.overlayRenderRow}
-          filterDefs={advancedSelectProps.filterDefs}
-          onChange={value => onConfirm(value, entityType)}
-          objectType={advancedSelectProps.objectType}
-          queryParams={advancedSelectProps.queryParams}
-          fields={advancedSelectProps.fields}
-          addon={advancedSelectProps.addon}
-        />
-      ) : (
-        <AdvancedSingleSelect
-          autofocus="true"
-          fieldName={fieldName}
-          fieldLabel="Search in ANET:"
-          placeholder={searchPlaceholder}
-          value={value}
-          showEmbedded
-          showRemoveButton={false}
-          overlayColumns={advancedSelectProps.overlayColumns}
-          overlayRenderRow={advancedSelectProps.overlayRenderRow}
-          filterDefs={advancedSelectProps.filterDefs}
-          onChange={value => onConfirm(value, entityType)}
-          objectType={advancedSelectProps.objectType}
-          queryParams={advancedSelectProps.queryParams}
-          fields={advancedSelectProps.fields}
-          addon={advancedSelectProps.addon}
-        />
-      )}
+      <SelectComponent
+        autofocus="true"
+        fieldName={fieldName}
+        fieldLabel="Search in ANET:"
+        placeholder={searchPlaceholder}
+        value={value}
+        showEmbedded
+        overlayColumns={advancedSelectProps.overlayColumns}
+        overlayRenderRow={advancedSelectProps.overlayRenderRow}
+        filterDefs={advancedSelectProps.filterDefs}
+        onChange={value => onConfirm(value, entityType)}
+        objectType={advancedSelectProps.objectType}
+        queryParams={advancedSelectProps.queryParams}
+        fields={advancedSelectProps.fields}
+        addon={advancedSelectProps.addon}
+        {...extraSelectProps}
+      />
     </>
   )
 }

--- a/client/src/components/advancedSelectWidget/MultiTypeAdvancedSelectComponent.js
+++ b/client/src/components/advancedSelectWidget/MultiTypeAdvancedSelectComponent.js
@@ -49,7 +49,7 @@ const widgetPropsReport = {
   overlayRenderRow: ReportDetailedOverlayRow,
   overlayColumns: ["Goal", "Author", "Updated"],
   filterDefs: entityFilters,
-  queryParams: {},
+  queryParams: {}, // allow any report, incl. one's own drafts
   fields: Models.Report.autocompleteQuery,
   addon: REPORTS_ICON
 }
@@ -59,7 +59,7 @@ const widgetPropsPeople = {
   overlayRenderRow: PersonDetailedOverlayRow,
   overlayColumns: ["Name", "Position", "Location", "Organization"],
   filterDefs: peopleFilters,
-  queryParams: {},
+  queryParams: { status: Models.Person.STATUS.ACTIVE },
   fields: Models.Person.autocompleteQueryWithNotes,
   addon: PEOPLE_ICON
 }
@@ -69,7 +69,7 @@ const widgetPropsOrganization = {
   overlayRenderRow: OrganizationOverlayRow,
   overlayColumns: ["Name"],
   filterDefs: entityFilters,
-  queryParams: {},
+  queryParams: { status: Models.Organization.STATUS.ACTIVE },
   fields: Models.Organization.autocompleteQuery,
   addon: ORGANIZATIONS_ICON
 }
@@ -79,7 +79,7 @@ const widgetPropsPosition = {
   overlayRenderRow: PositionOverlayRow,
   overlayColumns: ["Position", "Organization", "Current Occupant"],
   filterDefs: entityFilters,
-  queryParams: {},
+  queryParams: { status: Models.Position.STATUS.ACTIVE },
   fields: Models.Position.autocompleteQuery,
   addon: POSITIONS_ICON
 }

--- a/client/src/components/advancedSelectWidget/MultiTypeAdvancedSelectComponent.js
+++ b/client/src/components/advancedSelectWidget/MultiTypeAdvancedSelectComponent.js
@@ -7,6 +7,7 @@ import {
   ReportDetailedOverlayRow,
   TaskSimpleOverlayRow
 } from "components/advancedSelectWidget/AdvancedSelectOverlayRow"
+import AdvancedMultiSelect from "components/advancedSelectWidget/AdvancedMultiSelect"
 import AdvancedSingleSelect from "components/advancedSelectWidget/AdvancedSingleSelect"
 import ButtonToggleGroup from "components/ButtonToggleGroup"
 import * as Models from "models"
@@ -113,9 +114,12 @@ const widgetTypeMapping = {
 }
 
 const MultiTypeAdvancedSelectComponent = ({
+  fieldName,
   onConfirm,
   objectType,
-  entityTypes
+  entityTypes,
+  value,
+  isMultiSelect
 }) => {
   const [entityType, setEntityType] = useState(
     objectType ||
@@ -153,33 +157,58 @@ const MultiTypeAdvancedSelectComponent = ({
         </ButtonToggleGroup>
       )}
 
-      <AdvancedSingleSelect
-        autofocus="true"
-        fieldName="entitySelect"
-        fieldLabel="Search in ANET:"
-        placeholder={searchPlaceholder}
-        value={{}}
-        showEmbedded
-        overlayColumns={advancedSelectProps.overlayColumns}
-        overlayRenderRow={advancedSelectProps.overlayRenderRow}
-        filterDefs={advancedSelectProps.filterDefs}
-        onChange={value => onConfirm(value, entityType)}
-        objectType={advancedSelectProps.objectType}
-        queryParams={advancedSelectProps.queryParams}
-        fields={advancedSelectProps.fields}
-        addon={advancedSelectProps.addon}
-      />
+      {isMultiSelect ? (
+        <AdvancedMultiSelect
+          autofocus="true"
+          fieldName={fieldName}
+          fieldLabel="Search in ANET:"
+          placeholder={searchPlaceholder}
+          value={value}
+          showEmbedded
+          overlayColumns={advancedSelectProps.overlayColumns}
+          overlayRenderRow={advancedSelectProps.overlayRenderRow}
+          filterDefs={advancedSelectProps.filterDefs}
+          onChange={value => onConfirm(value, entityType)}
+          objectType={advancedSelectProps.objectType}
+          queryParams={advancedSelectProps.queryParams}
+          fields={advancedSelectProps.fields}
+          addon={advancedSelectProps.addon}
+        />
+      ) : (
+        <AdvancedSingleSelect
+          autofocus="true"
+          fieldName={fieldName}
+          fieldLabel="Search in ANET:"
+          placeholder={searchPlaceholder}
+          value={value}
+          showEmbedded
+          showRemoveButton={false}
+          overlayColumns={advancedSelectProps.overlayColumns}
+          overlayRenderRow={advancedSelectProps.overlayRenderRow}
+          filterDefs={advancedSelectProps.filterDefs}
+          onChange={value => onConfirm(value, entityType)}
+          objectType={advancedSelectProps.objectType}
+          queryParams={advancedSelectProps.queryParams}
+          fields={advancedSelectProps.fields}
+          addon={advancedSelectProps.addon}
+        />
+      )}
     </>
   )
 }
 
 MultiTypeAdvancedSelectComponent.propTypes = {
+  fieldName: PropTypes.string,
   onConfirm: PropTypes.func,
   objectType: PropTypes.string,
-  entityTypes: PropTypes.arrayOf(PropTypes.string).isRequired
+  entityTypes: PropTypes.arrayOf(PropTypes.string).isRequired,
+  value: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
+  isMultiSelect: PropTypes.bool.isRequired
 }
 MultiTypeAdvancedSelectComponent.defaultProps = {
-  entityTypes: Object.values(ENTITY_TYPES)
+  fieldName: "entitySelect",
+  entityTypes: Object.values(ENTITY_TYPES),
+  isMultiSelect: false
 }
 
 export default MultiTypeAdvancedSelectComponent

--- a/client/src/components/approvals/ApprovalsDefinition.js
+++ b/client/src/components/approvals/ApprovalsDefinition.js
@@ -5,12 +5,12 @@ import { ApproverOverlayRow } from "components/advancedSelectWidget/AdvancedSele
 import * as FieldHelper from "components/FieldHelper"
 import Fieldset from "components/Fieldset"
 import LinkTo from "components/LinkTo"
+import RemoveButton from "components/RemoveButton"
 import { FastField, FieldArray } from "formik"
 import { Position } from "models"
 import PropTypes from "prop-types"
 import React, { useState } from "react"
 import { Button, Checkbox, Modal, Table } from "react-bootstrap"
-import REMOVE_ICON from "resources/delete.png"
 import POSITIONS_ICON from "resources/positions.png"
 
 const GQL_GET_APPROVAL_STEP_IN_USE = gql`
@@ -41,10 +41,12 @@ const ApproverTable = ({ approvers, onDelete }) => (
           <td>
             <LinkTo modelType="Position" model={approver} target="_blank" />
           </td>
-          <td onClick={() => onDelete(approver)}>
-            <span style={{ cursor: "pointer" }}>
-              <img src={REMOVE_ICON} height={14} alt="Remove approver" />
-            </span>
+          <td>
+            <RemoveButton
+              title="Remove approver"
+              altText="Remove approver"
+              onClick={() => onDelete(approver)}
+            />
           </td>
         </tr>
       ))}
@@ -164,13 +166,11 @@ const ApprovalsDefinition = ({
 
     return (
       <Fieldset title={`Step ${index + 1}`} key={index}>
-        <Button
-          className="pull-right"
+        <RemoveButton
           title="Remove this step"
+          altText="Remove this step"
           onClick={() => removeApprovalStep(arrayHelpers, index, step)}
-        >
-          <img src={REMOVE_ICON} height={14} alt="Remove this step" />
-        </Button>
+        />
 
         <FastField
           name={`${fieldName}.${index}.name`}

--- a/client/src/components/editor/LinkAnet.js
+++ b/client/src/components/editor/LinkAnet.js
@@ -18,9 +18,10 @@ const LinkAnet = ({
 
   if (isAnetEntityLink) {
     return (
-      <LinkAnetEntity type={isAnetEntityLink.type} uuid={isAnetEntityLink.uuid}>
-        {children}
-      </LinkAnetEntity>
+      <LinkAnetEntity
+        type={isAnetEntityLink.type}
+        uuid={isAnetEntityLink.uuid}
+      />
     )
   } else {
     // Non ANET entity link

--- a/client/src/pages/locations/GeoLocation.js
+++ b/client/src/pages/locations/GeoLocation.js
@@ -1,9 +1,9 @@
+import RemoveButton from "components/RemoveButton"
 import React from "react"
 import PropTypes from "prop-types"
-import { Button, Col, ControlLabel, FormGroup } from "react-bootstrap"
+import { Col, ControlLabel, FormGroup } from "react-bootstrap"
 import { Field } from "formik"
 import { Location } from "models"
-import REMOVE_ICON from "resources/delete.png"
 import * as FieldHelper from "components/FieldHelper"
 
 export const GEO_LOCATION_DISPLAY_TYPE = {
@@ -77,19 +77,17 @@ const GeoLocation = ({
         </Col>
         {(lat || lng) && (
           <Col sm={1}>
-            <Button
-              style={{ width: "auto", margin: "8px 0 0 0", padding: "0" }}
-              bsStyle="link"
-              bsSize="sm"
+            <RemoveButton
+              title="Clear Location"
+              altText="Clear Location"
+              buttonStyle="link"
               onClick={() => {
                 setTouched(false) // prevent validation since lat, lng can be null together
                 setFieldValue("lat", null)
                 setFieldValue("lng", null)
               }}
               disabled={isSubmitting}
-            >
-              <img src={REMOVE_ICON} height={14} alt="Clear Location" />
-            </Button>
+            />
           </Col>
         )}
       </Col>

--- a/client/src/pages/reports/AttendeesTable.js
+++ b/client/src/pages/reports/AttendeesTable.js
@@ -1,24 +1,10 @@
 import LinkTo from "components/LinkTo"
+import RemoveButton from "components/RemoveButton"
 import { Person } from "models"
 import PropTypes from "prop-types"
 import React from "react"
-import { Button, Label, Radio, Table } from "react-bootstrap"
-import REMOVE_ICON from "resources/delete.png"
+import { Label, Radio, Table } from "react-bootstrap"
 import "./AttendeesTable.css"
-
-const RemoveIcon = () => (
-  <img src={REMOVE_ICON} height={14} alt="Remove attendee" />
-)
-
-const RemoveButton = ({ title, handleOnClick }) => (
-  <Button bsStyle="link" title={title} onClick={handleOnClick}>
-    <RemoveIcon />
-  </Button>
-)
-RemoveButton.propTypes = {
-  title: PropTypes.string,
-  handleOnClick: PropTypes.func
-}
 
 const AttendeeDividerRow = () => (
   <tr className="attendee-divider-row">
@@ -161,7 +147,8 @@ const AttendeesTable = ({
           <td>
             <RemoveButton
               title="Remove attendee"
-              handleOnClick={() => onDelete(person)}
+              altText="Remove attendee"
+              onClick={() => onDelete(person)}
             />
           </td>
         )}

--- a/client/src/pages/reports/AuthorizationGroupTable.js
+++ b/client/src/pages/reports/AuthorizationGroupTable.js
@@ -1,7 +1,7 @@
+import RemoveButton from "components/RemoveButton"
 import PropTypes from "prop-types"
 import React from "react"
 import { Table } from "react-bootstrap"
-import REMOVE_ICON from "resources/delete.png"
 
 const AuthorizationGroupTable = ({
   authorizationGroups,
@@ -22,10 +22,12 @@ const AuthorizationGroupTable = ({
           <td>{ag.name}</td>
           <td>{ag.description}</td>
           {showDelete && (
-            <td onClick={() => onDelete(ag)}>
-              <span style={{ cursor: "pointer" }}>
-                <img src={REMOVE_ICON} height={14} alt="Remove group" />
-              </span>
+            <td>
+              <RemoveButton
+                title="Remove group"
+                altText="Remove group"
+                onClick={() => onDelete(ag)}
+              />
             </td>
           )}
         </tr>

--- a/client/tests/webdriver/pages/createReport.page.js
+++ b/client/tests/webdriver/pages/createReport.page.js
@@ -26,6 +26,10 @@ class CreateReport extends Page {
     return this.testReferenceFieldFormGroup.$(`label[for="${trfId}"]`)
   }
 
+  get testReferenceFieldHelpText() {
+    return this.testReferenceFieldFormGroup.$('span[class="help-block"]')
+  }
+
   get testReferenceField() {
     return this.testReferenceFieldFormGroup.$(`input[id="${trfId}"]`)
   }
@@ -48,6 +52,10 @@ class CreateReport extends Page {
 
   get testMultiReferenceFieldLabel() {
     return this.testMultiReferenceFieldFormGroup.$(`label[for="${tmrfId}"]`)
+  }
+
+  get testMultiReferenceFieldHelpText() {
+    return this.testMultiReferenceFieldFormGroup.$('span[class="help-block"]')
   }
 
   get testMultiReferenceField() {

--- a/client/tests/webdriver/pages/createReport.page.js
+++ b/client/tests/webdriver/pages/createReport.page.js
@@ -1,0 +1,132 @@
+import Page from "./page"
+
+const PAGE_URL = "/reports/new"
+
+const trfId = "formCustomFields.relatedReport"
+const tmrfId = "formCustomFields.additionalEngagementNeeded"
+
+class CreateReport extends Page {
+  get form() {
+    return browser.$("form")
+  }
+
+  get alert() {
+    return browser.$(".alert")
+  }
+
+  get engagementInformationTitle() {
+    return browser.$('//span[text()="Engagement information"]')
+  }
+
+  get testReferenceFieldFormGroup() {
+    return browser.$(`div[id="fg-${trfId}"]`)
+  }
+
+  get testReferenceFieldLabel() {
+    return this.testReferenceFieldFormGroup.$(`label[for="${trfId}"]`)
+  }
+
+  get testReferenceField() {
+    return this.testReferenceFieldFormGroup.$(`input[id="${trfId}"]`)
+  }
+
+  get testReferenceFieldAdvancedSelectFirstItem() {
+    return this.testReferenceFieldFormGroup.$(
+      `div[id="${trfId}-popover"] tbody tr:first-child td:nth-child(2)`
+    )
+  }
+
+  get testReferenceFieldValue() {
+    return this.testReferenceFieldFormGroup.$(`div[id="${trfId}-value"]`)
+  }
+
+  get testMultiReferenceFieldFormGroup() {
+    return browser.$(`div[id="fg-${tmrfId}"]`)
+  }
+
+  get testMultiReferenceFieldLabel() {
+    return this.testMultiReferenceFieldFormGroup.$(`label[for="${tmrfId}"]`)
+  }
+
+  get testMultiReferenceField() {
+    return this.testMultiReferenceFieldFormGroup.$(`input[id="${tmrfId}"]`)
+  }
+
+  get testMultiReferenceFieldAdvancedSelect() {
+    return this.testMultiReferenceFieldFormGroup.$(
+      `div[id="${tmrfId}-popover"] tbody`
+    )
+  }
+
+  getTestMultiReferenceFieldAdvancedSelectItem(n) {
+    return this.testMultiReferenceFieldAdvancedSelect.$(
+      `tr:nth-child(${n}) td:nth-child(2)`
+    )
+  }
+
+  getTestMultiReferenceFieldAdvancedSelectItemLabel(n) {
+    return this.getTestMultiReferenceFieldAdvancedSelectItem(n).$("span")
+  }
+
+  get testMultiReferenceFieldValue() {
+    return this.testMultiReferenceFieldFormGroup.$(
+      `table[id="${tmrfId}-value"]`
+    )
+  }
+
+  get testMultiReferenceFieldValueRows() {
+    return this.testMultiReferenceFieldValue.$$("tbody tr")
+  }
+
+  getTestMultiReferenceFieldValueRow(n) {
+    return this.testMultiReferenceFieldValue.$(`tbody tr:nth-child(${n})`)
+  }
+
+  get submitButton() {
+    return browser.$("#formBottomSubmit")
+  }
+
+  get editButton() {
+    return browser.$('//a[text()="Edit"]')
+  }
+
+  get deleteButton() {
+    return browser.$('//button[text()="Delete this report"]')
+  }
+
+  get confirmButton() {
+    return browser.$(
+      '//button[contains(text(),"Yes, I am sure that I want to delete report")]'
+    )
+  }
+
+  open() {
+    super.open(PAGE_URL)
+  }
+
+  waitForAlertToLoad() {
+    if (!this.alert.isDisplayed()) {
+      this.alert.waitForExist()
+      this.alert.waitForDisplayed()
+    }
+  }
+
+  waitForAdvancedSelectToChange(item, value) {
+    item.waitForExist()
+    return browser.waitUntil(
+      () => {
+        return item.getText() === value
+      },
+      {
+        timeout: 5000,
+        timeoutMsg: `Expected advanced select input to contain "${value}" after 5s, but was "${item.getText()}"`
+      }
+    )
+  }
+
+  submitForm() {
+    this.submitButton.click()
+  }
+}
+
+export default new CreateReport()

--- a/client/tests/webdriver/pages/createReport.page.js
+++ b/client/tests/webdriver/pages/createReport.page.js
@@ -37,7 +37,9 @@ class CreateReport extends Page {
   }
 
   get testReferenceFieldValue() {
-    return this.testReferenceFieldFormGroup.$(`div[id="${trfId}-value"]`)
+    return this.testReferenceFieldFormGroup.$(
+      `table[id="${trfId}-value"] tbody tr:first-child`
+    )
   }
 
   get testMultiReferenceFieldFormGroup() {

--- a/client/tests/webdriver/specs/createAuthorizationGroup.spec.js
+++ b/client/tests/webdriver/specs/createAuthorizationGroup.spec.js
@@ -27,7 +27,8 @@ describe("Create authorization group form page", () => {
         CreateAuthorizationGroup.statusInactiveButton.getAttribute("class")
       ).to.not.include("active")
       CreateAuthorizationGroup.statusInactiveButton.click()
-      expect($(".positions_table").isExisting()).to.equal(false)
+      // eslint-disable-next-line no-unused-expressions
+      expect($(".positions_table").isExisting()).to.be.false
       CreateAuthorizationGroup.positionsInput.click()
       CreateAuthorizationGroup.positionsInput.setValue(POSITION)
       CreateAuthorizationGroup.waitForPositionsAdvancedSelectToChange(
@@ -42,7 +43,8 @@ describe("Create authorization group form page", () => {
       // Advanced select input gets empty, the position is added to a table underneath
       expect(CreateAuthorizationGroup.positionsInput.getValue()).to.equal("")
       // positions table exists now
-      expect($(".positions_table").isExisting())
+      // eslint-disable-next-line no-unused-expressions
+      expect($(".positions_table").isExisting()).to.be.true
       CreateAuthorizationGroup.submitForm()
       CreateAuthorizationGroup.waitForAlertSuccessToLoad()
       const alertMessage = CreateAuthorizationGroup.alertSuccess.getText()

--- a/client/tests/webdriver/specs/createReport.spec.js
+++ b/client/tests/webdriver/specs/createReport.spec.js
@@ -1,0 +1,293 @@
+import { expect } from "chai"
+import CreateReport from "../pages/createReport.page"
+
+const REPORT = "Interior"
+const REPORT_VALUE = "Talk to the Interior about things"
+const REPORT_COMPLETE = `${REPORT_VALUE}`
+
+const PERSON = "EF 2.1"
+const PERSON_VALUE_1 = "HENDERSON, Henry"
+const PERSON_VALUE_2 = "JACKSON, Jack"
+const PERSON_COMPLETE_1 = `BGen ${PERSON_VALUE_1}`
+const PERSON_COMPLETE_2 = `OF-9 ${PERSON_VALUE_2}`
+
+const POSITION = "MOD-FO"
+const POSITION_VALUE_1 = "Chief of Staff - MoD"
+const POSITION_VALUE_2 = "Executive Assistant to the MoD"
+const POSITION_VALUE_3 = "Minister of Defense"
+const POSITION_COMPLETE_1 = `${POSITION_VALUE_1}`
+const POSITION_COMPLETE_2 = `${POSITION_VALUE_2}`
+const POSITION_COMPLETE_3 = `${POSITION_VALUE_3}`
+
+describe("Create report form page", () => {
+  describe("When creating a report", () => {
+    it("Should be able to load the form", () => {
+      CreateReport.open()
+      CreateReport.form.waitForExist()
+      CreateReport.form.waitForDisplayed()
+    })
+
+    it("Should be able to select an ANET object reference", () => {
+      CreateReport.testReferenceFieldLabel.waitForExist()
+      CreateReport.testReferenceFieldLabel.waitForDisplayed()
+
+      // Only input type is Reports, so there should be no button to select a type
+      expect(
+        CreateReport.testReferenceField.getAttribute("placeholder")
+      ).to.equal("Find reports")
+      // eslint-disable-next-line no-unused-expressions
+      expect(
+        CreateReport.testReferenceFieldFormGroup
+          .$('//button[text()="Reports"]')
+          .isExisting()
+      ).to.be.false
+      CreateReport.testReferenceFieldLabel.click()
+      CreateReport.testReferenceField.setValue(REPORT)
+      CreateReport.waitForAdvancedSelectToChange(
+        CreateReport.testReferenceFieldAdvancedSelectFirstItem,
+        REPORT_COMPLETE
+      )
+      expect(
+        CreateReport.testReferenceFieldAdvancedSelectFirstItem.getText()
+      ).to.include(REPORT_COMPLETE)
+      CreateReport.testReferenceFieldAdvancedSelectFirstItem.click()
+      // Advanced select input gets empty, the selected element shown below the input
+      // eslint-disable-next-line no-unused-expressions
+      expect(CreateReport.testReferenceFieldLabel.getValue()).to.be.null
+      // Value should exist now
+      // eslint-disable-next-line no-unused-expressions
+      expect(CreateReport.testReferenceFieldValue.isExisting()).to.be.true
+      expect(CreateReport.testReferenceFieldValue.getText()).to.include(
+        REPORT_VALUE
+      )
+
+      // Delete selected value
+      CreateReport.testReferenceFieldValue.$("span").click()
+      // eslint-disable-next-line no-unused-expressions
+      expect(CreateReport.testReferenceFieldValue.isExisting()).to.be.false
+
+      // Select it again
+      CreateReport.testReferenceFieldLabel.click()
+      CreateReport.testReferenceField.setValue(REPORT)
+      CreateReport.waitForAdvancedSelectToChange(
+        CreateReport.testReferenceFieldAdvancedSelectFirstItem,
+        REPORT_COMPLETE
+      )
+      CreateReport.testReferenceFieldAdvancedSelectFirstItem.click()
+    })
+
+    it("Should be able to select multiple ANET object references", () => {
+      CreateReport.testMultiReferenceFieldLabel.waitForExist()
+      CreateReport.testMultiReferenceFieldLabel.waitForDisplayed()
+
+      // Default input type is People
+      expect(
+        CreateReport.testMultiReferenceField.getAttribute("placeholder")
+      ).to.equal("Find people")
+      CreateReport.testMultiReferenceFieldLabel.click()
+      CreateReport.testMultiReferenceField.setValue(PERSON)
+      CreateReport.waitForAdvancedSelectToChange(
+        CreateReport.getTestMultiReferenceFieldAdvancedSelectItemLabel(1),
+        PERSON_COMPLETE_1
+      )
+      expect(
+        CreateReport.getTestMultiReferenceFieldAdvancedSelectItemLabel(
+          1
+        ).getText()
+      ).to.include(PERSON_COMPLETE_1)
+      CreateReport.getTestMultiReferenceFieldAdvancedSelectItem(1).click()
+      expect(
+        CreateReport.getTestMultiReferenceFieldAdvancedSelectItemLabel(
+          2
+        ).getText()
+      ).to.include(PERSON_COMPLETE_2)
+      CreateReport.getTestMultiReferenceFieldAdvancedSelectItem(2).click()
+      // Click outside the overlay
+      CreateReport.engagementInformationTitle.click()
+      // Advanced select input gets empty, the selected element shown below the input
+      // eslint-disable-next-line no-unused-expressions
+      expect(CreateReport.testMultiReferenceFieldLabel.getValue()).to.be.null
+      // Value should exist now
+      // eslint-disable-next-line no-unused-expressions
+      expect(CreateReport.testMultiReferenceFieldValue.isExisting()).to.be.true
+      expect(
+        CreateReport.getTestMultiReferenceFieldValueRow(1).getText()
+      ).to.include(PERSON_VALUE_1)
+      expect(
+        CreateReport.getTestMultiReferenceFieldValueRow(2).getText()
+      ).to.include(PERSON_VALUE_2)
+
+      // Change input type to Positions
+      CreateReport.testMultiReferenceFieldFormGroup
+        .$('//button[text()="Positions"]')
+        .click()
+      expect(
+        CreateReport.testMultiReferenceField.getAttribute("placeholder")
+      ).to.equal("Find positions")
+      CreateReport.testMultiReferenceFieldLabel.click()
+      CreateReport.testMultiReferenceField.setValue(POSITION)
+      CreateReport.waitForAdvancedSelectToChange(
+        CreateReport.getTestMultiReferenceFieldAdvancedSelectItemLabel(1),
+        POSITION_COMPLETE_1
+      )
+      expect(
+        CreateReport.getTestMultiReferenceFieldAdvancedSelectItemLabel(
+          1
+        ).getText()
+      ).to.include(POSITION_COMPLETE_1)
+      CreateReport.getTestMultiReferenceFieldAdvancedSelectItem(1).click()
+      expect(
+        CreateReport.getTestMultiReferenceFieldAdvancedSelectItemLabel(
+          2
+        ).getText()
+      ).to.include(POSITION_COMPLETE_2)
+      CreateReport.getTestMultiReferenceFieldAdvancedSelectItem(2).click()
+      expect(
+        CreateReport.getTestMultiReferenceFieldAdvancedSelectItemLabel(
+          3
+        ).getText()
+      ).to.include(POSITION_COMPLETE_3)
+      CreateReport.getTestMultiReferenceFieldAdvancedSelectItem(3).click()
+      // Click outside the overlay
+      CreateReport.engagementInformationTitle.click()
+      // Advanced select input gets empty, the selected element shown below the input
+      // eslint-disable-next-line no-unused-expressions
+      expect(CreateReport.testMultiReferenceFieldLabel.getValue()).to.be.null
+      // Value should exist now
+      // eslint-disable-next-line no-unused-expressions
+      expect(CreateReport.testMultiReferenceFieldValue.isExisting()).to.be.true
+      expect(
+        CreateReport.getTestMultiReferenceFieldValueRow(3).getText()
+      ).to.include(POSITION_VALUE_1)
+      expect(
+        CreateReport.getTestMultiReferenceFieldValueRow(4).getText()
+      ).to.include(POSITION_VALUE_2)
+      expect(
+        CreateReport.getTestMultiReferenceFieldValueRow(5).getText()
+      ).to.include(POSITION_VALUE_3)
+
+      // Should have 5 values
+      expect(CreateReport.testMultiReferenceFieldValueRows).to.have.lengthOf(5)
+      // Delete one of the selected values
+      CreateReport.getTestMultiReferenceFieldValueRow(3).$("span").click()
+      // Should have only 4 values left
+      expect(CreateReport.testMultiReferenceFieldValueRows).to.have.lengthOf(4)
+      // 3rd value should have changed
+      expect(
+        CreateReport.getTestMultiReferenceFieldValueRow(3).getText()
+      ).to.include(POSITION_VALUE_2)
+    })
+
+    it("Should be able to save a report with ANET object references", () => {
+      // Submit the report
+      CreateReport.submitForm()
+      CreateReport.waitForAlertToLoad()
+      const alertMessage = CreateReport.alert.getText()
+      expect(alertMessage).to.include("The following errors must be fixed")
+
+      // Check ANET object reference
+      CreateReport.testReferenceFieldLabel.waitForExist()
+      CreateReport.testReferenceFieldLabel.waitForDisplayed()
+      expect(CreateReport.testReferenceFieldValue.getText()).to.include(
+        REPORT_VALUE
+      )
+
+      // Check ANET object multi-references
+      CreateReport.testMultiReferenceFieldLabel.waitForExist()
+      CreateReport.testMultiReferenceFieldLabel.waitForDisplayed()
+      expect(CreateReport.testMultiReferenceFieldValueRows).to.have.lengthOf(4)
+      expect(
+        CreateReport.getTestMultiReferenceFieldValueRow(1).getText()
+      ).to.include(PERSON_VALUE_1)
+      expect(
+        CreateReport.getTestMultiReferenceFieldValueRow(2).getText()
+      ).to.include(PERSON_VALUE_2)
+      expect(
+        CreateReport.getTestMultiReferenceFieldValueRow(3).getText()
+      ).to.include(POSITION_VALUE_2)
+      expect(
+        CreateReport.getTestMultiReferenceFieldValueRow(4).getText()
+      ).to.include(POSITION_VALUE_3)
+    })
+
+    it("Should be able to edit a report with ANET object references", () => {
+      // Edit the report
+      CreateReport.editButton.click()
+
+      CreateReport.testReferenceFieldLabel.waitForExist()
+      CreateReport.testReferenceFieldLabel.waitForDisplayed()
+      // Default input type is People
+      expect(
+        CreateReport.testReferenceField.getAttribute("placeholder")
+      ).to.equal("Find reports")
+      // Check ANET object reference
+      expect(CreateReport.testReferenceFieldValue.getText()).to.include(
+        REPORT_VALUE
+      )
+      // Delete selected value
+      CreateReport.testReferenceFieldValue.$("span").click()
+
+      CreateReport.testMultiReferenceFieldLabel.waitForExist()
+      CreateReport.testMultiReferenceFieldLabel.waitForDisplayed()
+      // Default input type is People
+      expect(
+        CreateReport.testMultiReferenceField.getAttribute("placeholder")
+      ).to.equal("Find people")
+      // Check ANET object multi-references
+      expect(CreateReport.testMultiReferenceFieldValueRows).to.have.lengthOf(4)
+      expect(
+        CreateReport.getTestMultiReferenceFieldValueRow(1).getText()
+      ).to.include(PERSON_VALUE_1)
+      expect(
+        CreateReport.getTestMultiReferenceFieldValueRow(2).getText()
+      ).to.include(PERSON_VALUE_2)
+      expect(
+        CreateReport.getTestMultiReferenceFieldValueRow(3).getText()
+      ).to.include(POSITION_VALUE_2)
+      expect(
+        CreateReport.getTestMultiReferenceFieldValueRow(4).getText()
+      ).to.include(POSITION_VALUE_3)
+      // Delete selected values
+      CreateReport.testMultiReferenceFieldValueRows.forEach(r =>
+        r.$("span").click()
+      )
+    })
+
+    it("Should be able to save a report without any ANET object references", () => {
+      // Submit the report
+      CreateReport.submitForm()
+      CreateReport.waitForAlertToLoad()
+      const alertMessage = CreateReport.alert.getText()
+      expect(alertMessage).to.include("The following errors must be fixed")
+
+      // Check ANET object reference
+      CreateReport.testReferenceFieldLabel.waitForExist()
+      CreateReport.testReferenceFieldLabel.waitForDisplayed()
+      // eslint-disable-next-line no-unused-expressions
+      expect(CreateReport.testReferenceFieldValue.isExisting()).to.be.false
+
+      // Check ANET object multi-references
+      CreateReport.testMultiReferenceFieldLabel.waitForExist()
+      CreateReport.testMultiReferenceFieldLabel.waitForDisplayed()
+      // eslint-disable-next-line no-unused-expressions
+      expect(CreateReport.testMultiReferenceFieldValue.isExisting()).to.be.false
+    })
+
+    it("Should be able to delete the report", () => {
+      // Edit the report
+      CreateReport.editButton.click()
+      // Delete it
+      CreateReport.deleteButton.waitForExist()
+      CreateReport.deleteButton.waitForDisplayed()
+      CreateReport.deleteButton.click()
+      // Confirm delete
+      CreateReport.confirmButton.waitForExist()
+      CreateReport.confirmButton.waitForDisplayed()
+      CreateReport.confirmButton.click()
+      // Report should be deleted
+      CreateReport.waitForAlertToLoad()
+      const alertMessage = CreateReport.alert.getText()
+      expect(alertMessage).to.include("Report deleted")
+    })
+  })
+})

--- a/client/tests/webdriver/specs/createReport.spec.js
+++ b/client/tests/webdriver/specs/createReport.spec.js
@@ -30,6 +30,14 @@ describe("Create report form page", () => {
     it("Should be able to select an ANET object reference", () => {
       CreateReport.testReferenceFieldLabel.waitForExist()
       CreateReport.testReferenceFieldLabel.waitForDisplayed()
+      expect(CreateReport.testReferenceFieldLabel.getText()).to.equal(
+        "Related report"
+      )
+      CreateReport.testReferenceFieldHelpText.waitForExist()
+      CreateReport.testReferenceFieldHelpText.waitForDisplayed()
+      expect(CreateReport.testReferenceFieldHelpText.getText()).to.equal(
+        "Here you can link to a related report"
+      )
 
       // Only input type is Reports, so there should be no button to select a type
       expect(
@@ -79,6 +87,14 @@ describe("Create report form page", () => {
     it("Should be able to select multiple ANET object references", () => {
       CreateReport.testMultiReferenceFieldLabel.waitForExist()
       CreateReport.testMultiReferenceFieldLabel.waitForDisplayed()
+      expect(CreateReport.testMultiReferenceFieldLabel.getText()).to.equal(
+        "Additional engagement needed for"
+      )
+      CreateReport.testMultiReferenceFieldHelpText.waitForExist()
+      CreateReport.testMultiReferenceFieldHelpText.waitForDisplayed()
+      expect(CreateReport.testMultiReferenceFieldHelpText.getText()).to.equal(
+        "Here you can link to people, positions and organizations that need an additional engagement"
+      )
 
       // Default input type is People
       expect(
@@ -182,8 +198,9 @@ describe("Create report form page", () => {
       // Submit the report
       CreateReport.submitForm()
       CreateReport.waitForAlertToLoad()
-      const alertMessage = CreateReport.alert.getText()
-      expect(alertMessage).to.include("The following errors must be fixed")
+      expect(CreateReport.alert.getText()).to.include(
+        "The following errors must be fixed"
+      )
 
       // Check ANET object reference
       CreateReport.testReferenceFieldLabel.waitForExist()
@@ -286,8 +303,7 @@ describe("Create report form page", () => {
       CreateReport.confirmButton.click()
       // Report should be deleted
       CreateReport.waitForAlertToLoad()
-      const alertMessage = CreateReport.alert.getText()
-      expect(alertMessage).to.include("Report deleted")
+      expect(CreateReport.alert.getText()).to.include("Report deleted")
     })
   })
 })

--- a/client/tests/webdriver/specs/createReport.spec.js
+++ b/client/tests/webdriver/specs/createReport.spec.js
@@ -62,7 +62,7 @@ describe("Create report form page", () => {
       )
 
       // Delete selected value
-      CreateReport.testReferenceFieldValue.$("span").click()
+      CreateReport.testReferenceFieldValue.$("button").click()
       // eslint-disable-next-line no-unused-expressions
       expect(CreateReport.testReferenceFieldValue.isExisting()).to.be.false
 
@@ -169,7 +169,7 @@ describe("Create report form page", () => {
       // Should have 5 values
       expect(CreateReport.testMultiReferenceFieldValueRows).to.have.lengthOf(5)
       // Delete one of the selected values
-      CreateReport.getTestMultiReferenceFieldValueRow(3).$("span").click()
+      CreateReport.getTestMultiReferenceFieldValueRow(3).$("button").click()
       // Should have only 4 values left
       expect(CreateReport.testMultiReferenceFieldValueRows).to.have.lengthOf(4)
       // 3rd value should have changed
@@ -225,7 +225,7 @@ describe("Create report form page", () => {
         REPORT_VALUE
       )
       // Delete selected value
-      CreateReport.testReferenceFieldValue.$("span").click()
+      CreateReport.testReferenceFieldValue.$("button").click()
 
       CreateReport.testMultiReferenceFieldLabel.waitForExist()
       CreateReport.testMultiReferenceFieldLabel.waitForDisplayed()
@@ -249,7 +249,7 @@ describe("Create report form page", () => {
       ).to.include(POSITION_VALUE_3)
       // Delete selected values
       CreateReport.testMultiReferenceFieldValueRows.forEach(r =>
-        r.$("span").click()
+        r.$("button").click()
       )
     })
 

--- a/client/tests/webdriver/specs/showTask.spec.js
+++ b/client/tests/webdriver/specs/showTask.spec.js
@@ -16,13 +16,15 @@ describe("Show task page", () => {
       const frenchFlagAssessmentMonthly = ShowTask.assessmentResultsMonthly.$(
         "id*=frenchFlag-assessment"
       )
-      expect(frenchFlagAssessmentMonthly.isExisting())
+      // eslint-disable-next-line no-unused-expressions
+      expect(frenchFlagAssessmentMonthly.isExisting()).to.be.true
 
       ShowTask.assessmentResultsWeekly.waitForDisplayed()
       const frenchFlagAssessmentWeekly = ShowTask.assessmentResultsWeekly.$(
         "id*=levels-assessment"
       )
-      expect(frenchFlagAssessmentWeekly.isExisting())
+      // eslint-disable-next-line no-unused-expressions
+      expect(frenchFlagAssessmentWeekly.isExisting()).to.be.true
     })
   })
 })

--- a/client/tests/webdriver/specs/showTask.spec.js
+++ b/client/tests/webdriver/specs/showTask.spec.js
@@ -14,14 +14,14 @@ describe("Show task page", () => {
     it("We should see a table of assessments related to the current task", () => {
       ShowTask.assessmentResultsMonthly.waitForDisplayed()
       const frenchFlagAssessmentMonthly = ShowTask.assessmentResultsMonthly.$(
-        "id*=frenchFlag-assessment"
+        "[id*=frenchFlag-assessment]"
       )
       // eslint-disable-next-line no-unused-expressions
       expect(frenchFlagAssessmentMonthly.isExisting()).to.be.true
 
       ShowTask.assessmentResultsWeekly.waitForDisplayed()
       const frenchFlagAssessmentWeekly = ShowTask.assessmentResultsWeekly.$(
-        "id*=levels-assessment"
+        "[id*=levels-assessment]"
       )
       // eslint-disable-next-line no-unused-expressions
       expect(frenchFlagAssessmentWeekly.isExisting()).to.be.true

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -6961,6 +6961,11 @@ eslint-module-utils@^2.6.0:
     debug "^2.6.9"
     pkg-dir "^2.0.0"
 
+eslint-plugin-chai-expect@2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-chai-expect/-/eslint-plugin-chai-expect-2.2.0.tgz#ff41fb00067fe6ff26e72b04ab1011ecaf3cb249"
+  integrity sha512-ExTJKhgeYMfY8wDj3UiZmgpMKJOUHGNHmWMlxT49JUDB1vTnw0sSNfXJSxnX+LcebyBD/gudXzjzD136WqPJrQ==
+
 eslint-plugin-es@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-es/-/eslint-plugin-es-3.0.1.tgz#75a7cdfdccddc0589934aeeb384175f221c57893"

--- a/src/main/resources/anet-schema.yml
+++ b/src/main/resources/anet-schema.yml
@@ -72,7 +72,7 @@ $defs:
       type:
         title: value type field
         type: string
-        enum: [text, number, date, datetime, enum, enumset, array_of_objects, special_field]
+        enum: [text, number, date, datetime, enum, enumset, array_of_objects, anet_object, array_of_anet_objects, special_field]
       typeError:
         title: custom value for type error
         type: string
@@ -132,6 +132,8 @@ $defs:
         type: object
         additionalProperties:
           "$ref": "#/$defs/customField"
+      types:
+        type: array
       widget:
         type: string
         enum: [likertScale, richTextEditor, default]
@@ -173,6 +175,16 @@ $defs:
               additionalProperties:
                 "$ref": "#/$defs/customField"
           required: [addButtonLabel,objectLabel,objectFields]
+        - properties:
+            type:
+              enum: [anet_object, array_of_anet_objects]
+            types:
+              type: array
+              uniqueItems: true
+              items:
+                type: string
+                enum: [Location, Organization, Person, Position, Report, Task]
+            required: [types]
         - properties:
             type:
               enum: [special_field]


### PR DESCRIPTION
It is now possible to add links to other ANET objects as custom fields. E.g. by adding this fragment to `anet.yml`:
```
dictionary:
  […]
  fields:
    […]
    report:
      […]
      customFields:
        relatedReport:
          type: anet_object
          label: Related report
          types:
            - Report
        additionalEngagementNeeded:
          type: array_of_anet_objects
          label: Additional engagement needed for
          types:
            - Person
            - Position
            - Organization
      […]
```
a report would have two additional custom fields, one for linking to another report, and one for linking to several people, positions and organizations.
The available types are Location, Organization, Person, Position, Report, Task.

### Release notes

Closes NCI-Agency/anet#3143

#### User changes
- depending on the application configuration, the user may see new custom fields allowing links to other ANET objects

#### Super User changes
- none

#### Admin changes
- none

#### System admin changes
- [x] anet.yml needs change if you want to add these new custom fields
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [x] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [x] Opened debt issues for anything not resolved here