### PR TITLE
Fix spurious auto-save

### DIFF
--- a/client/src/pages/reports/Form.js
+++ b/client/src/pages/reports/Form.js
@@ -976,7 +976,7 @@ const ReportForm = ({
                         onChange={value =>
                           setFieldValue(
                             "reportSensitiveInformation.text",
-                            value,
+                            value || null,
                             true
                           )}
                         widget={

--- a/client/src/pages/reports/Form.js
+++ b/client/src/pages/reports/Form.js
@@ -346,6 +346,18 @@ const ReportForm = ({
         resetForm,
         setSubmitting
       }) => {
+        // need up-to-date copies of these in the autosave handler
+        Object.assign(autoSaveSettings, { dirty, values, touched })
+        if (!autoSaveSettings.timeoutId) {
+          // Schedule the auto-save timer
+          const autosaveHandler = () =>
+            autoSave({ setFieldValue, setFieldTouched, resetForm })
+          autoSaveSettings.timeoutId = window.setTimeout(
+            autosaveHandler,
+            autoSaveSettings.autoSaveTimeout.asMilliseconds()
+          )
+        }
+
         if (!validateFieldDebounced) {
           validateFieldDebounced = _debounce(validateField, 400)
         }
@@ -445,19 +457,7 @@ const ReportForm = ({
             queryVars: {}
           }
         }
-        // need up-to-date copies of these in the autosave handler
-        autoSaveSettings.dirty = dirty
-        autoSaveSettings.values = values
-        autoSaveSettings.touched = touched
-        if (!autoSaveSettings.timeoutId) {
-          // Schedule the auto-save timer
-          const autosaveHandler = () =>
-            autoSave({ setFieldValue, setFieldTouched, resetForm })
-          autoSaveSettings.timeoutId = window.setTimeout(
-            autosaveHandler,
-            autoSaveSettings.autoSaveTimeout.asMilliseconds()
-          )
-        }
+
         // Only the author can delete a report, and only in DRAFT.
         const canDelete =
           !!values.uuid &&


### PR DESCRIPTION
When editing a report without sensitive information text, the report would be auto-saved even when no changes were made, because the sensitive information text would be changed from `null` to the empty string `""`.
This change keeps the text at `null` in this case.

#### User changes
- none

#### Super User changes
- none

#### Admin changes
- none

#### System admin changes
- none
- [ ] anet.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [ ] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here