### PR TITLE
Fix planning conflict e2e test errors

### DIFF
--- a/client/config/wdio.config.js
+++ b/client/config/wdio.config.js
@@ -140,7 +140,7 @@ const config = {
   mochaOpts: {
     ui: "bdd",
     compilers: ["js:@babel/register"],
-    timeout: 90000
+    timeout: 180000
   },
   //
   // =====

--- a/client/tests/webdriver/pages/report/createReport.page.js
+++ b/client/tests/webdriver/pages/report/createReport.page.js
@@ -24,21 +24,9 @@ class CreateReport extends Page {
     return browser.$("#engagementDate")
   }
 
-  get today() {
-    return browser.$(".bp3-datepicker-footer > button:first-child")
-  }
-
   get tomorrow() {
     const tomorrow = moment().add(1, "day").format("ddd MMM DD YYYY")
     return browser.$(`div[aria-label="${tomorrow}"]`)
-  }
-
-  get hour() {
-    return browser.$("input.bp3-timepicker-input.bp3-timepicker-hour")
-  }
-
-  get minute() {
-    return browser.$("input.bp3-timepicker-input.bp3-timepicker-minute")
   }
 
   get duration() {
@@ -61,52 +49,15 @@ class CreateReport extends Page {
     super.open(PAGE_URL)
   }
 
-  getAdvisorByName(name) {
-    const advisor = browser
-      .$$("#reportPeopleContainer .advisorAttendeesTable tbody tr")
-      .find(r => {
-        return (
-          r.$("td.reportPeopleName").isExisting() &&
-          r.$("td.reportPeopleName").getText() === name
-        )
-      })
-
-    if (!advisor) {
-      return null
-    }
-    // wait for conflict loader to disappear
-    advisor
-      .$("td.conflictButton div.bp3-spinner")
-      .waitForExist({ reverse: true })
-
-    const result = {
-      name: advisor.$("td.reportPeopleName").getText(),
-      conflictButton: advisor.$("td.conflictButton > span")
-    }
-
-    return result
-  }
-
-  getPrincipalByName(name) {
-    // principals table has an empty row at top
-    const principal = browser
-      .$$("#reportPeopleContainer .principalAttendeesTable tbody tr")
-      .find(
-        r =>
-          r.$("td.reportPeopleName").isExisting() &&
-          r.$("td.reportPeopleName").getText() === name
-      )
-    if (!principal) {
-      return null
-    }
-    // wait for conflict loader to disappear
-    principal
-      .$("td.conflictButton div.bp3-spinner")
-      .waitForExist({ reverse: true })
+  getPersonByName(name) {
+    const personRow = browser.$$(
+      `//div[@id="reportPeopleContainer"]//tr[td[@class="reportPeopleName" and ./a[text()="${name}"]]]/td[@class="conflictButton" or @class="reportPeopleName"]`
+    )
+    personRow[0].$("div.bp3-spinner").waitForExist({ reverse: true })
 
     return {
-      name: principal.$("td.reportPeopleName").getText(),
-      conflictButton: principal.$("td.conflictButton > span")
+      name: personRow[1].getText(),
+      conflictButton: personRow[0].$("./span")
     }
   }
 
@@ -127,7 +78,7 @@ class CreateReport extends Page {
       checkBox.click()
     }
     this.title.click()
-    this.reportPeopleTable.waitForDisplayed({ reverse: true })
+    this.reportPeopleTable.waitForExist({ reverse: true, timeout: 3000 })
   }
 
   fillForm(fields) {
@@ -143,22 +94,10 @@ class CreateReport extends Page {
       this.engagementDate.waitForClickable()
       this.engagementDate.click()
       this.tomorrow.waitForDisplayed()
-      this.tomorrow.waitForClickable()
-      browser.pause(300) // wait for calendar popup animation
-      this.tomorrow.click()
-      browser.waitUntil(() => !!browser.$("#engagementDate").getValue())
-      this.hour.waitForDisplayed()
-      this.hour.waitForClickable()
-      this.hour.click()
-      browser.keys(fields.engagementDate.format("HH"))
-      this.minute.waitForDisplayed()
-      this.minute.waitForClickable()
-      this.minute.click()
-      browser.keys(fields.engagementDate.format("mm"))
-      this.engagementDate.click()
+      browser.keys(fields.engagementDate.format("DD-MM-YYYY HH:mm"))
 
       this.title.click()
-      this.tomorrow.waitForDisplayed({ reverse: true })
+      this.tomorrow.waitForExist({ reverse: true, timeout: 3000 })
     }
 
     if (fields.duration !== undefined) {
@@ -175,7 +114,9 @@ class CreateReport extends Page {
   }
 
   submitForm() {
+    this.submitButton.waitForClickable()
     this.submitButton.click()
+    this.submitButton.waitForExist({ reverse: true })
   }
 }
 

--- a/client/tests/webdriver/pages/report/showReport.page.js
+++ b/client/tests/webdriver/pages/report/showReport.page.js
@@ -81,10 +81,11 @@ class ShowReport extends Page {
   }
 
   waitForShowReportToLoad() {
-    if (!this.reportStatus.isDisplayed()) {
-      this.reportStatus.waitForExist()
-      this.reportStatus.waitForDisplayed()
-    }
+    browser.waitUntil(() =>
+      /^.*\/reports\/[a-z0-9-]{36}/.test(browser.getUrl())
+    )
+    this.reportStatus.waitForExist()
+    this.reportStatus.waitForDisplayed()
   }
 }
 

--- a/client/tests/webdriver/specs/createReportWithPlanningConflict.spec.js
+++ b/client/tests/webdriver/specs/createReportWithPlanningConflict.spec.js
@@ -41,15 +41,15 @@ describe("When creating a Report with conflicts", () => {
       report01.engagementDate.format("DD-MM-YYYY HH:mm")
     )
     expect(CreateReport.duration.getValue()).to.equal(report01.duration)
-    const advisor01 = CreateReport.getAdvisorByName("CIV ERINSON, Erin")
+    const advisor01 = CreateReport.getPersonByName("CIV ERINSON, Erin")
     expect(advisor01.name).to.equal("CIV ERINSON, Erin")
     expect(advisor01.conflictButton.isExisting()).to.equal(false)
 
-    const advisor02 = CreateReport.getAdvisorByName(report01.advisors[0])
+    const advisor02 = CreateReport.getPersonByName(report01.advisors[0])
     expect(advisor02.name).to.equal(report01.advisors[0])
     expect(advisor02.conflictButton.isExisting()).to.equal(false)
 
-    const principal01 = CreateReport.getPrincipalByName(report01.principals[0])
+    const principal01 = CreateReport.getPersonByName(report01.principals[0])
     expect(principal01.name).to.equal(report01.principals[0])
     expect(principal01.conflictButton.isExisting()).to.equal(false)
 
@@ -73,23 +73,23 @@ describe("When creating a Report with conflicts", () => {
       report02.engagementDate.format("DD-MM-YYYY HH:mm")
     )
     expect(CreateReport.duration.getValue()).to.equal(report02.duration)
-    const advisor01 = CreateReport.getAdvisorByName("CIV ERINSON, Erin")
+    const advisor01 = CreateReport.getPersonByName("CIV ERINSON, Erin")
     expect(advisor01.name).to.equal("CIV ERINSON, Erin")
     expect(advisor01.conflictButton.isExisting()).to.equal(true)
 
-    const advisor02 = CreateReport.getAdvisorByName(report02.advisors[0])
+    const advisor02 = CreateReport.getPersonByName(report02.advisors[0])
     expect(advisor02.name).to.equal(report02.advisors[0])
     expect(advisor02.conflictButton.isExisting()).to.equal(true)
 
-    const advisor03 = CreateReport.getAdvisorByName(report02.advisors[1])
+    const advisor03 = CreateReport.getPersonByName(report02.advisors[1])
     expect(advisor03.name).to.equal(report02.advisors[1])
     expect(advisor03.conflictButton.isExisting()).to.equal(false)
 
-    const principal01 = CreateReport.getPrincipalByName(report02.principals[0])
+    const principal01 = CreateReport.getPersonByName(report02.principals[0])
     expect(principal01.name).to.equal(report02.principals[0])
     expect(principal01.conflictButton.isExisting()).to.equal(true)
 
-    const principal02 = CreateReport.getPrincipalByName(report02.principals[1])
+    const principal02 = CreateReport.getPersonByName(report02.principals[1])
     expect(principal02.name).to.equal(report02.principals[1])
     expect(principal02.conflictButton.isExisting()).to.equal(false)
 

--- a/client/tests/webdriver/specs/editLocation.spec.js
+++ b/client/tests/webdriver/specs/editLocation.spec.js
@@ -27,7 +27,7 @@ describe("When editing a location", () => {
     expect(EditLocation.lngInputField.getValue()).toEqual(LOCATION_COORDS.lng)
   })
 
-  it("Should correctly edit input fields and display the correct values in both formats in the popover window", () => {
+  it("Should correctly edit and save input fields and display the correct values in both formats in the popover window", () => {
     editLatLngFields()
     EditLocation.allFormatsPopover.click()
     EditLocation.allFormatsPopoverLat.waitForExist()
@@ -38,13 +38,11 @@ describe("When editing a location", () => {
     expect(EditLocation.allFormatsPopoverMGRS.getText()).toEqual(
       NEW_COORDS.mgrs
     )
-  })
 
-  it("Should successfully save and saved location should have the correct values for the lat-lng fields", () => {
-    editLatLngFields()
     EditLocation.saveLocationButton.click()
     ShowLocation.successMsg.waitForExist()
     ShowLocation.successMsg.waitForDisplayed()
+
     expect(ShowLocation.latField.getText()).toEqual(NEW_COORDS.lat)
     expect(ShowLocation.lngField.getText()).toEqual(NEW_COORDS.lng)
   })

--- a/client/tests/webdriver/specs/editPosition.spec.js
+++ b/client/tests/webdriver/specs/editPosition.spec.js
@@ -58,6 +58,9 @@ describe("Create position page", () => {
       EditPosition.orgAdvancedSelectFirstItem.click()
       expect(EditPosition.organizationInput.getValue()).to.equal(PRINCIPAL_ORG)
       EditPosition.cancelButton.click()
+
+      // prevents "unexpected alert open" errors on BrowserStack
+      browser.acceptAlert()
     })
   })
 })


### PR DESCRIPTION
wdio e2e test were failing randomly. I have continuously run the tests on BrowserStack in order to observe the problem. After detailed investigation it turns out that `createReportWithPlanningConflict` tests were suffering from timeout because this particular suit took 4-5 minutes (on BrowserStack) to run on average. Particularly `"Should create second draft report with conflicts"` spec was intermittently taking more than 90 seconds to run. I made changes to element queries in order to reduce run time and increased the timeout duration for test runner. As a result timeout related failures _almost_ disappeared.

![image](https://user-images.githubusercontent.com/62024178/99633155-7f369a80-2a4f-11eb-857c-a93d5e6fe30e.png)

As can be seen in the screenshot above out of 1315 spec (~77 runs for whole suit) runs only 1 failure happened. And that particular failure is also happened due to a timeout but as can be seen in the raw webdriver logs in the following screenshot and BrowserStack logs on the latter secreenshot, webdriver waits for more than 60 seconds between two consecutive requests for querying an element. I couldn't figure out the reason for that as it is almost impossible to reproduce and debug any further.

![image](https://user-images.githubusercontent.com/62024178/99633891-b0fc3100-2a50-11eb-9478-e817dd7d099c.png)

![image](https://user-images.githubusercontent.com/62024178/99634414-852d7b00-2a51-11eb-9ed9-b19bc7880ec7.png)

Consequnetly `createReportWithPlanningConflict` suit's run time has decreased to ~3-3.5 minutes and `"Should create second draft report with conflicts"` specs run time has decreased by ~20 seconds. Even though there was an intermittent test failure, this PR will significantly reduce the timeout related issues, hopefully.

I also had to tweak `editLocations` and `editPositions` specs because they were also suffering from an `unexpected alert open` error on BrowserStack.

UPDATE:
I have merged these changes into my local [keycloak-integration branch](https://github.com/NCI-Agency/anet/tree/keycloak-integration) and wdio-tests have been running on BrowserStack for almost 24 hours. All wdio-tests ran more than 100 times without any failures. Last two sessions in the following screenshot doesn't have any failures. (Both sessions are timed out by BrowserStack btw :slightly_smiling_face: hence the yellow warning icons).

![image](https://user-images.githubusercontent.com/62024178/99802111-28f95280-2b48-11eb-958d-c2d55a1a9aba.png)

Closes #

#### User changes
-

#### Super User changes
-

#### Admin changes
-

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [ ] Described the user behavior in PR body
  - [ ] Referenced/updated all related issues
  - [ ] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [ ] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [x] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [ ] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
