### PR TITLE
Fix nodeSize making useEffect run every render

### DIFF
--- a/client/src/components/graphs/OrganizationalChart.js
+++ b/client/src/components/graphs/OrganizationalChart.js
@@ -2,8 +2,8 @@ import API from "api"
 import { gql } from "apollo-boost"
 import SVGCanvas from "components/graphs/SVGCanvas"
 import {
-  PageDispatchersPropType,
   mapPageDispatchersToProps,
+  PageDispatchersPropType,
   useBoilerplate
 } from "components/Page"
 import * as d3 from "d3"
@@ -97,7 +97,6 @@ const OrganizationalChart = ({
   const tree = useRef(d3.tree())
   const [root, setRoot] = useState(null)
   const [height, setHeight] = useState(initialHeight)
-  const nodeSize = [200, 100 + 11 * personnelDepth]
   const { loading, error, data } = API.useApiQuery(GQL_GET_CHART_DATA, {
     uuid: org.uuid
   })
@@ -129,6 +128,7 @@ const OrganizationalChart = ({
     if (!data || !root) {
       return
     }
+    const nodeSize = [200, 100 + 11 * personnelDepth]
 
     const calculateBounds = rootArg => {
       const boundingBox = rootArg.descendants().reduce(
@@ -174,7 +174,7 @@ const OrganizationalChart = ({
     )
 
     setHeight(scale * bounds.size[1] + 50)
-  }, [nodeSize, canvas, data, height, width, root])
+  }, [personnelDepth, canvas, data, height, width, root])
 
   useEffect(() => {
     data && setExpanded([data.organization.uuid])


### PR DESCRIPTION
nodeSize array was created every render, causing useEffect to run every render, making dependency array useless. Now it is created inside and the dependency is the personnelDepth. 

#### User changes
- None

#### Super User changes
-

#### Admin changes
-

#### System admin changes
-
- [ ] anet.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [X] Described the user behavior in PR body
  - [ ] Referenced/updated all related issues
  - [ ] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [X] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [X] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
