### PR TITLE
Deprecate GHA `set-env`

### DIFF
--- a/.github/workflows/build-gradle.yml
+++ b/.github/workflows/build-gradle.yml
@@ -29,7 +29,7 @@ jobs:
     - uses: actions/setup-java@v1
       with:
         java-version: 1.8
-    - run: echo "::set-env name=CHROMEDRIVER_FILEPATH::$CHROMEWEBDRIVER/chromedriver"
+    - run: echo "CHROMEDRIVER_FILEPATH=$CHROMEWEBDRIVER/chromedriver" >> $GITHUB_ENV
     - name: cache gradle
       uses: actions/cache@v1
       with:
@@ -109,7 +109,7 @@ jobs:
     - uses: actions/setup-java@v1
       with:
         java-version: 1.8
-    - run: echo "::set-env name=CHROMEDRIVER_FILEPATH::$CHROMEWEBDRIVER/chromedriver"
+    - run: echo "CHROMEDRIVER_FILEPATH=$CHROMEWEBDRIVER/chromedriver" >> $GITHUB_ENV
     - uses: actions/cache@v1
       with:
         path: ~/.gradle/caches


### PR DESCRIPTION
Replace deprecated `set-env` on GHA with `$GITHUB_ENV`.