### PR TITLE
Enable questionless assessment definitions

### DIFF
--- a/client/src/components/assessments/PeriodicAssessmentResults.js
+++ b/client/src/components/assessments/PeriodicAssessmentResults.js
@@ -144,7 +144,7 @@ export const PeriodicAssessmentsRows = ({
     assessmentConfig,
     assessmentYupSchema
   } = entity.getPeriodicAssessmentDetails(recurrence)
-  if (!assessmentConfig) {
+  if (_isEmpty(assessmentConfig)) {
     return null
   }
 

--- a/client/src/periodUtils.js
+++ b/client/src/periodUtils.js
@@ -11,7 +11,8 @@ export const RECURRENCE_TYPE = {
   SEMIMONTHLY: "semimonthly",
   MONTHLY: "monthly",
   QUARTERLY: "quarterly",
-  SEMIANNUALY: "semiannualy"
+  SEMIANNUALY: "semiannualy",
+  ANNUALLY: "annually"
 }
 
 const PERIOD_FORMAT = {
@@ -68,6 +69,10 @@ export const PERIOD_FACTORIES = {
       .clone()
       .subtract(2 * offset, "quarters")
       .endOf("quarter")
+  }),
+  [RECURRENCE_TYPE.ANNUALLY]: (date, offset) => ({
+    start: date.clone().subtract(offset, "years").startOf("year"),
+    end: date.clone().subtract(offset, "years").endOf("year")
   })
 }
 

--- a/src/main/resources/anet-schema.yml
+++ b/src/main/resources/anet-schema.yml
@@ -224,7 +224,6 @@ $defs:
   assessmentDef:
     type: object
     additionalProperties: false
-    required: [questions]
     properties:
       recurrence:
         title: recurrence of an assessment


### PR DESCRIPTION
Previously, we couldn't define periodic assessment definition without also defining questionnaire. We needed to have at least one periodic assessment definition with questions to be able to see a periodic table for showing assessments. That meant that we couldn't see any "once"/"instant" assessments if a task/person had no periodic assessment definition. Now, task/person can have a questionless periodic assessment table, which will show all the non-periodic assessments without needing questionnaire.

Also added "annually" period support in client side.
### Release notes

Closes #3214 

#### User changes
- Users can see "once"/"instant" assessments at task/person page even if that task/person has no periodic assessment definition.

#### Super User changes
-

#### Admin changes
- Admins can now provide questionless assessment definition in "anet-dictionary.yml" to be able show "once"/"instant" assessments of task/person like this: 
```
        assessments:
          - recurrence: semiannually

```
#### System admin changes
-
- [X] anet.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [X] Described the user behavior in PR body
  - [X] Referenced/updated all related issues
  - [X] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [X] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [X] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
