### PR TITLE
Fix conflict detection when one of the reports is cancelled

### DIFF
--- a/client/src/models/Report.js
+++ b/client/src/models/Report.js
@@ -474,6 +474,13 @@ export default class Report extends Model {
       return false // same report is not a conflicting report
     }
 
+    // cancelled reports not counted as conflict
+    if (
+      Report.isCancelled(report01.state) ||
+      Report.isCancelled(report02.state)
+    ) {
+      return false
+    }
     let start01
     let end01
 


### PR DESCRIPTION
Cancelled reports shouldn't be accounted for conflict detection, fix that issue.

#### User changes
- Users won't see a conflict for cancelled engagements.

#### Super User changes
-

#### Admin changes
-

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [X] Described the user behavior in PR body
  - [X] Referenced/updated all related issues
  - [ ] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [X] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [X] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
