### PR TITLE
Fix double warning messages on report forms

### DIFF
--- a/client/src/models/Report.js
+++ b/client/src/models/Report.js
@@ -171,85 +171,61 @@ export default class Report extends Model {
       reportPeople: yup
         .array()
         .nullable()
-        .test(
-          "primary-principal",
-          "primary principal error",
-          // can't use arrow function here because of binding to 'this'
-          function(reportPeople) {
-            const err = Report.checkPrimaryAttendee(
-              reportPeople,
-              Person.ROLE.PRINCIPAL
-            )
-            return err ? this.createError({ message: err }) : true
-          }
-        )
-        .test(
-          "primary-advisor",
-          "primary advsior error",
-          // can't use arrow function here because of binding to 'this'
-          function(reportPeople) {
-            const err = Report.checkPrimaryAttendee(
-              reportPeople,
-              Person.ROLE.ADVISOR
-            )
-            return err ? this.createError({ message: err }) : true
-          }
-        )
-        .test(
-          "attending-author",
-          "no attending author error",
-          // can't use arrow function here because of binding to 'this'
-          function(reportPeople) {
-            const err = Report.checkAttendingAuthor(reportPeople)
-            return err ? this.createError({ message: err }) : true
-          }
-        )
-        .test(
-          "no-author",
-          "no author error",
-          // can't use arrow function here because of binding to 'this'
-          function(reportPeople) {
-            const err = Report.checkAnyAuthor(reportPeople)
-            return err ? this.createError({ message: err }) : true
-          }
-        )
-        .test(
-          "purposeless-people",
-          "purposeless people error",
-          // can't use arrow function here because of binding to 'this'
-          function(reportPeople) {
-            const err = Report.checkUnInvolvedPeople(reportPeople)
-            return err ? this.createError({ message: err }) : true
-          }
-        )
         .when("cancelled", (cancelled, schema) =>
           cancelled
             ? schema.nullable()
-            : schema.test(
-              "primary-advisor",
-              "primary advisor error",
-              // can't use arrow function here because of binding to 'this'
-              function(reportPeople) {
-                const err = Report.checkPrimaryAttendee(
-                  reportPeople,
-                  Person.ROLE.ADVISOR
-                )
-                return err ? this.createError({ message: err }) : true
-              }
-            )
-        )
-        .when("cancelled", (cancelled, schema) =>
-          cancelled
-            ? schema.nullable()
-            : schema.test(
-              "attending-author",
-              "no attending author error",
-              // can't use arrow function here because of binding to 'this'
-              function(reportPeople) {
-                const err = Report.checkAttendingAuthor(reportPeople)
-                return err ? this.createError({ message: err }) : true
-              }
-            )
+            : schema // Only do validation warning when engagement not cancelled
+              .test(
+                "primary-principal",
+                "primary principal error",
+                // can't use arrow function here because of binding to 'this'
+                function(reportPeople) {
+                  const err = Report.checkPrimaryAttendee(
+                    reportPeople,
+                    Person.ROLE.PRINCIPAL
+                  )
+                  return err ? this.createError({ message: err }) : true
+                }
+              )
+              .test(
+                "primary-advisor",
+                "primary advisor error",
+                // can't use arrow function here because of binding to 'this'
+                function(reportPeople) {
+                  const err = Report.checkPrimaryAttendee(
+                    reportPeople,
+                    Person.ROLE.ADVISOR
+                  )
+                  return err ? this.createError({ message: err }) : true
+                }
+              )
+              .test(
+                "no-author",
+                "no author error",
+                // can't use arrow function here because of binding to 'this'
+                function(reportPeople) {
+                  const err = Report.checkAnyAuthor(reportPeople)
+                  return err ? this.createError({ message: err }) : true
+                }
+              )
+              .test(
+                "attending-author",
+                "no attending author error",
+                // can't use arrow function here because of binding to 'this'
+                function(reportPeople) {
+                  const err = Report.checkAttendingAuthor(reportPeople)
+                  return err ? this.createError({ message: err }) : true
+                }
+              )
+              .test(
+                "purposeless-people",
+                "purposeless people error",
+                // can't use arrow function here because of binding to 'this'
+                function(reportPeople) {
+                  const err = Report.checkUnInvolvedPeople(reportPeople)
+                  return err ? this.createError({ message: err }) : true
+                }
+              )
         )
         .default([]),
       principalOrg: yup.object().nullable().default({}),


### PR DESCRIPTION
Currently, when a report is being created some warnings are shown multiple times. Also we don't show any warning when a report is in CANCELLED state, so we shouldn't validate the form in that case

Example screenshot:
![double-warnings](https://user-images.githubusercontent.com/69463668/99665479-bb332500-2a7a-11eb-9c52-61f405b199b7.png)


#### User changes
- Users will not see the same warning messages multiple times.

#### Super User changes
-

#### Admin changes
-

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [X] Described the user behavior in PR body
  - [ ] Referenced/updated all related issues
  - [ ] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [X] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [X] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
