### PR TITLE
Fix missing location in position table

### DIFF
--- a/client/src/components/PositionTable.js
+++ b/client/src/components/PositionTable.js
@@ -32,6 +32,10 @@ const GQL_GET_POSITION_LIST = gql`
           uuid
           shortName
         }
+        location {
+          uuid
+          name
+        }
         person {
           uuid
           name

--- a/client/src/pages/App.js
+++ b/client/src/pages/App.js
@@ -56,30 +56,23 @@ const GQL_GET_APP_DATA = gql`
         associatedPositions {
           uuid
           name
+          code
+          type
+          status
+          organization {
+            uuid
+            shortName
+          }
+          location {
+            uuid
+            name
+          }
           person {
             uuid
             name
             rank
             avatar(size: 32)
-            position {
-              uuid
-              name
-              code
-              type
-              organization {
-                uuid
-                shortName
-              }
-              location {
-                uuid
-                name
-              }
-            }
             ${GRAPHQL_NOTIFICATIONS_NOTE_FIELDS}
-          }
-          organization {
-            uuid
-            shortName
           }
         }
         responsibleTasks(


### PR DESCRIPTION
Also don't retrieve unneeded sub-object associatedPositions.person.position, as all position fields are already contained in the associatedPositions.