### PR TITLE
Pin Yarn version at 1.22.10

### DIFF
--- a/.github/workflows/build-gradle.yml
+++ b/.github/workflows/build-gradle.yml
@@ -29,8 +29,6 @@ jobs:
     - uses: actions/setup-java@v1
       with:
         java-version: 1.8
-    - run: echo "::add-path::./.gradle/yarn/yarn-latest/bin"
-    - run: echo "::add-path::./.gradle/nodejs/*/bin"
     - run: echo "::set-env name=CHROMEDRIVER_FILEPATH::$CHROMEWEBDRIVER/chromedriver"
     - name: cache gradle
       uses: actions/cache@v1
@@ -46,9 +44,10 @@ jobs:
         key: ${{ runner.os }}-node
         restore-keys: |
           ${{ runner.os }}-node
+    - run: ./gradlew yarnSetup
     - name: get yarn cache directory path
       id: yarn-cache-dir-path
-      run: echo "::set-output name=dir::$(yarn cache dir)"
+      run: echo "::set-output name=dir::$(./gradlew -q yarn_cache_dir)"
     - name: cache yarn
       uses: actions/cache@v1
       with:
@@ -57,8 +56,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-yarn-
     - run: ./gradlew jar
-    - working-directory: ./client
-      run: yarn run lint
+    - run: ./gradlew yarn_run_lint
     - name: Notify slack success
       if: success()
       env:
@@ -111,8 +109,6 @@ jobs:
     - uses: actions/setup-java@v1
       with:
         java-version: 1.8
-    - run: echo "::add-path::./.gradle/yarn/yarn-latest/bin"
-    - run: echo "::add-path::./.gradle/nodejs/*/bin"
     - run: echo "::set-env name=CHROMEDRIVER_FILEPATH::$CHROMEWEBDRIVER/chromedriver"
     - uses: actions/cache@v1
       with:
@@ -126,9 +122,10 @@ jobs:
         key: ${{ runner.os }}-node
         restore-keys: |
           ${{ runner.os }}-node
+    - run: ./gradlew yarnSetup
     - name: Get yarn cache directory path
       id: yarn-cache-dir-path
-      run: echo "::set-output name=dir::$(yarn cache dir)"
+      run: echo "::set-output name=dir::$(./gradlew -q yarn_cache_dir)"
     - uses: actions/cache@v1
       with:
         path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
@@ -154,8 +151,7 @@ jobs:
         unzip -q bsl.zip
         ./BrowserStackLocal --local-identifier ${{ steps.browserstack-local.outputs.identifier }} --key ${{ secrets.BROWSERSTACK_ACCESS_KEY }} &
       if: steps.tagName.outputs.tag != ''
-    - working-directory: ./client
-      run: yarn run test-all
+    - run: ./gradlew yarn_run_test-all
       env:
         GIT_TAG_NAME: ${{ steps.tagName.outputs.tag }}
         BROWSERSTACK_LOCAL_IDENTIFIER: ${{ steps.browserstack-local.outputs.identifier }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,14 +7,14 @@ Anybody is welcome to create a branch on this repository and make edits.  If you
 Our code style conventions are automatically checked on both the Java server side and the Javascript client side.  You can run these checks with: 
 
 - Java Checkstyle `./gradlew check`
-- JS Lint `cd client; yarn run lint`
+- JS Lint `./gradlew yarn_run_lint`
 
 ### Testing
 
 Before we merge any code into master we verify that all tests run.  You can run these yourself with: 
 
 - Backend Unit Tests `export DB_DRIVER='sqlserver'; ./gradlew -PtestEnv test`
-- Front-end Integration Tests `cd client; yarn run test-all`
+- Front-end Integration Tests `./gradlew yarn_run_test-all`
 
 If you are adding any new features, please write test cases that cover your features. 
 

--- a/build.gradle
+++ b/build.gradle
@@ -487,5 +487,6 @@ allprojects {
 node {
 	nodeModulesDir = file("${project.projectDir}/client")
 	version = '12.14.1'
+	yarnVersion = '1.22.10'
 	download = true
 }

--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -137,16 +137,16 @@ The tests are reliant on the data looking pretty similar to what you'd get after
 1. Start with a clean test-database when running tests: `./gradlew -PtestEnv dbDrop dbMigrate dbLoad`
 1. Start a test SMTP server (in a Docker container) in your local development environment: `./gradlew -PtestEnv dockerCreateFakeSmtpServer dockerStartFakeSmtpServer`
 1. In order to run the client-side tests you must start a server using the test-database: `./gradlew -PtestEnv run`
-1. Make sure you have the proper nodejs and yarn in your path (see the [React Frontend](#react-frontend) instructions).
+1. Optionally, make sure you have the proper nodejs and yarn in your path (see the [React Frontend](#react-frontend) instructions).
 
-Run `yarn run lint-fix` to automatically fix some kinds of lint errors.
+Run `./gradlew yarn_run_lint-fix` to automatically fix some kinds of lint errors.
 
 #### Client-side testing locally
 To run the tests locally, make sure you have the server using the test-database running as above.
-1. Run the client side E2E tests against the test database: `yarn run test-e2e`
-1. Run the client side wdio tests against the test database: `yarn run test-wdio`
-1. Run the client side jest tests against the test database: `yarn run test-jest`
-1. Or run all client side tests against the test database: `yarn run test-all`
+1. Run the client side E2E tests against the test database: `./gradlew yarn_run_test-e2e`
+1. Run the client side wdio tests against the test database: `./gradlew yarn_run_test-wdio`
+1. Run the client side jest tests against the test database: `./gradlew yarn_run_test-jest`
+1. Or run all client side tests against the test database: `./gradlew yarn_run_test-all`
 
 To run the tests locally, by having [`chromedriver`](https://www.npmjs.com/package/chromedriver) as an npm dependency, we automatically have access to run in Chrome. To use Firefox instead, see [`geckodriver`](https://www.npmjs.com/package/geckodriver).
 
@@ -155,7 +155,7 @@ When writing browser tests, remember that when you take an action, you need to g
 If the tests are failing and you don't know why, run them with env var `DEBUG_LOG=true`:
 
 ```
-$ DEBUG_LOG=true yarn run test-e2e
+$ DEBUG_LOG=true ./gradlew yarn_run_test-e2e
 ```
 
 You can also insert the following into your code to make the browser pause, allowing you to investigate what is currently happening:
@@ -198,40 +198,41 @@ When all is set up, run the remote tests:
 1. Run;
     1.  the client side E2E tests:
         ```
-        $ yarn run test-e2e
+        $ ./gradlew yarn_run_test-e2e
         ```
     1. the client side wdio tests:
         ```
-        $ yarn run test-wdio
+        $ ./gradlew yarn_run_test-wdio
         ```
     1. the client side wdio-ie tests:
         ```
-        $ yarn run test-wdio-ie
+        $ ./gradlew yarn_run_test-wdio-ie
         ```
        **About IE tests:** Internet Explorer is not fully supported by ANET and all features are **NOT** guaranteed to work with IE. For that reason, a warning banner is displayed when IE detected. `test-wdio-ie` runs tests for this scenario and these tests run only on remote testing. When testing locally, they gracefully abort.
     1. all client side tests:
         ```
-        $ yarn run test-all
+        $ ./gradlew yarn_run_test-all
         ```
 1. You can view the progress and results on [BrowserStack](https://www.browserstack.com/automate).
 
 ### Simulator
 ANET has a simulator that can exercise of the functions. It is located in 'client/test/sim'. It works by interfacing with ANET through GraphQL queries. The simulator executes `stories` which are assigned to different user types and have different probabilities.   
 
-The simulator can be started by running 'yarn run sim' in 'client'.
+The simulator can be started by running './gradlew yarn_run_sim'.
 
 ## React Frontend
+All of the frontend code is in the `client/` directory.
+
 ### Initial Setup
-1. Make sure you have the proper nodejs and yarn in your path. Example:
+1. You can run all client-side scripts via Yarn through Gradle. Otherwise, make sure you have the proper nodejs and yarn in your path; example:
     ```
-    export YARN_HOME=<anet_root_path>/.gradle/yarn/yarn-latest
+    export YARN_HOME=<anet_root_path>/.gradle/yarn/yarn-v1.22.10
     export NODEJS_HOME=<anet_root_path>/.gradle/nodejs/node-v12.14.1-linux-x64
     export PATH="$YARN_HOME/bin:$NODEJS_HOME/bin:$PATH"
+    cd client/
     ```
-    _Note_: nodejs version might have changed in the meanwhile, check inside <anet_root_path>/.gradle/nodejs/ for which version is being used and change the path accordingly.
-1. `cd client/`
-    1. All of the frontend code is in the `client/` directory.
-1. Run the server: `yarn run start`
+    _Note_: nodejs and yarn versions might have changed in the meanwhile, check inside `<anet_root_path>/.gradle/nodejs/` and `<anet_root_path>/.gradle/yarn/` for which versions are being used and change the path accordingly.
+1. Run the server: `./gradlew yarn_run_start`
 1. Go to [http://localhost:3000/](http://localhost:3000/) in your browser.
     1. When prompted for credentials:
         - **Username:** `erin`


### PR DESCRIPTION
(possibly the latest Yarn v1 version; Yarn v2 should be the future)
Also document how to run scripts from the client-side `package.json` through Gradle,
which will automatically pick up the correct nodejs and yarn versions from `build.gradle`.