### PR TITLE
Fix missing against variable in git hooks

### DIFF
--- a/scripts/githooks/pre-commit
+++ b/scripts/githooks/pre-commit
@@ -9,5 +9,13 @@ if [ "$branch" = "master" ] || [ "$branch" = "candidate" ]; then
   exit 1
 fi
 
+if git rev-parse --verify HEAD >/dev/null 2>&1
+then
+	against=HEAD
+else
+	# Initial commit: diff against an empty tree object
+	against=$(git hash-object -t tree /dev/null)
+fi
+
 # If there are whitespace errors, print the offending file names and fail.
 exec git diff-index --check --cached $against --


### PR DESCRIPTION
Last line in the pre-commit hook was using an undeclared variable "against" which causes an error when you use githooks, this pr fixes that.

Closes #3179 

#### User changes
-

#### Super User changes
-

#### Admin changes
-

#### System admin changes
-
- [ ] anet.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [X] Described the user behavior in PR body
  - [X] Referenced/updated all related issues
  - [ ] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [ ] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [X] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
