### PR TITLE
Fix required value prop failing on null values

### DIFF
--- a/client/src/components/advancedSelectWidget/AdvancedSingleSelect.js
+++ b/client/src/components/advancedSelectWidget/AdvancedSingleSelect.js
@@ -42,7 +42,7 @@ const AdvancedSingleSelect = props => {
 }
 AdvancedSingleSelect.propTypes = {
   ...advancedSelectPropTypes,
-  value: PropTypes.object.isRequired,
+  value: PropTypes.object,
   valueKey: PropTypes.string
 }
 AdvancedSingleSelect.defaultProps = {


### PR DESCRIPTION
AdvancedSingleSelect component's value prop being required makes it fail on null values. The component was already setting null value when selection was removed, which breaks a lot of parts

#### User changes
-

#### Super User changes
-

#### Admin changes
-

#### System admin changes
-
- [ ] anet.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [ ] Described the user behavior in PR body
  - [ ] Referenced/updated all related issues
  - [ ] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [ ] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [ ] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
