### PR TITLE
Fix ReportCollection undefined widgetIds as no mapId supplied

### DIFF
--- a/client/src/components/ReportMap.js
+++ b/client/src/components/ReportMap.js
@@ -61,7 +61,7 @@ const ReportMap = ({
   return (
     <ReportsMapWidget
       values={reports}
-      mapId={mapId}
+      widgetId={mapId}
       width={width}
       height={height}
       marginBottom={marginBottom}
@@ -74,10 +74,14 @@ ReportMap.propTypes = {
   pageDispatchers: PageDispatchersPropType,
   queryParams: PropTypes.object,
   setTotalCount: PropTypes.func,
-  mapId: PropTypes.string, // pass this when you have more than one map on a page
+  // pass mapId explicitly when you have more than one map on a page (else the default is fine):
+  mapId: PropTypes.string.isRequired,
   width: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   height: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   marginBottom: PropTypes.oneOfType([PropTypes.number, PropTypes.string])
 }
 
+ReportMap.defaultProps = {
+  mapId: "reports"
+}
 export default connect(null, mapPageDispatchersToProps)(ReportMap)


### PR DESCRIPTION
Since ReportsMapWidget's widgetId is required now, we need to pass map ids from higher level comps.

continuation from #3292 


#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [ ] Described the user behavior in PR body
  - [X] Referenced/updated all related issues
  - [ ] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [X] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [X] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
