### PR TITLE
Fix delete of associated position

### DIFF
--- a/client/src/components/EditAssociatedPositionsModal.js
+++ b/client/src/components/EditAssociatedPositionsModal.js
@@ -53,7 +53,7 @@ const AssociatedPositionsTable = ({ associatedPositions, onDelete }) => (
             <td>
               <RemoveButton
                 title="Unassign person"
-                handleOnClick={() => onDelete(relPos)}
+                onClick={() => onDelete(relPos)}
               />
             </td>
           </tr>


### PR DESCRIPTION
RemoveButton prop has been renamed to `onClick`, but "delete associated position" still used the old name.

### Release notes

Fixes NCI-Agency/anet#3188

#### User changes
- none

#### Super User changes
- Delete of associated position works again.

#### Admin changes
- Delete of associated position works again.

#### System admin changes
- none
- [ ] anet.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here