### PR TITLE
User without position can create draft reports again

### DIFF
--- a/client/src/components/advancedSelectWidget/AdvancedSelect.js
+++ b/client/src/components/advancedSelectWidget/AdvancedSelect.js
@@ -100,7 +100,7 @@ export const propTypes = {
   overlayColumns: PropTypes.array.isRequired,
   overlayRenderRow: PropTypes.func.isRequired,
   closeOverlayOnAdd: PropTypes.bool, // set to true if you want the overlay to be closed after an add action
-  filterDefs: PropTypes.object, // config of the search filters
+  filterDefs: PropTypes.object.isRequired, // config of the search filters
   onChange: PropTypes.func,
   // Required: ANET Object Type (Person, Report, etc) to search for.
   objectType: PropTypes.func.isRequired,
@@ -346,7 +346,7 @@ const AdvancedSelect = ({
                 }
                 isOpen={showOverlay}
                 captureDismiss
-                dsabled={disabled}
+                disabled={disabled}
                 interactionKind={PopoverInteractionKind.CLICK}
                 onInteraction={handleInteraction}
                 usePortal={false}

--- a/client/src/pages/reports/Form.js
+++ b/client/src/pages/reports/Form.js
@@ -793,67 +793,69 @@ const ReportForm = ({
                 />
               </Fieldset>
 
-              <Fieldset
-                title={Settings.fields.task.subLevel.longLabel}
-                className="tasks-selector"
-              >
-                <Field
-                  name="tasks"
-                  label={Settings.fields.task.subLevel.longLabel}
-                  component={FieldHelper.SpecialField}
-                  onChange={value => {
-                    // validation will be done by setFieldValue
-                    setFieldTouched("tasks", true, false) // onBlur doesn't work when selecting an option
-                    setFieldValue("tasks", value, true)
-                    setReportTasks(value)
-                  }}
-                  widget={
-                    <AdvancedMultiSelect
-                      fieldName="tasks"
-                      placeholder={`Search for ${tasksLabel}...`}
-                      value={values.tasks}
-                      renderSelected={
-                        <TaskTable
-                          id="tasks-tasks"
-                          tasks={values.tasks}
-                          showParent
-                          showDelete
-                          showDescription
-                          noTasksMessage={`No ${tasksLabel} selected; click in the efforts box to view your organization's efforts`}
-                        />
-                      }
-                      overlayColumns={[
-                        Settings.fields.task.subLevel.shortLabel,
-                        Settings.fields.task.topLevel.shortLabel
-                      ]}
-                      overlayRenderRow={TaskDetailedOverlayRow}
-                      filterDefs={tasksFilters}
-                      objectType={Task}
-                      queryParams={{ status: Task.STATUS.ACTIVE }}
-                      fields={Task.autocompleteQuery}
-                      addon={TASKS_ICON}
-                    />
-                  }
-                  extraColElem={
-                    <>
-                      <FieldHelper.FieldShortcuts
-                        title={`Recent ${tasksLabel}`}
-                        shortcuts={recents.tasks}
+              {!_isEmpty(tasksFilters) && (
+                <Fieldset
+                  title={Settings.fields.task.subLevel.longLabel}
+                  className="tasks-selector"
+                >
+                  <Field
+                    name="tasks"
+                    label={Settings.fields.task.subLevel.longLabel}
+                    component={FieldHelper.SpecialField}
+                    onChange={value => {
+                      // validation will be done by setFieldValue
+                      setFieldTouched("tasks", true, false) // onBlur doesn't work when selecting an option
+                      setFieldValue("tasks", value, true)
+                      setReportTasks(value)
+                    }}
+                    widget={
+                      <AdvancedMultiSelect
                         fieldName="tasks"
+                        placeholder={`Search for ${tasksLabel}...`}
+                        value={values.tasks}
+                        renderSelected={
+                          <TaskTable
+                            id="tasks-tasks"
+                            tasks={values.tasks}
+                            showParent
+                            showDelete
+                            showDescription
+                            noTasksMessage={`No ${tasksLabel} selected; click in the efforts box to view your organization's efforts`}
+                          />
+                        }
+                        overlayColumns={[
+                          Settings.fields.task.subLevel.shortLabel,
+                          Settings.fields.task.topLevel.shortLabel
+                        ]}
+                        overlayRenderRow={TaskDetailedOverlayRow}
+                        filterDefs={tasksFilters}
                         objectType={Task}
-                        curValue={values.tasks}
-                        onChange={value => {
-                          // validation will be done by setFieldValue
-                          setFieldTouched("tasks", true, false) // onBlur doesn't work when selecting an option
-                          setFieldValue("tasks", value, true)
-                          setReportTasks(value)
-                        }}
-                        handleAddItem={FieldHelper.handleMultiSelectAddItem}
+                        queryParams={{ status: Task.STATUS.ACTIVE }}
+                        fields={Task.autocompleteQuery}
+                        addon={TASKS_ICON}
                       />
-                    </>
-                  }
-                />
-              </Fieldset>
+                    }
+                    extraColElem={
+                      <>
+                        <FieldHelper.FieldShortcuts
+                          title={`Recent ${tasksLabel}`}
+                          shortcuts={recents.tasks}
+                          fieldName="tasks"
+                          objectType={Task}
+                          curValue={values.tasks}
+                          onChange={value => {
+                            // validation will be done by setFieldValue
+                            setFieldTouched("tasks", true, false) // onBlur doesn't work when selecting an option
+                            setFieldValue("tasks", value, true)
+                            setReportTasks(value)
+                          }}
+                          handleAddItem={FieldHelper.handleMultiSelectAddItem}
+                        />
+                      </>
+                    }
+                  />
+                </Fieldset>
+              )}
 
               {Settings.fields.report.customFields && (
                 <Fieldset title="Engagement information" id="custom-fields">


### PR DESCRIPTION
Due to a bug, a user without an assigned position could no longer create a draft report (a blank screen was shown instead). This PR fixes that.

### Release notes

Fixes NCI-Agency/anet#3210

#### User changes
- User without position can create draft reports again. Note that due to the user having no position (yet), no efforts can be added to the report (yet).

#### Super User changes
- none

#### Admin changes
- none

#### System admin changes
- none
- [ ] anet.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here