### PR TITLE
Fix getting responsibleTasks

### DIFF
--- a/client/src/components/EditAssociatedPositionsModal.js
+++ b/client/src/components/EditAssociatedPositionsModal.js
@@ -183,7 +183,11 @@ const EditAssociatedPositionsModal = ({
   }
 
   function save(values, form) {
-    const newPosition = Object.without(new Position(values), "notes")
+    const newPosition = Object.without(
+      new Position(values),
+      "notes",
+      "responsibleTasks" // Only for querying
+    )
     newPosition.associatedPositions = values.associatedPositions
     delete newPosition.previousPeople
     delete newPosition.person // prevent any changes to person.

--- a/client/src/notificationsUtils.js
+++ b/client/src/notificationsUtils.js
@@ -31,8 +31,8 @@ export const getNotifications = currentUser => {
 }
 
 export const getMyTasksWithPendingAssessments = currentUser => {
-  if (currentUser?.responsibleTasks?.length) {
-    const taskObjects = currentUser.responsibleTasks
+  if (currentUser?.position?.responsibleTasks?.length) {
+    const taskObjects = currentUser.position.responsibleTasks
       .filter(obj => obj)
       .map(obj => new Task(obj))
     taskObjects.forEach(task => {

--- a/client/src/pages/App.js
+++ b/client/src/pages/App.js
@@ -82,19 +82,19 @@ const GQL_GET_APP_DATA = gql`
             shortName
           }
         }
-      }
-      responsibleTasks(
-        query: {
-          status: ACTIVE
-        }
-      ) {
-        uuid
-        shortName
-        longName
-        customFieldRef1 {
+        responsibleTasks(
+          query: {
+            status: ACTIVE
+          }
+        ) {
           uuid
+          shortName
+          longName
+          customFieldRef1 {
+            uuid
+          }
+          ${GRAPHQL_NOTIFICATIONS_NOTE_FIELDS}
         }
-        ${GRAPHQL_NOTIFICATIONS_NOTE_FIELDS}
       }
     }
 

--- a/client/src/pages/people/Form.js
+++ b/client/src/pages/people/Form.js
@@ -595,7 +595,6 @@ const PersonForm = ({ edit, title, saveText, initialValues }) => {
       "firstName",
       "lastName",
       "customFields", // initial JSON from the db
-      "responsibleTasks", // notifications for UI
       DEFAULT_CUSTOM_FIELDS_PARENT
     )
     if (values.status === Person.STATUS.NEW_USER) {

--- a/client/src/pages/positions/Form.js
+++ b/client/src/pages/positions/Form.js
@@ -354,7 +354,11 @@ const PositionForm = ({ edit, title, initialValues }) => {
   }
 
   function save(values, form) {
-    const position = Object.without(new Position(values), "notes")
+    const position = Object.without(
+      new Position(values),
+      "notes",
+      "responsibleTasks" // Only for querying
+    )
     if (position.type !== Position.TYPE.PRINCIPAL) {
       position.type = position.permissions || Position.TYPE.ADVISOR
     }

--- a/client/src/pages/positions/Show.js
+++ b/client/src/pages/positions/Show.js
@@ -11,9 +11,9 @@ import GuidedTour from "components/GuidedTour"
 import LinkTo from "components/LinkTo"
 import Messages from "components/Messages"
 import {
-  PageDispatchersPropType,
   jumpToTop,
   mapPageDispatchersToProps,
+  PageDispatchersPropType,
   useBoilerplate
 } from "components/Page"
 import RelatedObjectNotes, {

--- a/client/src/pages/reports/Form.js
+++ b/client/src/pages/reports/Form.js
@@ -1343,7 +1343,6 @@ const ReportForm = ({
         "lastName",
         "position",
         "customFields",
-        "responsibleTasks", // notifications for UI
         DEFAULT_CUSTOM_FIELDS_PARENT
       )
     )

--- a/client/src/pages/tasks/MyTasks.js
+++ b/client/src/pages/tasks/MyTasks.js
@@ -62,7 +62,7 @@ const MyTasks = ({ pageDispatchers, searchQuery }) => {
         id="my-responsible-tasks"
         title={`${pluralize(taskShortLabel)} I am responsible for`}
       >
-        <TaskTable tasks={currentUser.responsibleTasks} />
+        <TaskTable tasks={currentUser?.position?.responsibleTasks} />
       </Fieldset>
       <Fieldset
         id="my-tasks-with-pending-assessments"

--- a/src/main/java/mil/dds/anet/beans/Person.java
+++ b/src/main/java/mil/dds/anet/beans/Person.java
@@ -16,9 +16,7 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import mil.dds.anet.AnetObjectEngine;
 import mil.dds.anet.beans.lists.AnetBeanList;
-import mil.dds.anet.beans.search.M2mBatchParams;
 import mil.dds.anet.beans.search.ReportSearchQuery;
-import mil.dds.anet.beans.search.TaskSearchQuery;
 import mil.dds.anet.utils.DaoUtils;
 import mil.dds.anet.utils.IdDataLoaderKey;
 import mil.dds.anet.utils.Utils;
@@ -77,8 +75,6 @@ public class Person extends AbstractCustomizableAnetBean implements Principal, R
   private Position position;
   // annotated below
   private List<PersonPositionHistory> previousPositions;
-  // annotated below
-  List<Task> tasks;
   // annotated below
   private Optional<byte[]> avatar;
   @GraphQLQuery
@@ -259,26 +255,6 @@ public class Person extends AbstractCustomizableAnetBean implements Principal, R
     query.setAttendeeUuid(uuid);
     query.setUser(DaoUtils.getUserFromContext(context));
     return AnetObjectEngine.getInstance().getReportDao().search(context, query);
-  }
-
-  @GraphQLQuery(name = "responsibleTasks")
-  public CompletableFuture<List<Task>> loadResponsibleTasks(
-      @GraphQLRootContext Map<String, Object> context,
-      @GraphQLArgument(name = "query") TaskSearchQuery query) {
-    if (tasks != null) {
-      return CompletableFuture.completedFuture(tasks);
-    }
-    if (query == null) {
-      query = new TaskSearchQuery();
-    }
-    query.setBatchParams(new M2mBatchParams<Task, TaskSearchQuery>("tasks",
-        "\"taskResponsiblePositions\"", "\"taskUuid\"", "\"positionUuid\""));
-    final Person user = DaoUtils.getUserFromContext(context);
-    return AnetObjectEngine.getInstance().getTaskDao()
-        .getTasksBySearch(context, DaoUtils.getUuid(user.getPosition()), query).thenApply(o -> {
-          tasks = o;
-          return o;
-        });
   }
 
   @GraphQLQuery(name = "avatar")


### PR DESCRIPTION
Fixes part of commit 5c8df12ae0fcd1f4b3cdedb159bb7d0cbac4b3f4, which would always get the responsibleTasks for the current user doing the request, instead of those belonging to the Person object.
Move responsibleTasks to Position, as that is the proper place for it, and reflect this change in the JavaScript code requesting them.

- [ ] anet.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [x] graphql schema has changed

### Checklist
  - [ ] Described the user behavior in PR body
  - [ ] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [ ] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here