### PR TITLE
Enable "include reports from sub-orgs" by default

### DIFF
--- a/client/src/pages/organizations/Show.js
+++ b/client/src/pages/organizations/Show.js
@@ -129,7 +129,7 @@ const OrganizationShow = ({ pageDispatchers }) => {
   const { currentUser } = useContext(AppContext)
   const routerLocation = useLocation()
   const [filterPendingApproval, setFilterPendingApproval] = useState(false)
-  const [includeChildrenOrgs, setIncludeChildrenOrgs] = useState(false)
+  const [includeChildrenOrgs, setIncludeChildrenOrgs] = useState(true)
   const { uuid } = useParams()
   const { loading, error, data } = API.useApiQuery(GQL_GET_ORGANIZATION, {
     uuid
@@ -394,27 +394,27 @@ const OrganizationShow = ({ pageDispatchers }) => {
                   paginationKey={`r_${uuid}`}
                   queryParams={reportQueryParams}
                   reportsFilter={
-                    !isSuperUser ? null : (
-                      <>
-                        <Button
-                          value="toggle-filter"
-                          className="btn btn-sm"
-                          onClick={() =>
-                            setFilterPendingApproval(!filterPendingApproval)}
-                        >
-                          {filterPendingApproval
-                            ? "Show all reports"
-                            : "Show pending approval"}
-                        </Button>
-                        <Checkbox
-                          checked={includeChildrenOrgs}
-                          onChange={() =>
-                            setIncludeChildrenOrgs(!includeChildrenOrgs)}
-                        >
-                          include reports from sub-orgs
-                        </Checkbox>
-                      </>
-                    )
+                    <>
+                      !isSuperUser ? null : (
+                      <Button
+                        value="toggle-filter"
+                        className="btn btn-sm"
+                        onClick={() =>
+                          setFilterPendingApproval(!filterPendingApproval)}
+                      >
+                        {filterPendingApproval
+                          ? "Show all reports"
+                          : "Show pending approval"}
+                      </Button>
+                      )
+                      <Checkbox
+                        checked={includeChildrenOrgs}
+                        onChange={() =>
+                          setIncludeChildrenOrgs(!includeChildrenOrgs)}
+                      >
+                        include reports from sub-orgs
+                      </Checkbox>
+                    </>
                   }
                 />
               </Fieldset>


### PR DESCRIPTION
Currently, the ability to display report collections and statistics from child organizations is disabled by default and is reserved only for superusers of the organization.
The desired behavior is for all users to be able to see that and for it to be enabled by default

### Release notes

#### User changes
- `include reports from sub-orgs` is available to users when viewing organizations
- `include reports from sub-orgs` is now on by default

#### Super User changes
- `include reports from sub-orgs` is available to super users when viewing organizations other than the ones they are super users of
- `include reports from sub-orgs` is now on by default

#### Admin changes
- `include reports from sub-orgs` is now on by default

- [ ] anet.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [ ] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [ ] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
