### PR TITLE
Add annually option to the dictionary for assessment period choice

### DIFF
--- a/anet-dictionary.yml
+++ b/anet-dictionary.yml
@@ -174,6 +174,8 @@ dictionary:
                   label: quarterly
                 semiannualy:
                   label: semiannualy
+                annually:
+                  label: annually
             relatedObjectType:
               type: enum
               label: Related object type


### PR DESCRIPTION
"annually" option was missing from the assessment definition options for tasks in the dictionary, a missing piece forgotten in #3214 

#### User changes
-

#### Super User changes
-

#### Admin changes
- Admins can add "annually" assessments when creating a task

#### System admin changes
-
- [X] anet.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [X] Described the user behavior in PR body
  - [X] Referenced/updated all related issues
  - [ ] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [ ] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [ ] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
