### PR TITLE
Make insights & rollup use the whole page under Chrome 86 and up

### DIFF
--- a/client/src/index.css
+++ b/client/src/index.css
@@ -120,6 +120,7 @@ fieldset.danger {
 }
 
 #daily-rollup fieldset,
+#advisor-reports fieldset,
 #cancelled-reports fieldset,
 #future-engagements-by-location fieldset,
 #not-approved-reports fieldset,

--- a/client/src/pages/insights/Show.js
+++ b/client/src/pages/insights/Show.js
@@ -100,6 +100,10 @@ const InsightsShow = ({ pageDispatchers, searchQuery, setSearchQuery }) => {
     height: "100%",
     overflow: "auto"
   }
+  const fieldsetStyle = {
+    height: "100%",
+    overflow: "auto"
+  }
   const mosaicLayoutStyle = {
     display: "flex",
     flex: "1 1 auto",
@@ -164,7 +168,11 @@ const InsightsShow = ({ pageDispatchers, searchQuery, setSearchQuery }) => {
   return (
     <div style={flexStyle}>
       {hasSearchCriteria ? (
-        <Fieldset id={insight} title={insightConfig.title} style={flexStyle}>
+        <Fieldset
+          id={insight}
+          title={insightConfig.title}
+          style={fieldsetStyle}
+        >
           <InsightComponent
             pageDispatchers={pageDispatchers}
             style={mosaicLayoutStyle}

--- a/client/src/pages/rollup/Show.js
+++ b/client/src/pages/rollup/Show.js
@@ -309,7 +309,12 @@ const RollupShow = ({ pageDispatchers, searchQuery }) => {
     display: "flex",
     flexDirection: "column",
     flex: "1 1 auto",
-    height: "100%"
+    height: "100%",
+    overflow: "auto"
+  }
+  const fieldsetStyle = {
+    height: "100%",
+    overflow: "auto"
   }
   const mosaicLayoutStyle = {
     display: "flex",
@@ -393,7 +398,7 @@ const RollupShow = ({ pageDispatchers, searchQuery }) => {
             </Button>
           </span>
         }
-        style={flexStyle}
+        style={fieldsetStyle}
       >
         <MosaicLayout
           style={mosaicLayoutStyle}


### PR DESCRIPTION
With Chrome 86 the insights & rollup used only 400px instead of the full height. This makes them use the full height again.
Note that pages with an additional header (Daily Rollup, NATO member Reports insight) may in some cases get two vertical scrollbars (one for the mosaic layout, one for the enclosing block).

### Release notes

Fixes NCI-Agency/anet#3282

#### User changes
- The insights & rollup will use the full height again under Chrome 86 and up.

#### Super User changes
- none

#### Admin changes
- none

#### System admin changes
- none
- [ ] anet.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here