### PR TITLE
Improve and extend merge for tasks object

### DIFF
--- a/client/src/components/MergeField.js
+++ b/client/src/components/MergeField.js
@@ -18,16 +18,15 @@ const MergeField = ({ label, value, align, action }) => {
 const MergeFieldBox = styled.div`
   display: flex;
   flex-direction: ${props => props.fDir};
-  justtify-content: space-between;
+  justify-content: space-between;
   align-items: center;
   padding: 8px 0;
-  height: 46px;
 `
 
 const LabelBox = styled.div`
   text-align: ${props => props.align};
   font-weight: bold;
-  text-decoratiın: underline;
+  text-decoration: underline;
 `
 
 MergeField.propTypes = {

--- a/client/src/components/MergeField.js
+++ b/client/src/components/MergeField.js
@@ -1,0 +1,40 @@
+import styled from "@emotion/styled"
+import PropTypes from "prop-types"
+import React from "react"
+
+const MergeField = ({ label, value, align, action }) => {
+  const fDir = align === "right" ? "row-reverse" : "row"
+  return (
+    <MergeFieldBox fDir={fDir}>
+      <div style={{ flex: "1 1 auto" }}>
+        <LabelBox align={align}>{label}</LabelBox>
+        <div style={{ textAlign: align }}>{value}</div>
+      </div>
+      {action}
+    </MergeFieldBox>
+  )
+}
+
+const MergeFieldBox = styled.div`
+  display: flex;
+  flex-direction: ${props => props.fDir};
+  justtify-content: space-between;
+  align-items: center;
+  padding: 8px 0;
+  height: 46px;
+`
+
+const LabelBox = styled.div`
+  text-align: ${props => props.align};
+  font-weight: bold;
+  text-decoratiın: underline;
+`
+
+MergeField.propTypes = {
+  label: PropTypes.string.isRequired,
+  value: PropTypes.node,
+  align: PropTypes.string.isRequired,
+  action: PropTypes.node
+}
+
+export default MergeField

--- a/client/src/components/Nav.js
+++ b/client/src/components/Nav.js
@@ -101,7 +101,7 @@ const Nav = ({
   const principalOrganizationUuids = principalOrganizations.map(o => o.uuid)
 
   const isAdvisor = currentUser.isAdvisor()
-  const taskShortLabel = Settings.fields.task.shortLabel
+  const pluralTaskLabel = pluralize(Settings.fields.task.shortLabel)
 
   return (
     <BSNav bsStyle="pills" stacked id="leftNav" className="hide-for-print">
@@ -129,7 +129,7 @@ const Nav = ({
             handleOnClick={resetPages}
             id="my-tasks-nav"
           >
-            {`My ${pluralize(taskShortLabel)}`}
+            {`My ${pluralTaskLabel}`}
             {notifications?.myTasksWithPendingAssessments?.length ? (
               <NotificationBadge>
                 {notifications.myTasksWithPendingAssessments.length}
@@ -221,6 +221,9 @@ const Nav = ({
         <BSNav>
           <LinkContainer to="/admin/mergePeople" onClick={resetPages}>
             <NavItem>Merge people</NavItem>
+          </LinkContainer>
+          <LinkContainer to="/admin/mergeTasks" onClick={resetPages}>
+            <NavItem>Merge {pluralTaskLabel}</NavItem>
           </LinkContainer>
           <LinkContainer to="/admin/authorizationGroups" onClick={resetPages}>
             <NavItem>Authorization groups</NavItem>

--- a/client/src/mergeUtils.js
+++ b/client/src/mergeUtils.js
@@ -3,14 +3,15 @@ import Leaflet from "components/Leaflet"
 import { MODEL_TO_OBJECT_TYPE } from "components/Model"
 import * as L from "leaflet"
 import _escape from "lodash/escape"
+import _isEmpty from "lodash/isEmpty"
 import { Location } from "models"
 import React, { useState } from "react"
 import { toast } from "react-toastify"
 
 const useMergeValidation = (
-  initMergeable1 = null,
-  initMergeable2 = null,
-  initMergedState = null,
+  initMergeable1 = {},
+  initMergeable2 = {},
+  initMergedState = {},
   mergeableType
 ) => {
   const [mergeable1, setMergeable1] = useState(initMergeable1)
@@ -37,9 +38,9 @@ const useMergeValidation = (
     }
 
     return function setValidState(newMergeable) {
-      // One of them being nullish means first time selecting or removing of a selection (which should always happen)
-      // Only validate if both set
-      if (other && newMergeable) {
+      // One of them being empty means first time selecting or removing of a selection (cases which should always happen)
+      // Only validate if other and incoming selections are set
+      if (areAllSet(other, newMergeable)) {
         if (
           !validForGeneral(other, newMergeable, mergeableType) ||
           !validForThatType(other, newMergeable)
@@ -47,8 +48,8 @@ const useMergeValidation = (
           return
         }
       }
-      setMergeable(newMergeable)
-      setMerged(initMergedState) // merged state should reset when a mergeable changes
+      setMergeable(newMergeable || {})
+      setMerged(initMergedState || {}) // merged state should reset when a mergeable changes
     }
   }
 
@@ -57,7 +58,7 @@ const useMergeValidation = (
     [createStateSetter(1), createStateSetter(2), setMerged]
   ]
 }
-
+// FIXME: Fill when ready
 const OBJECT_TYPE_TO_VALIDATOR = {
   [MODEL_TO_OBJECT_TYPE.AuthorizationGroup]: null,
   [MODEL_TO_OBJECT_TYPE.Location]: null,
@@ -73,9 +74,12 @@ function validForGeneral(otherMergeable, newMergeable, mergeableType) {
     toast(`Please select different ${mergeableType}`)
     return false
   }
+  return true
 }
-
-function validTasks() {}
+// FIXME: validation steps for tasks
+function validTasks() {
+  return true
+}
 
 function validPositions(otherPos, newPos) {
   if (!sameOrganization(otherPos, newPos)) {
@@ -102,7 +106,7 @@ function bothPosOccupied(otherPos, newPos) {
 }
 
 export function areAllSet(...args) {
-  return args.every(item => item)
+  return args.every(item => item && !_isEmpty(item))
 }
 
 export function getInfoButton(infoText) {

--- a/client/src/mergeUtils.js
+++ b/client/src/mergeUtils.js
@@ -1,0 +1,176 @@
+import { Button, Tooltip } from "@blueprintjs/core"
+import Leaflet from "components/Leaflet"
+import * as L from "leaflet"
+import _escape from "lodash/escape"
+import { Location } from "models"
+import React, { useState } from "react"
+import { toast } from "react-toastify"
+
+const useMergeValidation = (
+  initMergeable1 = null,
+  initMergeable2 = null,
+  initMergedState = null,
+  mergeableType = "value"
+) => {
+  const [mergeable1, setMergeable1] = useState(initMergeable1)
+  const [mergeable2, setMergeable2] = useState(initMergeable2)
+  const [merged, setMerged] = useState(initMergedState)
+
+  function createStateSetter(mergeableNumber) {
+    let other
+    let setMergeable
+
+    if (mergeableNumber === 1) {
+      other = mergeable2
+      setMergeable = setMergeable1
+    } else if (mergeableNumber === 2) {
+      other = mergeable1
+      setMergeable = setMergeable2
+    } else {
+      throw new Error("Pass a valid mergeable number")
+    }
+
+    return function setValidState(newMergeable) {
+      // One of them being nullish means first time selecting or removing of a selection (which should always happen)
+      // Only validate if both set
+      if (other && newMergeable) {
+        // Validations applicable to all types
+        if (sameMergeable(other, newMergeable)) {
+          toast(`Please select a different ${mergeableType}`)
+          return
+        }
+        // Type specific validations
+        if (mergeableType === "position") {
+          if (!validPositions(other, newMergeable)) {
+            return
+          }
+        }
+      }
+      setMergeable(newMergeable)
+      setMerged(initMergedState) // merged state should reset when a mergeable changes
+    }
+  }
+
+  return [
+    [mergeable1, mergeable2, merged],
+    [createStateSetter(1), createStateSetter(2), setMerged]
+  ]
+}
+
+function validPositions(otherPos, newPos) {
+  if (!sameOrganization(otherPos, newPos)) {
+    toast("Please select two positions with the same organization")
+    return false
+  }
+  if (bothPosOccupied(otherPos, newPos)) {
+    toast("Please select at least one unoccupied position")
+    return false
+  }
+  return true
+}
+
+function sameMergeable(otherMergeable, newMergeable) {
+  return otherMergeable.uuid === newMergeable.uuid
+}
+
+function sameOrganization(otherMergeable, newMergeable) {
+  return otherMergeable.organization.uuid === newMergeable.organization.uuid
+}
+
+function bothPosOccupied(otherPos, newPos) {
+  return otherPos.person.uuid && newPos.person.uuid
+}
+
+export function areAllSet(...args) {
+  return args.every(item => item)
+}
+
+export function getInfoButton(infoText) {
+  return (
+    <Tooltip content={infoText} intent="primary">
+      <Button minimal icon="info-sign" intent="primary" />
+    </Tooltip>
+  )
+}
+
+export function getClearButton(onClear) {
+  return (
+    <Tooltip content="Clear field value" intent="danger">
+      <Button icon="delete" outlined intent="danger" onClick={onClear} />
+    </Tooltip>
+  )
+}
+
+export function getActivationButton(
+  isActive,
+  onClickAction,
+  mergeableType = "value"
+) {
+  return (
+    <Tooltip
+      content={
+        isActive ? `Deactivate ${mergeableType}` : `Activate ${mergeableType}`
+      }
+      intent={isActive ? "danger" : "success"}
+    >
+      <Button
+        icon={isActive ? "stop" : "play"}
+        outlined
+        intent={isActive ? "danger" : "success"}
+        onClick={onClickAction}
+      />
+    </Tooltip>
+  )
+}
+
+export function getActionButton(
+  onClickAction,
+  align,
+  disabled = false,
+  text = "Use value"
+) {
+  const icon = align === "right" ? "double-chevron-left" : ""
+  const rightIcon = align === "right" ? "" : "double-chevron-right"
+  return (
+    <small>
+      <Button
+        icon={icon}
+        rightIcon={rightIcon}
+        intent="primary"
+        text={text}
+        onClick={onClickAction}
+        disabled={disabled}
+        style={{ textAlign: "center" }}
+      />
+    </small>
+  )
+}
+// A workaround for "Map container is already initialized" error
+// Don't wait leaflet to set its id to null, do it here
+// FIXME: is there a better way?
+export function removePrevMapEarly(mapId) {
+  mapId = "map-" + mapId // to get map's real id, extra "map-" is added in the Leaflet
+  const map = L.DomUtil.get(mapId)
+  if (map) {
+    map._leaflet_id = null
+  }
+}
+
+export function getLeafletMap(mapId, location) {
+  removePrevMapEarly(mapId)
+  return (
+    <Leaflet
+      mapId={mapId}
+      markers={[
+        {
+          id: "marker-" + mapId,
+          name: _escape(location.name) || "", // escape HTML in location name!
+          lat: Location.hasCoordinates(location) ? location.lat : null,
+          lng: Location.hasCoordinates(location) ? location.lng : null
+        }
+      ]}
+    />
+  )
+}
+
+export default useMergeValidation

--- a/client/src/mergeUtils.js
+++ b/client/src/mergeUtils.js
@@ -106,7 +106,12 @@ function bothPosOccupied(otherPos, newPos) {
 }
 
 export function areAllSet(...args) {
-  return args.every(item => item && !_isEmpty(item))
+  return args.every(item => {
+    if (typeof item === "boolean") {
+      return item
+    }
+    return !_isEmpty(item)
+  })
 }
 
 export function getInfoButton(infoText) {

--- a/client/src/mergeUtils.js
+++ b/client/src/mergeUtils.js
@@ -125,15 +125,11 @@ export function getClearButton(onClear) {
   )
 }
 
-export function getActivationButton(
-  isActive,
-  onClickAction,
-  mergeableType = "value"
-) {
+export function getActivationButton(isActive, onClickAction, resourceName) {
   return (
     <Tooltip
       content={
-        isActive ? `Deactivate ${mergeableType}` : `Activate ${mergeableType}`
+        isActive ? `Deactivate ${resourceName}` : `Activate ${resourceName}`
       }
       intent={isActive ? "danger" : "success"}
     >

--- a/client/src/models/Task.js
+++ b/client/src/models/Task.js
@@ -160,6 +160,10 @@ export default class Task extends Model {
     super(Model.fillObject(props, Task.yupSchema))
   }
 
+  isActive() {
+    return this.status === Task.STATUS.ACTIVE
+  }
+
   isTopLevelTask() {
     return _isEmpty(this.customFieldRef1)
   }

--- a/client/src/pages/Routing.js
+++ b/client/src/pages/Routing.js
@@ -5,6 +5,7 @@ import AuthorizationGroupShow from "pages/admin/authorizationgroup/Show"
 import AuthorizationGroups from "pages/admin/AuthorizationGroups"
 import AdminIndex from "pages/admin/Index"
 import MergePeople from "pages/admin/MergePeople"
+import MergeTasks from "pages/admin/MergeTasks"
 import BoardDashboard from "pages/dashboards/BoardDashboard"
 import DecisivesDashboard from "pages/dashboards/DecisivesDashboard"
 import KanbanDashboard from "pages/dashboards/KanbanDashboard"
@@ -130,6 +131,7 @@ const Routing = () => {
             <Switch>
               <Route exact path={`${url}/`} component={AdminIndex} />
               <Route path={`${url}/mergePeople`} component={MergePeople} />
+              <Route path={`${url}/mergeTasks`} component={MergeTasks} />
               <Route
                 exact
                 path={`${url}/authorizationGroups`}

--- a/client/src/pages/admin/MergeTasks.js
+++ b/client/src/pages/admin/MergeTasks.js
@@ -5,6 +5,7 @@ import API from "api"
 import { gql } from "apollo-boost"
 import { TaskSimpleOverlayRow } from "components/advancedSelectWidget/AdvancedSelectOverlayRow"
 import AdvancedSingleSelect from "components/advancedSelectWidget/AdvancedSingleSelect"
+import Approvals from "components/approvals/Approvals"
 import { customFieldsJSONString } from "components/CustomFields"
 import LinkTo from "components/LinkTo"
 import TaskField from "components/MergeField"
@@ -288,6 +289,15 @@ const MergeTasks = ({ pageDispatchers }) => {
                   setFieldValue("customFields", "")
                 })}
               />
+              <TaskField
+                label="Engagement planning approval process"
+                value={<Approvals relatedObject={mergedTask} />}
+                align="center"
+                action={getClearButton(() => {
+                  setFieldValue("approvalSteps", [])
+                  setFieldValue("planningApprovalSteps", [])
+                })}
+              />
             </>
           )}
         </Col>
@@ -458,7 +468,7 @@ const TaskColumn = ({ task, setTask, setFieldValue, align, label }) => {
             }
             align={align}
             action={getActionButton(() => {
-              setFieldValue("taskedOrganizations", task.taskedOrganizations)
+              setFieldValue("responsiblePositions", task.responsiblePositions)
             }, align)}
           />
           <TaskField
@@ -467,6 +477,15 @@ const TaskColumn = ({ task, setTask, setFieldValue, align, label }) => {
             align={align}
             action={getActionButton(() => {
               setFieldValue("customFields", task.customFields)
+            }, align)}
+          />
+          <TaskField
+            label="Engagement planning approval process"
+            value={<Approvals relatedObject={task} />}
+            align={align}
+            action={getActionButton(() => {
+              setFieldValue("planningApprovalSteps", task.planningApprovalSteps)
+              setFieldValue("approvalSteps", task.approvalSteps)
             }, align)}
           />
         </>

--- a/client/src/pages/admin/MergeTasks.js
+++ b/client/src/pages/admin/MergeTasks.js
@@ -1,30 +1,431 @@
-// import { DEFAULT_PAGE_PROPS, DEFAULT_SEARCH_PROPS } from "actions"
-// import {
-//   mapPageDispatchersToProps,
-//   PageDispatchersPropType,
-//   useBoilerplate
-// } from "components/Page"
-// import useMergeValidation from "mergeUtils"
-// import { Task } from "models"
-// import React, { useState } from "react"
-// import { connect } from "react-redux"
-// import { useHistory } from "react-router-dom"
-// const MergeTasks = ({ pageDispatchers }) => {
-//   const history = useHistory()
-//   const [saveError, setSaveError] = useState(null)
-//   const [
-//     [position1, position2, mergedPosition],
-//     [setPosition1, setPosition2, setMergedPosition]
-//   ] = useMergeValidation(null, null, new Task(), "task")
+import { Button, Callout } from "@blueprintjs/core"
+import styled from "@emotion/styled"
+import { DEFAULT_PAGE_PROPS, DEFAULT_SEARCH_PROPS } from "actions"
+import API from "api"
+import { gql } from "apollo-boost"
+import { TaskDetailedOverlayRow } from "components/advancedSelectWidget/AdvancedSelectOverlayRow"
+import AdvancedSingleSelect from "components/advancedSelectWidget/AdvancedSingleSelect"
+import TaskField from "components/MergeField"
+import Messages from "components/Messages"
+import { MODEL_TO_OBJECT_TYPE } from "components/Model"
+import {
+  jumpToTop,
+  mapPageDispatchersToProps,
+  PageDispatchersPropType,
+  useBoilerplate
+} from "components/Page"
+import useMergeValidation, {
+  areAllSet,
+  getActionButton,
+  getActivationButton,
+  getClearButton,
+  getInfoButton,
+  getLeafletMap
+} from "mergeUtils"
+import { Task } from "models"
+import GeoLocation from "pages/locations/GeoLocation"
+import PropTypes from "prop-types"
+import React, { useState } from "react"
+import { Col, Grid, Row } from "react-bootstrap"
+import { connect } from "react-redux"
+import { useHistory } from "react-router-dom"
+import { toast } from "react-toastify"
+import TASKS_ICON from "resources/tasks.png"
 
-//   useBoilerplate({
-//     pageProps: DEFAULT_PAGE_PROPS,
-//     searchProps: DEFAULT_SEARCH_PROPS,
-//     pageDispatchers
-//   })
-//   return <div>Hello Merge Tasks</div>
-// }
-// MergeTasks.propTypes = {
-//   pageDispatchers: PageDispatchersPropType
-// }
-// export default connect(null, mapPageDispatchersToProps)(MergeTasks)
+const GQL_MERGE_TASK = gql`
+  mutation($loserUuid: String!, $winnerTask: TaskInput!) {
+    mergeTask(loserUuid: $loserUuid, winnerTask: $winnerTask) {
+      uuid
+    }
+  }
+`
+const TASK_FIELDS = `
+  uuid,
+  shortName,
+  longName,
+  responsiblePositions,
+
+`
+
+const tasksFilters = {
+  allAdvisorTasks: {
+    label: "All",
+    queryVars: {
+      status: Task.STATUS.ACTIVE
+    }
+  }
+}
+
+const MergeTasks = ({ pageDispatchers }) => {
+  const history = useHistory()
+  const [saveError, setSaveError] = useState(null)
+  const [
+    [task1, task2, mergedTask],
+    [setTask1, setTask2, setMergedTask]
+  ] = useMergeValidation(null, null, new Task(), MODEL_TO_OBJECT_TYPE.Task)
+
+  console.dir(tasksFilters)
+  console.dir(TASK_FIELDS)
+  useBoilerplate({
+    pageProps: DEFAULT_PAGE_PROPS,
+    searchProps: DEFAULT_SEARCH_PROPS,
+    pageDispatchers
+  })
+
+  return (
+    <Grid fluid>
+      <Row>
+        <Messages error={saveError} />
+        <h2>Merge Tasks Tool</h2>
+      </Row>
+      <Row>
+        <Col md={4}>
+          <TaskColumn
+            task={task1}
+            setTask={setTask1}
+            setFieldValue={setFieldValue}
+            align="left"
+            label="Task 1"
+          />
+        </Col>
+        <Col md={4}>
+          <MidColTitle>
+            {getActionButton(
+              () => setAllFields(task1),
+              "left",
+              !areAllSet(task1, task2),
+              "Use All"
+            )}
+            <h4 style={{ margin: "0" }}>Merged Task</h4>
+            {getActionButton(
+              () => setAllFields(task2),
+              "right",
+              !areAllSet(task1, task2),
+              "Use All"
+            )}
+          </MidColTitle>
+          {!areAllSet(task1, task2) && (
+            <div style={{ padding: "16px 5%" }}>
+              <Callout intent="warning">
+                Please select <strong>both</strong> tasks to proceed...
+              </Callout>
+            </div>
+          )}
+          {areAllSet(task1, task2, !mergedTask?.name) && (
+            <div style={{ padding: "16px 5%" }}>
+              <Callout intent="primary">
+                Please choose a <strong>name</strong> to proceed...
+              </Callout>
+            </div>
+          )}
+          {areAllSet(task1, task2, mergedTask?.name) && (
+            <>
+              <TaskField
+                label="Name"
+                value={mergedTask.name}
+                align="center"
+                action={getInfoButton("Name is required.")}
+              />
+              <TaskField
+                label="Type"
+                value={mergedTask.type}
+                align="center"
+                action={getClearButton(() => {
+                  setFieldValue("type", Task.TYPE.ADVISOR)
+                })}
+              />
+              <TaskField
+                label="Code"
+                value={mergedTask.code}
+                align="center"
+                action={getClearButton(() => {
+                  setFieldValue("code", "")
+                })}
+              />
+              <TaskField
+                label="Status"
+                value={mergedTask.status}
+                align="center"
+                action={getActivationButton(
+                  mergedTask.isActive(),
+                  () => {
+                    setFieldValue(
+                      "status",
+                      mergedTask.isActive()
+                        ? Task.STATUS.INACTIVE
+                        : Task.STATUS.ACTIVE
+                    )
+                  },
+                  "task"
+                )}
+              />
+              <TaskField
+                label="Associated Tasks"
+                value={mergedTask.associatedTasks}
+                align="center"
+                action={getClearButton(() => {
+                  setFieldValue("associatedTasks", "")
+                })}
+              />
+              <TaskField
+                label="Previous People"
+                value={mergedTask.previousPeople}
+                align="center"
+                action={getClearButton(() => {
+                  setFieldValue("previousPeople", "")
+                })}
+              />
+              <TaskField
+                label="Organization"
+                value={mergedTask.organization.shortName}
+                align="center"
+                action={getClearButton(() => {
+                  setFieldValue("organization", {})
+                })}
+              />
+              <TaskField
+                label="Person"
+                value={mergedTask.person.name}
+                align="center"
+                action={getClearButton(() => {
+                  setFieldValue("person", "")
+                })}
+              />
+              <TaskField
+                label="Location"
+                value={
+                  <GeoLocation
+                    lat={mergedTask.location.lat}
+                    lng={mergedTask.location.lng}
+                  />
+                }
+                align="center"
+                action={getClearButton(() => {
+                  setFieldValue("location", "")
+                })}
+              />
+              {getLeafletMap("merged-location", mergedTask.location)}
+            </>
+          )}
+        </Col>
+        <Col md={4}>
+          <TaskColumn
+            task={task2}
+            setTask={setTask2}
+            setFieldValue={setFieldValue}
+            align="right"
+            label="Task 2"
+          />
+        </Col>
+      </Row>
+      <Row>
+        <Button
+          style={{ width: "98%", margin: "16px 1%" }}
+          large
+          intent="primary"
+          text="Merge Tasks"
+          onClick={mergeTask}
+          disabled={!areAllSet(task1, task2, mergedTask?.name)}
+        />
+      </Row>
+    </Grid>
+  )
+
+  function mergeTask() {
+    if (unassignedPerson()) {
+      return
+    }
+    let loser
+    if (mergedTask.uuid) {
+      // uuid only gets set by person field, loser must be the task with different uuid
+      loser = mergedTask.uuid === task1.uuid ? task2 : task1
+    } else {
+      // if not set, means no person in both tasks, doesn't matter which one is loser
+      mergedTask.uuid = task1.uuid
+      loser = task2
+    }
+
+    API.mutation(GQL_MERGE_TASK, {
+      loserUuid: loser.uuid,
+      winnerTask: mergedTask
+    })
+      .then(res => {
+        if (res.mergeTask) {
+          history.push(Task.pathFor({ uuid: res.mergeTask.uuid }), {
+            success: "Tasks merged. Displaying merged Task below."
+          })
+        }
+      })
+      .catch(error => {
+        setSaveError(error)
+        jumpToTop()
+      })
+  }
+
+  function setFieldValue(field, value) {
+    setMergedTask(oldState => new Task({ ...oldState, [field]: value }))
+  }
+
+  function setAllFields(task) {
+    setMergedTask(new Task({ ...task }))
+  }
+
+  function unassignedPerson() {
+    const msg = "You can't merge if a person is left unassigned"
+    // both tasks having a person is validated in useMergeValidation, can't happen
+    // warn when one of them has it and merged doesn't
+    if (
+      // only task1 has it
+      !mergedTask.person.uuid &&
+      task1.person.uuid &&
+      !task2.person.uuid
+    ) {
+      toast(msg)
+      return true
+    } else if (
+      // only task2 has it
+      !mergedTask.person.uuid &&
+      !task1.person.uuid &&
+      task2.person.uuid
+    ) {
+      toast(msg)
+      return true
+    } else {
+      return false
+    }
+  }
+}
+
+const TaskColumn = ({ task, setTask, setFieldValue, align, label }) => {
+  return (
+    <TaskCol>
+      {/* FIXME: label hmtlFor needs AdvancedSingleSelect id, no prop in AdvSelect to set id */}
+      <label style={{ textAlign: align }}>{label}</label>
+      <AdvancedSingleSelect
+        fieldName="Task"
+        fieldLabel="Select a Task"
+        placeholder="Select a Task to merge"
+        value={task}
+        overlayColumns={["Task", "Organization", "Current Occupant"]}
+        overlayRenderRow={TaskDetailedOverlayRow}
+        filterDefs={tasksFilters}
+        onChange={value => {
+          return setTask(value)
+        }}
+        objectType={Task}
+        valueKey="name"
+        fields={TASK_FIELDS}
+        addon={TASKS_ICON}
+        vertical
+      />
+      {task && (
+        <>
+          <TaskField
+            label="Name"
+            value={task.name}
+            align={align}
+            action={getActionButton(() => {
+              setFieldValue("name", Task.name)
+            }, align)}
+          />
+          <TaskField
+            label="Type"
+            value={task.type}
+            align={align}
+            action={getActionButton(
+              () => setFieldValue("type", task.type),
+              align
+            )}
+          />
+          <TaskField
+            label="Code"
+            value={task.code}
+            align={align}
+            action={getActionButton(
+              () => setFieldValue("code", task.code),
+              align
+            )}
+          />
+          <TaskField
+            label="Status"
+            value={task.status}
+            align={align}
+            action={getActionButton(
+              () => setFieldValue("status", task.status),
+              align
+            )}
+          />
+          <TaskField
+            label="Associated Tasks"
+            value={task.associatedTasks}
+            align={align}
+            action={getActionButton(
+              () => setFieldValue("associatedTasks", task.associatedTasks),
+              align
+            )}
+          />
+          <TaskField
+            label="Previous People"
+            value={task.previousPeople}
+            align={align}
+            action={getActionButton(
+              () => setFieldValue("previousPeople", task.previousPeople),
+              align
+            )}
+          />
+          <TaskField
+            label="Organization"
+            value={task.organization.shortName}
+            align={align}
+            action={getActionButton(
+              () => setFieldValue("organization", task.organization),
+              align
+            )}
+          />
+          <TaskField
+            label="Person"
+            value={task.person.name}
+            align={align}
+            action={getActionButton(() => {
+              setFieldValue("person", task.person)
+              // setting person should also set uuid
+              setFieldValue("uuid", task.uuid)
+            }, align)}
+          />
+          <TaskField
+            label="Location"
+            value={
+              <GeoLocation lat={task.location.lat} lng={task.location.lng} />
+            }
+            align={align}
+            action={getActionButton(() => {
+              setFieldValue("location", task.location)
+            }, align)}
+          />
+          {getLeafletMap(task.uuid, task.location)}
+        </>
+      )}
+    </TaskCol>
+  )
+}
+const TaskCol = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+`
+
+TaskColumn.propTypes = {
+  task: PropTypes.instanceOf(Task),
+  setTask: PropTypes.func.isRequired,
+  setFieldValue: PropTypes.func.isRequired,
+  align: PropTypes.string.isRequired,
+  label: PropTypes.string.isRequired
+}
+
+const MidColTitle = ""
+
+MergeTasks.propTypes = {
+  pageDispatchers: PageDispatchersPropType
+}
+export default connect(null, mapPageDispatchersToProps)(MergeTasks)

--- a/client/src/pages/admin/MergeTasks.js
+++ b/client/src/pages/admin/MergeTasks.js
@@ -1,0 +1,30 @@
+// import { DEFAULT_PAGE_PROPS, DEFAULT_SEARCH_PROPS } from "actions"
+// import {
+//   mapPageDispatchersToProps,
+//   PageDispatchersPropType,
+//   useBoilerplate
+// } from "components/Page"
+// import useMergeValidation from "mergeUtils"
+// import { Task } from "models"
+// import React, { useState } from "react"
+// import { connect } from "react-redux"
+// import { useHistory } from "react-router-dom"
+// const MergeTasks = ({ pageDispatchers }) => {
+//   const history = useHistory()
+//   const [saveError, setSaveError] = useState(null)
+//   const [
+//     [position1, position2, mergedPosition],
+//     [setPosition1, setPosition2, setMergedPosition]
+//   ] = useMergeValidation(null, null, new Task(), "task")
+
+//   useBoilerplate({
+//     pageProps: DEFAULT_PAGE_PROPS,
+//     searchProps: DEFAULT_SEARCH_PROPS,
+//     pageDispatchers
+//   })
+//   return <div>Hello Merge Tasks</div>
+// }
+// MergeTasks.propTypes = {
+//   pageDispatchers: PageDispatchersPropType
+// }
+// export default connect(null, mapPageDispatchersToProps)(MergeTasks)

--- a/client/src/pages/admin/MergeTasks.js
+++ b/client/src/pages/admin/MergeTasks.js
@@ -263,6 +263,31 @@ const MergeTasks = ({ pageDispatchers }) => {
                   setFieldValue("taskedOrganizations", [])
                 })}
               />
+              <TaskField
+                label="Responsible Positions"
+                value={
+                  <>
+                    {mergedTask.responsiblePositions.map(pos => (
+                      <React.Fragment key={`${pos.uuid}`}>
+                        <LinkTo modelType="Position" model={pos} />{" "}
+                      </React.Fragment>
+                    ))}
+                  </>
+                }
+                align="center"
+                action={getClearButton(() => {
+                  setFieldValue("responsiblePositions", [])
+                })}
+              />
+
+              <TaskField
+                label="Custom fields"
+                value={mergedTask.customFields}
+                align="center"
+                action={getClearButton(() => {
+                  setFieldValue("customFields", "")
+                })}
+              />
             </>
           )}
         </Col>

--- a/client/src/pages/admin/MergeTasks.js
+++ b/client/src/pages/admin/MergeTasks.js
@@ -15,9 +15,11 @@ import {
   PageDispatchersPropType,
   useBoilerplate
 } from "components/Page"
+import { GRAPHQL_NOTES_FIELDS } from "components/RelatedObjectNotes"
 import useMergeValidation, {
   areAllSet,
   getActionButton,
+  getActivationButton,
   getClearButton,
   getInfoButton
 } from "mergeUtils"
@@ -39,17 +41,79 @@ const GQL_MERGE_TASK = gql`
   }
 `
 const TASK_FIELDS = `
-  uuid,
-  shortName,
-  longName,
-  customFieldRef1 {
-    uuid,
-    shortName,
-    longName
-  }
-  responsiblePositions {
+uuid
+shortName
+longName
+status
+customField
+customFieldEnum1
+customFieldEnum2
+plannedCompletion
+projectedCompletion
+taskedOrganizations {
+  uuid
+  shortName
+  longName
+  identificationCode
+}
+customFieldRef1 {
+  uuid
+  shortName
+  longName
+}
+responsiblePositions {
+  uuid
+  name
+  code
+  type
+  status
+  organization {
     uuid
+    shortName
   }
+  person {
+    uuid
+    name
+    rank
+    role
+    avatar(size: 32)
+  }
+}
+planningApprovalSteps {
+  uuid
+  name
+  restrictedApproval
+  approvers {
+    uuid
+    name
+    person {
+      uuid
+      name
+      rank
+      role
+      avatar(size: 32)
+    }
+  }
+}
+approvalSteps {
+  uuid
+  name
+  restrictedApproval
+  approvers {
+    uuid
+    name
+    person {
+      uuid
+      name
+      rank
+      role
+      avatar(size: 32)
+    }
+  }
+}
+customFields
+${GRAPHQL_NOTES_FIELDS}
+
 `
 
 const tasksFilters = {
@@ -142,6 +206,23 @@ const MergeTasks = ({ pageDispatchers }) => {
                 }
                 align="center"
                 action={getInfoButton("Name is required.")}
+              />
+              <TaskField
+                label="Status"
+                value={mergedTask.status}
+                align="center"
+                action={getActivationButton(
+                  mergedTask.isActive(),
+                  () => {
+                    setFieldValue(
+                      "status",
+                      mergedTask.isActive()
+                        ? Task.STATUS.INACTIVE
+                        : Task.STATUS.ACTIVE
+                    )
+                  },
+                  Task.getInstanceName
+                )}
               />
               <TaskField
                 label={Settings.fields.task.customFieldRef1.label}
@@ -291,6 +372,14 @@ const TaskColumn = ({ task, setTask, setFieldValue, align, label }) => {
             }, align)}
           />
           <TaskField
+            label="Status"
+            value={task.status}
+            align={align}
+            action={getActionButton(() => {
+              setFieldValue("status", task.status)
+            }, align)}
+          />
+          <TaskField
             label={Settings.fields.task.customFieldRef1.label}
             value={
               <LinkTo modelType="Task" model={task.customFieldRef1}>
@@ -315,17 +404,39 @@ const TaskColumn = ({ task, setTask, setFieldValue, align, label }) => {
             value={
               <>
                 {task.taskedOrganizations.map(org => (
-                  <LinkTo
-                    modelType="Organization"
-                    model={org}
-                    key={`${org.uuid}`}
-                  />
+                  <React.Fragment key={`${org.uuid}`}>
+                    <LinkTo modelType="Organization" model={org} />{" "}
+                  </React.Fragment>
                 ))}
               </>
             }
             align={align}
             action={getActionButton(() => {
               setFieldValue("taskedOrganizations", task.taskedOrganizations)
+            }, align)}
+          />
+          <TaskField
+            label="Responsible Positions"
+            value={
+              <>
+                {task.responsiblePositions.map(pos => (
+                  <React.Fragment key={`${pos.uuid}`}>
+                    <LinkTo modelType="Position" model={pos} />{" "}
+                  </React.Fragment>
+                ))}
+              </>
+            }
+            align={align}
+            action={getActionButton(() => {
+              setFieldValue("taskedOrganizations", task.taskedOrganizations)
+            }, align)}
+          />
+          <TaskField
+            label="Custom fields"
+            value={task.customFields}
+            align={align}
+            action={getActionButton(() => {
+              setFieldValue("customFields", task.customFields)
             }, align)}
           />
         </>

--- a/client/src/pages/tasks/Show.js
+++ b/client/src/pages/tasks/Show.js
@@ -182,6 +182,8 @@ const TaskShow = ({ pageDispatchers }) => {
           position => currentUser.position.uuid === position.uuid
         )
       ))
+  console.log("Task Show")
+  console.dir(task)
   return (
     <Formik enableReinitialize initialValues={task}>
       {({ values }) => {

--- a/src/main/java/mil/dds/anet/database/TaskDao.java
+++ b/src/main/java/mil/dds/anet/database/TaskDao.java
@@ -197,14 +197,8 @@ public class TaskDao extends AnetBaseDao<Task, TaskSearchQuery> {
   }
 
   @InTransaction
-  public List<Task> getTopLevelTasks() {
-    return getDbHandle()
-        .createQuery("/* getTopTasks */ SELECT * FROM tasks WHERE \"customFieldRef1Uuid\" IS NULL")
-        .map(new TaskMapper()).list();
-  }
-
-  @InTransaction
   public int mergeTask(Task loser, Task winnerTask) {
+    // Move notes of loser task to winner task
     getDbHandle().createUpdate(
         "UPDATE \"noteRelatedObjects\" SET \"relatedObjectUuid\" = :winnerUuid WHERE \"relatedObjectUuid\" = :loserUuid"
             + " AND \"noteUuid\" NOT IN ("
@@ -212,6 +206,7 @@ public class TaskDao extends AnetBaseDao<Task, TaskSearchQuery> {
             + ")")
         .bind("winnerUuid", winnerTask.getUuid()).bind("loserUuid", loser.getUuid()).execute();
 
+    // Update task information of reportTask object with winner task which related to loser task
     getDbHandle()
         .createUpdate(
             "UPDATE \"reportTasks\" SET \"taskUuid\" = :winnerUuid WHERE \"taskUuid\" = :loserUuid")

--- a/src/main/java/mil/dds/anet/database/TaskDao.java
+++ b/src/main/java/mil/dds/anet/database/TaskDao.java
@@ -196,6 +196,31 @@ public class TaskDao extends AnetBaseDao<Task, TaskSearchQuery> {
         FkDataLoaderKey.TASK_TASKED_ORGANIZATIONS, taskUuid);
   }
 
+  @InTransaction
+  public List<Task> getTopLevelTasks() {
+    return getDbHandle()
+        .createQuery("/* getTopTasks */ SELECT * FROM tasks WHERE \"customFieldRef1Uuid\" IS NULL")
+        .map(new TaskMapper()).list();
+  }
+
+  @InTransaction
+  public int mergeTask(Task loser, Task winnerTask) {
+    getDbHandle().createUpdate(
+        "UPDATE \"noteRelatedObjects\" SET \"relatedObjectUuid\" = :winnerUuid WHERE \"relatedObjectUuid\" = :loserUuid"
+            + " AND \"noteUuid\" NOT IN ("
+            + "SELECT \"noteUuid\" FROM \"noteRelatedObjects\" WHERE \"relatedObjectUuid\" = :winnerUuid"
+            + ")")
+        .bind("winnerUuid", winnerTask.getUuid()).bind("loserUuid", loser.getUuid()).execute();
+
+    getDbHandle()
+        .createUpdate(
+            "UPDATE \"reportTasks\" SET \"taskUuid\" = :winnerUuid WHERE \"taskUuid\" = :loserUuid")
+        .bind("winnerUuid", winnerTask.getUuid()).bind("loserUuid", loser.getUuid()).execute();
+
+    return getDbHandle().createUpdate("DELETE FROM \"tasks\" WHERE \"uuid\" = :loserUuid")
+        .bind("loserUuid", loser.getUuid()).execute();
+  }
+
   @Override
   public AnetBeanList<Task> search(TaskSearchQuery query) {
     return AnetObjectEngine.getInstance().getSearcher().getTaskSearcher().runSearch(query);

--- a/src/main/java/mil/dds/anet/resources/TaskResource.java
+++ b/src/main/java/mil/dds/anet/resources/TaskResource.java
@@ -178,6 +178,7 @@ public class TaskResource {
       @GraphQLArgument(name = "winnerTask") Task winnerTask) {
     final Person user = DaoUtils.getUserFromContext(context);
     final Task loser = dao.getByUuid(loserUuid);
+    final Task winnerBeforeUpdate = dao.getByUuid(winnerTask.getUuid());
 
     final Map<String, Task> children =
         AnetObjectEngine.getInstance().buildTopLevelTaskHash(DaoUtils.getUuid(winnerTask));
@@ -241,12 +242,12 @@ public class TaskResource {
       final List<ApprovalStep> existingPlanningApprovalSteps =
           loser.loadPlanningApprovalSteps(engine.getContext()).join();
       final List<ApprovalStep> existing2PlanningApprovalSteps =
-          winnerTask.loadPlanningApprovalSteps(engine.getContext()).join();
+          winnerBeforeUpdate.loadPlanningApprovalSteps(engine.getContext()).join();
       existingPlanningApprovalSteps.addAll(existing2PlanningApprovalSteps);
       final List<ApprovalStep> existingApprovalSteps =
           loser.loadApprovalSteps(engine.getContext()).join();
       final List<ApprovalStep> existingApprovalSteps2 =
-          winnerTask.loadApprovalSteps(engine.getContext()).join();
+          winnerBeforeUpdate.loadApprovalSteps(engine.getContext()).join();
       existingApprovalSteps.addAll(existingApprovalSteps2);
       Utils.updateApprovalSteps(winnerTask, winnerTask.getPlanningApprovalSteps(),
           existingPlanningApprovalSteps, winnerTask.getApprovalSteps(), existingApprovalSteps);


### PR DESCRIPTION
 From #3147, i tried to reuse same logic, but depending on the changes to that branch, same logic may be updated in #3147, namely `MergeField.js` and `mergeUtils.js`. Latest versions are in that branch. After that PR is merged, use that files.
Added an admin page to merge duplicate tasks. Admins can choose two task objects and can merge these tasks by picking each field as they wish.
### Release notes

Closes #2993 

#### User changes
-

#### Super User changes
-

#### Admin changes
- Added merge tasks link and page

#### System admin changes
-
- [ ] anet.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [X] Described the user behavior in PR body
  - [X] Referenced/updated all related issues
  - [X] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [X] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [X] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
