### PR TITLE
Fix 'No assessments' message when there are assessments

### DIFF
--- a/client/src/components/assessments/InstantAssessmentResults.js
+++ b/client/src/components/assessments/InstantAssessmentResults.js
@@ -37,7 +37,7 @@ export const InstantAssessmentsRow = ({
           <td key={key}>
             {_isEmpty(periodsData[index]) ? (
               isFirstRow ? (
-                <em>No assessments</em>
+                <em>No engagement assessments</em>
               ) : null
             ) : (
               <AggregationWidgetContainer

--- a/client/src/components/assessments/PeriodicAssessmentResults.js
+++ b/client/src/components/assessments/PeriodicAssessmentResults.js
@@ -165,39 +165,37 @@ export const PeriodicAssessmentsRows = ({
         _isEmpty(myPeriodAssessments)
     )
   })
-  const hasPeriodicAssessmentsRow = !_isEmpty(
-    periodsAssessments.filter(x => !_isEmpty(x))
-  )
   const hasAddAssessmentRow = !_isEmpty(
     periodsAllowNewAssessment.filter(x => x)
   )
   return (
     <>
-      {hasPeriodicAssessmentsRow && (
-        <tr>
-          {periodsAssessments.map((periodAssessments, index) => {
-            return (
-              <td key={index}>
-                {periodAssessments &&
-                  periodAssessments.map(({ note, assessment }, i) => (
-                    <div key={note.uuid}>
-                      <PeriodicAssessment
-                        note={note}
-                        assessment={assessment}
-                        assessmentYupSchema={assessmentYupSchema}
-                        assessmentConfig={assessmentConfig}
-                        entity={entity}
-                        period={periods[index]}
-                        recurrence={recurrence}
-                        onUpdateAssessment={onUpdateAssessment}
-                      />
-                    </div>
-                  ))}
-              </td>
-            )
-          })}
-        </tr>
-      )}
+      <tr>
+        {periodsAssessments.map((periodAssessments, index) => {
+          return (
+            <td key={index}>
+              {!_isEmpty(periodAssessments) ? (
+                periodAssessments.map(({ note, assessment }, i) => (
+                  <div key={note.uuid}>
+                    <PeriodicAssessment
+                      note={note}
+                      assessment={assessment}
+                      assessmentYupSchema={assessmentYupSchema}
+                      assessmentConfig={assessmentConfig}
+                      entity={entity}
+                      period={periods[index]}
+                      recurrence={recurrence}
+                      onUpdateAssessment={onUpdateAssessment}
+                    />
+                  </div>
+                ))
+              ) : (
+                <em>No periodic assessments</em>
+              )}
+            </td>
+          )
+        })}
+      </tr>
       {hasAddAssessmentRow && (
         <tr>
           {periods.map((period, index) => {


### PR DESCRIPTION
This pull request solves the issue of showing "No assessments" message in the assessments' table when there are assessments to show. Assessments are divided into two groups when dealing with user feedback. "Engagement Assessments" and "Periodic Assessments". 

The reason for the previous behavior was that both of these assessments are evaluated separately but only engagement assessments returned a user feedback. Now both return a user feedback.

Note: If there is no config for "Engagement Assessments" or "Periodic Assessments", we don't show "No engagement/periodic assessments" message, as  that task/person isn't even configured for such assessments.

#### User changes
- Users will see a more detailed feedback on assessments table

#### Super User changes
-

#### Admin changes
-

#### System admin changes
-
- [ ] anet.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [X] Described the user behavior in PR body
  - [ ] Referenced/updated all related issues
  - [ ] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [X] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [ ] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
