### PR TITLE
Fix createreport test failing intermittently

### DIFF
--- a/client/tests/webdriver/specs/createReport.spec.js
+++ b/client/tests/webdriver/specs/createReport.spec.js
@@ -290,20 +290,31 @@ describe("Create report form page", () => {
       expect(CreateReport.testMultiReferenceFieldValue.isExisting()).to.be.false
     })
 
-    it("Should be able to delete the report", () => {
+    it("Should be able to delete the report", async() => {
+      // See https://webdriver.io/docs/sync-vs-async.html
       // Edit the report
-      CreateReport.editButton.click()
+      const editButton = await CreateReport.editButton
+      await editButton.waitForExist()
+      await editButton.waitForDisplayed()
+      await editButton.click()
+
       // Delete it
-      CreateReport.deleteButton.waitForExist()
-      CreateReport.deleteButton.waitForDisplayed()
-      CreateReport.deleteButton.click()
+      const deleteButton = await CreateReport.deleteButton
+      await deleteButton.waitForExist()
+      await deleteButton.waitForDisplayed()
+      await deleteButton.click()
+
       // Confirm delete
-      CreateReport.confirmButton.waitForExist()
-      CreateReport.confirmButton.waitForDisplayed()
-      CreateReport.confirmButton.click()
+      const confirmButton = await CreateReport.confirmButton
+      await confirmButton.waitForExist()
+      await confirmButton.waitForDisplayed()
+      await confirmButton.click()
+
       // Report should be deleted
-      CreateReport.waitForAlertToLoad()
-      expect(CreateReport.alert.getText()).to.include("Report deleted")
+      const alertEl = await CreateReport.alert
+      await alertEl.waitForExist()
+      await alertEl.waitForDisplayed()
+      expect(await alertEl.getText()).to.include("Report deleted")
     })
   })
 })


### PR DESCRIPTION
The createreport test was failing intermittently at the step of deleting
a report, because the test was sync but using async calls like the
confirmDelete click.

#### User changes
-

#### Super User changes
-

#### Admin changes
-

#### System admin changes
-
- [ ] anet.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [ ] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [x] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [ ] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
