### PR TITLE
Removes the service script from RPM dist (workaround)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -565,34 +565,33 @@ node {
 }
 
 ospackage {
-        release = '2'
-        os = LINUX
-
-        into '/opt'
-		from(jpackageImage.outputs.files)
-		from('anet.yml') {
-			rename('anet.yml', 'anet.yml.template')
-			into 'anet/docs'
+	release = '2'
+	os = LINUX
+	into '/opt'
+	from(jpackageImage.outputs.files)
+	from('anet.yml') {
+		rename('anet.yml', 'anet.yml.template')
+		into 'anet/docs'
+	}
+	from('docs/INSTALL.md') { into 'anet/docs' }
+	from('docs/TROUBLESHOOT.md') { into 'anet/docs' }
+	from('anet-dictionary.yml') {
+		rename('anet-dictionary.yml', 'anet-dictionary.yml.template')
+		into 'anet/docs'
 		}
-		from('scripts/anet.service') { into '/etc/systemd/system' }
-		from('docs/INSTALL.md') { into 'anet/docs' }
-		from('docs/TROUBLESHOOT.md') { into 'anet/docs' }
-		from('anet-dictionary.yml') {
-			rename('anet-dictionary.yml', 'anet-dictionary.yml.template')
-			into 'anet/docs'
+	from('prepare-psql.sql') {
+		into 'anet/docs'
+	}
+	from('prepare-mssql.sql') {
+		into 'anet/docs'
 			}
-		from('prepare-psql.sql') {
-			into 'anet/docs'
-		}
-		from('prepare-mssql.sql') {
-			into 'anet/docs'
-        }
-    }
+	}
 
 task distDeb(dependsOn: "jpackageImage",type: Deb) {
-        arch = 'amd64'
+	arch = 'amd64'
 }
 
 task distRpm(dependsOn: "jpackageImage",type: Rpm) {
-		arch = 'x86_64'
+	prefix '/opt' // Relocations: /opt
+	arch = 'x86_64'
 }


### PR DESCRIPTION
Removes the service script from the distribution as a workaround for #3303.

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [ ] Described the user behavior in PR body
  - [ ] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [ ] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
