### PR TITLE
Update READ_COMMITTED_SNAPSHOT migration

### DIFF
--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -3518,11 +3518,11 @@
 		</sql>
 	</changeSet>
 
-	<changeSet id="set-read_committed_snapshot-on" author="gjvoosten">
+	<changeSet id="set-read_committed_snapshot-on" author="gjvoosten" runInTransaction="false" runOnChange="true">
 		<comment>Set READ_COMMITTED_SNAPSHOT to ON to prevent hangs due to locking</comment>
 		<!-- Requires at least SQL Server 2012: -->
 		<sql dbms="mssql">
-                        ALTER DATABASE CURRENT SET READ_COMMITTED_SNAPSHOT ON;
+                        ALTER DATABASE CURRENT SET READ_COMMITTED_SNAPSHOT ON WITH ROLLBACK IMMEDIATE;
 		</sql>
 	</changeSet>
 


### PR DESCRIPTION
Small update to NCI-Agency/anet#3277:
Change it so it doesn't wait for other open transactions.
Don't run this change itself inside a transaction, and tell Liquibase to run it each time the checksum changes (like now).

