### PR TITLE
Ensure left-side navigation menu is present when needed

### DIFF
--- a/client/src/pages/dashboards/BoardDashboard.js
+++ b/client/src/pages/dashboards/BoardDashboard.js
@@ -17,9 +17,14 @@ import {
   PathFindingLinkFactory,
   DagreEngine
 } from "@projectstorm/react-diagrams-routing"
+import { DEFAULT_PAGE_PROPS } from "actions"
 import LinkTo from "components/LinkTo"
 import MultiTypeAdvancedSelectComponent from "components/advancedSelectWidget/MultiTypeAdvancedSelectComponent"
-import { mapPageDispatchersToProps } from "components/Page"
+import {
+  mapPageDispatchersToProps,
+  PageDispatchersPropType,
+  useBoilerplate
+} from "components/Page"
 import FileSaver from "file-saver"
 import * as Models from "models"
 import PropTypes from "prop-types"
@@ -96,7 +101,12 @@ PrototypeNode.propTypes = {
   onClick: PropTypes.func
 }
 
-const BoardDashboard = () => {
+const BoardDashboard = ({ pageDispatchers }) => {
+  // Make sure we have a navigation menu
+  useBoilerplate({
+    pageProps: DEFAULT_PAGE_PROPS,
+    pageDispatchers
+  })
   const { dashboard } = useParams()
   const dashboardSettings = Settings.dashboards.find(o => o.label === dashboard)
   const [dropEvent, setDropEvent] = useState(null)
@@ -329,6 +339,10 @@ const BoardDashboard = () => {
       </div>
     </div>
   )
+}
+
+BoardDashboard.propTypes = {
+  pageDispatchers: PageDispatchersPropType
 }
 
 export default connect(null, mapPageDispatchersToProps)(BoardDashboard)

--- a/client/src/pages/positions/MyCounterparts.js
+++ b/client/src/pages/positions/MyCounterparts.js
@@ -1,9 +1,21 @@
+import { DEFAULT_PAGE_PROPS } from "actions"
 import AppContext from "components/AppContext"
 import Fieldset from "components/Fieldset"
+import {
+  mapPageDispatchersToProps,
+  PageDispatchersPropType,
+  useBoilerplate
+} from "components/Page"
 import PositionTable from "components/PositionTable"
 import React, { useContext } from "react"
+import { connect } from "react-redux"
 
-const MyCounterparts = () => {
+const MyCounterparts = ({ pageDispatchers }) => {
+  // Make sure we have a navigation menu
+  useBoilerplate({
+    pageProps: DEFAULT_PAGE_PROPS,
+    pageDispatchers
+  })
   const { currentUser } = useContext(AppContext)
   return (
     <div>
@@ -13,4 +25,9 @@ const MyCounterparts = () => {
     </div>
   )
 }
-export default MyCounterparts
+
+MyCounterparts.propTypes = {
+  pageDispatchers: PageDispatchersPropType
+}
+
+export default connect(null, mapPageDispatchersToProps)(MyCounterparts)

--- a/client/src/pages/reports/MyReports.js
+++ b/client/src/pages/reports/MyReports.js
@@ -1,9 +1,11 @@
+import { DEFAULT_PAGE_PROPS } from "actions"
 import AppContext from "components/AppContext"
 import Fieldset from "components/Fieldset"
 import { AnchorNavItem } from "components/Nav"
 import {
+  mapPageDispatchersToProps,
   PageDispatchersPropType,
-  mapPageDispatchersToProps
+  useBoilerplate
 } from "components/Page"
 import ReportCollection, {
   FORMAT_CALENDAR,
@@ -20,6 +22,11 @@ import { Nav } from "react-bootstrap"
 import { connect } from "react-redux"
 
 const MyReports = ({ pageDispatchers, searchQuery }) => {
+  // Make sure we have a navigation menu
+  useBoilerplate({
+    pageProps: DEFAULT_PAGE_PROPS,
+    pageDispatchers
+  })
   const {
     currentUser: { uuid }
   } = useContext(AppContext)

--- a/client/src/pages/tasks/MyTasks.js
+++ b/client/src/pages/tasks/MyTasks.js
@@ -1,10 +1,11 @@
-import { setPagination } from "actions"
+import { DEFAULT_PAGE_PROPS, setPagination } from "actions"
 import AppContext from "components/AppContext"
 import Fieldset from "components/Fieldset"
 import LinkTo from "components/LinkTo"
 import {
+  mapPageDispatchersToProps,
   PageDispatchersPropType,
-  mapPageDispatchersToProps
+  useBoilerplate
 } from "components/Page"
 import {
   SearchQueryPropType,
@@ -25,6 +26,11 @@ const MyTasks = ({
   pagination,
   setPagination
 }) => {
+  // Make sure we have a navigation menu
+  useBoilerplate({
+    pageProps: DEFAULT_PAGE_PROPS,
+    pageDispatchers
+  })
   const { currentUser } = useContext(AppContext)
   const taskShortLabel = Settings.fields.task.shortLabel
   // Memo'ize the search query parameters we use to prevent unnecessary re-renders


### PR DESCRIPTION
Make sure the My Counterparts, My Tasks, My Reports and Board Dashboard pages have a left-side navigation menu.
Left-side navigation might have been missing if the user was on a page without it (e.g. an edit form), and then navigated directly to one of these pages.