### PR TITLE
Fix report number fields' errors

### DIFF
--- a/client/src/components/CustomFields.js
+++ b/client/src/components/CustomFields.js
@@ -37,7 +37,6 @@ const SPECIAL_WIDGET_COMPONENTS = {
   [SPECIAL_WIDGET_TYPES.LIKERT_SCALE]: LikertScale,
   [SPECIAL_WIDGET_TYPES.RICH_TEXT_EDITOR]: RichTextEditor
 }
-const RENDERERS = {}
 
 const SpecialField = ({ name, widget, formikProps, ...otherFieldProps }) => {
   const WidgetComponent = SPECIAL_WIDGET_COMPONENTS[widget]
@@ -210,11 +209,11 @@ ReadonlyJsonField.propTypes = {
 }
 
 const EnumField = fieldProps => {
-  const { choices, renderer, ...otherFieldProps } = fieldProps
+  const { choices, ...otherFieldProps } = fieldProps
   return (
     <FastField
       buttons={FieldHelper.customEnumButtons(choices)}
-      component={RENDERERS[renderer] || FieldHelper.RadioButtonToggleGroupField}
+      component={FieldHelper.RadioButtonToggleGroupField}
       {...otherFieldProps}
     />
   )
@@ -243,13 +242,11 @@ const ReadonlyEnumField = fieldProps => {
 }
 
 const EnumSetField = fieldProps => {
-  const { choices, renderer, ...otherFieldProps } = fieldProps
+  const { choices, ...otherFieldProps } = fieldProps
   return (
     <FastField
       buttons={FieldHelper.customEnumButtons(choices)}
-      component={
-        RENDERERS[renderer] || FieldHelper.CheckboxButtonToggleGroupField
-      }
+      component={FieldHelper.CheckboxButtonToggleGroupField}
       {...otherFieldProps}
     />
   )

--- a/client/src/components/CustomFields.js
+++ b/client/src/components/CustomFields.js
@@ -118,6 +118,7 @@ const NumberField = fieldProps => {
   return (
     <FastField
       onChange={value => onChange(value, false)} // do debounced validation
+      onWheelCapture={event => event.currentTarget.blur()} // Prevent scroll action on number input
       component={FieldHelper.InputField}
       inputType="number"
       {...otherFieldProps}

--- a/client/src/components/CustomFields.js
+++ b/client/src/components/CustomFields.js
@@ -733,8 +733,10 @@ const CustomField = ({
   ) // with validateField it somehow doesn't work
   const handleChange = useMemo(
     () => (value, shouldValidate = true) => {
-      const val =
-        value?.target?.value !== undefined ? value.target.value : value
+      let val = value?.target?.value !== undefined ? value.target.value : value
+      if (type === "number" && val === "") {
+        val = null
+      }
       const sv = shouldValidate === undefined ? true : shouldValidate
       setFieldTouched(fieldName, true, false)
       setFieldValue(fieldName, val, sv)
@@ -742,7 +744,7 @@ const CustomField = ({
         validateFormDebounced()
       }
     },
-    [fieldName, setFieldTouched, setFieldValue, validateFormDebounced]
+    [fieldName, setFieldTouched, setFieldValue, validateFormDebounced, type]
   )
   const FieldComponent = FIELD_COMPONENTS[type]
   const extraProps = useMemo(() => {

--- a/client/src/components/CustomFields.js
+++ b/client/src/components/CustomFields.js
@@ -113,6 +113,18 @@ const TextField = fieldProps => {
   )
 }
 
+const NumberField = fieldProps => {
+  const { onChange, onBlur, ...otherFieldProps } = fieldProps
+  return (
+    <FastField
+      onChange={value => onChange(value, false)} // do debounced validation
+      component={FieldHelper.InputField}
+      inputType="number"
+      {...otherFieldProps}
+    />
+  )
+}
+
 const ReadonlyTextField = fieldProps => {
   const { name, label, vertical } = fieldProps
   return (
@@ -608,7 +620,7 @@ ReadonlyArrayOfAnetObjectsField.propTypes = {
 
 const FIELD_COMPONENTS = {
   [CUSTOM_FIELD_TYPE.TEXT]: TextField,
-  [CUSTOM_FIELD_TYPE.NUMBER]: TextField,
+  [CUSTOM_FIELD_TYPE.NUMBER]: NumberField,
   [CUSTOM_FIELD_TYPE.DATE]: DateField,
   [CUSTOM_FIELD_TYPE.DATETIME]: DateTimeField,
   [CUSTOM_FIELD_TYPE.JSON]: JsonField,

--- a/client/src/components/FieldHelper.js
+++ b/client/src/components/FieldHelper.js
@@ -142,6 +142,7 @@ export const InputField = ({
   field, // { name, value, onChange, onBlur }
   form, // contains, touched, errors, values, setXXXX, handleXXXX, dirty, isValid, status, etc.
   label,
+  inputType,
   children,
   extraColElem,
   addon,
@@ -152,12 +153,13 @@ export const InputField = ({
   const widgetElem = useMemo(
     () => (
       <FormControl
+        type={inputType}
         {...Object.without(field, "value")}
         value={utils.isNullOrUndefined(field.value) ? "" : field.value}
         {...otherProps}
       />
     ),
-    [field, otherProps]
+    [field, otherProps, inputType]
   )
   return (
     <Field
@@ -177,6 +179,7 @@ InputField.propTypes = {
   field: PropTypes.object,
   form: PropTypes.object,
   label: PropTypes.string,
+  inputType: PropTypes.string,
   children: PropTypes.any,
   extraColElem: PropTypes.object,
   addon: PropTypes.object,

--- a/client/src/pages/reports/Form.js
+++ b/client/src/pages/reports/Form.js
@@ -527,10 +527,13 @@ const ReportForm = ({
                     name="duration"
                     label="Duration (minutes)"
                     component={FieldHelper.InputField}
+                    inputType="number"
                     onChange={event => {
                       const safeVal =
-                        (event.target.value || "").replace(/[^0-9]+/g, "") ||
-                        null
+                        utils.preventNegativeAndLongDigits(
+                          event.target.value,
+                          4
+                        ) || null
                       setFieldTouched("duration", true, false)
                       setFieldValue("duration", safeVal, false)
                       validateFieldDebounced("duration")

--- a/client/src/pages/reports/Form.js
+++ b/client/src/pages/reports/Form.js
@@ -528,6 +528,7 @@ const ReportForm = ({
                     label="Duration (minutes)"
                     component={FieldHelper.InputField}
                     inputType="number"
+                    onWheelCapture={event => event.currentTarget.blur()} // Prevent scroll action on number input
                     onChange={event => {
                       const safeVal =
                         utils.preventNegativeAndLongDigits(

--- a/client/src/utils.js
+++ b/client/src/utils.js
@@ -197,6 +197,19 @@ export default {
       arr &&
       arr.filter(n => !isNaN(parseFloat(n)) && isFinite(n)).map(n => Number(n))
     )
+  },
+
+  preventNegativeAndLongDigits: function(valueStr, maxLen) {
+    let safeVal
+    const dangerVal = Number(valueStr)
+    if (!isNaN(dangerVal) && dangerVal < 0) {
+      safeVal = "0"
+    } else {
+      const nonDigitsRemoved = valueStr.replace(/\D/g, "")
+      safeVal =
+        maxLen <= 0 ? nonDigitsRemoved : nonDigitsRemoved.slice(0, maxLen)
+    }
+    return safeVal
   }
 }
 

--- a/client/tests/webdriver/pages/createReport.page.js
+++ b/client/tests/webdriver/pages/createReport.page.js
@@ -14,6 +14,10 @@ class CreateReport extends Page {
     return browser.$(".alert")
   }
 
+  get duration() {
+    return browser.$("#duration")
+  }
+
   get engagementInformationTitle() {
     return browser.$('//span[text()="Engagement information"]')
   }

--- a/client/tests/webdriver/specs/createReport.spec.js
+++ b/client/tests/webdriver/specs/createReport.spec.js
@@ -5,6 +5,12 @@ const REPORT = "Interior"
 const REPORT_VALUE = "Talk to the Interior about things"
 const REPORT_COMPLETE = `${REPORT_VALUE}`
 
+const INVALID_ENGAGEMENT_DURATION_1 = "123456"
+const INVALID_ENGAGEMENT_DURATION_2 = "-1"
+// positive sliced at 4th digit, negative should turn into 0
+const VALID_ENGAGEMENT_DURATION_1 = "1234"
+const VALID_ENGAGEMENT_DURATION_2 = "0"
+
 const PERSON = "EF 2.1"
 const PERSON_VALUE_1 = "HENDERSON, Henry"
 const PERSON_VALUE_2 = "JACKSON, Jack"
@@ -27,6 +33,33 @@ describe("Create report form page", () => {
       CreateReport.open()
       CreateReport.form.waitForExist()
       CreateReport.form.waitForDisplayed()
+    })
+
+    it("Should be able to prevent invalid duration values", () => {
+      CreateReport.duration.setValue(INVALID_ENGAGEMENT_DURATION_1)
+      browser.waitUntil(
+        () => {
+          return (
+            CreateReport.duration.getValue() === VALID_ENGAGEMENT_DURATION_1
+          )
+        },
+        {
+          timeout: 3000,
+          timeoutMsg: "Large positive duration value was not sliced "
+        }
+      )
+      CreateReport.duration.setValue(INVALID_ENGAGEMENT_DURATION_2)
+      browser.waitUntil(
+        () => {
+          return (
+            CreateReport.duration.getValue() === VALID_ENGAGEMENT_DURATION_2
+          )
+        },
+        {
+          timeout: 3000,
+          timeoutMsg: "Negative duration value did not change to zero"
+        }
+      )
     })
 
     it("Should be able to select an ANET object reference", () => {


### PR DESCRIPTION
Limit duration value to max 4 digits as it was resulting in 500 error from server if the value is too large to hold in INTEGER, also create NumberField for custom fields that are type number, use the native browser input type=number as it is more robust against errors and more accessible in mobile devices as well. 


#### User changes
- Users will use native number input type for number fields

#### Super User changes
-

#### Admin changes
-

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [X] Described the user behavior in PR body
  - [X] Referenced/updated all related issues
  - [ ] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [X] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [x] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [X] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
