### PR TITLE
Fix position table missing locations in task page

### DIFF
--- a/client/src/pages/tasks/Show.js
+++ b/client/src/pages/tasks/Show.js
@@ -62,6 +62,10 @@ const GQL_GET_TASK = gql`
           uuid
           shortName
         }
+        location {
+          uuid
+          name
+        }
         person {
           uuid
           name


### PR DESCRIPTION
Continuation of https://github.com/NCI-Agency/anet/pull/3269. Task page had the similar issue which is fixed with this pr.
### Release notes

Closes #3288 

#### User changes
- Users can now see locations in position table in the tasks page.

#### Super User changes
-

#### Admin changes
-

#### System admin changes
-
- [ ] anet.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [X] Described the user behavior in PR body
  - [X] Referenced/updated all related issues
  - [ ] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [ ] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [ ] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
