### PR TITLE
Correct parent organization selection for new principal organizations

### DIFF
--- a/client/src/pages/organizations/Form.js
+++ b/client/src/pages/organizations/Form.js
@@ -16,7 +16,7 @@ import Model from "components/Model"
 import NavigationWarning from "components/NavigationWarning"
 import { jumpToTop } from "components/Page"
 import NoPaginationTaskTable from "components/NoPaginationTaskTable"
-import { FastField, Form, Formik } from "formik"
+import { FastField, Field, Form, Formik } from "formik"
 import { Organization, Position, Task } from "models"
 import pluralize from "pluralize"
 import PropTypes from "prop-types"
@@ -224,7 +224,7 @@ const OrganizationForm = ({ edit, title, initialValues }) => {
                       buttons={typeButtons}
                       onChange={value => setFieldValue("type", value)}
                     />
-                    <FastField
+                    <Field
                       name="parentOrg"
                       label={Settings.fields.organization.parentOrg}
                       component={FieldHelper.SpecialField}


### PR DESCRIPTION
Admins can now also correctly find and select parent organizations when creating new **principal** organizations.

### Release notes

Fixes NCI-Agency/anet#3004

#### User changes
- none

#### Super User changes
- none

#### Admin changes
- When creating a new principal organization, a parent organization can be found and selected. (For advisor organizations this was already the case.)

#### System admin changes
- none
- [ ] anet.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here