### PR TITLE
Make the RelatedObjectsTable a true multi-select

### DIFF
--- a/client/src/components/RelatedObjectNoteModal.js
+++ b/client/src/components/RelatedObjectNoteModal.js
@@ -5,7 +5,6 @@ import Messages from "components/Messages"
 import Model, {
   GQL_CREATE_NOTE,
   GQL_UPDATE_NOTE,
-  MODEL_TO_OBJECT_TYPE,
   NOTE_TYPE
 } from "components/Model"
 import RelatedObjectsTable from "components/RelatedObjectsTable"
@@ -118,9 +117,8 @@ const RelatedObjectNoteModal = ({
                   <RelatedObjectsTable
                     relatedObjects={relatedObjects}
                     currentObject={edit ? undefined : currentObject}
-                    onSelect={handleRelatedObjectSelect}
+                    setRelatedObjects={setRelatedObjects}
                     showDelete
-                    onDelete={handleRelatedObjectDelete}
                   />
                 </div>
               </Modal.Body>
@@ -153,25 +151,6 @@ const RelatedObjectNoteModal = ({
       </Formik>
     </Modal>
   )
-
-  function handleRelatedObjectSelect(value, model) {
-    const relatedObjectsUuids = relatedObjects.map(o => o.relatedObjectUuid)
-    if (!relatedObjectsUuids.includes(value.uuid)) {
-      const newRelatedObject = {
-        relatedObjectType: MODEL_TO_OBJECT_TYPE[model],
-        relatedObjectUuid: value.uuid,
-        relatedObject: value
-      }
-      setRelatedObjects([...relatedObjects, newRelatedObject])
-    }
-  }
-
-  function handleRelatedObjectDelete(relatedObject) {
-    const newRelatedObjects = relatedObjects.filter(
-      item => item.relatedObjectUuid !== relatedObject.relatedObjectUuid
-    )
-    setRelatedObjects(newRelatedObjects)
-  }
 
   function onSubmit(values, form) {
     return save(values, form)


### PR DESCRIPTION
It was not possible to multi-(de)select the related objects for a note, you could only add one object at a time, and only remove one at a time from the displayed table of related objects, not from the matching advanced select list.

#### User changes
- Now you can (de)select multiple related objects for a note with the checkboxes in the matching advanced select list itself.

#### Super User changes
- none

#### Admin changes
- none

#### System admin changes
- none
- [ ] anet.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [ ] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here