### PR TITLE
Fix a bug where periodic assessments were always missing

### DIFF
--- a/client/src/components/Model.js
+++ b/client/src/components/Model.js
@@ -504,10 +504,8 @@ export default class Model {
       .map(note => ({ note: note, assessment: utils.parseJsonSafe(note.text) }))
       .filter(
         obj =>
-          // FIXME: make a nicer implementation of the check on period start
           obj.assessment.__recurrence === recurrence &&
-          obj.assessment.__periodStart ===
-            utils.parseJsonSafe(JSON.stringify(period.start))
+          moment(obj.assessment.__periodStart).isSame(period.start)
       )
   }
 


### PR DESCRIPTION
`__periodStart` date is a string and `period.start` is an object, different type of data when compared always results in false, that is why always an empty array returned from `getPeriodAssessments` method


#### User changes
- Users now can see periodic assessments in the Assessment Results section at the page /tasks/:uuid or /people/:uuid

#### Super User changes
- none

#### Admin changes
- none

#### System admin changes
- none
- [ ] anet.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [X] Described the user behavior in PR body
  - [ ] Referenced/updated all related issues
  - [ ] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [X] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [X] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
