### PR TITLE
Set READ_COMMITTED_SNAPSHOT to ON on MS SQL to prevent hangs due to locking

### DIFF
--- a/src/main/java/mil/dds/anet/threads/AbstractWorker.java
+++ b/src/main/java/mil/dds/anet/threads/AbstractWorker.java
@@ -25,14 +25,15 @@ public abstract class AbstractWorker implements Runnable {
 
   @Override
   public final void run() {
-    logger.debug(startMessage);
+    final String className = this.getClass().getSimpleName();
+    logger.debug("Starting {}: {}", className, startMessage);
     try {
-      jobHistoryDao.runInTransaction(this.getClass().getSimpleName(),
-          (now, jobHistory) -> runInternal(now, jobHistory));
+      jobHistoryDao.runInTransaction(className, (now, jobHistory) -> runInternal(now, jobHistory));
     } catch (Throwable e) {
       // Cannot let this thread die. Otherwise ANET will stop checking.
       logger.error("Exception in run()", e);
     }
+    logger.debug("Ending {}", className);
   }
 
 }

--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -3518,4 +3518,12 @@
 		</sql>
 	</changeSet>
 
+	<changeSet id="set-read_committed_snapshot-on" author="gjvoosten">
+		<comment>Set READ_COMMITTED_SNAPSHOT to ON to prevent hangs due to locking</comment>
+		<!-- Requires at least SQL Server 2012: -->
+		<sql dbms="mssql">
+                        ALTER DATABASE CURRENT SET READ_COMMITTED_SNAPSHOT ON;
+		</sql>
+	</changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
Also log start *and* end of workers.