### PR TITLE
Don't show assessments for future engagements

### DIFF
--- a/client/src/components/CustomFields.js
+++ b/client/src/components/CustomFields.js
@@ -659,10 +659,14 @@ function getInvisibleFields(
 export const CustomFieldsContainer = props => {
   const { parentFieldName, formikProps } = props
   const [invisibleFields, setInvisibleFields] = useState([])
+  const prevInvisibleFields = useRef(invisibleFields)
   const { setFieldValue } = formikProps
   const invisibleFieldsFieldName = `${parentFieldName}.${INVISIBLE_CUSTOM_FIELDS_FIELD}`
   useEffect(() => {
-    setFieldValue(invisibleFieldsFieldName, invisibleFields, true)
+    if (!_isEqual(invisibleFields, prevInvisibleFields.current)) {
+      prevInvisibleFields.current = invisibleFields
+      setFieldValue(invisibleFieldsFieldName, invisibleFields, true)
+    }
   }, [invisibleFieldsFieldName, invisibleFields, setFieldValue])
 
   return (
@@ -718,6 +722,7 @@ const CustomField = ({
   const { type, helpText } = fieldConfig
   const fieldProps = getFieldPropsFromFieldConfig(fieldConfig)
   const { setFieldValue, setFieldTouched, validateForm } = formikProps
+  const prevVal = useRef()
   const { callback: validateFormDebounced } = useDebouncedCallback(
     validateForm,
     400
@@ -728,7 +733,10 @@ const CustomField = ({
         value?.target?.value !== undefined ? value.target.value : value
       const sv = shouldValidate === undefined ? true : shouldValidate
       setFieldTouched(fieldName, true, false)
-      setFieldValue(fieldName, val, sv)
+      if (!_isEqual(val, prevVal.current)) {
+        prevVal.current = val
+        setFieldValue(fieldName, val, sv)
+      }
       if (!sv) {
         validateFormDebounced()
       }

--- a/client/src/pages/reports/Form.js
+++ b/client/src/pages/reports/Form.js
@@ -433,6 +433,7 @@ const ReportForm = ({
           </div>
         )
         const isFutureEngagement = Report.isFuture(values.engagementDate)
+        const hasAssessments = values.engagementDate && !isFutureEngagement
         return (
           <div className="report-form">
             <NavigationWarning isBlocking={dirty} />
@@ -1021,45 +1022,51 @@ const ReportForm = ({
                 </Collapse>
               </Fieldset>
 
-              <Fieldset
-                title="Attendees engagement assessments"
-                id="attendees-engagement-assessments"
-              >
-                <InstantAssessmentsContainerField
-                  entityType={Person}
-                  entities={values.reportPeople?.filter(rp => rp.attendee)}
-                  entitiesInstantAssessmentsConfig={
-                    attendeesInstantAssessmentsConfig
-                  }
-                  parentFieldName={Report.ATTENDEES_ASSESSMENTS_PARENT_FIELD}
-                  formikProps={{
-                    setFieldTouched,
-                    setFieldValue,
-                    values,
-                    validateForm
-                  }}
-                />
-              </Fieldset>
+              {hasAssessments && (
+                <>
+                  <Fieldset
+                    title="Attendees engagement assessments"
+                    id="attendees-engagement-assessments"
+                  >
+                    <InstantAssessmentsContainerField
+                      entityType={Person}
+                      entities={values.reportPeople?.filter(rp => rp.attendee)}
+                      entitiesInstantAssessmentsConfig={
+                        attendeesInstantAssessmentsConfig
+                      }
+                      parentFieldName={
+                        Report.ATTENDEES_ASSESSMENTS_PARENT_FIELD
+                      }
+                      formikProps={{
+                        setFieldTouched,
+                        setFieldValue,
+                        values,
+                        validateForm
+                      }}
+                    />
+                  </Fieldset>
 
-              <Fieldset
-                title={`${Settings.fields.task.subLevel.longLabel} engagement assessments`}
-                id="tasks-engagement-assessments"
-              >
-                <InstantAssessmentsContainerField
-                  entityType={Task}
-                  entities={values.tasks}
-                  entitiesInstantAssessmentsConfig={
-                    tasksInstantAssessmentsConfig
-                  }
-                  parentFieldName={Report.TASKS_ASSESSMENTS_PARENT_FIELD}
-                  formikProps={{
-                    setFieldTouched,
-                    setFieldValue,
-                    values,
-                    validateForm
-                  }}
-                />
-              </Fieldset>
+                  <Fieldset
+                    title={`${Settings.fields.task.subLevel.longLabel} engagement assessments`}
+                    id="tasks-engagement-assessments"
+                  >
+                    <InstantAssessmentsContainerField
+                      entityType={Task}
+                      entities={values.tasks}
+                      entitiesInstantAssessmentsConfig={
+                        tasksInstantAssessmentsConfig
+                      }
+                      parentFieldName={Report.TASKS_ASSESSMENTS_PARENT_FIELD}
+                      formikProps={{
+                        setFieldTouched,
+                        setFieldValue,
+                        values,
+                        validateForm
+                      }}
+                    />
+                  </Fieldset>
+                </>
+              )}
 
               <div className="submit-buttons">
                 <div>
@@ -1258,7 +1265,7 @@ const ReportForm = ({
     const edit = isEditMode(values)
     // After successful submit, reset the form in order to make sure the dirty
     // prop is also reset (otherwise we would get a blocking navigation warning)
-    resetForm()
+    resetForm({ isSubmitting: true })
     if (!edit) {
       history.replace(Report.pathForEdit(report))
     }

--- a/client/src/pages/reports/Form.js
+++ b/client/src/pages/reports/Form.js
@@ -1090,6 +1090,7 @@ const ReportForm = ({
                       objectDisplay={values.uuid}
                       bsStyle="warning"
                       buttonLabel={`Delete this ${getReportType(values)}`}
+                      disabled={isSubmitting}
                     />
                   )}
                   {/* Skip validation on save! */}
@@ -1237,7 +1238,7 @@ const ReportForm = ({
       .then(data => {
         // After successful delete, reset the form in order to make sure the dirty
         // prop is also reset (otherwise we would get a blocking navigation warning)
-        resetForm()
+        resetForm({ isSubmitting: true })
         history.push("/", { success: "Report deleted" })
       })
       .catch(error => {

--- a/client/src/pages/reports/Show.js
+++ b/client/src/pages/reports/Show.js
@@ -369,8 +369,11 @@ const ReportShow = ({ setSearchQuery, pageDispatchers }) => {
     report.authorizationGroups && report.authorizationGroups.length > 0
 
   // Get initial tasks/people instant assessments values
-  report = Object.assign(report, report.getTasksEngagementAssessments())
-  report = Object.assign(report, report.getAttendeesEngagementAssessments())
+  const hasAssessments = report.engagementDate && !report.isFuture()
+  if (hasAssessments) {
+    report = Object.assign(report, report.getTasksEngagementAssessments())
+    report = Object.assign(report, report.getAttendeesEngagementAssessments())
+  }
 
   return (
     <Formik
@@ -677,34 +680,41 @@ const ReportShow = ({ setSearchQuery, pageDispatchers }) => {
                   />
                 </Fieldset>
               )}
-              <Fieldset
-                title="Attendees engagement assessments"
-                id="attendees-engagement-assessments"
-              >
-                <InstantAssessmentsContainerField
-                  entityType={Person}
-                  entities={values.reportPeople?.filter(rp => rp.attendee)}
-                  parentFieldName={Report.ATTENDEES_ASSESSMENTS_PARENT_FIELD}
-                  formikProps={{
-                    values
-                  }}
-                  readonly
-                />
-              </Fieldset>
-              <Fieldset
-                title={`${Settings.fields.task.subLevel.longLabel} engagement assessments`}
-                id="tasks-engagement-assessments"
-              >
-                <InstantAssessmentsContainerField
-                  entityType={Task}
-                  entities={values.tasks}
-                  parentFieldName={Report.TASKS_ASSESSMENTS_PARENT_FIELD}
-                  formikProps={{
-                    values
-                  }}
-                  readonly
-                />
-              </Fieldset>
+              {hasAssessments && (
+                <>
+                  <Fieldset
+                    title="Attendees engagement assessments"
+                    id="attendees-engagement-assessments"
+                  >
+                    <InstantAssessmentsContainerField
+                      entityType={Person}
+                      entities={values.reportPeople?.filter(rp => rp.attendee)}
+                      parentFieldName={
+                        Report.ATTENDEES_ASSESSMENTS_PARENT_FIELD
+                      }
+                      formikProps={{
+                        values
+                      }}
+                      readonly
+                    />
+                  </Fieldset>
+
+                  <Fieldset
+                    title={`${Settings.fields.task.subLevel.longLabel} engagement assessments`}
+                    id="tasks-engagement-assessments"
+                  >
+                    <InstantAssessmentsContainerField
+                      entityType={Task}
+                      entities={values.tasks}
+                      parentFieldName={Report.TASKS_ASSESSMENTS_PARENT_FIELD}
+                      formikProps={{
+                        values
+                      }}
+                      readonly
+                    />
+                  </Fieldset>
+                </>
+              )}
               {report.showWorkflow() && (
                 <ReportFullWorkflow workflow={report.workflow} />
               )}

--- a/client/tests/webdriver/pages/createFutureReport.page.js
+++ b/client/tests/webdriver/pages/createFutureReport.page.js
@@ -1,0 +1,92 @@
+import { CreateReport } from "./createReport.page"
+
+const PAGE_URL = "/reports/new"
+
+const attId = "reportPeople"
+const tskId = "tasks"
+
+class CreateFutureReport extends CreateReport {
+  get engagementDate() {
+    return browser.$('input[id="engagementDate"]')
+  }
+
+  get attendeesFieldFormGroup() {
+    return browser.$(`div[id="fg-${attId}"]`)
+  }
+
+  get attendeesFieldLabel() {
+    return this.attendeesFieldFormGroup.$(`label[for="${attId}"]`)
+  }
+
+  get attendeesField() {
+    return this.attendeesFieldFormGroup.$(`input[id="${attId}"]`)
+  }
+
+  get attendeesFieldAdvancedSelectFirstItem() {
+    return this.attendeesFieldFormGroup.$(
+      `div[id="${attId}-popover"] tbody tr:first-child td:nth-child(2)`
+    )
+  }
+
+  get attendeesFieldValue() {
+    return this.attendeesFieldFormGroup.$(
+      `div[id="${attId}Container"] .principalAttendeesTable`
+    )
+  }
+
+  getAttendeesFieldValueRow(n) {
+    return this.attendeesFieldValue.$(`tbody tr:nth-child(${n})`)
+  }
+
+  get attendeesAssessments() {
+    return browser.$("#attendees-engagement-assessments")
+  }
+
+  getAttendeeAssessment(name) {
+    return this.attendeesAssessments.$(`//td/a[text()="${name}"]`)
+  }
+
+  get tasksFieldFormGroup() {
+    return browser.$(`div[id="fg-${tskId}"]`)
+  }
+
+  get tasksFieldLabel() {
+    return this.tasksFieldFormGroup.$(`label[for="${tskId}"]`)
+  }
+
+  get tasksField() {
+    return this.tasksFieldFormGroup.$(`input[id="${tskId}"]`)
+  }
+
+  get tasksFieldAdvancedSelectFirstItem() {
+    return this.tasksFieldFormGroup.$(
+      `div[id="${tskId}-popover"] tbody tr:first-child td:nth-child(2)`
+    )
+  }
+
+  get tasksFieldValue() {
+    return this.tasksFieldFormGroup.$(`div[id="${tskId}-${tskId}"]`)
+  }
+
+  getTasksFieldValueRow(n) {
+    return this.tasksFieldValue.$(`tbody tr:nth-child(${n})`)
+  }
+
+  get tasksAssessments() {
+    return browser.$("#tasks-engagement-assessments")
+  }
+
+  getTaskAssessment(shortName) {
+    return this.tasksAssessments.$(`//td/a[text()="${shortName}"]`)
+  }
+
+  get deleteButton() {
+    return browser.$('//button[text()="Delete this planned engagement"]')
+  }
+
+  open() {
+    super.open(PAGE_URL, "selena")
+  }
+}
+
+export default new CreateFutureReport()

--- a/client/tests/webdriver/pages/createReport.page.js
+++ b/client/tests/webdriver/pages/createReport.page.js
@@ -5,7 +5,7 @@ const PAGE_URL = "/reports/new"
 const trfId = "formCustomFields.relatedReport"
 const tmrfId = "formCustomFields.additionalEngagementNeeded"
 
-class CreateReport extends Page {
+export class CreateReport extends Page {
   get form() {
     return browser.$("form")
   }
@@ -110,8 +110,8 @@ class CreateReport extends Page {
     )
   }
 
-  open() {
-    super.open(PAGE_URL)
+  open(pathName = PAGE_URL, credentials = Page.DEFAULT_CREDENTIALS.user) {
+    super.open(pathName, credentials)
   }
 
   waitForAlertToLoad() {

--- a/client/tests/webdriver/specs/createFutureReport.spec.js
+++ b/client/tests/webdriver/specs/createFutureReport.spec.js
@@ -1,0 +1,203 @@
+import { expect } from "chai"
+import moment from "moment"
+import CreateFutureReport from "../pages/createFutureReport.page"
+
+const PRINCIPAL = "Christopf"
+const PRINCIPAL_VALUE = `CIV TOPFERNESS, ${PRINCIPAL}`
+
+const TASK = "1.2.A"
+const TASK_VALUE = `${TASK}`
+
+const ENGAGEMENT_DATE_FORMAT = "DD-MM-YYYY HH:mm"
+const SHORT_WAIT_MS = 1000
+
+describe("Create report form page", () => {
+  describe("When creating a report", () => {
+    it("Should be able to load the form", () => {
+      CreateFutureReport.open()
+      CreateFutureReport.form.waitForExist()
+      CreateFutureReport.form.waitForDisplayed()
+    })
+
+    it("Should be able to select principal and task", () => {
+      CreateFutureReport.attendeesFieldLabel.waitForExist()
+      CreateFutureReport.attendeesFieldLabel.waitForDisplayed()
+      // Don't set engagementDate yet
+
+      // Select principal
+      CreateFutureReport.attendeesFieldLabel.click()
+      CreateFutureReport.attendeesField.setValue(PRINCIPAL)
+      CreateFutureReport.waitForAdvancedSelectToChange(
+        CreateFutureReport.attendeesFieldAdvancedSelectFirstItem,
+        PRINCIPAL_VALUE
+      )
+      expect(
+        CreateFutureReport.attendeesFieldAdvancedSelectFirstItem.getText()
+      ).to.include(PRINCIPAL_VALUE)
+      CreateFutureReport.attendeesFieldAdvancedSelectFirstItem.click()
+      // Click outside the overlay
+      CreateFutureReport.engagementInformationTitle.click()
+      /* eslint-disable no-unused-expressions */
+      // Advanced select input gets empty, the selected element is shown below the input
+      expect(CreateFutureReport.attendeesField.getValue()).to.be.empty
+      // Value should exist now
+      expect(CreateFutureReport.attendeesFieldValue.isExisting()).to.be.true
+      /* eslint-enable no-unused-expressions */
+      expect(
+        CreateFutureReport.getAttendeesFieldValueRow(2).getText()
+      ).to.include(PRINCIPAL_VALUE)
+
+      // Select task
+      CreateFutureReport.tasksFieldLabel.click()
+      CreateFutureReport.tasksField.setValue(TASK)
+      CreateFutureReport.waitForAdvancedSelectToChange(
+        CreateFutureReport.tasksFieldAdvancedSelectFirstItem,
+        TASK_VALUE
+      )
+      expect(
+        CreateFutureReport.tasksFieldAdvancedSelectFirstItem.getText()
+      ).to.include(TASK_VALUE)
+      CreateFutureReport.tasksFieldAdvancedSelectFirstItem.click()
+      // Click outside the overlay
+      CreateFutureReport.engagementInformationTitle.click()
+      /* eslint-disable no-unused-expressions */
+      // Advanced select input gets empty, the selected element is shown below the input
+      expect(CreateFutureReport.tasksField.getValue()).to.be.empty
+      // Value should exist now
+      expect(CreateFutureReport.tasksFieldValue.isExisting()).to.be.true
+      /* eslint-enable no-unused-expressions */
+      expect(CreateFutureReport.getTasksFieldValueRow(1).getText()).to.include(
+        TASK_VALUE
+      )
+    })
+
+    it("Should not show assessments without engagement date", () => {
+      /* eslint-disable no-unused-expressions */
+      // Attendee assessments should not be shown in the form
+      expect(CreateFutureReport.attendeesAssessments.isExisting()).to.be.false
+      // Task assessments should not be shown in the form
+      expect(CreateFutureReport.tasksAssessments.isExisting()).to.be.false
+      /* eslint-enable no-unused-expressions */
+
+      // Save report
+      CreateFutureReport.submitForm()
+      CreateFutureReport.waitForAlertToLoad()
+      expect(CreateFutureReport.alert.getText()).to.include(
+        "The following errors must be fixed"
+      )
+
+      /* eslint-disable no-unused-expressions */
+      // Attendee assessments should not be shown in the display
+      expect(CreateFutureReport.attendeesAssessments.isExisting()).to.be.false
+      // Task assessments should not be shown in the display
+      expect(CreateFutureReport.tasksAssessments.isExisting()).to.be.false
+      /* eslint-enable no-unused-expressions */
+    })
+
+    it("Should show assessments with past engagement date", () => {
+      // Edit the report
+      CreateFutureReport.editButton.click()
+      CreateFutureReport.attendeesFieldLabel.waitForExist()
+      CreateFutureReport.attendeesFieldLabel.waitForDisplayed()
+
+      // Set engagement date to today
+      CreateFutureReport.engagementDate.setValue(
+        moment().format(ENGAGEMENT_DATE_FORMAT)
+      )
+      // Click outside the overlay
+      CreateFutureReport.engagementInformationTitle.click()
+
+      /* eslint-disable no-unused-expressions */
+      // Attendee assessments should be shown in the form
+      expect(CreateFutureReport.attendeesAssessments.isExisting()).to.be.true
+      expect(
+        CreateFutureReport.getAttendeeAssessment(PRINCIPAL_VALUE).isExisting()
+      ).to.be.true
+      // Task assessments should be shown in the form
+      expect(CreateFutureReport.tasksAssessments.isExisting()).to.be.true
+      expect(CreateFutureReport.getTaskAssessment(TASK_VALUE).isExisting()).to
+        .be.true
+      /* eslint-enable no-unused-expressions */
+
+      // Save report
+      CreateFutureReport.submitForm()
+      CreateFutureReport.waitForAlertToLoad()
+      expect(CreateFutureReport.alert.getText()).to.include(
+        "The following errors must be fixed"
+      )
+
+      /* eslint-disable no-unused-expressions */
+      // Attendee assessments should be shown in the display
+      expect(CreateFutureReport.tasksAssessments.isExisting()).to.be.true
+      expect(
+        CreateFutureReport.getAttendeeAssessment(PRINCIPAL_VALUE).isExisting()
+      ).to.be.true
+      // Task assessments should be shown in the display
+      expect(CreateFutureReport.tasksAssessments.isExisting()).to.be.true
+      expect(CreateFutureReport.getTaskAssessment(TASK_VALUE).isExisting()).to
+        .be.true
+      /* eslint-enable no-unused-expressions */
+    })
+
+    it("Should not show assessments with future engagement date", () => {
+      // Edit the report
+      CreateFutureReport.editButton.click()
+      CreateFutureReport.attendeesFieldLabel.waitForExist()
+      CreateFutureReport.attendeesFieldLabel.waitForDisplayed()
+
+      // Set engagement date to tomorrow
+      CreateFutureReport.engagementDate.click()
+      // Clumsy way to clear input first…
+      browser.keys(
+        ["End"].concat(Array(ENGAGEMENT_DATE_FORMAT.length).fill("Backspace"))
+      )
+      CreateFutureReport.engagementDate.setValue(
+        moment().add(1, "days").format(ENGAGEMENT_DATE_FORMAT)
+      )
+      // Click outside the overlay
+      CreateFutureReport.engagementInformationTitle.click()
+
+      /* eslint-disable no-unused-expressions */
+      // Attendee assessments should not be shown in the form
+      expect(CreateFutureReport.attendeesAssessments.isExisting()).to.be.false
+      // Task assessments should not be shown in the form
+      expect(CreateFutureReport.tasksAssessments.isExisting()).to.be.false
+      /* eslint-enable no-unused-expressions */
+
+      // Save report
+      CreateFutureReport.submitForm()
+      CreateFutureReport.waitForAlertToLoad()
+      expect(CreateFutureReport.alert.getText()).to.include(
+        "You'll need to fill out these required fields before you can submit your final planned engagement"
+      )
+
+      /* eslint-disable no-unused-expressions */
+      // Attendee assessments should not be shown in the display
+      expect(CreateFutureReport.attendeesAssessments.isExisting()).to.be.false
+      // Task assessments should not be shown in the display
+      expect(CreateFutureReport.tasksAssessments.isExisting()).to.be.false
+      /* eslint-enable no-unused-expressions */
+    })
+
+    it("Should be able to delete the report", () => {
+      // Edit the report
+      CreateFutureReport.editButton.click()
+      CreateFutureReport.attendeesFieldLabel.waitForExist()
+      CreateFutureReport.attendeesFieldLabel.waitForDisplayed()
+
+      // Delete it
+      CreateFutureReport.deleteButton.waitForExist()
+      CreateFutureReport.deleteButton.waitForDisplayed()
+      CreateFutureReport.deleteButton.click()
+      // Confirm delete
+      browser.pause(SHORT_WAIT_MS) // wait for the modal to slide in (transition is 300 ms)
+      CreateFutureReport.confirmButton.waitForExist()
+      CreateFutureReport.confirmButton.waitForDisplayed()
+      CreateFutureReport.confirmButton.click()
+      browser.pause(SHORT_WAIT_MS) // wait for the modal to slide out (transition is 300 ms)
+      // Report should be deleted
+      CreateFutureReport.waitForAlertToLoad()
+      expect(CreateFutureReport.alert.getText()).to.include("Report deleted")
+    })
+  })
+})

--- a/client/tests/webdriver/specs/createReport.spec.js
+++ b/client/tests/webdriver/specs/createReport.spec.js
@@ -63,7 +63,7 @@ describe("Create report form page", () => {
       CreateReport.testReferenceFieldAdvancedSelectFirstItem.click()
       // Advanced select input gets empty, the selected element shown below the input
       // eslint-disable-next-line no-unused-expressions
-      expect(CreateReport.testReferenceFieldLabel.getValue()).to.be.null
+      expect(CreateReport.testReferenceField.getValue()).to.be.empty
       // Value should exist now
       // eslint-disable-next-line no-unused-expressions
       expect(CreateReport.testReferenceFieldValue.isExisting()).to.be.true
@@ -124,7 +124,7 @@ describe("Create report form page", () => {
       CreateReport.engagementInformationTitle.click()
       // Advanced select input gets empty, the selected element shown below the input
       // eslint-disable-next-line no-unused-expressions
-      expect(CreateReport.testMultiReferenceFieldLabel.getValue()).to.be.null
+      expect(CreateReport.testMultiReferenceField.getValue()).to.be.empty
       // Value should exist now
       // eslint-disable-next-line no-unused-expressions
       expect(CreateReport.testMultiReferenceFieldValue.isExisting()).to.be.true
@@ -170,7 +170,7 @@ describe("Create report form page", () => {
       CreateReport.engagementInformationTitle.click()
       // Advanced select input gets empty, the selected element shown below the input
       // eslint-disable-next-line no-unused-expressions
-      expect(CreateReport.testMultiReferenceFieldLabel.getValue()).to.be.null
+      expect(CreateReport.testMultiReferenceField.getValue()).to.be.empty
       // Value should exist now
       // eslint-disable-next-line no-unused-expressions
       expect(CreateReport.testMultiReferenceFieldValue.isExisting()).to.be.true

--- a/insertBaseData-mssql.sql
+++ b/insertBaseData-mssql.sql
@@ -63,6 +63,8 @@ INSERT INTO people (uuid, name, status, role, emailAddress, phoneNumber, rank, b
 INSERT INTO people (uuid, name, status, role, emailAddress, phoneNumber, rank, biography, domainUsername, country, gender, endOfTourDate, createdAt, updatedAt)
 	VALUES (lower(newid()), 'ELIZAWELL, Elizabeth', 0, 0, 'hunter+liz@example.com', '+1-777-7777', 'Capt', 'Elizabeth is a test advisor we have in the database who is in EF 1.1', 'elizabeth', 'United States of America', 'FEMALE', DATEADD(year, 1, CURRENT_TIMESTAMP), CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
 INSERT INTO people (uuid, name, status, role, emailAddress, phoneNumber, rank, biography, domainUsername, country, gender, endOfTourDate, createdAt, updatedAt)
+	VALUES (lower(newid()), 'SOLENOID, Selena', 0, 0, 'hunter+selena@example.com', '+1-111-1111', 'CIV', 'Selena is a test advisor in EF 1.2', 'selena', 'United States of America', 'FEMALE', DATEADD(year, 1, CURRENT_TIMESTAMP), CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+INSERT INTO people (uuid, name, status, role, emailAddress, phoneNumber, rank, biography, domainUsername, country, gender, endOfTourDate, createdAt, updatedAt)
 	VALUES (lower(newid()), 'ERINSON, Erin', 0, 0, 'hunter+erin@example.com', '+9-23-2323-2323', 'CIV', 'Erin is an Advisor in EF 2.2 who can approve reports', 'erin', 'Australia', 'FEMALE', DATEADD(year, 1, CURRENT_TIMESTAMP), CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
 INSERT INTO people (uuid, name, status, role, emailAddress, phoneNumber, rank, biography, domainUsername, country, gender, endOfTourDate, createdAt, updatedAt)
 	VALUES (lower(newid()), 'REINTON, Reina', 0, 0, 'hunter+reina@example.com', '+23-23-11222', 'CIV', 'Reina is an Advisor in EF 2.2', 'reina', 'Italy', 'FEMALE', DATEADD(year, 1, CURRENT_TIMESTAMP), CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
@@ -130,6 +132,8 @@ INSERT INTO positions (uuid, name, type, status, currentPersonUuid, createdAt, u
 INSERT INTO positions (uuid, name, type, status, currentPersonUuid, createdAt, updatedAt)
 	VALUES (lower(newid()), 'EF 1.1 SuperUser', 2, 0, NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
 INSERT INTO positions (uuid, name, type, status, currentPersonUuid, createdAt, updatedAt)
+	VALUES (lower(newid()), 'EF 1.2 Advisor', 0, 0, NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+INSERT INTO positions (uuid, name, type, status, currentPersonUuid, createdAt, updatedAt)
 	VALUES (lower(newid()), 'EF 2.1 Advisor B', 0, 0, NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
 INSERT INTO positions (uuid, name, type, status, currentPersonUuid, createdAt, updatedAt)
 	VALUES (lower(newid()), 'EF 2.1 Advisor for Accounting', 0, 0, NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
@@ -196,6 +200,11 @@ INSERT INTO peoplePositions (positionUuid, personUuid, createdAt)
 	VALUES ((SELECT uuid from positions where name = 'EF 1.1 Advisor A'), (SELECT uuid from people where emailAddress = 'hunter+liz@example.com'), CURRENT_TIMESTAMP);
 UPDATE positions SET currentPersonUuid = (SELECT uuid from people where emailAddress = 'hunter+liz@example.com') WHERE name = 'EF 1.1 Advisor A';
 
+-- Put Selena into the EF 1.2 Advisor Billet
+INSERT INTO peoplePositions (positionUuid, personUuid, createdAt)
+	VALUES ((SELECT uuid from positions where name = 'EF 1.2 Advisor'), (SELECT uuid from people where emailAddress = 'hunter+selena@example.com'), CURRENT_TIMESTAMP);
+UPDATE positions SET currentPersonUuid = (SELECT uuid from people where emailAddress = 'hunter+selena@example.com') WHERE name = 'EF 1.2 Advisor';
+
 -- Put Reina into the EF 2.2 Advisor C Billet
 INSERT INTO peoplePositions (positionUuid, personUuid, createdAt)
 	VALUES ((SELECT uuid from positions where name = 'EF 2.2 Advisor C'), (SELECT uuid from people where emailAddress = 'hunter+reina@example.com'), CURRENT_TIMESTAMP);
@@ -227,7 +236,9 @@ INSERT INTO organizations(uuid, shortName, longName, type, createdAt, updatedAt)
 INSERT INTO organizations(uuid, shortName, longName, type, createdAt, updatedAt)
 	VALUES (lower(newid()), 'EF 1', 'Planning Programming, Budgeting and Execution', 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
 	INSERT INTO organizations(uuid, shortName, longName, type, parentOrgUuid, createdAt, updatedAt)
-		VALUES (lower(newid()), 'EF 1.1', '',0, (SELECT uuid from organizations WHERE shortName ='EF 1'), CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+		VALUES (lower(newid()), 'EF 1.1', '', 0, (SELECT uuid from organizations WHERE shortName ='EF 1'), CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+	INSERT INTO organizations(uuid, shortName, longName, type, parentOrgUuid, createdAt, updatedAt)
+		VALUES (lower(newid()), 'EF 1.2', '', 0, (SELECT uuid from organizations WHERE shortName ='EF 1'), CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
 INSERT INTO organizations(uuid, shortName, longName, type, createdAt, updatedAt)
 	VALUES (lower(newid()), 'EF 2', '',0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
 	INSERT INTO organizations(uuid, shortName, longName, type, parentOrgUuid, createdAt, updatedAt)
@@ -283,6 +294,7 @@ INSERT INTO organizations(uuid, shortName, longName, type, createdAt, updatedAt)
 
 UPDATE positions SET organizationUuid = (SELECT uuid FROM organizations WHERE shortName ='EF 1') WHERE name LIKE 'EF 1 %';
 UPDATE positions SET organizationUuid = (SELECT uuid FROM organizations WHERE shortName ='EF 1.1') WHERE name LIKE 'EF 1.1%';
+UPDATE positions SET organizationUuid = (SELECT uuid FROM organizations WHERE shortName ='EF 1.2') WHERE name LIKE 'EF 1.2%';
 UPDATE positions SET organizationUuid = (SELECT uuid FROM organizations WHERE shortName ='EF 2.1') WHERE name LIKE 'EF 2.1%';
 UPDATE positions SET organizationUuid = (SELECT uuid FROM organizations WHERE shortName ='EF 2.2') WHERE name LIKE 'EF 2.2%';
 UPDATE positions SET organizationUuid = (SELECT uuid FROM organizations WHERE shortName ='EF 3') WHERE name LIKE 'EF 3%';
@@ -366,10 +378,10 @@ INSERT INTO taskTaskedOrganizations (taskUuid, organizationUuid)
 		((SELECT uuid from tasks where shortName = '1.1.A'), (SELECT uuid from organizations where shortName='EF 1.1')),
 		((SELECT uuid from tasks where shortName = '1.1.B'), (SELECT uuid from organizations where shortName='EF 1.1')),
 		((SELECT uuid from tasks where shortName = '1.1.C'), (SELECT uuid from organizations where shortName='EF 1.1')),
-		-- ((SELECT uuid from tasks where shortName = 'EF 1.2'), (SELECT uuid from organizations WHERE shortName='EF 1.2')),
-		-- ((SELECT uuid from tasks where shortName = '1.2.A'), (SELECT uuid from organizations where shortName='EF 1.2')),
-		-- ((SELECT uuid from tasks where shortName = '1.2.B'), (SELECT uuid from organizations where shortName='EF 1.2')),
-		-- ((SELECT uuid from tasks where shortName = '1.2.C'), (SELECT uuid from organizations where shortName='EF 1.2')),
+		((SELECT uuid from tasks where shortName = 'EF 1.2'), (SELECT uuid from organizations WHERE shortName='EF 1.2')),
+		((SELECT uuid from tasks where shortName = '1.2.A'), (SELECT uuid from organizations where shortName='EF 1.2')),
+		((SELECT uuid from tasks where shortName = '1.2.B'), (SELECT uuid from organizations where shortName='EF 1.2')),
+		((SELECT uuid from tasks where shortName = '1.2.C'), (SELECT uuid from organizations where shortName='EF 1.2')),
 		-- ((SELECT uuid from tasks where shortName = 'EF 1.3'), (SELECT uuid FROM organizations WHERE shortName='EF 1.3')),
 		-- ((SELECT uuid from tasks where shortName = '1.3.A'), (SELECT uuid from organizations where shortName='EF 1.3')),
 		-- ((SELECT uuid from tasks where shortName = '1.3.B'), (SELECT uuid from organizations where shortName='EF 1.3')),


### PR DESCRIPTION
For future (or date-less) engagements, assessments are no longer shown.

Closes NCI-Agency/anet#3199

#### User changes
- For future (or date-less) engagements, assessments are no longer shown.

#### Super User changes
- none

#### Admin changes
- none

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [x] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here