### PR TITLE
Improve account deactivation warning mechanism

### DIFF
--- a/src/main/java/mil/dds/anet/AnetObjectEngine.java
+++ b/src/main/java/mil/dds/anet/AnetObjectEngine.java
@@ -28,6 +28,7 @@ import mil.dds.anet.database.ApprovalStepDao;
 import mil.dds.anet.database.AuthorizationGroupDao;
 import mil.dds.anet.database.CommentDao;
 import mil.dds.anet.database.EmailDao;
+import mil.dds.anet.database.JobHistoryDao;
 import mil.dds.anet.database.LocationDao;
 import mil.dds.anet.database.NoteDao;
 import mil.dds.anet.database.OrganizationDao;
@@ -67,6 +68,7 @@ public class AnetObjectEngine {
   private final ReportSensitiveInformationDao reportSensitiveInformationDao;
   private final AuthorizationGroupDao authorizationGroupDao;
   private final NoteDao noteDao;
+  private final JobHistoryDao jobHistoryDao;
   private ThreadLocal<Map<String, Object>> context;
 
   ISearcher searcher;
@@ -96,6 +98,7 @@ public class AnetObjectEngine {
     emailDao = injector.getInstance(EmailDao.class);
     authorizationGroupDao = injector.getInstance(AuthorizationGroupDao.class);
     noteDao = injector.getInstance(NoteDao.class);
+    jobHistoryDao = injector.getInstance(JobHistoryDao.class);
     searcher = Searcher.getSearcher(DaoUtils.getDbType(dbUrl), injector);
     instance = this;
   }
@@ -166,6 +169,10 @@ public class AnetObjectEngine {
 
   public NoteDao getNoteDao() {
     return noteDao;
+  }
+
+  public JobHistoryDao getJobHistoryDao() {
+    return jobHistoryDao;
   }
 
   public EmailDao getEmailDao() {

--- a/src/main/java/mil/dds/anet/beans/JobHistory.java
+++ b/src/main/java/mil/dds/anet/beans/JobHistory.java
@@ -1,0 +1,33 @@
+package mil.dds.anet.beans;
+
+import java.time.Instant;
+
+public class JobHistory {
+
+  private String jobName;
+  private Instant lastRun;
+
+  public JobHistory() {}
+
+  public JobHistory(String jobName, Instant lastRun) {
+    this.jobName = jobName;
+    this.lastRun = lastRun;
+  }
+
+  public String getJobName() {
+    return jobName;
+  }
+
+  public void setJobName(String jobName) {
+    this.jobName = jobName;
+  }
+
+  public Instant getLastRun() {
+    return lastRun;
+  }
+
+  public void setLastRun(Instant lastRun) {
+    this.lastRun = lastRun;
+  }
+
+}

--- a/src/main/java/mil/dds/anet/database/JobHistoryDao.java
+++ b/src/main/java/mil/dds/anet/database/JobHistoryDao.java
@@ -1,0 +1,62 @@
+package mil.dds.anet.database;
+
+import java.time.Instant;
+import java.util.function.BiConsumer;
+import javax.inject.Inject;
+import javax.inject.Provider;
+import mil.dds.anet.beans.JobHistory;
+import mil.dds.anet.database.mappers.JobHistoryMapper;
+import mil.dds.anet.utils.DaoUtils;
+import org.jdbi.v3.core.Handle;
+import ru.vyarus.guicey.jdbi3.tx.InTransaction;
+
+public class JobHistoryDao {
+
+  @Inject
+  private Provider<Handle> handle;
+
+  protected Handle getDbHandle() {
+    return handle.get();
+  }
+
+  @InTransaction
+  public JobHistory getByJobName(String jobName) {
+    return getDbHandle()
+        .createQuery("/* getJobHistoryByJobName */ SELECT * FROM \"jobHistory\""
+            + " WHERE \"jobName\" = :jobName")
+        .bind("jobName", jobName).map(new JobHistoryMapper()).findFirst().orElse(null);
+  }
+
+  @InTransaction
+  public JobHistory insert(JobHistory jobHistory) {
+    getDbHandle()
+        .createUpdate("/* insertJobHistory */ INSERT INTO \"jobHistory\""
+            + " (\"jobName\", \"lastRun\") VALUES (:jobName, :lastRun)")
+        .bindBean(jobHistory).bind("lastRun", DaoUtils.asLocalDateTime(jobHistory.getLastRun()))
+        .execute();
+    return jobHistory;
+  }
+
+  @InTransaction
+  public int update(JobHistory jobHistory) {
+    return getDbHandle()
+        .createUpdate("/* updateJobHistory */ UPDATE \"jobHistory\""
+            + " SET \"lastRun\" = :lastRun WHERE \"jobName\" = :jobName")
+        .bindBean(jobHistory).bind("lastRun", DaoUtils.asLocalDateTime(jobHistory.getLastRun()))
+        .execute();
+  }
+
+  @InTransaction
+  public void runInTransaction(String jobName, BiConsumer<Instant, JobHistory> runner) {
+    final Instant now = Instant.now().atZone(DaoUtils.getDefaultZoneId()).toInstant();
+    final JobHistory jobHistory = getByJobName(jobName);
+    runner.accept(now, jobHistory);
+    final JobHistory newJobHistory = new JobHistory(jobName, now);
+    if (jobHistory == null) {
+      insert(newJobHistory);
+    } else {
+      update(newJobHistory);
+    }
+  }
+
+}

--- a/src/main/java/mil/dds/anet/database/mappers/JobHistoryMapper.java
+++ b/src/main/java/mil/dds/anet/database/mappers/JobHistoryMapper.java
@@ -1,0 +1,19 @@
+package mil.dds.anet.database.mappers;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import mil.dds.anet.beans.JobHistory;
+import org.jdbi.v3.core.mapper.RowMapper;
+import org.jdbi.v3.core.statement.StatementContext;
+
+public class JobHistoryMapper implements RowMapper<JobHistory> {
+
+  @Override
+  public JobHistory map(ResultSet rs, StatementContext ctx) throws SQLException {
+    final JobHistory jh = new JobHistory();
+    jh.setJobName(rs.getString("jobName"));
+    jh.setLastRun(MapperUtils.getInstantAsLocalDateTime(rs, "lastRun"));
+    return jh;
+  }
+
+}

--- a/src/main/java/mil/dds/anet/threads/AbstractWorker.java
+++ b/src/main/java/mil/dds/anet/threads/AbstractWorker.java
@@ -1,0 +1,37 @@
+package mil.dds.anet.threads;
+
+import java.lang.invoke.MethodHandles;
+import java.time.Instant;
+import mil.dds.anet.AnetObjectEngine;
+import mil.dds.anet.beans.JobHistory;
+import mil.dds.anet.database.JobHistoryDao;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public abstract class AbstractWorker implements Runnable {
+
+  private static final Logger logger =
+      LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+  private final String startMessage;
+  private JobHistoryDao jobHistoryDao;
+
+  public AbstractWorker(String startMessage) {
+    this.startMessage = startMessage;
+    this.jobHistoryDao = AnetObjectEngine.getInstance().getJobHistoryDao();
+  }
+
+  protected abstract void runInternal(Instant now, JobHistory jobHistory);
+
+  public final void run() {
+    logger.debug(startMessage);
+    try {
+      jobHistoryDao.runInTransaction(this.getClass().getSimpleName(),
+          (now, jobHistory) -> runInternal(now, jobHistory));
+    } catch (Throwable e) {
+      // Cannot let this thread die. Otherwise ANET will stop checking.
+      logger.error("Exception in run()", e);
+    }
+  }
+
+}

--- a/src/main/java/mil/dds/anet/threads/AbstractWorker.java
+++ b/src/main/java/mil/dds/anet/threads/AbstractWorker.java
@@ -23,6 +23,7 @@ public abstract class AbstractWorker implements Runnable {
 
   protected abstract void runInternal(Instant now, JobHistory jobHistory);
 
+  @Override
   public final void run() {
     logger.debug(startMessage);
     try {

--- a/src/main/java/mil/dds/anet/threads/AccountDeactivationWorker.java
+++ b/src/main/java/mil/dds/anet/threads/AccountDeactivationWorker.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import mil.dds.anet.AnetObjectEngine;
 import mil.dds.anet.beans.AnetEmail;
+import mil.dds.anet.beans.JobHistory;
 import mil.dds.anet.beans.Person;
 import mil.dds.anet.beans.Person.PersonStatus;
 import mil.dds.anet.beans.Position;
@@ -18,12 +19,11 @@ import mil.dds.anet.database.PersonDao;
 import mil.dds.anet.emails.AccountDeactivationEmail;
 import mil.dds.anet.emails.AccountDeactivationWarningEmail;
 import mil.dds.anet.utils.AnetAuditLogger;
-import mil.dds.anet.utils.DaoUtils;
 import mil.dds.anet.utils.Utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class AccountDeactivationWorker implements Runnable {
+public class AccountDeactivationWorker extends AbstractWorker {
 
   private static final Logger logger =
       LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
@@ -37,6 +37,7 @@ public class AccountDeactivationWorker implements Runnable {
 
   public AccountDeactivationWorker(AnetConfiguration config, PersonDao dao,
       int warningIntervalInSecs) {
+    super("Deactivation Warning Worker waking up to check for Future Account Deactivations");
     this.dao = dao;
 
     @SuppressWarnings("unchecked")
@@ -55,23 +56,12 @@ public class AccountDeactivationWorker implements Runnable {
   }
 
   @Override
-  public void run() {
-    logger.debug("Deactivation Warning Worker waking up to check for Future Account Deactivations");
-
-    try {
-      runInternal(this.daysTillEndOfTourWarnings);
-    } catch (Throwable e) {
-      // Cannot let this thread die. Otherwise ANET will stop checking.
-      logger.error("Exception in run()", e);
-    }
-  }
-
-  private void runInternal(final List<Integer> daysTillNextWarning) {
+  protected void runInternal(Instant now, JobHistory jobHistory) {
     // Make sure the mechanism will be triggered, so account deactivation checking can take place
     final List<Integer> warningDays =
         (daysTillEndOfTourWarnings == null || daysTillEndOfTourWarnings.isEmpty())
             ? new ArrayList<>(0)
-            : daysTillNextWarning;
+            : daysTillEndOfTourWarnings;
 
     // Sort in descending order so largest value is first (so there is no need to make multiple
     // queries)
@@ -83,7 +73,6 @@ public class AccountDeactivationWorker implements Runnable {
     // Get a list of all people with a end of tour coming up using the earliest warning date
     final PersonSearchQuery query = new PersonSearchQuery();
     query.setPageSize(0);
-    final Instant now = Instant.now().atZone(DaoUtils.getDefaultZoneId()).toInstant();
     final Instant latestWarningDate = now.plus(daysBeforeLatestWarning, ChronoUnit.DAYS);
     query.setEndOfTourDateEnd(latestWarningDate);
     final List<Person> persons =
@@ -95,31 +84,35 @@ public class AccountDeactivationWorker implements Runnable {
       for (int i = 0; i < warningDays.size(); i++) {
         final Integer warning = warningDays.get(i);
         final Integer nextWarning = i == warningDays.size() - 1 ? null : warningDays.get(i + 1);
-        checkDeactivationStatus(p, warning, nextWarning, now);
+        checkDeactivationStatus(p, warning, nextWarning, now,
+            jobHistory == null ? null : jobHistory.getLastRun());
       }
     });
   }
 
   private void checkDeactivationStatus(final Person person, final Integer daysBeforeWarning,
-      final Integer nextWarning, final Instant now) {
-    // Skip inactive ANET users or users from ignored domains
+      final Integer nextWarning, final Instant now, final Instant lastRun) {
     if (person.getStatus() == PersonStatus.INACTIVE
         || Utils.isDomainUserNameIgnored(person.getDomainUsername(), this.ignoredDomainNames)) {
+      // Skip inactive ANET users or users from ignored domains
       return;
     }
 
-    // Deactivate account as end-of-tour date has been reached
     if (person.getEndOfTourDate().isBefore(now)) {
+      // Deactivate account as end-of-tour date has been reached
       deactivateAccount(person);
       return;
     }
 
-    // Send deactivation warning email
     final Instant warningDate = now.plus(daysBeforeWarning, ChronoUnit.DAYS);
-    final Instant nextReminder =
-        nextWarning == null ? null : now.plus(nextWarning, ChronoUnit.DAYS);
-    if (person.getEndOfTourDate().isBefore(warningDate) && person.getEndOfTourDate()
-        .isAfter(warningDate.minus(this.warningIntervalInSecs, ChronoUnit.SECONDS))) {
+    final Instant prevWarningDate =
+        (lastRun == null) ? warningDate.minus(this.warningIntervalInSecs, ChronoUnit.SECONDS)
+            : lastRun.plus(daysBeforeWarning, ChronoUnit.DAYS);
+    if (person.getEndOfTourDate().isBefore(warningDate)
+        && person.getEndOfTourDate().isAfter(prevWarningDate)) {
+      // Send deactivation warning email
+      final Instant nextReminder =
+          nextWarning == null ? null : now.plus(nextWarning, ChronoUnit.DAYS);
       sendDeactivationWarningEmail(person, nextReminder);
     }
   }

--- a/src/main/java/mil/dds/anet/threads/AnetEmailWorker.java
+++ b/src/main/java/mil/dds/anet/threads/AnetEmailWorker.java
@@ -14,6 +14,7 @@ import java.lang.invoke.MethodHandles;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -29,6 +30,7 @@ import javax.mail.internet.InternetAddress;
 import javax.ws.rs.WebApplicationException;
 import mil.dds.anet.AnetObjectEngine;
 import mil.dds.anet.beans.AnetEmail;
+import mil.dds.anet.beans.JobHistory;
 import mil.dds.anet.config.AnetConfiguration;
 import mil.dds.anet.config.AnetConfiguration.SmtpConfiguration;
 import mil.dds.anet.database.AdminDao.AdminSettingKeys;
@@ -43,7 +45,7 @@ import org.simplejavamail.mailer.MailerBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class AnetEmailWorker implements Runnable {
+public class AnetEmailWorker extends AbstractWorker {
 
   private static final Logger logger =
       LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
@@ -69,6 +71,7 @@ public class AnetEmailWorker implements Runnable {
 
   @SuppressWarnings("unchecked")
   public AnetEmailWorker(EmailDao dao, AnetConfiguration config) {
+    super("AnetEmailWorker waking up to send emails!");
     this.dao = dao;
     this.mapper = MapperUtils.getDefaultMapper();
     this.fromAddr = config.getEmailFromAddr();
@@ -128,18 +131,8 @@ public class AnetEmailWorker implements Runnable {
   }
 
   @Override
-  public void run() {
-    logger.debug("AnetEmailWorker waking up to send emails!");
-    try {
-      runInternal();
-    } catch (Throwable e) {
-      // Cannot let this thread die, otherwise ANET will stop sending emails until you
-      // reboot the server :(
-      logger.error("Exception in run()", e);
-    }
-  }
-
-  private void runInternal() {
+  protected void runInternal(Instant now, JobHistory jobHistory) {
+    final Instant staleTime = now.minus(nbOfHoursForStaleEmails, ChronoUnit.HOURS);
     // check the database for any emails we need to send.
     final List<AnetEmail> emails = dao.getAll();
 
@@ -163,8 +156,7 @@ public class AnetEmailWorker implements Runnable {
         logger.error("Error sending email", t);
 
         // Process stale emails
-        if (this.nbOfHoursForStaleEmails != null && email.getCreatedAt().isBefore(Instant.now()
-            .atZone(DaoUtils.getDefaultZoneId()).minusHours(nbOfHoursForStaleEmails).toInstant())) {
+        if (this.nbOfHoursForStaleEmails != null && email.getCreatedAt().isBefore(staleTime)) {
           String message = "Purging stale email to ";
           try {
             message += email.getToAddresses();

--- a/src/main/java/mil/dds/anet/threads/MaterializedViewRefreshWorker.java
+++ b/src/main/java/mil/dds/anet/threads/MaterializedViewRefreshWorker.java
@@ -1,11 +1,13 @@
 package mil.dds.anet.threads;
 
 import java.lang.invoke.MethodHandles;
+import java.time.Instant;
+import mil.dds.anet.beans.JobHistory;
 import mil.dds.anet.database.AdminDao;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class MaterializedViewRefreshWorker implements Runnable {
+public class MaterializedViewRefreshWorker extends AbstractWorker {
 
   private static final Logger logger =
       LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
@@ -17,18 +19,18 @@ public class MaterializedViewRefreshWorker implements Runnable {
   private final AdminDao dao;
 
   public MaterializedViewRefreshWorker(AdminDao dao) {
+    super("Refreshing materialized views");
     this.dao = dao;
   }
 
   @Override
-  public void run() {
-    logger.debug("Refreshing materialized views");
+  protected void runInternal(Instant now, JobHistory jobHistory) {
     for (final String materializedView : materializedViews) {
       try {
         dao.updateMaterializedView(materializedView);
       } catch (Throwable e) {
-        // Cannot let this thread die, otherwise ANET will stop this worker.
-        logger.error("Exception in run()", e);
+        // Log and continue with next view
+        logger.error("Exception in runInternal()", e);
       }
     }
   }

--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -3495,4 +3495,15 @@
 		</addColumn>
 	</changeSet>
 
+	<changeSet id="add-jobHistory-table" author="gjvoosten">
+		<createTable tableName="jobHistory">
+			<column name="jobName" type="nvarchar(100)">
+				<constraints primaryKey="true" nullable="false"/>
+			</column>
+			<column name="lastRun" type="datetime">
+				<constraints nullable="false" />
+			</column>
+		</createTable>
+	</changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
The current account deactivation warning mechanism may result in missing or duplicate warnings after server downtime, as there is no way of tracking whether a warning has already been sent.

To solve this a table has been added to the database which keeps track of the the last time a worker job was run. This timestamp is used to only send warnings that weren't sent before.

### Release notes

Closes NCI-Agency/anet#2516
Closes NCI-Agency/anet#2554 (PR) as well since it implements similar functionality but in a more general way.

#### User changes
- none

#### Super User changes
- none

#### Admin changes
- none

#### System admin changes
- [ ] anet.yml needs change
- [x] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [x] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here