### PR TITLE
Fix my tasks and my counterparts tests

### DIFF
--- a/client/tests/webdriver/pages/home.page.js
+++ b/client/tests/webdriver/pages/home.page.js
@@ -39,6 +39,10 @@ class Home extends Page {
     return browser.$("#my-counterparts-nav")
   }
 
+  get onboardingPopover() {
+    return browser.$(".hopscotch-bubble-container")
+  }
+
   waitForSecurityBannerValue(value) {
     this.securityBanner.waitForExist()
     this.securityBanner.waitForDisplayed()

--- a/client/tests/webdriver/pages/page.js
+++ b/client/tests/webdriver/pages/page.js
@@ -36,8 +36,11 @@ class Page {
     this._open(pathName, Page.DEFAULT_CREDENTIALS.adminUser)
   }
 
-  openAsOnboardUser(pathName = "/") {
-    this._open(pathName, Page.DEFAULT_CREDENTIALS.onboardUser)
+  openAsOnboardUser(
+    pathName = "/",
+    uniqueName = Page.DEFAULT_CREDENTIALS.onboardUser
+  ) {
+    this._open(pathName, uniqueName)
   }
 
   getRandomOption(select) {

--- a/client/tests/webdriver/specs/myCounterparts.spec.js
+++ b/client/tests/webdriver/specs/myCounterparts.spec.js
@@ -1,6 +1,7 @@
 import { expect } from "chai"
 import Home from "../pages/home.page"
 import MyCounterparts from "../pages/myCounterparts.page"
+import { createOnboardingNewPerson, examplePersonDetails } from "./newUserUtils"
 
 describe("Home page", () => {
   describe("When checking the navigation items", () => {
@@ -8,8 +9,10 @@ describe("Home page", () => {
       Home.open()
       Home.myCounterpartsLink.waitForDisplayed()
     })
-    it("Should NOT see a link to my counterparts page when the user is not an advisor", () => {
-      Home.openAsOnboardUser()
+  })
+  describe("When checking new user after onboarding to home page", () => {
+    it("Should NOT see a link to my counterparts page when the user does not have a position", () => {
+      createOnboardingNewPerson(examplePersonDetails, "bonny1")
       expect(Home.myCounterpartsLink.isExisting()).to.equal(false)
     })
   })

--- a/client/tests/webdriver/specs/myTasks.spec.js
+++ b/client/tests/webdriver/specs/myTasks.spec.js
@@ -1,6 +1,7 @@
 import { expect } from "chai"
 import Home from "../pages/home.page"
 import MyTasks from "../pages/myTasks.page"
+import { createOnboardingNewPerson, examplePersonDetails } from "./newUserUtils"
 
 describe("Home page", () => {
   describe("When checking the navigation items", () => {
@@ -8,8 +9,10 @@ describe("Home page", () => {
       Home.open()
       Home.myTasksLink.waitForDisplayed()
     })
-    it("Should NOT see a link to my tasks page when the user is not an advisor", () => {
-      Home.openAsOnboardUser()
+  })
+  describe("When checking new user after onboarding to home page", () => {
+    it("Should NOT see a link to my tasks page when the user does not have a position", () => {
+      createOnboardingNewPerson(examplePersonDetails, "bonny1")
       expect(Home.myTasksLink.isExisting()).to.equal(false)
     })
   })

--- a/client/tests/webdriver/specs/newUserUtils.js
+++ b/client/tests/webdriver/specs/newUserUtils.js
@@ -1,0 +1,34 @@
+import moment from "moment"
+import CreatePerson from "../pages/createNewPerson.page"
+import Home from "../pages/home.page"
+import OnboardPage from "../pages/onboard.page"
+
+// Only required fields in onboarding/Edit page
+// No lastName, status, role
+export const examplePersonDetails = {
+  firstName: "Bonnie",
+  emailAddress: "bonny@cmil.mil",
+  rank: "CIV",
+  gender: "FEMALE",
+  country: "Albania",
+  endOfTourDate: ""
+}
+// need uniqueName due to saving previous ones as normal user
+export function createOnboardingNewPerson(personDetails, uniqueName) {
+  OnboardPage.openAsOnboardUser("/", uniqueName)
+
+  OnboardPage.createYourAccountBtn.waitForExist()
+  OnboardPage.createYourAccountBtn.waitForDisplayed()
+  OnboardPage.createYourAccountBtn.click()
+  CreatePerson.firstName.setValue(personDetails.firstName)
+  CreatePerson.emailAddress.setValue(personDetails.emailAddress)
+  CreatePerson.rank.selectByAttribute("value", personDetails.rank)
+  CreatePerson.gender.selectByAttribute("value", personDetails.gender)
+  CreatePerson.country.selectByAttribute("value", personDetails.country)
+  const tomorrow = moment().add(1, "days").format("DD-MM-YYYY")
+  CreatePerson.endOfTourDate.setValue(tomorrow)
+
+  CreatePerson.submitForm()
+  Home.onboardingPopover.waitForExist()
+  Home.onboardingPopover.waitForDisplayed()
+}


### PR DESCRIPTION
The removed test cases were testing basically nothing, as the onboard user is redirected to a different page than home page, testing to not have a link on that page always passed, which was basically testing if onboard page had links, which it doesn't by design. Also, onboard users are default advisor, so tests would also be wrong in that scenario as well.

After this change, we test the new user, passing the onboarding process, creating a Person, which doesn't have a position yet. People without position shouldn't see the my tasks and my counterparts pages, which is what we test now. That makes the tests fail which is what was intended, now we can actually catch the bug with these tests ( #3226 ). Fix for the bug also here (#3208)

### Release notes

Closes #3239 

#### User changes
-

#### Super User changes
-

#### Admin changes
-

#### System admin changes
-
- [ ] anet.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [X] Described the user behavior in PR body
  - [X] Referenced/updated all related issues
  - [X] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [X] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [X] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [X] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
