### PR TITLE
Fix FutureEngagementWorker

### DIFF
--- a/src/main/java/mil/dds/anet/database/ReportDao.java
+++ b/src/main/java/mil/dds/anet/database/ReportDao.java
@@ -893,54 +893,42 @@ public class ReportDao extends AnetBaseDao<Report, ReportSearchQuery> {
     StringBuilder sql = new StringBuilder();
 
     sql.append("/* getFutureToPastReports */");
-    sql.append(
-        " SELECT reports.uuid AS reports_uuid, reports.\"authorUuid\" AS \"reports_authorUuid\"");
-    sql.append(" FROM reports");
-    // We are not interested in draft reports, as they will remain draft.
-    // We are not interested in cancelled reports, as they will remain cancelled.
-    sql.append(
-        " WHERE reports.state IN ( :reportApproved, :reportRejected, :reportPendingApproval, :reportPublished )");
-    // Get past reports relative to the endDate argument
-    sql.append(" AND reports.\"engagementDate\" <= :endDate");
-    sql.append(" AND ((");
-    // Get reports for engagements which just became past engagements during or
-    // after the planning approval process, but which are not in the report approval process yet
-    sql.append("   reports.uuid IN (");
-    sql.append("     SELECT pr.uuid");
-    sql.append("     FROM (");
-    sql.append("       SELECT r.uuid, ra.\"approvalStepUuid\"");
-    sql.append("       FROM reports r");
+    sql.append(" SELECT r.uuid AS reports_uuid, r.\"authorUuid\" AS \"reports_authorUuid\"");
+    sql.append(" FROM reports r");
     // FIXME: Hard-coded MS SQL or PostgreSQL specific query stanza
     if (DaoUtils.isMsSql()) {
-      sql.append("     CROSS APPLY (SELECT");
-      sql.append("       TOP (1)");
+      sql.append(" OUTER APPLY (SELECT TOP (1)");
     } else {
-      sql.append("     INNER JOIN LATERAL (SELECT"); // PostgreSQL
+      sql.append(" LEFT JOIN LATERAL (SELECT"); // PostgreSQL
     }
-    sql.append("           \"reportActions\".\"reportUuid\",");
-    sql.append("           \"reportActions\".\"approvalStepUuid\",");
-    sql.append("           \"reportActions\".planned");
-    sql.append("         FROM \"reportActions\"");
-    sql.append("         WHERE \"reportActions\".\"reportUuid\" = r.uuid");
-    sql.append("         AND ( \"reportActions\".\"approvalStepUuid\" IS NOT NULL");
-    sql.append("         OR    \"reportActions\".planned = :planned )");
-    sql.append("         ORDER BY \"reportActions\".\"createdAt\" DESC");
+    sql.append("   ra.\"approvalStepUuid\", ra.planned");
+    sql.append("   FROM \"reportActions\" ra");
+    sql.append("   WHERE ra.\"reportUuid\" = r.uuid");
+    sql.append("   ORDER BY ra.\"createdAt\" DESC");
     if (DaoUtils.isMsSql()) {
-      sql.append("     ) ra");
+      sql.append(" ) ra");
     } else {
-      sql.append("       LIMIT 1"); // PostgreSQL
-      sql.append("     ) ra ON TRUE");
+      sql.append(" LIMIT 1) ra ON TRUE"); // PostgreSQL
     }
-    sql.append("       WHERE ra.planned = :planned OR ra.\"approvalStepUuid\" IN");
-    sql.append("         ( SELECT \"approvalSteps\".uuid FROM \"approvalSteps\"");
-    sql.append("           WHERE \"approvalSteps\".type = :planningApprovalStepType )");
-    sql.append("     ) pr");
+    // We are not interested in draft reports, as they will remain draft.
+    // We are not interested in cancelled reports, as they will remain cancelled.
+    sql.append(" WHERE r.state IN (");
+    sql.append("   :reportApproved, :reportRejected, :reportPendingApproval, :reportPublished");
+    sql.append(" )");
+    // Get past reports relative to the endDate argument
+    sql.append(" AND r.\"engagementDate\" <= :endDate");
+    sql.append(" AND (");
+    // Get reports for engagements which just became past engagements during or
+    // after the planning approval process, but which are not in the report approval process yet
+    sql.append("   ra.planned = :planned");
+    sql.append("   OR ra.\"approvalStepUuid\" IN (");
+    sql.append("     SELECT a.uuid FROM \"approvalSteps\" a");
+    sql.append("     WHERE a.type = :planningApprovalStepType");
     sql.append("   )");
-    sql.append(" ) OR (");
     // Also get reports pending planning approval when the approval action was not taken yet
-    sql.append("   reports.\"approvalStepUuid\" IN");
-    sql.append("     ( SELECT \"approvalSteps\".uuid FROM \"approvalSteps\"");
-    sql.append("       WHERE \"approvalSteps\".type = :planningApprovalStepType )");
+    sql.append("   OR r.\"approvalStepUuid\" IN (");
+    sql.append("     SELECT a.uuid FROM \"approvalSteps\" a");
+    sql.append("     WHERE a.type = :planningApprovalStepType");
     sql.append(" ))");
     DaoUtils.addInstantAsLocalDateTime(sqlArgs, "endDate", end);
     sqlArgs.put("reportApproved", DaoUtils.getEnumId(ReportState.APPROVED));

--- a/src/test/java/mil/dds/anet/test/integration/db/FutureEngagementWorkerTest.java
+++ b/src/test/java/mil/dds/anet/test/integration/db/FutureEngagementWorkerTest.java
@@ -314,7 +314,6 @@ public class FutureEngagementWorkerTest {
     engine.getApprovalStepDao().insertAtEnd(approvalStep);
 
     final Report report = TestBeans.getTestReport(author, approvalStep, ImmutableList.of());
-    engine.getReportDao().insert(report);
-    return report;
+    return engine.getReportDao().insert(report);
   }
 }


### PR DESCRIPTION
Fix the logic for finding planned engagements that should go to draft because their engagement date has come.

Fixes NCI-Agency/anet#3304

#### User changes
- Users should no longer repeatedly receive notifications that their report for an upcoming engagement was turned into a draft report (because its engagement date has come) again, after they already submitted it for regular approval.

#### Super User changes
- none

#### Admin changes
- none

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here