### PR TITLE
Add a biweekly period implementation

### DIFF
--- a/anet-dictionary.yml
+++ b/anet-dictionary.yml
@@ -164,6 +164,8 @@ dictionary:
                   label: daily
                 weekly:
                   label: weekly
+                  # start of the week Monday(true) or Sunday(false) ?
+                  startsWithMonday: true
                 biweekly:
                   label: biweekly
                   # There are two possible ways to arrange biweekly periods
@@ -172,7 +174,7 @@ dictionary:
                   # Second way: (8 Jan - 21 Jan ) => (22 Jan - 4 Feb)
                   # So you need to pick one of two mondays in a biweekly period, depending on your use case, pick a monday which suits your schedule
                   # Periods will be arranged based on that monday
-                  selectedMonday: "2020-06-01"
+                  referenceMonday: "2020-06-01"
                 semimonthly:
                   label: semimonthly
                 monthly:

--- a/anet-dictionary.yml
+++ b/anet-dictionary.yml
@@ -164,17 +164,8 @@ dictionary:
                   label: daily
                 weekly:
                   label: weekly
-                  # start of the week Monday(true) or Sunday(false) ?
-                  startsWithMonday: true
                 biweekly:
                   label: biweekly
-                  # There are two possible ways to arrange biweekly periods
-                  # For example, if 1 Jan is Monday:
-                  # First way: (1 Jan - 14 Jan) => (15 Jan - 28 Jan)
-                  # Second way: (8 Jan - 21 Jan ) => (22 Jan - 4 Feb)
-                  # So you need to pick one of two mondays in a biweekly period, depending on your use case, pick a monday which suits your schedule
-                  # Periods will be arranged based on that monday
-                  referenceMonday: "2020-06-01"
                 semimonthly:
                   label: semimonthly
                 monthly:

--- a/anet-dictionary.yml
+++ b/anet-dictionary.yml
@@ -166,6 +166,13 @@ dictionary:
                   label: weekly
                 biweekly:
                   label: biweekly
+                  # There are two possible ways to arrange biweekly periods
+                  # For example, if 1 Jan is Monday:
+                  # First way: (1 Jan - 14 Jan) => (15 Jan - 28 Jan)
+                  # Second way: (8 Jan - 21 Jan ) => (22 Jan - 4 Feb)
+                  # So you need to pick one of two mondays in a biweekly period, depending on your use case, pick a monday which suits your schedule
+                  # Periods will be arranged based on that monday
+                  selectedMonday: "2020-06-01"
                 semimonthly:
                   label: semimonthly
                 monthly:

--- a/client/src/periodUtils.js
+++ b/client/src/periodUtils.js
@@ -53,7 +53,7 @@ export const PERIOD_FACTORIES = {
   [RECURRENCE_TYPE.BIWEEKLY]: (date, offset) => {
     // every biweekly period's start is even number of weeks apart from reference monday
     const refMonday = moment(refMondayForBiweekly).startOf(weekType)
-    const curWeekMonday = date.startOf(weekType)
+    const curWeekMonday = date.clone().startOf(weekType)
 
     const diffInWeeks = refMonday.diff(curWeekMonday, "weeks")
     // current biweekly period's start has to be even number of weeks apart from reference monday
@@ -64,8 +64,8 @@ export const PERIOD_FACTORIES = {
 
     const curBiweeklyEnd = curBiweeklyStart
       .clone()
-      .endOf(weekType)
       .add(1, "weeks")
+      .endOf(weekType)
 
     return {
       start: curBiweeklyStart.clone().subtract(2 * offset, "weeks"),

--- a/client/src/periodUtils.js
+++ b/client/src/periodUtils.js
@@ -2,7 +2,6 @@ import moment from "moment"
 import PropTypes from "prop-types"
 import React from "react"
 import { momentObj } from "react-moment-proptypes"
-import Settings from "settings"
 
 const ASSESSMENT_PERIOD_DATE_FORMAT = "YYYY-MM-DD"
 
@@ -37,15 +36,10 @@ const PERIOD_FORMAT = {
   START_LONG: "D MMMM YYYY",
   END_LONG: "D MMMM YYYY"
 }
-const weeksStartsWithMonday =
-  Settings.fields.task.customFields.assessments.objectFields.recurrence.choices
-    .weekly.startsWithMonday
 
-const weekType = weeksStartsWithMonday ? "isoWeek" : "week"
+const weekType = "isoWeek"
 
-const refMondayForBiweekly =
-  Settings.fields.task.customFields.assessments.objectFields.recurrence.choices
-    .biweekly.referenceMonday
+const refMondayForBiweekly = "2021-01-04" // lets select 1st monday of 2021
 
 export const PERIOD_FACTORIES = {
   [RECURRENCE_TYPE.DAILY]: (date, offset) => ({
@@ -53,15 +47,16 @@ export const PERIOD_FACTORIES = {
     end: date.clone().subtract(offset, "days").endOf("day")
   }),
   [RECURRENCE_TYPE.WEEKLY]: (date, offset) => ({
-    start: date.clone().subtract(offset, "weeks").startOf(weekType),
-    end: date.clone().subtract(offset, "weeks").endOf(weekType)
+    start: date.clone().subtract(offset, "weeks").startOf("week"),
+    end: date.clone().subtract(offset, "weeks").endOf("week")
   }),
   [RECURRENCE_TYPE.BIWEEKLY]: (date, offset) => {
-    const refMonday = moment(refMondayForBiweekly)
+    // every biweekly period's start is even number of weeks apart from reference monday
+    const refMonday = moment(refMondayForBiweekly).startOf(weekType)
     const curWeekMonday = date.startOf(weekType)
 
     const diffInWeeks = refMonday.diff(curWeekMonday, "weeks")
-    // current biweekly period's start has to be even number of weeks apart from origin
+    // current biweekly period's start has to be even number of weeks apart from reference monday
     const curBiweeklyStart =
       diffInWeeks % 2 === 0
         ? curWeekMonday

--- a/client/src/periodUtils.js
+++ b/client/src/periodUtils.js
@@ -37,6 +37,15 @@ const PERIOD_FORMAT = {
   START_LONG: "D MMMM YYYY",
   END_LONG: "D MMMM YYYY"
 }
+const weeksStartsWithMonday =
+  Settings.fields.task.customFields.assessments.objectFields.recurrence.choices
+    .weekly.startsWithMonday
+
+const weekType = weeksStartsWithMonday ? "isoWeek" : "week"
+
+const refMondayForBiweekly =
+  Settings.fields.task.customFields.assessments.objectFields.recurrence.choices
+    .biweekly.referenceMonday
 
 export const PERIOD_FACTORIES = {
   [RECURRENCE_TYPE.DAILY]: (date, offset) => ({
@@ -44,17 +53,14 @@ export const PERIOD_FACTORIES = {
     end: date.clone().subtract(offset, "days").endOf("day")
   }),
   [RECURRENCE_TYPE.WEEKLY]: (date, offset) => ({
-    start: date.clone().subtract(offset, "weeks").startOf("week"),
-    end: date.clone().subtract(offset, "weeks").endOf("week")
+    start: date.clone().subtract(offset, "weeks").startOf(weekType),
+    end: date.clone().subtract(offset, "weeks").endOf(weekType)
   }),
   [RECURRENCE_TYPE.BIWEEKLY]: (date, offset) => {
-    const originMondayStr =
-      Settings.fields.task.customFields.assessments.objectFields.recurrence
-        .choices.biweekly.selectedMonday
-    const originMonday = moment(originMondayStr)
-    const curWeekMonday = date.startOf("isoWeek")
+    const refMonday = moment(refMondayForBiweekly)
+    const curWeekMonday = date.startOf(weekType)
 
-    const diffInWeeks = originMonday.diff(curWeekMonday, "weeks")
+    const diffInWeeks = refMonday.diff(curWeekMonday, "weeks")
     // current biweekly period's start has to be even number of weeks apart from origin
     const curBiweeklyStart =
       diffInWeeks % 2 === 0
@@ -63,8 +69,8 @@ export const PERIOD_FACTORIES = {
 
     const curBiweeklyEnd = curBiweeklyStart
       .clone()
-      .endOf("isoWeek")
-      .add(1, "week")
+      .endOf(weekType)
+      .add(1, "weeks")
 
     return {
       start: curBiweeklyStart.clone().subtract(2 * offset, "weeks"),

--- a/client/tests/utils/periodUtils.test.js
+++ b/client/tests/utils/periodUtils.test.js
@@ -16,6 +16,10 @@ const EXAMPLE_INPUT_DATES_AND_OFFSETS = [
       semiAnnually: {
         start: "2019-07-01",
         end: "2019-12-31"
+      },
+      biweekly: {
+        start: "2019-12-09",
+        end: "2019-12-22"
       }
     }
   },
@@ -31,6 +35,10 @@ const EXAMPLE_INPUT_DATES_AND_OFFSETS = [
       semiAnnually: {
         start: "2018-07-01",
         end: "2018-12-31"
+      },
+      biweekly: {
+        start: "2019-12-09",
+        end: "2019-12-22"
       }
     }
   },
@@ -46,6 +54,10 @@ const EXAMPLE_INPUT_DATES_AND_OFFSETS = [
       semiAnnually: {
         start: "2019-07-01",
         end: "2019-12-31"
+      },
+      biweekly: {
+        start: "2020-02-03",
+        end: "2020-02-16"
       }
     }
   },
@@ -61,6 +73,10 @@ const EXAMPLE_INPUT_DATES_AND_OFFSETS = [
       semiAnnually: {
         start: "2020-07-01",
         end: "2020-12-31"
+      },
+      biweekly: {
+        start: "2020-03-02",
+        end: "2020-03-15"
       }
     }
   },
@@ -76,6 +92,10 @@ const EXAMPLE_INPUT_DATES_AND_OFFSETS = [
       semiAnnually: {
         start: "2021-01-01",
         end: "2021-06-30"
+      },
+      biweekly: {
+        start: "2021-01-04",
+        end: "2021-01-17"
       }
     }
   },
@@ -91,6 +111,10 @@ const EXAMPLE_INPUT_DATES_AND_OFFSETS = [
       semiAnnually: {
         start: "2019-07-01",
         end: "2019-12-31"
+      },
+      biweekly: {
+        start: "2020-05-25",
+        end: "2020-06-07"
       }
     }
   },
@@ -106,6 +130,10 @@ const EXAMPLE_INPUT_DATES_AND_OFFSETS = [
       semiAnnually: {
         start: "2021-07-01",
         end: "2021-12-31"
+      },
+      biweekly: {
+        start: "2020-07-20",
+        end: "2020-08-02"
       }
     }
   }
@@ -113,6 +141,20 @@ const EXAMPLE_INPUT_DATES_AND_OFFSETS = [
 
 // test with index so that if it fails we know which date from the array
 describe("For period creation utility", () => {
+  it("We should get the correct biweekly periods given example input", () => {
+    EXAMPLE_INPUT_DATES_AND_OFFSETS.forEach((input, index) => {
+      const period = PERIOD_FACTORIES[RECURRENCE_TYPE.BIWEEKLY](
+        moment(input.date),
+        input.offset
+      )
+      expect(prefix(index) + period.start.format(FORMAT)).toEqual(
+        prefix(index) + input.expectedPeriods.biweekly.start
+      )
+      expect(prefix(index) + period.end.format(FORMAT)).toEqual(
+        prefix(index) + input.expectedPeriods.biweekly.end
+      )
+    })
+  })
   it("We should get the correct semimonthly periods given example input", () => {
     EXAMPLE_INPUT_DATES_AND_OFFSETS.forEach((input, index) => {
       const period = PERIOD_FACTORIES[RECURRENCE_TYPE.SEMIMONTHLY](


### PR DESCRIPTION
Currently, we have a broken biweekly period implementation for the task assessments' period. Now we have a biweely period which is basically the other Monday calculation from a specific date(chose "2021-01-04", 1st monday of 2021). Every monday that has even number of weeks apart from this date can be a biweekly period start.


### Release notes

Closes #3068 

#### User changes
- Users can now see correct biweekly period.

#### Super User changes
-

#### Admin changes
- 
#### System admin changes
-
- [ ] anet.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [X] Described the user behavior in PR body
  - [X] Referenced/updated all related issues
  - [X] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [X] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [X] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
