### PR TITLE
Use 'now' instead of the end-of-day in UTC

### DIFF
--- a/src/main/java/mil/dds/anet/beans/Report.java
+++ b/src/main/java/mil/dds/anet/beans/Report.java
@@ -788,7 +788,7 @@ public class Report extends AbstractCustomizableAnetBean implements RelatableObj
 
   @JsonIgnore
   public boolean isFutureEngagement() {
-    return engagementDate != null && engagementDate.isAfter(Utils.endOfToday());
+    return engagementDate != null && engagementDate.isAfter(Instant.now());
   }
 
   @GraphQLQuery(name = "engagementStatus")

--- a/src/main/java/mil/dds/anet/search/AbstractReportSearcher.java
+++ b/src/main/java/mil/dds/anet/search/AbstractReportSearcher.java
@@ -3,6 +3,7 @@ package mil.dds.anet.search;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Sets;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
@@ -29,7 +30,6 @@ import mil.dds.anet.database.PositionDao;
 import mil.dds.anet.database.ReportDao;
 import mil.dds.anet.search.AbstractSearchQueryBuilder.Comparison;
 import mil.dds.anet.utils.DaoUtils;
-import mil.dds.anet.utils.Utils;
 
 public abstract class AbstractReportSearcher extends AbstractSearcher<Report, ReportSearchQuery>
     implements IReportSearcher {
@@ -177,11 +177,11 @@ public abstract class AbstractReportSearcher extends AbstractSearcher<Report, Re
         switch (es) {
           case HAPPENED:
             engagementStatusClauses.add(" reports.\"engagementDate\" <= :endOfHappened");
-            DaoUtils.addInstantAsLocalDateTime(qb.sqlArgs, "endOfHappened", Utils.endOfToday());
+            DaoUtils.addInstantAsLocalDateTime(qb.sqlArgs, "endOfHappened", Instant.now());
             break;
           case FUTURE:
             engagementStatusClauses.add(" reports.\"engagementDate\" > :startOfFuture");
-            DaoUtils.addInstantAsLocalDateTime(qb.sqlArgs, "startOfFuture", Utils.endOfToday());
+            DaoUtils.addInstantAsLocalDateTime(qb.sqlArgs, "startOfFuture", Instant.now());
             break;
           case CANCELLED:
             engagementStatusClauses.add(" reports.state = :cancelledState");

--- a/src/main/java/mil/dds/anet/threads/FutureEngagementWorker.java
+++ b/src/main/java/mil/dds/anet/threads/FutureEngagementWorker.java
@@ -1,6 +1,7 @@
 package mil.dds.anet.threads;
 
 import java.lang.invoke.MethodHandles;
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import mil.dds.anet.AnetObjectEngine;
@@ -8,7 +9,6 @@ import mil.dds.anet.beans.AnetEmail;
 import mil.dds.anet.beans.Report;
 import mil.dds.anet.database.ReportDao;
 import mil.dds.anet.emails.FutureEngagementUpdated;
-import mil.dds.anet.utils.Utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -43,7 +43,7 @@ public class FutureEngagementWorker implements Runnable {
     // afterwards this report needs to go through the approval process of past
     // engagements.
     List<Report> reports =
-        AnetObjectEngine.getInstance().getReportDao().getFutureToPastReports(Utils.endOfToday());
+        AnetObjectEngine.getInstance().getReportDao().getFutureToPastReports(Instant.now());
 
     // update to draft state and send emails to the authors to let them know we updated their
     // report.

--- a/src/main/java/mil/dds/anet/utils/Utils.java
+++ b/src/main/java/mil/dds/anet/utils/Utils.java
@@ -11,7 +11,6 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -448,14 +447,6 @@ public class Utils {
     final String regex = domain.replace(".", "[.]") // replace dots
         .replace(wildcard, ".*?"); // replace wildcards
     return Pattern.compile("^" + regex + "$");
-  }
-
-
-  // Returns an instant representing the very end of today.
-  // Used to determine if a date is tomorrow or later.
-  public static Instant endOfToday() {
-    return Instant.now().atZone(DaoUtils.getDefaultZoneId()).withHour(23).withMinute(59)
-        .withSecond(59).withNano(999999999).toInstant();
   }
 
   /**

--- a/src/test/java/mil/dds/anet/test/integration/db/FutureEngagementWorkerTest.java
+++ b/src/test/java/mil/dds/anet/test/integration/db/FutureEngagementWorkerTest.java
@@ -28,7 +28,6 @@ import mil.dds.anet.test.integration.utils.TestApp;
 import mil.dds.anet.test.integration.utils.TestBeans;
 import mil.dds.anet.threads.AnetEmailWorker;
 import mil.dds.anet.threads.FutureEngagementWorker;
-import mil.dds.anet.utils.Utils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -119,7 +118,7 @@ public class FutureEngagementWorkerTest {
   public void testReportDueEndToday() {
     final AnetObjectEngine engine = AnetObjectEngine.getInstance();
     final Report report = createTestReport("testReportDueEndToday_1");
-    report.setEngagementDate(Utils.endOfToday());
+    report.setEngagementDate(Instant.now());
     engine.getReportDao().update(report);
 
     expectedIds.add("testReportDueEndToday_1");
@@ -197,7 +196,7 @@ public class FutureEngagementWorkerTest {
     ra.setStep(step);
     ra.setStepUuid(step.getUuid());
     ra.setType(ActionType.APPROVE);
-    ra.setCreatedAt(Utils.endOfToday());
+    ra.setCreatedAt(Instant.now());
     engine.getReportActionDao().insert(ra);
 
     unexpectedIds.add("testApprovalStepReport_1");


### PR DESCRIPTION
For the cut-off datetime in deciding if something is a future (planned) engagement, use the current datetime, instead of the end-of-day in UTC, which in some cases would lead to engagements being changed to 'draft' status on the wrong day.

### Release notes

Fixes NCI-Agency/anet#3220

#### User changes
- E-mail messages informing the author that their planned engagement report has received 'draft' status are now sent shortly after the start of the meeting, instead of possibly on the wrong day.

#### Super User changes
- none

#### Admin changes
- none

#### System admin changes
- none
- [ ] anet.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [x] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here