### PR TITLE
Change the format of assessment period start date

### DIFF
--- a/client/src/components/Model.js
+++ b/client/src/components/Model.js
@@ -3,7 +3,11 @@ import { gql } from "apollo-boost"
 import _forEach from "lodash/forEach"
 import _isEmpty from "lodash/isEmpty"
 import moment from "moment"
-import { PERIOD_FACTORIES, RECURRENCE_TYPE } from "periodUtils"
+import {
+  dateBelongsToPeriod,
+  PERIOD_FACTORIES,
+  RECURRENCE_TYPE
+} from "periodUtils"
 import PropTypes from "prop-types"
 import encodeQuery from "querystring/encode"
 import utils from "utils"
@@ -513,7 +517,7 @@ export default class Model {
       .filter(
         obj =>
           obj.assessment.__recurrence === recurrence &&
-          moment(obj.assessment.__periodStart).isSame(period.start)
+          dateBelongsToPeriod(obj.assessment.__periodStart, period)
       )
   }
 

--- a/client/src/components/assessments/AssessmentModal.js
+++ b/client/src/components/assessments/AssessmentModal.js
@@ -3,15 +3,16 @@ import {
   CustomFieldsContainer,
   customFieldsJSONString
 } from "components/CustomFields"
+import Messages from "components/Messages"
 import Model, {
   ENTITY_ASSESSMENT_PARENT_FIELD,
   GQL_CREATE_NOTE,
   GQL_UPDATE_NOTE
 } from "components/Model"
-import Messages from "components/Messages"
 import { Form, Formik } from "formik"
 import _cloneDeep from "lodash/cloneDeep"
 import _isEmpty from "lodash/isEmpty"
+import { formatPeriodBoundary } from "periodUtils"
 import PropTypes from "prop-types"
 import React, { useMemo, useState } from "react"
 import { Button, Modal } from "react-bootstrap"
@@ -136,8 +137,9 @@ const AssessmentModal = ({
     // values contains the assessment fields
     const clonedValues = _cloneDeep(values)
     clonedValues[ENTITY_ASSESSMENT_PARENT_FIELD].__recurrence = recurrence
-    clonedValues[ENTITY_ASSESSMENT_PARENT_FIELD].__periodStart =
-      assessmentPeriod.start
+    clonedValues[
+      ENTITY_ASSESSMENT_PARENT_FIELD
+    ].__periodStart = formatPeriodBoundary(assessmentPeriod.start)
     updatedNote.text = customFieldsJSONString(
       clonedValues,
       true,

--- a/client/src/periodUtils.js
+++ b/client/src/periodUtils.js
@@ -3,6 +3,21 @@ import PropTypes from "prop-types"
 import React from "react"
 import { momentObj } from "react-moment-proptypes"
 
+const ASSESSMENT_PERIOD_DATE_FORMAT = "YYYY-MM-DD"
+
+export function formatPeriodBoundary(periodBoundary) {
+  return periodBoundary.format(ASSESSMENT_PERIOD_DATE_FORMAT)
+}
+
+export function dateBelongsToPeriod(date, period) {
+  const momentDate = moment(date)
+  // true when date is same as period start date or inside the period
+  return (
+    formatPeriodBoundary(momentDate) === formatPeriodBoundary(period.start) ||
+    (momentDate.isAfter(period.start) && momentDate.isBefore(period.end))
+  )
+}
+
 export const RECURRENCE_TYPE = {
   ONCE: "once",
   DAILY: "daily",

--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -3526,4 +3526,16 @@
 		</sql>
 	</changeSet>
 
+	<changeSet id="change-periodStart-format" author="gjvoosten">
+		<comment>Convert zone-specific timestamp to zone-agnostic date in yyyy-MM-dd format</comment>
+		<!-- Requires at least SQL Server 2016: -->
+		<sql dbms="mssql">
+			UPDATE notes
+			SET text = JSON_MODIFY(text, '$.__periodStart', FORMAT(CONVERT(datetime, JSON_VALUE(text, 'lax $.__periodStart'), 127) + 0.5, 'yyyy-MM-dd'))
+			WHERE type = 3
+			AND ISJSON(text) = 1
+			AND JSON_VALUE(text, 'lax $.__periodStart') IS NOT NULL;
+		</sql>
+	</changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION

Since storing the assessment period's start date as iso string (ex: "2020-01-01T00:00:00.000Z" ) was causing timezone issues, we are changing the format of the date to "YYYY-MM-DD". Example "2020-01-30" . Database entries also needs to be updated, so there is a migration rule as well.
#### User changes
- Users can now get consistent pending assessment emails ( After backend work as well)

#### Super User changes
-

#### Admin changes
-

#### System admin changes
-
- [ ] anet.yml needs change
- [x] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [X] Described the user behavior in PR body
  - [X] Referenced/updated all related issues
  - [X] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [X] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [x] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
