### PR TITLE
Fix planning conflict intermittent wdio test errors

### DIFF
--- a/client/tests/webdriver/pages/report/createReport.page.js
+++ b/client/tests/webdriver/pages/report/createReport.page.js
@@ -16,6 +16,10 @@ class CreateReport extends Page {
     return browser.$("#intent")
   }
 
+  get intentHelpBlock() {
+    return browser.$("#fg-intent .help-block")
+  }
+
   get engagementDate() {
     return browser.$("#engagementDate")
   }
@@ -117,7 +121,10 @@ class CreateReport extends Page {
       this.intent.setValue(fields.intent)
     }
 
+    this.intentHelpBlock.waitForExist({ reverse: true })
+
     if (moment.isMoment(fields.engagementDate)) {
+      this.engagementDate.waitForClickable()
       this.engagementDate.click()
       this.tomorrow.waitForDisplayed()
       this.tomorrow.waitForClickable()


### PR DESCRIPTION
Fix an issue that causes planning conflict detection wdio tests to fail intermittently. Sometimes engagementDate field was not being clicked due to the validation message on intent field appearing/disappearing unexpectedly.

Proposed fix in this PR has been tested 56 times on BrowserStack and 24 times on Github Actions.

### Release notes

Closes #

#### User changes
- none

#### Super User changes
- none

#### Admin changes
- none

#### System admin changes
-
- [ ] anet.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [X] Described the user behavior in PR body
  - [ ] Referenced/updated all related issues
  - [ ] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [ ] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [X] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [X] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
