### PR TITLE
Remove uses of `_uniqueId` for React component keys

### DIFF
--- a/client/src/components/AdvisorReports/AdvisorReportsRow.js
+++ b/client/src/components/AdvisorReports/AdvisorReportsRow.js
@@ -1,5 +1,4 @@
 import Checkbox from "components/Checkbox"
-import _uniqueId from "lodash/uniqueId"
 import PropTypes from "prop-types"
 import React from "react"
 
@@ -8,14 +7,16 @@ const _advisorStats = (columnGroups, statistics) => {
   columnGroups.forEach(group => {
     let rowCell = statistics.filter(s => s.week === group)
     rowCell = rowCell ? rowCell[0] : null
-    const keySubmitted = _uniqueId("submitted_")
-    const keyAttended = _uniqueId("attended_")
     if (rowCell) {
-      stats.push(<td key={keySubmitted}>{rowCell.nrReportsSubmitted}</td>)
-      stats.push(<td key={keyAttended}>{rowCell.nrEngagementsAttended}</td>)
+      stats.push(
+        <td key={`submitted_${group}`}>{rowCell.nrReportsSubmitted}</td>
+      )
+      stats.push(
+        <td key={`attended_${group}`}>{rowCell.nrEngagementsAttended}</td>
+      )
     } else {
-      stats.push(<td key={keySubmitted}>0</td>)
-      stats.push(<td key={keyAttended}>0</td>)
+      stats.push(<td key={`submitted_${group}`}>0</td>)
+      stats.push(<td key={`attended_${group}`}>0</td>)
     }
   })
   return stats

--- a/client/src/components/AdvisorReports/AdvisorReportsTable.js
+++ b/client/src/components/AdvisorReports/AdvisorReportsTable.js
@@ -7,7 +7,6 @@ import {
   mapPageDispatchersToProps,
   useBoilerplate
 } from "components/Page"
-import _uniqueId from "lodash/uniqueId"
 import PropTypes from "prop-types"
 import React from "react"
 import { Table } from "react-bootstrap"
@@ -51,7 +50,7 @@ const AdvisorReportsTable = ({ pageDispatchers, columnGroups, orgUuid }) => {
     <AdvisorReportsRow
       row={advisor}
       columnGroups={columnGroups}
-      key={_uniqueId(`${advisor.uuid}_`)}
+      key={`${advisor.uuid}`}
     />
   ))
 

--- a/client/src/components/ReportMap.js
+++ b/client/src/components/ReportMap.js
@@ -65,6 +65,7 @@ const ReportMap = ({
       width={width}
       height={height}
       marginBottom={marginBottom}
+      whenUnspecified={<em>No reports with a location found</em>}
     />
   )
 }

--- a/client/src/components/aggregations/AggregationWidgetContainer.js
+++ b/client/src/components/aggregations/AggregationWidgetContainer.js
@@ -159,11 +159,9 @@ const AggregationWidgetContainer = ({
   const WidgetComponent =
     (aggregationWidget && AGGREGATION_WIDGET_COMPONENTS[aggregationWidget]) ||
     AGGREGATION_WIDGET_COMPONENTS.default
-  if (WidgetComponent === ReportsMapWidget) {
-    otherWidgetProps.mapId = widgetId
-  }
   const widgetElem = (
     <WidgetComponent
+      widgetId={widgetId}
       values={values}
       valueType={dataType}
       vertical={vertical}

--- a/client/src/components/aggregations/DefaultAggWidget.js
+++ b/client/src/components/aggregations/DefaultAggWidget.js
@@ -3,7 +3,6 @@ import {
   aggregationWidgetPropTypes
 } from "components/aggregations/utils"
 import _isEmpty from "lodash/isEmpty"
-import _uniqueId from "lodash/uniqueId"
 import React, { useState } from "react"
 import { Button, Collapse, Table } from "react-bootstrap"
 import utils from "utils"
@@ -27,14 +26,11 @@ const DefaultAggWidget = ({ values, whenUnspecified, ...otherWidgetProps }) => {
       <Collapse in={showValues}>
         <Table>
           <tbody>
-            {filteredValues.map(val => {
-              const keyValue = _uniqueId("value_")
-              return (
-                <tr key={keyValue}>
-                  <td>{JSON.stringify(val)}</td>
-                </tr>
-              )
-            })}
+            {filteredValues.map((val, index) => (
+              <tr key={index}>
+                <td>{JSON.stringify(val)}</td>
+              </tr>
+            ))}
           </tbody>
         </Table>
       </Collapse>

--- a/client/src/components/aggregations/ReportsByTaskWidget.js
+++ b/client/src/components/aggregations/ReportsByTaskWidget.js
@@ -3,13 +3,12 @@ import {
   aggregationWidgetPropTypes
 } from "components/aggregations/utils"
 import BarChart from "components/BarChart"
-import _uniqueId from "lodash/uniqueId"
 import React from "react"
 
-const ReportsByTaskWidget = ({ values, ...otherWidgetProps }) => (
+const ReportsByTaskWidget = ({ widgetId, values, ...otherWidgetProps }) => (
   <div className="non-scrollable">
     <BarChart
-      chartId={_uniqueId("ReportsByTaskWidget")}
+      chartId={`ReportsByTaskWidget-${widgetId}`}
       data={values}
       xProp="task.uuid"
       yProp="reportsCount"

--- a/client/src/components/aggregations/ReportsMapWidget.js
+++ b/client/src/components/aggregations/ReportsMapWidget.js
@@ -11,7 +11,7 @@ import React, { useMemo } from "react"
 
 const ReportsMapWidget = ({
   values,
-  mapId,
+  widgetId,
   width,
   height,
   whenUnspecified,
@@ -45,7 +45,7 @@ const ReportsMapWidget = ({
         markers={markers}
         width={width}
         height={height}
-        mapId={mapId}
+        mapId={widgetId}
         marginBottom={0}
       />
     </div>
@@ -53,7 +53,6 @@ const ReportsMapWidget = ({
 }
 ReportsMapWidget.propTypes = {
   ...aggregationWidgetPropTypes,
-  mapId: PropTypes.string,
   width: PropTypes.number,
   height: PropTypes.number
 }

--- a/client/src/components/aggregations/utils.js
+++ b/client/src/components/aggregations/utils.js
@@ -7,6 +7,7 @@ import PropTypes from "prop-types"
 import Settings from "settings"
 
 export const aggregationWidgetPropTypes = {
+  widgetId: PropTypes.string.isRequired,
   values: PropTypes.oneOfType([
     PropTypes.object,
     PropTypes.arrayOf(

--- a/client/src/pages/dashboards/DiagramNode.js
+++ b/client/src/pages/dashboards/DiagramNode.js
@@ -24,7 +24,6 @@ import { SPECIAL_WIDGET_TYPES } from "components/CustomFields"
 import LinkTo from "components/LinkTo"
 import { CUSTOM_FIELD_TYPE, GRAPHQL_ENTITY_FIELDS } from "components/Model"
 import { GRAPHQL_NOTES_FIELDS } from "components/RelatedObjectNotes"
-import _uniqueId from "lodash/uniqueId"
 import * as Models from "models"
 import moment from "moment"
 import { PERIOD_FACTORIES, RECURRENCE_TYPE } from "periodUtils"
@@ -177,7 +176,7 @@ export const DiagramNodeWidget = ({ size, node, engine }) => {
                     fieldName={questionKey}
                     data={instantAssessmentResults}
                     widget={aggregationWidget}
-                    widgetId={`${questionKey}-${_uniqueId("assessment")}`}
+                    widgetId={`${questionKey}-assessment`}
                   />
                 ) : null
               })}


### PR DESCRIPTION
It would make the component always be recreated at every (re)render.
Replace this by a unique key, or in some cases an index (which is marginally better, provided the array being looped over is in some stable order).