### PR TITLE
Add coordinates to location link label

### DIFF
--- a/client/src/models/Location.js
+++ b/client/src/models/Location.js
@@ -1,5 +1,5 @@
 import Model from "components/Model"
-import { convertMGRSToLatLng } from "geoUtils"
+import { convertLatLngToMGRS, convertMGRSToLatLng } from "geoUtils"
 import _isEmpty from "lodash/isEmpty"
 import LOCATIONS_ICON from "resources/locations.png"
 import Settings from "settings"
@@ -146,6 +146,13 @@ export default class Location extends Model {
   }
 
   toString() {
+    if (this.lat && this.lng) {
+      const coordinate =
+        Settings?.fields?.location?.format === "MGRS"
+          ? convertLatLngToMGRS(this.lat, this.lng)
+          : `${this.lat},${this.lng}`
+      return `${this.name} ${coordinate}`
+    }
     return this.name
   }
 }

--- a/client/src/pages/reports/Show.js
+++ b/client/src/pages/reports/Show.js
@@ -68,6 +68,8 @@ const GQL_GET_REPORT = gql`
       location {
         uuid
         name
+        lat
+        lng
       }
       author {
         uuid

--- a/client/tests/e2e/permissions.js
+++ b/client/tests/e2e/permissions.js
@@ -63,7 +63,7 @@ test.serial("checking super user permissions", async t => {
   const $locationLink = await getFromSearchResults(
     t,
     "General Hospital",
-    "General Hospital",
+    "General Hospital 47.571772,-52.741935",
     "locations"
   )
   await $locationLink.click()
@@ -143,7 +143,7 @@ test("checking admin permissions", async t => {
   const $locationLink = await getFromSearchResults(
     t,
     "General Hospital",
-    "General Hospital",
+    "General Hospital 47.571772,-52.741935",
     "locations"
   )
   await $locationLink.click()


### PR DESCRIPTION
### Release notes

When displaying a link to a location, also show the coordinates of that location

Closes #3262 

#### User changes
- Users now can see the coordinates of a location prior to following a link

- [ ] anet.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [x] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [ ] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
