### PR TITLE
Fix customFields's bugs and refactor / add test cases

### DIFF
--- a/client/src/components/CustomFields.js
+++ b/client/src/components/CustomFields.js
@@ -292,7 +292,7 @@ const ArrayOfObjectsField = fieldProps => {
   const fieldsetTitle = fieldConfig.label || ""
   const addButtonLabel = fieldConfig.addButtonLabel || "Add a new item"
   return (
-    <Fieldset title={fieldsetTitle}>
+    <Fieldset title={fieldsetTitle} id={name}>
       {children}
       <FieldArray
         name={name}

--- a/client/src/components/CustomFields.js
+++ b/client/src/components/CustomFields.js
@@ -16,6 +16,7 @@ import RichTextEditor from "components/RichTextEditor"
 import { FastField, FieldArray } from "formik"
 import { JSONPath } from "jsonpath-plus"
 import _cloneDeep from "lodash/cloneDeep"
+import _get from "lodash/get"
 import _isEmpty from "lodash/isEmpty"
 import _isEqual from "lodash/isEqual"
 import _set from "lodash/set"
@@ -648,10 +649,18 @@ export function getInvisibleFields(
   return curInvisibleFields
 }
 
+function resetInvalidInvisibleFields(invisibleFields, setFieldValue, errors) {
+  invisibleFields?.forEach(fieldName => {
+    if (_get(errors, fieldName)) {
+      setFieldValue(fieldName, null)
+    }
+  })
+}
+
 export const CustomFieldsContainer = props => {
   const {
     parentFieldName,
-    formikProps: { values, setFieldValue },
+    formikProps: { values, errors, setFieldValue },
     fieldsConfig
   } = props
   const invisibleFields = useMemo(
@@ -665,9 +674,10 @@ export const CustomFieldsContainer = props => {
   useEffect(() => {
     if (!_isEqual(prevInvisibleFields.current, invisibleFields)) {
       prevInvisibleFields.current = invisibleFields
+      resetInvalidInvisibleFields(invisibleFields, setFieldValue, errors)
       setFieldValue(invisibleFieldsFieldName, invisibleFields, true)
     }
-  }, [invisibleFields, invisibleFieldsFieldName, setFieldValue])
+  }, [invisibleFields, invisibleFieldsFieldName, setFieldValue, errors])
 
   return (
     <>

--- a/client/src/components/CustomFields.js
+++ b/client/src/components/CustomFields.js
@@ -628,7 +628,11 @@ const FIELD_COMPONENTS = {
   [CUSTOM_FIELD_TYPE.ARRAY_OF_ANET_OBJECTS]: ArrayOfAnetObjectsField
 }
 
-function getInvisibleFields(fieldsConfig, parentFieldName, formikValues) {
+export function getInvisibleFields(
+  fieldsConfig,
+  parentFieldName,
+  formikValues
+) {
   const curInvisibleFields = []
   Object.keys(fieldsConfig).forEach(key => {
     const fieldConfig = fieldsConfig[key]

--- a/client/src/components/CustomFields.js
+++ b/client/src/components/CustomFields.js
@@ -285,7 +285,11 @@ const ArrayOfObjectsField = fieldProps => {
   ])
   const objDefault = useMemo(() => {
     const objDefault = {}
-    const objSchema = createYupObjectShape(fieldConfig.objectFields)
+    const objSchema = createYupObjectShape(
+      fieldConfig.objectFields,
+      DEFAULT_CUSTOM_FIELDS_PARENT,
+      false
+    )
     return Model.fillObject(objDefault, objSchema)
   }, [fieldConfig.objectFields])
 

--- a/client/src/components/CustomFields.js
+++ b/client/src/components/CustomFields.js
@@ -838,8 +838,7 @@ const CustomFields = ({
 }) => {
   return (
     <>
-      {Object.keys(fieldsConfig).map(key => {
-        const fieldConfig = fieldsConfig[key]
+      {Object.entries(fieldsConfig).map(([key, fieldConfig]) => {
         const fieldName = `${parentFieldName}.${key}`
         return invisibleFields.includes(fieldName) ? null : (
           <CustomField
@@ -889,9 +888,8 @@ export const ReadonlyCustomFields = ({
 }) => {
   return (
     <>
-      {Object.keys(fieldsConfig).map(key => {
+      {Object.entries(fieldsConfig).map(([key, fieldConfig]) => {
         const fieldName = `${parentFieldName}.${key}`
-        const fieldConfig = fieldsConfig[key]
         const fieldProps = getFieldPropsFromFieldConfig(fieldConfig)
         const { type } = fieldConfig
         let extraProps = {}

--- a/client/src/components/CustomFields.js
+++ b/client/src/components/CustomFields.js
@@ -640,16 +640,16 @@ export function getInvisibleFields(
   isArrayOfObjects = false
 ) {
   const curInvisibleFields = []
-  // loop through fields of the config to check for visibility field
+  // loop through fields of the config to check for visibility of a field
   Object.entries(fieldsConfig).forEach(([key, fieldConfig]) => {
     const visibleWhenPath = fieldConfig.visibleWhen
     const isVisible =
-      !visibleWhenPath ||
-      (visibleWhenPath && !_isEmpty(JSONPath(visibleWhenPath, formikValues)))
+      !visibleWhenPath || !_isEmpty(JSONPath(visibleWhenPath, formikValues))
 
     const fieldName = `${parentFieldName}.${key}`
 
-    // recursively get invisible fields in case of array of objects
+    // recursively append invisible fields in case of array of objects
+    // we can have customFields.array_of_objects.objectFields.array_of_objects.objectFields...
     if (fieldConfig.type === CUSTOM_FIELD_TYPE.ARRAY_OF_OBJECTS) {
       curInvisibleFields.push(
         ...getInvisibleFields(

--- a/client/src/components/CustomFields.js
+++ b/client/src/components/CustomFields.js
@@ -23,7 +23,7 @@ import _set from "lodash/set"
 import _upperFirst from "lodash/upperFirst"
 import moment from "moment"
 import PropTypes from "prop-types"
-import React, { useEffect, useMemo, useRef } from "react"
+import React, { useEffect, useMemo } from "react"
 import { Button, HelpBlock, Table } from "react-bootstrap"
 import Settings from "settings"
 import { useDebouncedCallback } from "use-debounce"
@@ -695,16 +695,13 @@ export const CustomFieldsContainer = props => {
     [fieldsConfig, parentFieldName, values]
   )
 
-  const prevInvisibleFields = useRef(invisibleFields)
-
   const invisibleFieldsFieldName = `${parentFieldName}.${INVISIBLE_CUSTOM_FIELDS_FIELD}`
   useEffect(() => {
-    if (!_isEqual(prevInvisibleFields.current, invisibleFields)) {
-      prevInvisibleFields.current = invisibleFields
+    if (!_isEqual(_get(values, invisibleFieldsFieldName), invisibleFields)) {
       resetInvalidInvisibleFields(invisibleFields, setFieldValue, errors)
       setFieldValue(invisibleFieldsFieldName, invisibleFields, true)
     }
-  }, [invisibleFields, invisibleFieldsFieldName, setFieldValue, errors])
+  }, [invisibleFields, values, invisibleFieldsFieldName, setFieldValue, errors])
 
   return (
     <>

--- a/client/src/components/CustomFields.js
+++ b/client/src/components/CustomFields.js
@@ -675,18 +675,10 @@ export function getInvisibleFields(
   return curInvisibleFields
 }
 
-function resetInvalidInvisibleFields(invisibleFields, setFieldValue, errors) {
-  invisibleFields?.forEach(fieldName => {
-    if (_get(errors, fieldName)) {
-      setFieldValue(fieldName, null)
-    }
-  })
-}
-
 export const CustomFieldsContainer = props => {
   const {
     parentFieldName,
-    formikProps: { values, errors, setFieldValue },
+    formikProps: { values, setFieldValue },
     fieldsConfig
   } = props
 
@@ -698,10 +690,9 @@ export const CustomFieldsContainer = props => {
   const invisibleFieldsFieldName = `${parentFieldName}.${INVISIBLE_CUSTOM_FIELDS_FIELD}`
   useEffect(() => {
     if (!_isEqual(_get(values, invisibleFieldsFieldName), invisibleFields)) {
-      resetInvalidInvisibleFields(invisibleFields, setFieldValue, errors)
       setFieldValue(invisibleFieldsFieldName, invisibleFields, true)
     }
-  }, [invisibleFields, values, invisibleFieldsFieldName, setFieldValue, errors])
+  }, [invisibleFields, values, invisibleFieldsFieldName, setFieldValue])
 
   return (
     <>

--- a/client/src/components/CustomFields.js
+++ b/client/src/components/CustomFields.js
@@ -306,7 +306,7 @@ const ArrayOfObjectsField = fieldProps => {
               className="pull-right"
               onClick={() => addObject(objDefault, arrayHelpers)}
               bsStyle="primary"
-              id="addObjectButton"
+              id={`add-${name}`}
             >
               {addButtonLabel}
             </Button>

--- a/client/src/components/Kanban.js
+++ b/client/src/components/Kanban.js
@@ -65,8 +65,8 @@ const Column = ({ name, tasks }) => {
           segmentFill={entity => {
             const matching = Object.entries(
               Settings.fields.task.customFieldEnum1.enum
-            ).filter(candidate => {
-              return candidate[0] === entity.data.key
+            ).filter(([key, val]) => {
+              return key === entity.data.key
             })
             return matching.length > 0 ? matching[0][1].color : "#bbbbbb"
           }}

--- a/client/src/components/Model.js
+++ b/client/src/components/Model.js
@@ -218,7 +218,7 @@ const createFieldYupSchema = (fieldKey, fieldConfig, parentFieldName) => {
 export const createYupObjectShape = (
   config,
   parentFieldName = DEFAULT_CUSTOM_FIELDS_PARENT,
-  isTopLevel = true
+  isTopLevel = true // only add invisible fields field to the top level object
 ) => {
   let objShape = {}
   if (config) {

--- a/client/src/components/Model.js
+++ b/client/src/components/Model.js
@@ -218,7 +218,7 @@ const createFieldYupSchema = (fieldKey, fieldConfig, parentFieldName) => {
 export const createYupObjectShape = (
   config,
   parentFieldName = DEFAULT_CUSTOM_FIELDS_PARENT,
-  isTopLevel = true // only add invisible fields field to the top level object
+  isTopLevel = true
 ) => {
   let objShape = {}
   if (config) {
@@ -227,8 +227,7 @@ export const createYupObjectShape = (
         .map(([k, v]) => [k, createFieldYupSchema(k, v, parentFieldName)])
         .filter(([k, v]) => v !== null)
     )
-    // do not include invisibleFields field to a inner objects
-    // as it won't be used
+    // only the top level config objects keep hold of the invisible fields info
     if (isTopLevel) {
       objShape[INVISIBLE_CUSTOM_FIELDS_FIELD] = yup
         .mixed()

--- a/client/src/components/Model.js
+++ b/client/src/components/Model.js
@@ -184,7 +184,7 @@ const createFieldYupSchema = (fieldKey, fieldConfig, parentFieldName) => {
     fieldTypeYupSchema = fieldTypeYupSchema.typeError(typeError)
   }
   if (!_isEmpty(objectFields)) {
-    const objSchema = createYupObjectShape(objectFields, parentFieldName)
+    const objSchema = createYupObjectShape(objectFields, parentFieldName, false)
     fieldTypeYupSchema = fieldTypeYupSchema.of(objSchema)
   }
   if (!_isEmpty(validations)) {
@@ -217,22 +217,24 @@ const createFieldYupSchema = (fieldKey, fieldConfig, parentFieldName) => {
 
 export const createYupObjectShape = (
   config,
-  parentFieldName = DEFAULT_CUSTOM_FIELDS_PARENT
+  parentFieldName = DEFAULT_CUSTOM_FIELDS_PARENT,
+  isTopLevel = true
 ) => {
   let objShape = {}
   if (config) {
     objShape = Object.fromEntries(
       Object.entries(config)
-        .map(([k, v]) => [
-          k,
-          createFieldYupSchema(k, config[k], parentFieldName)
-        ])
+        .map(([k, v]) => [k, createFieldYupSchema(k, v, parentFieldName)])
         .filter(([k, v]) => v !== null)
     )
-    objShape[INVISIBLE_CUSTOM_FIELDS_FIELD] = yup
-      .mixed()
-      .nullable()
-      .default(null)
+    // do not include invisibleFields field to a inner objects
+    // as it won't be used
+    if (isTopLevel) {
+      objShape[INVISIBLE_CUSTOM_FIELDS_FIELD] = yup
+        .mixed()
+        .nullable()
+        .default(null)
+    }
   }
   return yup.object().shape(objShape)
 }

--- a/client/src/components/ReportStatistics.js
+++ b/client/src/components/ReportStatistics.js
@@ -253,24 +253,28 @@ const ReportStatistics = ({
           <>
             {!hasStatistics && <NoStatisticsRow periods={periods} />}
             {hasStatistics &&
-              Object.keys(REPORT_FIELDS_FOR_STATISTICS).map((key, index) => (
+              Object.entries(
+                REPORT_FIELDS_FOR_STATISTICS
+              ).map(([key, field], index) => (
                 <FieldStatisticsRow
                   key={key}
                   idSuffix={`${key}-${idSuffix}`}
                   fieldName={key}
-                  fieldConfig={REPORT_FIELDS_FOR_STATISTICS[key]}
+                  fieldConfig={field}
                   periods={periods}
                   periodsData={dataPerPeriod}
                   isFirstRow={index === 0}
                 />
               ))}
             {hasStatistics &&
-              Object.keys(customFieldsConfig || {}).map((key, index) => (
+              Object.entries(
+                customFieldsConfig || {}
+              ).map(([key, field], index) => (
                 <FieldStatisticsRow
                   key={key}
                   idSuffix={`${key}-${idSuffix}`}
                   fieldName={`${CUSTOM_FIELDS_KEY}.${key}`}
-                  fieldConfig={customFieldsConfig[key]}
+                  fieldConfig={field}
                   periods={periods}
                   periodsData={dataPerPeriod}
                   isFirstRow={

--- a/client/src/components/SearchFilters.js
+++ b/client/src/components/SearchFilters.js
@@ -525,7 +525,7 @@ export const searchFilters = function() {
     filters: taskFilters()
   }
 
-  for (const [, filtersForType] of Object.entries(filters)) {
+  for (const filtersForType of Object.values(filters)) {
     filtersForType.filters.Status = StatusFilter
   }
 
@@ -646,8 +646,7 @@ export const deserializeQueryParams = (
     })
     const ALL_FILTERS = searchFilters()
     const filterDefs = ALL_FILTERS[objType].filters
-    Object.keys(filterDefs).map(filterKey => {
-      const filterDef = filterDefs[filterKey]
+    Object.entries(filterDefs).map(([filterKey, filterDef]) => {
       const deser = filterDef.deserializer(
         filterDef.props,
         queryParams,

--- a/client/src/components/advancedSearch/ReportStateFilter.js
+++ b/client/src/components/advancedSearch/ReportStateFilter.js
@@ -73,9 +73,9 @@ const ReportStateFilter = ({
           onChange={handleChangeState}
           multiple
         >
-          {Object.keys(Report.STATE_LABELS).map(key => (
+          {Object.entries(Report.STATE_LABELS).map(([key, label]) => (
             <option key={key} value={key}>
-              {Report.STATE_LABELS[key]}
+              {label}
             </option>
           ))}
         </select>
@@ -88,9 +88,9 @@ const ReportStateFilter = ({
               onChange={handleChangeCancelledReason}
             >
               <option value="">Everything</option>
-              {Object.keys(CANCELLATION_REASON_LABELS).map(key => (
+              {Object.entries(CANCELLATION_REASON_LABELS).map((key, label) => (
                 <option key={key} value={key}>
-                  {CANCELLATION_REASON_LABELS[key]}
+                  {label}
                 </option>
               ))}
             </select>

--- a/client/src/components/advancedSelectWidget/AdvancedSelect.js
+++ b/client/src/components/advancedSelectWidget/AdvancedSelect.js
@@ -33,13 +33,13 @@ const FilterAsNav = ({ items, currentFilter, handleOnClick }) =>
   hasMultipleItems(items) && (
     <Col md={2} xsHidden smHidden>
       <ul className="advanced-select-filters" style={{ paddingInlineStart: 0 }}>
-        {Object.keys(items).map(filterType => (
+        {Object.entries(items).map(([filterType, filter]) => (
           <li
             key={filterType}
             className={currentFilter === filterType ? "active" : null}
           >
             <Button bsStyle="link" onClick={() => handleOnClick(filterType)}>
-              {items[filterType].label}
+              {filter.label}
             </Button>
           </li>
         ))}
@@ -58,9 +58,9 @@ const FilterAsDropdown = ({ items, handleOnChange }) =>
       <p style={{ padding: "5px 0" }}>
         Filter:
         <select onChange={handleOnChange} style={{ marginLeft: "5px" }}>
-          {Object.keys(items).map(filterType => (
+          {Object.entries(items).map(([filterType, filter]) => (
             <option key={filterType} value={filterType}>
-              {items[filterType].label}
+              {filter.label}
             </option>
           ))}
         </select>

--- a/client/src/components/advancedSelectWidget/MultiTypeAdvancedSelectComponent.js
+++ b/client/src/components/advancedSelectWidget/MultiTypeAdvancedSelectComponent.js
@@ -1,4 +1,5 @@
 import { SEARCH_OBJECT_LABELS, SEARCH_OBJECT_TYPES } from "actions"
+import AdvancedMultiSelect from "components/advancedSelectWidget/AdvancedMultiSelect"
 import {
   LocationOverlayRow,
   OrganizationOverlayRow,
@@ -7,7 +8,6 @@ import {
   ReportDetailedOverlayRow,
   TaskSimpleOverlayRow
 } from "components/advancedSelectWidget/AdvancedSelectOverlayRow"
-import AdvancedMultiSelect from "components/advancedSelectWidget/AdvancedMultiSelect"
 import AdvancedSingleSelect from "components/advancedSelectWidget/AdvancedSingleSelect"
 import ButtonToggleGroup from "components/ButtonToggleGroup"
 import Model from "components/Model"
@@ -154,7 +154,7 @@ const MultiTypeAdvancedSelectComponent = ({
         <ButtonToggleGroup value={entityType} onChange={changeEntityType}>
           {Object.entries(ENTITY_TYPES)
             .filter(([, et]) => entityTypes.includes(et))
-            .map(([key, entityName], value) => {
+            .map(([key, entityName]) => {
               const entityLabel = SEARCH_OBJECT_LABELS[SEARCH_OBJECT_TYPES[key]]
               return (
                 <Button key={entityName} value={entityName}>

--- a/client/src/components/aggregations/utils.js
+++ b/client/src/components/aggregations/utils.js
@@ -89,13 +89,13 @@ export const countPerValueAggregation = (fieldName, fieldConfig, data) => {
   const legendColors = _clone(CHART_COLORS)
   const legend = fieldConfig?.choices || {}
   const legendKeys = !_isEmpty(legend)
-    ? Object.keys(legend)
-    : Object.keys(counters)
+    ? Object.entries(legend)
+    : Object.entries(counters)
   legendKeys.forEach(
-    key =>
+    ([key, val]) =>
       (legend[key] = {
-        label: legend[key]?.label || key,
-        color: legend[key]?.color || legendColors.shift()
+        label: val?.label || key,
+        color: val?.color || legendColors.shift()
       })
   )
   legend.null = { label: "Unspecified", color: "#bbbbbb" }

--- a/client/src/components/assessments/AssessmentResultsTable.js
+++ b/client/src/components/assessments/AssessmentResultsTable.js
@@ -53,17 +53,19 @@ const EntityAssessmentResults = ({
           <LinkTo modelType={entityType.resourceName} model={entity} />
         </td>
       </tr>
-      {Object.keys(instantAssessmentConfig || {}).map((key, index) => (
-        <InstantAssessmentsRow
-          key={key}
-          idSuffix={`${key}-${idSuffix}`}
-          questionKey={key}
-          questionConfig={instantAssessmentConfig[key]}
-          periods={periods}
-          periodsData={dataPerPeriod}
-          isFirstRow={index === 0}
-        />
-      ))}
+      {Object.entries(instantAssessmentConfig || {}).map(
+        ([key, config], index) => (
+          <InstantAssessmentsRow
+            key={key}
+            idSuffix={`${key}-${idSuffix}`}
+            questionKey={key}
+            questionConfig={config}
+            periods={periods}
+            periodsData={dataPerPeriod}
+            isFirstRow={index === 0}
+          />
+        )
+      )}
       <PeriodicAssessmentsRows
         entity={entity}
         entityType={entityType}

--- a/client/src/components/graphs/Pie.js
+++ b/client/src/components/graphs/Pie.js
@@ -17,7 +17,7 @@ const Pie = ({ label, segmentFill, segmentLabel, data, width, height }) => {
     const canvas = d3.select(canvasRef.current)
     const radius = Math.min(width, height) / 2 - 2
     const arcs = pie.current(
-      Array.from(Object.entries(data), ([key, value]) => ({
+      Object.entries(data).map(([key, value]) => ({
         key,
         value
       }))

--- a/client/src/models/Report.js
+++ b/client/src/models/Report.js
@@ -304,7 +304,10 @@ export default class Report extends Model {
         .nullable()
         .default([])
         .label(Settings.fields.report.reportTags),
-      reportSensitiveInformation: yup.object().nullable().default({}), // null?
+      reportSensitiveInformation: yup
+        .object()
+        .nullable()
+        .default({ uuid: null, text: null }),
       authorizationGroups: yup.array().nullable().default([])
     })
     // not actually in the database, the database contains the JSON customFields

--- a/client/src/pages/admin/Index.js
+++ b/client/src/pages/admin/Index.js
@@ -204,9 +204,9 @@ const AdminIndex = ({ pageDispatchers }) => {
   }
 
   function onSubmitSuccess(response, values, form) {
-    // After successful submit, reset the form in order to make sure the dirty
-    // prop is also reset (otherwise we would get a blocking navigation warning)
-    form.resetForm()
+    // reset the form to latest values
+    // to avoid unsaved changes propmt if it somehow becomes dirty
+    form.resetForm({ values, isSubmitting: true })
     setSaveError(null)
     setSaveSuccess("Admin settings saved")
     jumpToTop()

--- a/client/src/pages/admin/authorizationgroup/Form.js
+++ b/client/src/pages/admin/authorizationgroup/Form.js
@@ -217,9 +217,9 @@ const AuthorizationGroupForm = ({ edit, title, initialValues }) => {
         ? response[operation].uuid
         : initialValues.uuid
     })
-    // After successful submit, reset the form in order to make sure the dirty
-    // prop is also reset (otherwise we would get a blocking navigation warning)
-    form.resetForm()
+    // reset the form to latest values
+    // to avoid unsaved changes propmt if it somehow becomes dirty
+    form.resetForm({ values, isSubmitting: true })
     if (!edit) {
       history.replace(AuthorizationGroup.pathForEdit(authGroup))
     }

--- a/client/src/pages/dashboards/DiagramNode.js
+++ b/client/src/pages/dashboards/DiagramNode.js
@@ -161,25 +161,26 @@ export const DiagramNodeWidget = ({ size, node, engine }) => {
           />
           <>
             {instantAssessmentConfig &&
-              Object.keys(instantAssessmentConfig || {}).map(questionKey => {
-                const questionConfig = instantAssessmentConfig[questionKey]
-                const aggregationWidget = getAggregationWidget(
-                  questionConfig,
-                  DIAGRAM_AGGREGATION_WIDGET_PER_FIELD_TYPE,
-                  true
-                )
-                questionConfig.showLegend = false
-                return aggregationWidget ? (
-                  <AggregationWidgetContainer
-                    key={`assessment-${questionKey}`}
-                    fieldConfig={questionConfig}
-                    fieldName={questionKey}
-                    data={instantAssessmentResults}
-                    widget={aggregationWidget}
-                    widgetId={`${questionKey}-assessment`}
-                  />
-                ) : null
-              })}
+              Object.entries(instantAssessmentConfig || {}).map(
+                ([questionKey, questionConfig]) => {
+                  const aggregationWidget = getAggregationWidget(
+                    questionConfig,
+                    DIAGRAM_AGGREGATION_WIDGET_PER_FIELD_TYPE,
+                    true
+                  )
+                  questionConfig.showLegend = false
+                  return aggregationWidget ? (
+                    <AggregationWidgetContainer
+                      key={`assessment-${questionKey}`}
+                      fieldConfig={questionConfig}
+                      fieldName={questionKey}
+                      data={instantAssessmentResults}
+                      widget={aggregationWidget}
+                      widgetId={`${questionKey}-assessment`}
+                    />
+                  ) : null
+                }
+              )}
           </>
         </div>
       )}

--- a/client/src/pages/locations/Form.js
+++ b/client/src/pages/locations/Form.js
@@ -245,9 +245,9 @@ const LocationForm = ({ edit, title, initialValues }) => {
         ? response[operation].uuid
         : initialValues.uuid
     })
-    // After successful submit, reset the form in order to make sure the dirty
-    // prop is also reset (otherwise we would get a blocking navigation warning)
-    form.resetForm()
+    // reset the form to latest values
+    // to avoid unsaved changes propmt if it somehow becomes dirty
+    form.resetForm({ values, isSubmitting: true })
     if (!edit) {
       history.replace(Location.pathForEdit(location))
     }

--- a/client/src/pages/organizations/Form.js
+++ b/client/src/pages/organizations/Form.js
@@ -14,8 +14,8 @@ import LinkTo from "components/LinkTo"
 import Messages from "components/Messages"
 import Model from "components/Model"
 import NavigationWarning from "components/NavigationWarning"
-import { jumpToTop } from "components/Page"
 import NoPaginationTaskTable from "components/NoPaginationTaskTable"
+import { jumpToTop } from "components/Page"
 import { FastField, Field, Form, Formik } from "formik"
 import { Organization, Position, Task } from "models"
 import pluralize from "pluralize"
@@ -396,9 +396,9 @@ const OrganizationForm = ({ edit, title, initialValues }) => {
         ? response[operation].uuid
         : initialValues.uuid
     })
-    // After successful submit, reset the form in order to make sure the dirty
-    // prop is also reset (otherwise we would get a blocking navigation warning)
-    form.resetForm()
+    // reset the form to latest values
+    // to avoid unsaved changes propmt if it somehow becomes dirty
+    form.resetForm({ values, isSubmitting: true })
     if (!edit) {
       history.replace(Organization.pathForEdit(organization))
     }

--- a/client/src/pages/people/Edit.js
+++ b/client/src/pages/people/Edit.js
@@ -1,7 +1,11 @@
 import { DEFAULT_SEARCH_PROPS, PAGE_PROPS_NO_NAV } from "actions"
 import API from "api"
 import { gql } from "apollo-boost"
-import { DEFAULT_CUSTOM_FIELDS_PARENT } from "components/Model"
+import { getInvisibleFields } from "components/CustomFields"
+import {
+  DEFAULT_CUSTOM_FIELDS_PARENT,
+  INVISIBLE_CUSTOM_FIELDS_FIELD
+} from "components/Model"
 import {
   mapPageDispatchersToProps,
   PageDispatchersPropType,
@@ -15,6 +19,7 @@ import moment from "moment"
 import React from "react"
 import { connect } from "react-redux"
 import { useParams } from "react-router-dom"
+import Settings from "settings"
 import utils from "utils"
 import PersonForm from "./Form"
 
@@ -88,6 +93,15 @@ const PersonEdit = ({ pageDispatchers }) => {
   const saveText = person.isPendingVerification()
     ? "Update profile"
     : "Save Person"
+
+  // set initial invisible custom fields
+  person[DEFAULT_CUSTOM_FIELDS_PARENT][
+    INVISIBLE_CUSTOM_FIELDS_FIELD
+  ] = getInvisibleFields(
+    Settings.fields.person.customFields,
+    DEFAULT_CUSTOM_FIELDS_PARENT,
+    person
+  )
 
   return (
     <div>

--- a/client/src/pages/people/Form.js
+++ b/client/src/pages/people/Form.js
@@ -475,6 +475,7 @@ const PersonForm = ({ edit, title, saveText, initialValues }) => {
                   name="biography"
                   component={FieldHelper.SpecialField}
                   onChange={value => {
+                    // prevent initial unnecessary render of RichTextEditor
                     if (!_isEqual(value, values.biography)) {
                       setFieldValue("biography", value)
                     }

--- a/client/src/pages/people/Form.js
+++ b/client/src/pages/people/Form.js
@@ -20,6 +20,7 @@ import RichTextEditor from "components/RichTextEditor"
 import TriggerableConfirm from "components/TriggerableConfirm"
 import { FastField, Field, Form, Formik } from "formik"
 import _isEmpty from "lodash/isEmpty"
+import _isEqual from "lodash/isEqual"
 import { Person } from "models"
 import pluralize from "pluralize"
 import PropTypes from "prop-types"
@@ -473,7 +474,11 @@ const PersonForm = ({ edit, title, saveText, initialValues }) => {
                 <FastField
                   name="biography"
                   component={FieldHelper.SpecialField}
-                  onChange={value => setFieldValue("biography", value)}
+                  onChange={value => {
+                    if (!_isEqual(value, values.biography)) {
+                      setFieldValue("biography", value)
+                    }
+                  }}
                   widget={
                     <RichTextEditor
                       className="biography"

--- a/client/src/pages/people/Form.js
+++ b/client/src/pages/people/Form.js
@@ -494,7 +494,8 @@ const PersonForm = ({ edit, title, saveText, initialValues }) => {
                       setFieldTouched,
                       setFieldValue,
                       values,
-                      validateForm
+                      validateForm,
+                      errors
                     }}
                   />
                 </Fieldset>

--- a/client/src/pages/people/Form.js
+++ b/client/src/pages/people/Form.js
@@ -113,10 +113,8 @@ const PersonForm = ({ edit, title, saveText, initialValues }) => {
       initialValues={initialValues}
     >
       {({
-        handleSubmit,
         isSubmitting,
         dirty,
-        errors,
         setFieldValue,
         setFieldTouched,
         values,
@@ -500,8 +498,7 @@ const PersonForm = ({ edit, title, saveText, initialValues }) => {
                       setFieldTouched,
                       setFieldValue,
                       values,
-                      validateForm,
-                      errors
+                      validateForm
                     }}
                   />
                 </Fieldset>

--- a/client/src/pages/people/Form.js
+++ b/client/src/pages/people/Form.js
@@ -564,7 +564,7 @@ const PersonForm = ({ edit, title, saveText, initialValues }) => {
   function onSubmitSuccess(response, values, form) {
     // After successful submit, reset the form in order to make sure the dirty
     // prop is also reset (otherwise we would get a blocking navigation warning)
-    form.resetForm()
+    form.resetForm({ values })
     if (onSaveRedirectToHome) {
       localStorage.clear()
       localStorage.newUser = "true"

--- a/client/src/pages/people/Form.js
+++ b/client/src/pages/people/Form.js
@@ -562,9 +562,9 @@ const PersonForm = ({ edit, title, saveText, initialValues }) => {
   }
 
   function onSubmitSuccess(response, values, form) {
-    // After successful submit, reset the form in order to make sure the dirty
-    // prop is also reset (otherwise we would get a blocking navigation warning)
-    form.resetForm({ values })
+    // reset the form to latest values
+    // to avoid unsaved changes propmt if it somehow becomes dirty
+    form.resetForm({ values, isSubmitting: true })
     if (onSaveRedirectToHome) {
       localStorage.clear()
       localStorage.newUser = "true"

--- a/client/src/pages/people/New.js
+++ b/client/src/pages/people/New.js
@@ -1,12 +1,18 @@
 import { DEFAULT_SEARCH_PROPS, PAGE_PROPS_NO_NAV } from "actions"
+import { getInvisibleFields } from "components/CustomFields"
 import {
-  PageDispatchersPropType,
+  DEFAULT_CUSTOM_FIELDS_PARENT,
+  INVISIBLE_CUSTOM_FIELDS_FIELD
+} from "components/Model"
+import {
   mapPageDispatchersToProps,
+  PageDispatchersPropType,
   useBoilerplate
 } from "components/Page"
 import { Person } from "models"
 import React from "react"
 import { connect } from "react-redux"
+import Settings from "settings"
 import PersonForm from "./Form"
 
 const PersonNew = ({ pageDispatchers }) => {
@@ -17,6 +23,14 @@ const PersonNew = ({ pageDispatchers }) => {
   })
 
   const person = new Person()
+  // set initial invisible custom fields
+  person[DEFAULT_CUSTOM_FIELDS_PARENT][
+    INVISIBLE_CUSTOM_FIELDS_FIELD
+  ] = getInvisibleFields(
+    Settings.fields.person.customFields,
+    DEFAULT_CUSTOM_FIELDS_PARENT,
+    person
+  )
 
   return <PersonForm initialValues={person} title="Create a new Person" />
 }

--- a/client/src/pages/positions/Form.js
+++ b/client/src/pages/positions/Form.js
@@ -343,9 +343,9 @@ const PositionForm = ({ edit, title, initialValues }) => {
         ? response[operation].uuid
         : initialValues.uuid
     })
-    // After successful submit, reset the form in order to make sure the dirty
-    // prop is also reset (otherwise we would get a blocking navigation warning)
-    form.resetForm()
+    // reset the form to latest values
+    // to avoid unsaved changes propmt if it somehow becomes dirty
+    form.resetForm({ values, isSubmitting: true })
     if (!edit) {
       history.replace(Position.pathForEdit(position))
     }

--- a/client/src/pages/reports/Edit.js
+++ b/client/src/pages/reports/Edit.js
@@ -167,10 +167,7 @@ const ReportEdit = ({ pageDispatchers }) => {
         edit
         initialValues={reportInitialValues}
         title={`Report #${report.uuid}`}
-        showSensitiveInfo={
-          !!report.reportSensitiveInformation &&
-          !!report.reportSensitiveInformation.text
-        }
+        showSensitiveInfo={!!report.reportSensitiveInformation?.text}
       />
     </div>
   )

--- a/client/src/pages/reports/Edit.js
+++ b/client/src/pages/reports/Edit.js
@@ -1,7 +1,11 @@
 import { DEFAULT_SEARCH_PROPS, PAGE_PROPS_NO_NAV } from "actions"
 import API from "api"
 import { gql } from "apollo-boost"
-import { DEFAULT_CUSTOM_FIELDS_PARENT } from "components/Model"
+import { getInvisibleFields } from "components/CustomFields"
+import {
+  DEFAULT_CUSTOM_FIELDS_PARENT,
+  INVISIBLE_CUSTOM_FIELDS_FIELD
+} from "components/Model"
 import {
   mapPageDispatchersToProps,
   PageDispatchersPropType,
@@ -14,6 +18,7 @@ import { Person, Report, Task } from "models"
 import React from "react"
 import { connect } from "react-redux"
 import { useParams } from "react-router-dom"
+import Settings from "settings"
 import utils from "utils"
 import ReportForm from "./Form"
 
@@ -132,6 +137,14 @@ const ReportEdit = ({ pageDispatchers }) => {
     report,
     report.getTasksEngagementAssessments(),
     report.getAttendeesEngagementAssessments()
+  )
+  // set initial invisible custom fields
+  reportInitialValues[DEFAULT_CUSTOM_FIELDS_PARENT][
+    INVISIBLE_CUSTOM_FIELDS_FIELD
+  ] = getInvisibleFields(
+    Settings.fields.report.customFields,
+    DEFAULT_CUSTOM_FIELDS_PARENT,
+    report
   )
   reportInitialValues.tasks = Task.fromArray(reportInitialValues.tasks)
   reportInitialValues.reportPeople = Person.fromArray(

--- a/client/src/pages/reports/Form.js
+++ b/client/src/pages/reports/Form.js
@@ -1304,16 +1304,14 @@ const ReportForm = ({
   ) {
     const entitiesUuids = entities.map(e => e.uuid)
     const entitiesAssessments = values[asessmentsFieldName]
-    return Object.keys(entitiesAssessments)
+    return Object.entries(entitiesAssessments)
       .filter(
-        key =>
-          entitiesUuids.includes(key) &&
-          !isEmptyAssessment(entitiesAssessments[key])
+        ([key, assessment]) =>
+          entitiesUuids.includes(key) && !isEmptyAssessment(assessment)
       )
-      .map(key => {
-        entitiesAssessments[key].__recurrence = RECURRENCE_TYPE.ONCE
-        entitiesAssessments[key].__relatedObjectType =
-          ASSESSMENTS_RELATED_OBJECT_TYPE.REPORT
+      .map(([key, assessment]) => {
+        assessment.__recurrence = RECURRENCE_TYPE.ONCE
+        assessment.__relatedObjectType = ASSESSMENTS_RELATED_OBJECT_TYPE.REPORT
         const noteObj = {
           type: NOTE_TYPE.ASSESSMENT,
           noteRelatedObjects: [

--- a/client/src/pages/reports/Form.js
+++ b/client/src/pages/reports/Form.js
@@ -958,7 +958,7 @@ const ReportForm = ({
                           ) {
                             setFieldValue(
                               "reportSensitiveInformation.text",
-                              value,
+                              safeVal,
                               true
                             )
                           }
@@ -1254,8 +1254,8 @@ const ReportForm = ({
   function onConfirmDelete(values, resetForm) {
     API.mutation(GQL_DELETE_REPORT, { uuid: values.uuid })
       .then(data => {
-        // After successful delete, reset the form in order to make sure the dirty
-        // prop is also reset (otherwise we would get a blocking navigation warning)
+        // reset the form to latest values
+        // to avoid unsaved changes propmt if it somehow becomes dirty
         resetForm({ values, isSubmitting: true })
         history.push("/", { success: "Report deleted" })
       })

--- a/client/src/pages/reports/Form.js
+++ b/client/src/pages/reports/Form.js
@@ -41,6 +41,7 @@ import { FastField, Field, Form, Formik } from "formik"
 import _cloneDeep from "lodash/cloneDeep"
 import _debounce from "lodash/debounce"
 import _isEmpty from "lodash/isEmpty"
+import _isEqual from "lodash/isEqual"
 import _upperFirst from "lodash/upperFirst"
 import { AuthorizationGroup, Location, Person, Report, Tag, Task } from "models"
 import moment from "moment"
@@ -915,7 +916,11 @@ const ReportForm = ({
                   name="reportText"
                   label={Settings.fields.report.reportText}
                   component={FieldHelper.SpecialField}
-                  onChange={value => setFieldValue("reportText", value, true)}
+                  onChange={value => {
+                    if (!_isEqual(values.reportText, value)) {
+                      setFieldValue("reportText", value, true)
+                    }
+                  }}
                   widget={
                     <RichTextEditor
                       className="reportTextField"
@@ -943,13 +948,21 @@ const ReportForm = ({
                         name="reportSensitiveInformation.text"
                         component={FieldHelper.SpecialField}
                         label="Report sensitive information text"
-                        onChange={value =>
-                          setFieldValue(
-                            "reportSensitiveInformation.text",
-                            value || null,
-                            true
-                          )
-                        }
+                        onChange={value => {
+                          const safeVal = value || null
+                          if (
+                            !_isEqual(
+                              values.reportSensitiveInformation.text,
+                              safeVal
+                            )
+                          ) {
+                            setFieldValue(
+                              "reportSensitiveInformation.text",
+                              value,
+                              true
+                            )
+                          }
+                        }}
                         widget={
                           <RichTextEditor
                             className="reportSensitiveInformationField"

--- a/client/src/pages/reports/Form.js
+++ b/client/src/pages/reports/Form.js
@@ -1102,9 +1102,7 @@ const ReportForm = ({
                   )}
                   {canDelete && (
                     <ConfirmDelete
-                      onConfirmDelete={() =>
-                        onConfirmDelete(values.uuid, resetForm)
-                      }
+                      onConfirmDelete={() => onConfirmDelete(values, resetForm)}
                       objectType="report"
                       objectDisplay={values.uuid}
                       bsStyle="warning"
@@ -1253,12 +1251,12 @@ const ReportForm = ({
     }
   }
 
-  function onConfirmDelete(uuid, resetForm) {
-    API.mutation(GQL_DELETE_REPORT, { uuid })
+  function onConfirmDelete(values, resetForm) {
+    API.mutation(GQL_DELETE_REPORT, { uuid: values.uuid })
       .then(data => {
         // After successful delete, reset the form in order to make sure the dirty
         // prop is also reset (otherwise we would get a blocking navigation warning)
-        resetForm({ isSubmitting: true })
+        resetForm({ values, isSubmitting: true })
         history.push("/", { success: "Report deleted" })
       })
       .catch(error => {
@@ -1286,7 +1284,7 @@ const ReportForm = ({
     const edit = isEditMode(values)
     // After successful submit, reset the form in order to make sure the dirty
     // prop is also reset (otherwise we would get a blocking navigation warning)
-    resetForm({ isSubmitting: true })
+    resetForm({ values, isSubmitting: true })
     if (!edit) {
       history.replace(Report.pathForEdit(report))
     }

--- a/client/src/pages/reports/Form.js
+++ b/client/src/pages/reports/Form.js
@@ -300,7 +300,6 @@ const ReportForm = ({
         validateField,
         validateForm,
         touched,
-        errors,
         resetForm,
         setSubmitting
       }) => {
@@ -833,8 +832,7 @@ const ReportForm = ({
                       setFieldTouched,
                       setFieldValue,
                       values,
-                      validateForm,
-                      errors
+                      validateForm
                     }}
                   />
                 </Fieldset>

--- a/client/src/pages/reports/Form.js
+++ b/client/src/pages/reports/Form.js
@@ -917,6 +917,7 @@ const ReportForm = ({
                   label={Settings.fields.report.reportText}
                   component={FieldHelper.SpecialField}
                   onChange={value => {
+                    // prevent initial unnecessary render of RichTextEditor
                     if (!_isEqual(values.reportText, value)) {
                       setFieldValue("reportText", value, true)
                     }
@@ -950,6 +951,7 @@ const ReportForm = ({
                         label="Report sensitive information text"
                         onChange={value => {
                           const safeVal = value || null
+                          // prevent initial unnecessary render of RichTextEditor
                           if (
                             !_isEqual(
                               values.reportSensitiveInformation.text,

--- a/client/src/pages/reports/Form.js
+++ b/client/src/pages/reports/Form.js
@@ -299,6 +299,7 @@ const ReportForm = ({
         validateField,
         validateForm,
         touched,
+        errors,
         resetForm,
         setSubmitting
       }) => {
@@ -831,7 +832,8 @@ const ReportForm = ({
                       setFieldTouched,
                       setFieldValue,
                       values,
-                      validateForm
+                      validateForm,
+                      errors
                     }}
                   />
                 </Fieldset>

--- a/client/src/pages/reports/Form.js
+++ b/client/src/pages/reports/Form.js
@@ -1197,7 +1197,8 @@ const ReportForm = ({
           const newValues = _cloneDeep(autoSaveSettings.current.values)
           Object.assign(newValues, response)
           if (newValues.reportSensitiveInformation === null) {
-            newValues.reportSensitiveInformation = {} // object must exist for Collapse children
+            // object must exist for Collapse children
+            newValues.reportSensitiveInformation = { uuid: null, text: null }
           }
           // After successful autosave, reset the form with the new values in order to make sure the dirty
           // prop is also reset (otherwise we would get a blocking navigation warning)

--- a/client/src/pages/reports/Form.js
+++ b/client/src/pages/reports/Form.js
@@ -1282,8 +1282,8 @@ const ReportForm = ({
 
   function onSubmitSuccess(report, values, resetForm) {
     const edit = isEditMode(values)
-    // After successful submit, reset the form in order to make sure the dirty
-    // prop is also reset (otherwise we would get a blocking navigation warning)
+    // reset the form to latest values
+    // to avoid unsaved changes propmt if it somehow becomes dirty
     resetForm({ values, isSubmitting: true })
     if (!edit) {
       history.replace(Report.pathForEdit(report))

--- a/client/src/pages/reports/MyReports.js
+++ b/client/src/pages/reports/MyReports.js
@@ -14,7 +14,7 @@ import ReportCollection, {
   FORMAT_SUMMARY,
   FORMAT_TABLE
 } from "components/ReportCollection"
-import { SearchQueryPropType, getSearchQuery } from "components/SearchFilters"
+import { getSearchQuery, SearchQueryPropType } from "components/SearchFilters"
 import SubNav from "components/SubNav"
 import { Report } from "models"
 import React, { useContext } from "react"
@@ -50,9 +50,7 @@ const MyReports = ({ pageDispatchers, searchQuery }) => {
       state: [Report.STATE.CANCELLED]
     }
   }
-  Object.keys(sectionQueryParams).forEach(
-    key => (sectionQueryParams[key].authorUuid = uuid)
-  )
+  Object.values(sectionQueryParams).forEach(val => (val.authorUuid = uuid))
 
   return (
     <div>

--- a/client/src/pages/reports/New.js
+++ b/client/src/pages/reports/New.js
@@ -1,6 +1,11 @@
 import { DEFAULT_SEARCH_PROPS, PAGE_PROPS_NO_NAV } from "actions"
 import AppContext from "components/AppContext"
+import { getInvisibleFields } from "components/CustomFields"
 import GuidedTour from "components/GuidedTour"
+import {
+  DEFAULT_CUSTOM_FIELDS_PARENT,
+  INVISIBLE_CUSTOM_FIELDS_FIELD
+} from "components/Model"
 import {
   mapPageDispatchersToProps,
   PageDispatchersPropType,
@@ -10,6 +15,7 @@ import { Person, Report } from "models"
 import { reportTour } from "pages/HopscotchTour"
 import React, { useContext } from "react"
 import { connect } from "react-redux"
+import Settings from "settings"
 import ReportForm from "./Form"
 
 const ReportNew = ({ pageDispatchers }) => {
@@ -21,6 +27,16 @@ const ReportNew = ({ pageDispatchers }) => {
   })
 
   const report = new Report()
+
+  // set initial invisible custom fields
+  report[DEFAULT_CUSTOM_FIELDS_PARENT][
+    INVISIBLE_CUSTOM_FIELDS_FIELD
+  ] = getInvisibleFields(
+    Settings.fields.report.customFields,
+    DEFAULT_CUSTOM_FIELDS_PARENT,
+    report
+  )
+
   if (currentUser && currentUser.uuid) {
     const person = new Person(currentUser)
     person.primary = true

--- a/client/src/pages/reports/Show.js
+++ b/client/src/pages/reports/Show.js
@@ -10,9 +10,9 @@ import AppContext from "components/AppContext"
 import InstantAssessmentsContainerField from "components/assessments/InstantAssessmentsContainerField"
 import ConfirmDelete from "components/ConfirmDelete"
 import { ReadonlyCustomFields } from "components/CustomFields"
+import { parseHtmlWithLinkTo } from "components/editor/LinkAnet"
 import * as FieldHelper from "components/FieldHelper"
 import Fieldset from "components/Fieldset"
-import { parseHtmlWithLinkTo } from "components/editor/LinkAnet"
 import LinkTo from "components/LinkTo"
 import Messages from "components/Messages"
 import { DEFAULT_CUSTOM_FIELDS_PARENT } from "components/Model"
@@ -656,21 +656,18 @@ const ReportShow = ({ setSearchQuery, pageDispatchers }) => {
                   {parseHtmlWithLinkTo(report.reportText)}
                 </Fieldset>
               )}
-              {report.reportSensitiveInformation &&
-                report.reportSensitiveInformation.text && (
-                  <Fieldset title="Sensitive information">
-                    {parseHtmlWithLinkTo(
-                      report.reportSensitiveInformation.text
-                    )}
-                    {(hasAuthorizationGroups && (
-                      <div>
-                        <h5>Authorized groups:</h5>
-                        <AuthorizationGroupTable
-                          authorizationGroups={values.authorizationGroups}
-                        />
-                      </div>
-                    )) || <h5>No groups are authorized!</h5>}
-                  </Fieldset>
+              {report.reportSensitiveInformation?.text && (
+                <Fieldset title="Sensitive information">
+                  {parseHtmlWithLinkTo(report.reportSensitiveInformation.text)}
+                  {(hasAuthorizationGroups && (
+                    <div>
+                      <h5>Authorized groups:</h5>
+                      <AuthorizationGroupTable
+                        authorizationGroups={values.authorizationGroups}
+                      />
+                    </div>
+                  )) || <h5>No groups are authorized!</h5>}
+                </Fieldset>
               )}
               {Settings.fields.report.customFields && (
                 <Fieldset title="Engagement information" id="custom-fields">

--- a/client/src/pages/tasks/Edit.js
+++ b/client/src/pages/tasks/Edit.js
@@ -1,7 +1,11 @@
 import { DEFAULT_SEARCH_PROPS, PAGE_PROPS_NO_NAV } from "actions"
 import API from "api"
 import { gql } from "apollo-boost"
-import { DEFAULT_CUSTOM_FIELDS_PARENT } from "components/Model"
+import { getInvisibleFields } from "components/CustomFields"
+import {
+  DEFAULT_CUSTOM_FIELDS_PARENT,
+  INVISIBLE_CUSTOM_FIELDS_FIELD
+} from "components/Model"
 import {
   mapPageDispatchersToProps,
   PageDispatchersPropType,
@@ -120,6 +124,15 @@ const TaskEdit = ({ pageDispatchers }) => {
     )
   }
   const task = new Task(data ? data.task : {})
+
+  // set initial invisible custom fields
+  task[DEFAULT_CUSTOM_FIELDS_PARENT][
+    INVISIBLE_CUSTOM_FIELDS_FIELD
+  ] = getInvisibleFields(
+    Settings.fields.task.customFields,
+    DEFAULT_CUSTOM_FIELDS_PARENT,
+    task
+  )
 
   return (
     <div>

--- a/client/src/pages/tasks/Form.js
+++ b/client/src/pages/tasks/Form.js
@@ -23,9 +23,9 @@ import Model, {
   NOTE_TYPE
 } from "components/Model"
 import NavigationWarning from "components/NavigationWarning"
+import OrganizationTable from "components/OrganizationTable"
 import { jumpToTop } from "components/Page"
 import PositionTable from "components/PositionTable"
-import OrganizationTable from "components/OrganizationTable"
 import RichTextEditor from "components/RichTextEditor"
 import { FastField, Field, Form, Formik } from "formik"
 import { Organization, Position, Task } from "models"
@@ -415,7 +415,8 @@ const TaskForm = ({ edit, title, initialValues }) => {
                       setFieldTouched,
                       setFieldValue,
                       values,
-                      validateForm
+                      validateForm,
+                      errors
                     }}
                   />
                 </Fieldset>

--- a/client/src/pages/tasks/Form.js
+++ b/client/src/pages/tasks/Form.js
@@ -415,8 +415,7 @@ const TaskForm = ({ edit, title, initialValues }) => {
                       setFieldTouched,
                       setFieldValue,
                       values,
-                      validateForm,
-                      errors
+                      validateForm
                     }}
                   />
                 </Fieldset>

--- a/client/src/pages/tasks/Form.js
+++ b/client/src/pages/tasks/Form.js
@@ -488,8 +488,8 @@ const TaskForm = ({ edit, title, initialValues }) => {
         ? response[operation].uuid
         : initialValues.uuid
     })
-    // After successful submit, reset the form in order to make sure the dirty
-    // prop is also reset (otherwise we would get a blocking navigation warning)
+    // reset the form to latest values
+    // to avoid unsaved changes propmt if it somehow becomes dirty
     form.resetForm({ values, isSubmitting: true })
     history.replace(Task.pathForEdit(task))
     if (!edit) {

--- a/client/src/pages/tasks/Form.js
+++ b/client/src/pages/tasks/Form.js
@@ -490,7 +490,7 @@ const TaskForm = ({ edit, title, initialValues }) => {
     })
     // After successful submit, reset the form in order to make sure the dirty
     // prop is also reset (otherwise we would get a blocking navigation warning)
-    form.resetForm()
+    form.resetForm({ values, isSubmitting: true })
     history.replace(Task.pathForEdit(task))
     if (!edit) {
       history.replace(Task.pathForEdit(task))

--- a/client/src/pages/tasks/New.js
+++ b/client/src/pages/tasks/New.js
@@ -1,9 +1,14 @@
 import { DEFAULT_SEARCH_PROPS, PAGE_PROPS_NO_NAV } from "actions"
 import API from "api"
 import { gql } from "apollo-boost"
+import { getInvisibleFields } from "components/CustomFields"
 import {
-  PageDispatchersPropType,
+  DEFAULT_CUSTOM_FIELDS_PARENT,
+  INVISIBLE_CUSTOM_FIELDS_FIELD
+} from "components/Model"
+import {
   mapPageDispatchersToProps,
+  PageDispatchersPropType,
   useBoilerplate
 } from "components/Page"
 import { Organization, Task } from "models"
@@ -87,6 +92,15 @@ const TaskNewConditional = ({
   if (data) {
     task.taskedOrganizations = [new Organization(data.organization)]
   }
+
+  // set initial invisible custom fields
+  task[DEFAULT_CUSTOM_FIELDS_PARENT][
+    INVISIBLE_CUSTOM_FIELDS_FIELD
+  ] = getInvisibleFields(
+    Settings.fields.task.customFields,
+    DEFAULT_CUSTOM_FIELDS_PARENT,
+    task
+  )
 
   return (
     <TaskForm

--- a/client/tests/webdriver/pages/createNewPerson.page.js
+++ b/client/tests/webdriver/pages/createNewPerson.page.js
@@ -100,6 +100,16 @@ class CreatePerson extends Page {
     return this.customFieldsContainer.$('label[id="AMBER"]')
   }
 
+  get addObjectButton() {
+    return this.customFieldsContainer.$('button[id="addObjectButton"]')
+  }
+
+  get objectDateField() {
+    return this.customFieldsContainer.$(
+      'input[id="formCustomFields.arrayFieldName.0.dateF"]'
+    )
+  }
+
   getCustomFieldContainerByName(name) {
     return this.customFieldsContainer.$(`div[id="fg-${name}"]`)
   }

--- a/client/tests/webdriver/pages/createNewPerson.page.js
+++ b/client/tests/webdriver/pages/createNewPerson.page.js
@@ -2,6 +2,11 @@ import Page from "./page"
 
 const PAGE_URL = "/people/new"
 
+const INVISIBLE_CUSTOM_FIELDS = {
+  textArea: "formCustomFields.textareaFieldName",
+  number: "formCustomFields.numberFieldName"
+}
+
 class CreatePerson extends Page {
   get form() {
     return browser.$("form")
@@ -61,6 +66,42 @@ class CreatePerson extends Page {
 
   get endOfTourToday() {
     return browser.$(".bp3-datepicker-footer button.bp3-button:first-child")
+  }
+
+  get customFieldsContainer() {
+    return browser.$("#custom-fields")
+  }
+
+  get numberCustomFieldContainer() {
+    return this.getCustomFieldContainerByName(INVISIBLE_CUSTOM_FIELDS.number)
+  }
+
+  get numberCustomField() {
+    return this.numberCustomFieldContainer.$('input[type="number"]')
+  }
+
+  get numberCustomFieldHelpText() {
+    return this.numberCustomFieldContainer.$(
+      '//span[contains(text(), "greater than")]'
+    )
+  }
+
+  get defaultInvisibleCustomFields() {
+    return Object.keys(INVISIBLE_CUSTOM_FIELDS).map(field =>
+      this.getCustomFieldContainerByName(INVISIBLE_CUSTOM_FIELDS[field])
+    )
+  }
+
+  get greenButton() {
+    return this.customFieldsContainer.$('label[id="GREEN"]')
+  }
+
+  get amberButton() {
+    return this.customFieldsContainer.$('label[id="AMBER"]')
+  }
+
+  getCustomFieldContainerByName(name) {
+    return this.customFieldsContainer.$(`div[id="fg-${name}"]`)
   }
 
   openAsSuperUser() {

--- a/client/tests/webdriver/pages/createNewPerson.page.js
+++ b/client/tests/webdriver/pages/createNewPerson.page.js
@@ -9,7 +9,7 @@ const INVISIBLE_CUSTOM_FIELDS = {
 
 class CreatePerson extends Page {
   get form() {
-    return browser.$("form")
+    return browser.$("form.form-horizontal")
   }
 
   get alertSuccess() {
@@ -17,7 +17,7 @@ class CreatePerson extends Page {
   }
 
   get lastName() {
-    return browser.$("#lastName")
+    return this.form.$("#lastName")
   }
 
   get firstName() {
@@ -100,8 +100,10 @@ class CreatePerson extends Page {
     return this.customFieldsContainer.$('label[id="AMBER"]')
   }
 
-  get addObjectButton() {
-    return this.customFieldsContainer.$('button[id="addObjectButton"]')
+  get addArrayObjectButton() {
+    return this.customFieldsContainer.$(
+      'button[id="add-formCustomFields.arrayFieldName"]'
+    )
   }
 
   get objectDateField() {

--- a/client/tests/webdriver/pages/createNewTask.page.js
+++ b/client/tests/webdriver/pages/createNewTask.page.js
@@ -1,0 +1,38 @@
+import Page from "./page"
+
+const PAGE_URL = "/tasks/new"
+
+class CreateTask extends Page {
+  get form() {
+    return browser.$("form")
+  }
+
+  get alertSuccess() {
+    return browser.$(".alert-success")
+  }
+
+  get submitButton() {
+    return browser.$("#formBottomSubmit")
+  }
+
+  openAsSuperUser() {
+    super.openAsSuperUser(PAGE_URL)
+  }
+
+  openAsAdmin() {
+    super.openAsAdminUser(PAGE_URL)
+  }
+
+  waitForAlertSuccessToLoad() {
+    if (!this.alertSuccess.isDisplayed()) {
+      this.alertSuccess.waitForExist()
+      this.alertSuccess.waitForDisplayed()
+    }
+  }
+
+  submitForm() {
+    this.submitButton.click()
+  }
+}
+
+export default new CreateTask()

--- a/client/tests/webdriver/pages/createNewTask.page.js
+++ b/client/tests/webdriver/pages/createNewTask.page.js
@@ -48,10 +48,6 @@ class CreateTask extends Page {
     )
   }
 
-  get questionsFieldHelpText() {
-    return this.firstQuestionsFieldContainer.$(".help-block")
-  }
-
   get addAssessmentButton() {
     return browser.$('button[id="add-formCustomFields.assessments"]')
   }

--- a/client/tests/webdriver/pages/createNewTask.page.js
+++ b/client/tests/webdriver/pages/createNewTask.page.js
@@ -19,28 +19,41 @@ class CreateTask extends Page {
     return browser.$('input[id="shortName"]')
   }
 
-  get addObjectButton() {
-    return browser.$('button[id="addObjectButton"]')
+  get customFieldsContainer() {
+    return browser.$("#custom-fields")
   }
 
-  get objectFields() {
-    return browser
-      .$("#custom-fields")
-      .$$("//div[starts-with(@id,'fg-formCustomFields')]")
+  get assessmentFields() {
+    // since only custom field is assessments
+    return this.customFieldsContainer.$$(
+      '//div[starts-with(@id,"fg-formCustomFields")]'
+    )
+  }
+
+  get firstQuestionsFieldContainer() {
+    return this.customFieldsContainer.$(
+      'div[id="fg-formCustomFields.assessments.0.questions"]'
+    )
   }
 
   get questionsField() {
-    return browser
-      .$("#custom-fields")
-      .$("//textarea[contains(@id,'questions')]")
+    return this.firstQuestionsFieldContainer.$(
+      'textarea[id="formCustomFields.assessments.0.questions"]'
+    )
   }
 
   get questionsFieldWarningText() {
-    return this.questionsField.$("//span[contains(text(), 'Invalid')]")
+    return this.firstQuestionsFieldContainer.$(
+      '//span[contains(text(), "Invalid")]'
+    )
   }
 
   get questionsFieldHelpText() {
-    return this.questionsField.$(".help-block")
+    return this.firstQuestionsFieldContainer.$(".help-block")
+  }
+
+  get addAssessmentButton() {
+    return browser.$('button[id="add-formCustomFields.assessments"]')
   }
 
   openAsSuperUser() {

--- a/client/tests/webdriver/pages/createNewTask.page.js
+++ b/client/tests/webdriver/pages/createNewTask.page.js
@@ -15,6 +15,34 @@ class CreateTask extends Page {
     return browser.$("#formBottomSubmit")
   }
 
+  get shortName() {
+    return browser.$('input[id="shortName"]')
+  }
+
+  get addObjectButton() {
+    return browser.$('button[id="addObjectButton"]')
+  }
+
+  get objectFields() {
+    return browser
+      .$("#custom-fields")
+      .$$("//div[starts-with(@id,'fg-formCustomFields')]")
+  }
+
+  get questionsField() {
+    return browser
+      .$("#custom-fields")
+      .$("//textarea[contains(@id,'questions')]")
+  }
+
+  get questionsFieldWarningText() {
+    return this.questionsField.$("//span[contains(text(), 'Invalid')]")
+  }
+
+  get questionsFieldHelpText() {
+    return this.questionsField.$(".help-block")
+  }
+
   openAsSuperUser() {
     super.openAsSuperUser(PAGE_URL)
   }

--- a/client/tests/webdriver/pages/createReport.page.js
+++ b/client/tests/webdriver/pages/createReport.page.js
@@ -137,6 +137,10 @@ export class CreateReport extends Page {
     )
   }
 
+  get numberTrainedFieldShowed() {
+    return this.numberTrainedFormGroup.$("div.form-control-static")
+  }
+
   get numberTrainedHelpText() {
     return this.numberTrainedFormGroup.$('span[class="help-block"]')
   }

--- a/client/tests/webdriver/pages/createReport.page.js
+++ b/client/tests/webdriver/pages/createReport.page.js
@@ -137,6 +137,10 @@ export class CreateReport extends Page {
     )
   }
 
+  get numberTrainedHelpText() {
+    return this.numberTrainedFormGroup.$('span[class="help-block"]')
+  }
+
   getTestMultiReferenceFieldAdvancedSelectItem(n) {
     return this.testMultiReferenceFieldAdvancedSelect.$(
       `tr:nth-child(${n}) td:nth-child(2)`

--- a/client/tests/webdriver/pages/createReport.page.js
+++ b/client/tests/webdriver/pages/createReport.page.js
@@ -19,8 +19,8 @@ const nonTrainingFields = {
 }
 
 const nonTrainingFieldsets = {
-  itemsAgreed: "",
-  assetsUsed: ""
+  itemsAgreed: "formCustomFields.itemsAgreed",
+  assetsUsed: "formCustomFields.assetsUsed"
 }
 
 export class CreateReport extends Page {

--- a/client/tests/webdriver/pages/createReport.page.js
+++ b/client/tests/webdriver/pages/createReport.page.js
@@ -2,24 +2,24 @@ import Page from "./page"
 
 const PAGE_URL = "/reports/new"
 
-const trfId = "formCustomFields.relatedReport"
-const tmrfId = "formCustomFields.additionalEngagementNeeded"
-const engagementTypesId = "formCustomFields.multipleButtons"
+const RELATED_REPORT_ID = "formCustomFields.relatedReport"
+const ADDITIONAL_ENGAGEMENTS_ID = "formCustomFields.additionalEngagementNeeded"
+const ENGAGEMENT_TYPES_ID = "formCustomFields.multipleButtons"
 
-const trainingFields = {
+const TRAINING_TOGGLED_FIELDS = {
   trainingEvent: "formCustomFields.trainingEvent",
   numberTrained: "formCustomFields.numberTrained",
   levelTrained: "formCustomFields.levelTrained",
   trainingDate: "formCustomFields.trainingDate"
 }
 
-const nonTrainingFields = {
+const ADVISE_FIELDS = {
   systemProcess: "formCustomFields.systemProcess",
+  itemsAgreed: "formCustomFields.itemsAgreed",
   echelons: "formCustomFields.echelons"
 }
 
-const nonTrainingFieldsets = {
-  itemsAgreed: "formCustomFields.itemsAgreed",
+const OTHER_FIELDS = {
   assetsUsed: "formCustomFields.assetsUsed"
 }
 
@@ -45,11 +45,13 @@ export class CreateReport extends Page {
   }
 
   get testReferenceFieldFormGroup() {
-    return this.getCustomFieldFormGroup(trfId)
+    return this.getCustomFieldFormGroup(RELATED_REPORT_ID)
   }
 
   get testReferenceFieldLabel() {
-    return this.testReferenceFieldFormGroup.$(`label[for="${trfId}"]`)
+    return this.testReferenceFieldFormGroup.$(
+      `label[for="${RELATED_REPORT_ID}"]`
+    )
   }
 
   get testReferenceFieldHelpText() {
@@ -57,27 +59,31 @@ export class CreateReport extends Page {
   }
 
   get testReferenceField() {
-    return this.testReferenceFieldFormGroup.$(`input[id="${trfId}"]`)
+    return this.testReferenceFieldFormGroup.$(
+      `input[id="${RELATED_REPORT_ID}"]`
+    )
   }
 
   get testReferenceFieldAdvancedSelectFirstItem() {
     return this.testReferenceFieldFormGroup.$(
-      `div[id="${trfId}-popover"] tbody tr:first-child td:nth-child(2)`
+      `div[id="${RELATED_REPORT_ID}-popover"] tbody tr:first-child td:nth-child(2)`
     )
   }
 
   get testReferenceFieldValue() {
     return this.testReferenceFieldFormGroup.$(
-      `table[id="${trfId}-value"] tbody tr:first-child`
+      `table[id="${RELATED_REPORT_ID}-value"] tbody tr:first-child`
     )
   }
 
   get testMultiReferenceFieldFormGroup() {
-    return this.getCustomFieldFormGroup(tmrfId)
+    return this.getCustomFieldFormGroup(ADDITIONAL_ENGAGEMENTS_ID)
   }
 
   get testMultiReferenceFieldLabel() {
-    return this.testMultiReferenceFieldFormGroup.$(`label[for="${tmrfId}"]`)
+    return this.testMultiReferenceFieldFormGroup.$(
+      `label[for="${ADDITIONAL_ENGAGEMENTS_ID}"]`
+    )
   }
 
   get testMultiReferenceFieldHelpText() {
@@ -85,22 +91,24 @@ export class CreateReport extends Page {
   }
 
   get testMultiReferenceField() {
-    return this.testMultiReferenceFieldFormGroup.$(`input[id="${tmrfId}"]`)
+    return this.testMultiReferenceFieldFormGroup.$(
+      `input[id="${ADDITIONAL_ENGAGEMENTS_ID}"]`
+    )
   }
 
   get testMultiReferenceFieldAdvancedSelect() {
     return this.testMultiReferenceFieldFormGroup.$(
-      `div[id="${tmrfId}-popover"] tbody`
+      `div[id="${ADDITIONAL_ENGAGEMENTS_ID}-popover"] tbody`
     )
   }
 
   get engagementTypesFieldFormGroup() {
-    return this.getCustomFieldFormGroup(engagementTypesId)
+    return this.getCustomFieldFormGroup(ENGAGEMENT_TYPES_ID)
   }
 
   get engagementTypesFieldLabel() {
     return this.engagementTypesFieldFormGroup.$(
-      `label[for="${engagementTypesId}"]`
+      `label[for="${ENGAGEMENT_TYPES_ID}"]`
     )
   }
 
@@ -109,31 +117,31 @@ export class CreateReport extends Page {
   }
 
   get fieldsToggledVisibilityByTrainButton() {
-    return Object.keys(trainingFields).map(fieldId => {
-      return this.getCustomFieldFormGroup(trainingFields[fieldId])
+    return Object.keys(TRAINING_TOGGLED_FIELDS).map(fieldId => {
+      return this.getCustomFieldFormGroup(TRAINING_TOGGLED_FIELDS[fieldId])
     })
   }
 
   get fieldsNotToggledVisibilityByTrainButton() {
-    return Object.keys(nonTrainingFields)
+    return Object.keys(ADVISE_FIELDS)
       .map(fieldId => {
-        return this.getCustomFieldFormGroup(trainingFields[fieldId])
+        return this.getCustomFieldFormGroup(ADVISE_FIELDS[fieldId])
       })
       .concat(
         // fieldsets are not prepended with fg-
-        Object.keys(nonTrainingFieldsets).map(fieldsetId => {
-          return browser.$(`div[id="${nonTrainingFieldsets[fieldsetId]}"]`)
+        Object.keys(OTHER_FIELDS).map(fieldsetId => {
+          return browser.$(`div[id="${OTHER_FIELDS[fieldsetId]}"]`)
         })
       )
   }
 
   get numberTrainedFormGroup() {
-    return this.getCustomFieldFormGroup(trainingFields.numberTrained)
+    return this.getCustomFieldFormGroup(TRAINING_TOGGLED_FIELDS.numberTrained)
   }
 
   get numberTrainedField() {
     return this.numberTrainedFormGroup.$(
-      `input[id="${trainingFields.numberTrained}"]`
+      `input[id="${TRAINING_TOGGLED_FIELDS.numberTrained}"]`
     )
   }
 
@@ -157,7 +165,7 @@ export class CreateReport extends Page {
 
   get testMultiReferenceFieldValue() {
     return this.testMultiReferenceFieldFormGroup.$(
-      `table[id="${tmrfId}-value"]`
+      `table[id="${ADDITIONAL_ENGAGEMENTS_ID}-value"]`
     )
   }
 

--- a/client/tests/webdriver/pages/createReport.page.js
+++ b/client/tests/webdriver/pages/createReport.page.js
@@ -4,6 +4,24 @@ const PAGE_URL = "/reports/new"
 
 const trfId = "formCustomFields.relatedReport"
 const tmrfId = "formCustomFields.additionalEngagementNeeded"
+const engagementTypesId = "formCustomFields.multipleButtons"
+
+const trainingFields = {
+  trainingEvent: "formCustomFields.trainingEvent",
+  numberTrained: "formCustomFields.numberTrained",
+  levelTrained: "formCustomFields.levelTrained",
+  trainingDate: "formCustomFields.trainingDate"
+}
+
+const nonTrainingFields = {
+  systemProcess: "formCustomFields.systemProcess",
+  echelons: "formCustomFields.echelons"
+}
+
+const nonTrainingFieldsets = {
+  itemsAgreed: "",
+  assetsUsed: ""
+}
 
 export class CreateReport extends Page {
   get form() {
@@ -18,12 +36,16 @@ export class CreateReport extends Page {
     return browser.$("#duration")
   }
 
+  getCustomFieldFormGroup(id) {
+    return browser.$(`div[id="fg-${id}"]`)
+  }
+
   get engagementInformationTitle() {
     return browser.$('//span[text()="Engagement information"]')
   }
 
   get testReferenceFieldFormGroup() {
-    return browser.$(`div[id="fg-${trfId}"]`)
+    return this.getCustomFieldFormGroup(trfId)
   }
 
   get testReferenceFieldLabel() {
@@ -51,7 +73,7 @@ export class CreateReport extends Page {
   }
 
   get testMultiReferenceFieldFormGroup() {
-    return browser.$(`div[id="fg-${tmrfId}"]`)
+    return this.getCustomFieldFormGroup(tmrfId)
   }
 
   get testMultiReferenceFieldLabel() {
@@ -69,6 +91,49 @@ export class CreateReport extends Page {
   get testMultiReferenceFieldAdvancedSelect() {
     return this.testMultiReferenceFieldFormGroup.$(
       `div[id="${tmrfId}-popover"] tbody`
+    )
+  }
+
+  get engagementTypesFieldFormGroup() {
+    return this.getCustomFieldFormGroup(engagementTypesId)
+  }
+
+  get engagementTypesFieldLabel() {
+    return this.engagementTypesFieldFormGroup.$(
+      `label[for="${engagementTypesId}"]`
+    )
+  }
+
+  getEngagementTypesButtonByName(name) {
+    return this.engagementTypesFieldFormGroup.$(`label[id="${name}"]`)
+  }
+
+  get fieldsToggledVisibilityByTrainButton() {
+    return Object.keys(trainingFields).map(fieldId => {
+      return this.getCustomFieldFormGroup(trainingFields[fieldId])
+    })
+  }
+
+  get fieldsNotToggledVisibilityByTrainButton() {
+    return Object.keys(nonTrainingFields)
+      .map(fieldId => {
+        return this.getCustomFieldFormGroup(trainingFields[fieldId])
+      })
+      .concat(
+        // fieldsets are not prepended with fg-
+        Object.keys(nonTrainingFieldsets).map(fieldsetId => {
+          return browser.$(`div[id="${nonTrainingFieldsets[fieldsetId]}"]`)
+        })
+      )
+  }
+
+  get numberTrainedFormGroup() {
+    return this.getCustomFieldFormGroup(trainingFields.numberTrained)
+  }
+
+  get numberTrainedField() {
+    return this.numberTrainedFormGroup.$(
+      `input[id="${trainingFields.numberTrained}"]`
     )
   }
 
@@ -116,6 +181,10 @@ export class CreateReport extends Page {
 
   open(pathName = PAGE_URL, credentials = Page.DEFAULT_CREDENTIALS.user) {
     super.open(pathName, credentials)
+  }
+
+  openAsAdminUser() {
+    super.openAsAdminUser(PAGE_URL)
   }
 
   waitForAlertToLoad() {

--- a/client/tests/webdriver/specs/customFields.spec.js
+++ b/client/tests/webdriver/specs/customFields.spec.js
@@ -3,9 +3,9 @@ import CreatePerson from "../pages/createNewPerson.page"
 import CreateTask from "../pages/createNewTask.page"
 import CreateReport from "../pages/createReport.page"
 
-const inValidNumberInput = "-10"
-const validNumberInput = "10"
-const TESTED_ENGAGEMENT_BUTTON = "train"
+const INVALID_NUMBER_INPUT = "-10"
+const VALID_NUMBER_INPUT = "10"
+const TRAIN_ENGAGEMENT_BUTTON = "train"
 
 const REQUIRED_PERSON_FIELDS = {
   lastname: "customPerson",
@@ -20,14 +20,13 @@ const REQUIRED_TASK_FIELDS = {
 describe("When working with custom fields for different anet objects", () => {
   // ------------------------------ REPORT CUSTOM FIELDS -----------------------------------------
   describe("For report's custom fields", () => {
-    it("Should open a create new report page", () => {
+    it("Should be able load a new report form", () => {
       CreateReport.openAsAdminUser()
       CreateReport.form.waitForExist()
       CreateReport.form.waitForDisplayed()
     })
 
-    it("Should not show default invisible fields", () => {
-      // both of these fields invisible at first
+    it("When the engagement type is not defined, it should not display fields only visible when a certain engagement type is selected", () => {
       CreateReport.fieldsToggledVisibilityByTrainButton.forEach(invisField => {
         expect(invisField.isExisting()).to.equal(false)
       })
@@ -39,19 +38,20 @@ describe("When working with custom fields for different anet objects", () => {
       )
     })
 
-    it("Should toggle the correct invisible fields", () => {
-      const button = CreateReport.getEngagementTypesButtonByName(
-        TESTED_ENGAGEMENT_BUTTON
+    it("Selecting the train engagement type should toggle the correct invisible fields", () => {
+      const trainButton = CreateReport.getEngagementTypesButtonByName(
+        TRAIN_ENGAGEMENT_BUTTON
       )
-      button.waitForExist()
-      button.waitForDisplayed()
-      button.click()
+      trainButton.waitForExist()
+      trainButton.waitForDisplayed()
+      trainButton.click()
       CreateReport.fieldsToggledVisibilityByTrainButton.forEach(
-        nowVisisbleField => {
-          nowVisisbleField.waitForExist()
-          nowVisisbleField.waitForDisplayed()
+        nowVisibleField => {
+          nowVisibleField.waitForExist()
+          nowVisibleField.waitForDisplayed()
         }
       )
+      // train button active here so numberField will be visible
 
       CreateReport.fieldsNotToggledVisibilityByTrainButton.forEach(
         stillInvisField => {
@@ -61,48 +61,51 @@ describe("When working with custom fields for different anet objects", () => {
     })
 
     it("Should persist previous valid data when toggling field's visibility", () => {
-      CreateReport.numberTrainedField.setValue(validNumberInput)
-      const button = CreateReport.getEngagementTypesButtonByName(
-        TESTED_ENGAGEMENT_BUTTON
+      CreateReport.numberTrainedField.setValue(VALID_NUMBER_INPUT)
+      const trainButton = CreateReport.getEngagementTypesButtonByName(
+        TRAIN_ENGAGEMENT_BUTTON
       )
-      // make invisible
-      button.click()
+      // turn off train option to make numberField invisible
+      trainButton.click()
       CreateReport.numberTrainedFormGroup.waitForExist({ reverse: true })
-      // make visible
-      button.click()
+      // turn on train option to make numberField visible
+      trainButton.click()
       CreateReport.numberTrainedFormGroup.waitForExist()
 
       expect(CreateReport.numberTrainedField.getValue()).to.equal(
-        validNumberInput
+        VALID_NUMBER_INPUT
       )
     })
 
     it("Should not persist previous invalid data when toggling field's visibility", () => {
-      CreateReport.numberTrainedField.setValue(inValidNumberInput)
+      CreateReport.numberTrainedField.setValue(INVALID_NUMBER_INPUT)
       CreateReport.numberTrainedHelpText.waitForExist()
       // Actually see the validation warning
       expect(CreateReport.numberTrainedHelpText.getText()).to.equal(
         "Number trained must be greater than or equal to 1"
       )
-      const button = CreateReport.getEngagementTypesButtonByName(
-        TESTED_ENGAGEMENT_BUTTON
+      const trainButton = CreateReport.getEngagementTypesButtonByName(
+        TRAIN_ENGAGEMENT_BUTTON
       )
-      // make invisible
-      button.click()
+      // turn off train option to make numberField invisible
+      trainButton.click()
       CreateReport.numberTrainedFormGroup.waitForExist({ reverse: true })
-      // make visible
-      button.click()
+      // turn on train option to make numberField visible
+      trainButton.click()
       CreateReport.numberTrainedFormGroup.waitForExist()
 
       expect(CreateReport.numberTrainedField.getValue()).not.be.equal(
-        inValidNumberInput
+        INVALID_NUMBER_INPUT
       )
       expect(CreateReport.numberTrainedField.getValue()).to.be.equal("")
     })
 
     it("Should validate visible field", () => {
-      CreateReport.numberTrainedField.setValue(inValidNumberInput)
+      CreateReport.numberTrainedField.setValue(INVALID_NUMBER_INPUT)
       CreateReport.numberTrainedHelpText.waitForExist()
+      expect(CreateReport.numberTrainedHelpText.getText()).to.include(
+        "Number trained must be greater than or equal to 1"
+      )
       CreateReport.submitForm()
       CreateReport.waitForAlertToLoad()
 
@@ -111,23 +114,17 @@ describe("When working with custom fields for different anet objects", () => {
       )
     })
 
-    it("Should show valid visible field", () => {
-      // we are already at show page
-      expect(CreateReport.numberTrainedFieldShowed.getText()).to.include(
-        validNumberInput.toString()
-      )
-    })
-
     it("Should not validate invisible field", () => {
       CreateReport.editButton.click()
       CreateReport.form.waitForExist()
       CreateReport.form.waitForDisplayed()
 
-      const button = CreateReport.getEngagementTypesButtonByName(
-        TESTED_ENGAGEMENT_BUTTON
+      const trainButton = CreateReport.getEngagementTypesButtonByName(
+        TRAIN_ENGAGEMENT_BUTTON
       )
-      // make the trained number field invisible
-      button.click()
+      // turn off train option to make numberField invisible
+      // It was invalid from previous test case
+      trainButton.click()
 
       CreateReport.submitForm()
       CreateReport.waitForAlertToLoad()
@@ -137,31 +134,51 @@ describe("When working with custom fields for different anet objects", () => {
       )
     })
 
-    it("Should discard invisible fields even if it is valid", () => {
+    it("Should show valid visible field after saving", () => {
+      // we are on show page after submitting
       CreateReport.editButton.click()
       CreateReport.form.waitForExist()
       CreateReport.form.waitForDisplayed()
 
-      const button = CreateReport.getEngagementTypesButtonByName(
-        TESTED_ENGAGEMENT_BUTTON
+      const trainButton = CreateReport.getEngagementTypesButtonByName(
+        TRAIN_ENGAGEMENT_BUTTON
       )
-      // make the trained number field visible
-      button.click()
+      // turn on train option to make numberField visible
+      trainButton.click()
+      CreateReport.numberTrainedFormGroup.waitForExist()
+      CreateReport.numberTrainedField.setValue(VALID_NUMBER_INPUT)
+
+      CreateReport.submitForm()
+      CreateReport.waitForAlertToLoad()
+
+      expect(CreateReport.numberTrainedFieldShowed.getText()).to.include(
+        VALID_NUMBER_INPUT.toString()
+      )
+    })
+
+    it("Should discard invisible fields after saving even if it is valid", () => {
+      CreateReport.editButton.click()
+      CreateReport.form.waitForExist()
+      CreateReport.form.waitForDisplayed()
+
+      const trainButton = CreateReport.getEngagementTypesButtonByName(
+        TRAIN_ENGAGEMENT_BUTTON
+      )
       // give valid input before making invisible
-      CreateReport.numberTrainedField.setValue(validNumberInput)
+      CreateReport.numberTrainedField.setValue(VALID_NUMBER_INPUT)
       // goes invisible
-      button.click()
+      trainButton.click()
       CreateReport.submitForm()
       CreateReport.waitForAlertToLoad()
 
       expect(CreateReport.numberTrainedFieldShowed.getText()).to.not.include(
-        validNumberInput.toString()
+        VALID_NUMBER_INPUT.toString()
       )
     })
   })
   // ------------------------------ PERSON CUSTOM FIELDS -----------------------------------------
   describe("For person's custom fields", () => {
-    it("Should open create new person page", () => {
+    it("Should be able load a new person form and fill normal required fields", () => {
       CreatePerson.openAsAdmin()
       CreatePerson.form.waitForExist()
       CreatePerson.form.waitForDisplayed()
@@ -179,7 +196,7 @@ describe("When working with custom fields for different anet objects", () => {
         expect(field.isExisting()).to.eq(false)
       })
       // Date field is invisible by default
-      CreatePerson.addObjectButton.click()
+      CreatePerson.addArrayObjectButton.click()
       CreatePerson.objectDateField.waitForExist({ reverse: true })
     })
 
@@ -194,7 +211,7 @@ describe("When working with custom fields for different anet objects", () => {
     })
 
     it("Should persist previous valid data when toggling field's visibility", () => {
-      CreatePerson.numberCustomField.setValue(validNumberInput)
+      CreatePerson.numberCustomField.setValue(VALID_NUMBER_INPUT)
       // make default invisible fields invisible again, amber color does that
       CreatePerson.amberButton.click()
       CreatePerson.numberCustomFieldContainer.waitForExist({ reverse: true })
@@ -203,12 +220,12 @@ describe("When working with custom fields for different anet objects", () => {
       CreatePerson.numberCustomFieldContainer.waitForExist()
 
       expect(CreatePerson.numberCustomField.getValue()).be.equal(
-        validNumberInput
+        VALID_NUMBER_INPUT
       )
     })
 
     it("Should not persist previous invalid data when toggling field's visibility", () => {
-      CreatePerson.numberCustomField.setValue(inValidNumberInput)
+      CreatePerson.numberCustomField.setValue(INVALID_NUMBER_INPUT)
       // Actually see the validation warning
       CreatePerson.numberCustomFieldHelpText.waitForExist()
       // make invisible
@@ -219,14 +236,17 @@ describe("When working with custom fields for different anet objects", () => {
       CreatePerson.numberCustomFieldContainer.waitForExist()
 
       expect(CreatePerson.numberCustomField.getValue()).not.be.equal(
-        inValidNumberInput
+        INVALID_NUMBER_INPUT
       )
       expect(CreatePerson.numberCustomField.getValue()).to.equal("")
     })
 
     it("Should validate visible field", () => {
-      CreatePerson.numberCustomField.setValue(inValidNumberInput)
+      CreatePerson.numberCustomField.setValue(INVALID_NUMBER_INPUT)
       CreatePerson.numberCustomFieldHelpText.waitForExist()
+      expect(CreatePerson.numberCustomFieldHelpText.getText()).to.include(
+        "greater than"
+      )
     })
 
     it("Should not validate invisible field so we can submit the form", () => {
@@ -239,7 +259,7 @@ describe("When working with custom fields for different anet objects", () => {
   })
   // ------------------------------ TASK CUSTOM FIELDS -----------------------------------------
   describe("For task's custom fields", () => {
-    it("Should open create new task page", () => {
+    it("Should be able load a new task form and fill normal required fields", () => {
       CreateTask.openAsAdmin()
       CreateTask.form.waitForExist()
       CreateTask.form.waitForDisplayed()
@@ -248,22 +268,22 @@ describe("When working with custom fields for different anet objects", () => {
     })
 
     it("Should be able to see assessment fields", () => {
-      CreateTask.addObjectButton.click()
-      CreateTask.objectFields.forEach(field => {
+      CreateTask.addAssessmentButton.click()
+      CreateTask.assessmentFields.forEach(field => {
         field.waitForExist()
       })
     })
 
     it("Should warn invalid json for questions", () => {
       CreateTask.questionsField.setValue("invalidJsonTest")
-      // normally there is already a help block, we need other warning text
+      // normally there is already a help block, we need the other warning text
       CreateTask.questionsFieldWarningText.waitForExist()
     })
 
     it("Should not warn valid json for questions", () => {
       CreateTask.questionsField.setValue("{}")
-      // all help texts should be removed with valid json
-      CreateTask.questionsFieldHelpText.waitForExist({ reverse: true })
+      // only the warning help text should be removed with valid json
+      CreateTask.questionsFieldWarningText.waitForExist({ reverse: true })
     })
 
     it("Should be able to submit valid task", () => {

--- a/client/tests/webdriver/specs/customFields.spec.js
+++ b/client/tests/webdriver/specs/customFields.spec.js
@@ -1,18 +1,27 @@
 import { expect } from "chai"
+import CreatePerson from "../pages/createNewPerson.page"
+import CreateTask from "../pages/createNewTask.page"
 import CreateReport from "../pages/createReport.page"
 
+const inValidInput = "-10"
+const validInput = "10"
+const TESTED_BUTTON_NAME = "train"
+
 describe("When working with custom fields for different anet objects", () => {
-  describe("On a new report form", () => {
+  describe("For report's custom fields", () => {
     it("Should open a create new report page", () => {
       CreateReport.openAsAdminUser()
       CreateReport.form.waitForExist()
       CreateReport.form.waitForDisplayed()
     })
 
-    it("It should toggle the correct invisible fields", () => {
-      CreateReport.getEngagementTypesButtonByName("train").waitForExist()
-      CreateReport.getEngagementTypesButtonByName("train").waitForDisplayed()
-      CreateReport.getEngagementTypesButtonByName("train").click()
+    it("Should toggle the correct invisible fields", () => {
+      const button = CreateReport.getEngagementTypesButtonByName(
+        TESTED_BUTTON_NAME
+      )
+      button.waitForExist()
+      button.waitForDisplayed()
+      button.click()
       CreateReport.fieldsToggledVisibilityByTrainButton.forEach(
         nowVisisbleField => {
           nowVisisbleField.waitForExist()
@@ -26,15 +35,57 @@ describe("When working with custom fields for different anet objects", () => {
         }
       )
     })
-    it("Toggling visibility of a field should persist previous data", () => {
-      CreateReport.numberTrainedField.setValue("10")
-      CreateReport.getEngagementTypesButtonByName("train").click()
+
+    it("Should persist previous valid data when toggling field's visibility", () => {
+      CreateReport.numberTrainedField.setValue(validInput)
+      const button = CreateReport.getEngagementTypesButtonByName(
+        TESTED_BUTTON_NAME
+      )
+      button.click()
       CreateReport.numberTrainedFormGroup.waitForExist({ reverse: true })
 
-      CreateReport.getEngagementTypesButtonByName("train").click()
+      button.click()
       CreateReport.numberTrainedFormGroup.waitForExist()
 
-      expect(CreateReport.numberTrainedField.getValue()).to.equal("10")
+      expect(CreateReport.numberTrainedField.getValue()).to.equal(validInput)
+    })
+
+    it("Should not persist previous invalid data when toggling field's visibility", () => {
+      CreateReport.numberTrainedField.setValue(inValidInput)
+      CreateReport.numberTrainedHelpText.waitForExist()
+      // Actually see the validation warning
+      expect(CreateReport.numberTrainedHelpText.getText()).to.equal(
+        "Number trained must be greater than or equal to 1"
+      )
+      const button = CreateReport.getEngagementTypesButtonByName(
+        TESTED_BUTTON_NAME
+      )
+      button.click()
+      CreateReport.numberTrainedFormGroup.waitForExist({ reverse: true })
+
+      button.click()
+      CreateReport.numberTrainedFormGroup.waitForExist()
+
+      expect(CreateReport.numberTrainedField.getValue()).not.be.equal(
+        inValidInput
+      )
+      expect(CreateReport.numberTrainedField.getValue()).not.be.equal("")
+    })
+  })
+
+  describe("For person's custom fields", () => {
+    it("Should open create new person page", () => {
+      CreatePerson.openAsAdminUser()
+      CreatePerson.form.waitForExist()
+      CreatePerson.form.waitForDisplayed()
+    })
+  })
+
+  describe("For task's custom fields", () => {
+    it("Should open create new task page", () => {
+      CreateTask.openAsAdminUser()
+      CreateTask.form.waitForExist()
+      CreateTask.form.waitForDisplayed()
     })
   })
 })

--- a/client/tests/webdriver/specs/customFields.spec.js
+++ b/client/tests/webdriver/specs/customFields.spec.js
@@ -8,9 +8,13 @@ const validNumberInput = "10"
 const TESTED_ENGAGEMENT_BUTTON = "train"
 
 const REQUIRED_PERSON_FIELDS = {
-  lastname: "customField",
+  lastname: "customPerson",
   rank: "CIV",
   gender: "MALE"
+}
+
+const REQUIRED_TASK_FIELDS = {
+  shortName: "customTask"
 }
 
 describe("When working with custom fields for different anet objects", () => {
@@ -191,6 +195,32 @@ describe("When working with custom fields for different anet objects", () => {
       CreateTask.openAsAdmin()
       CreateTask.form.waitForExist()
       CreateTask.form.waitForDisplayed()
+      // Fill other required fields so that we can test custom field validation
+      CreateTask.shortName.setValue(REQUIRED_TASK_FIELDS.shortName)
+    })
+
+    it("Should be able to see assessment fields", () => {
+      CreateTask.addObjectButton.click()
+      CreateTask.objectFields.forEach(field => {
+        field.waitForExist()
+      })
+    })
+
+    it("Should warn invalid json for questions", () => {
+      CreateTask.questionsField.setValue("invalidJsonTest")
+      // normally there is already a help block, we need other warning text
+      CreateTask.questionsFieldWarningText.waitForExist()
+    })
+
+    it("Should not warn valid json for questions", () => {
+      CreateTask.questionsField.setValue("{}")
+      // all help texts should be removed with valid json
+      CreateTask.questionsFieldHelpText.waitForExist({ reverse: true })
+    })
+
+    it("Should be able to submit valid task", () => {
+      CreateTask.submitForm()
+      CreateTask.waitForAlertSuccessToLoad()
     })
   })
 })

--- a/client/tests/webdriver/specs/customFields.spec.js
+++ b/client/tests/webdriver/specs/customFields.spec.js
@@ -111,6 +111,13 @@ describe("When working with custom fields for different anet objects", () => {
       )
     })
 
+    it("Should show valid visible field", () => {
+      // we are already at show page
+      expect(CreateReport.numberTrainedFieldShowed.getText()).to.include(
+        validNumberInput.toString()
+      )
+    })
+
     it("Should not validate invisible field", () => {
       CreateReport.editButton.click()
       CreateReport.form.waitForExist()
@@ -127,6 +134,28 @@ describe("When working with custom fields for different anet objects", () => {
 
       expect(CreateReport.alert.getText()).to.not.include(
         "Number trained must be greater than or equal to 1"
+      )
+    })
+
+    it("Should discard invisible fields even if it is valid", () => {
+      CreateReport.editButton.click()
+      CreateReport.form.waitForExist()
+      CreateReport.form.waitForDisplayed()
+
+      const button = CreateReport.getEngagementTypesButtonByName(
+        TESTED_ENGAGEMENT_BUTTON
+      )
+      // make the trained number field visible
+      button.click()
+      // give valid input before making invisible
+      CreateReport.numberTrainedField.setValue(validNumberInput)
+      // goes invisible
+      button.click()
+      CreateReport.submitForm()
+      CreateReport.waitForAlertToLoad()
+
+      expect(CreateReport.numberTrainedFieldShowed.getText()).to.not.include(
+        validNumberInput.toString()
       )
     })
   })

--- a/client/tests/webdriver/specs/customFields.spec.js
+++ b/client/tests/webdriver/specs/customFields.spec.js
@@ -3,9 +3,15 @@ import CreatePerson from "../pages/createNewPerson.page"
 import CreateTask from "../pages/createNewTask.page"
 import CreateReport from "../pages/createReport.page"
 
-const inValidInput = "-10"
-const validInput = "10"
-const TESTED_BUTTON_NAME = "train"
+const inValidNumberInput = "-10"
+const validNumberInput = "10"
+const TESTED_ENGAGEMENT_BUTTON = "train"
+
+const REQUIRED_PERSON_FIELDS = {
+  lastname: "customField",
+  rank: "CIV",
+  gender: "MALE"
+}
 
 describe("When working with custom fields for different anet objects", () => {
   describe("For report's custom fields", () => {
@@ -17,7 +23,7 @@ describe("When working with custom fields for different anet objects", () => {
 
     it("Should toggle the correct invisible fields", () => {
       const button = CreateReport.getEngagementTypesButtonByName(
-        TESTED_BUTTON_NAME
+        TESTED_ENGAGEMENT_BUTTON
       )
       button.waitForExist()
       button.waitForDisplayed()
@@ -37,43 +43,47 @@ describe("When working with custom fields for different anet objects", () => {
     })
 
     it("Should persist previous valid data when toggling field's visibility", () => {
-      CreateReport.numberTrainedField.setValue(validInput)
+      CreateReport.numberTrainedField.setValue(validNumberInput)
       const button = CreateReport.getEngagementTypesButtonByName(
-        TESTED_BUTTON_NAME
+        TESTED_ENGAGEMENT_BUTTON
       )
+      // make invisible
       button.click()
       CreateReport.numberTrainedFormGroup.waitForExist({ reverse: true })
-
+      // make visible
       button.click()
       CreateReport.numberTrainedFormGroup.waitForExist()
 
-      expect(CreateReport.numberTrainedField.getValue()).to.equal(validInput)
+      expect(CreateReport.numberTrainedField.getValue()).to.equal(
+        validNumberInput
+      )
     })
 
     it("Should not persist previous invalid data when toggling field's visibility", () => {
-      CreateReport.numberTrainedField.setValue(inValidInput)
+      CreateReport.numberTrainedField.setValue(inValidNumberInput)
       CreateReport.numberTrainedHelpText.waitForExist()
       // Actually see the validation warning
       expect(CreateReport.numberTrainedHelpText.getText()).to.equal(
         "Number trained must be greater than or equal to 1"
       )
       const button = CreateReport.getEngagementTypesButtonByName(
-        TESTED_BUTTON_NAME
+        TESTED_ENGAGEMENT_BUTTON
       )
+      // make invisible
       button.click()
       CreateReport.numberTrainedFormGroup.waitForExist({ reverse: true })
-
+      // make visible
       button.click()
       CreateReport.numberTrainedFormGroup.waitForExist()
 
       expect(CreateReport.numberTrainedField.getValue()).not.be.equal(
-        inValidInput
+        inValidNumberInput
       )
       expect(CreateReport.numberTrainedField.getValue()).to.be.equal("")
     })
 
     it("Should validate visible field", () => {
-      CreateReport.numberTrainedField.setValue(inValidInput)
+      CreateReport.numberTrainedField.setValue(inValidNumberInput)
       CreateReport.numberTrainedHelpText.waitForExist()
       CreateReport.submitForm()
       CreateReport.waitForAlertToLoad()
@@ -89,7 +99,7 @@ describe("When working with custom fields for different anet objects", () => {
       CreateReport.form.waitForDisplayed()
 
       const button = CreateReport.getEngagementTypesButtonByName(
-        TESTED_BUTTON_NAME
+        TESTED_ENGAGEMENT_BUTTON
       )
       // make the trained number field invisible
       button.click()
@@ -102,18 +112,83 @@ describe("When working with custom fields for different anet objects", () => {
       )
     })
   })
-
+  // ------------------------------ PERSON CUSTOM FIELDS -----------------------------------------
   describe("For person's custom fields", () => {
     it("Should open create new person page", () => {
-      CreatePerson.openAsAdminUser()
+      CreatePerson.openAsAdmin()
       CreatePerson.form.waitForExist()
       CreatePerson.form.waitForDisplayed()
+      // fill other required fields at the beginning
+      CreatePerson.lastName.setValue(REQUIRED_PERSON_FIELDS.lastname)
+      CreatePerson.rank.selectByAttribute("value", REQUIRED_PERSON_FIELDS.rank)
+      CreatePerson.gender.selectByAttribute(
+        "value",
+        REQUIRED_PERSON_FIELDS.gender
+      )
+    })
+
+    it("Should not show default invisible fields", () => {
+      CreatePerson.defaultInvisibleCustomFields.forEach(field => {
+        expect(field.isExisting()).to.eq(false)
+      })
+    })
+
+    it("Should toggle correct invisible fields", () => {
+      // green toggles every invisible field to visible
+      CreatePerson.greenButton.click()
+      CreatePerson.defaultInvisibleCustomFields.forEach(field => {
+        field.waitForExist()
+      })
+    })
+
+    it("Should persist previous valid data when toggling field's visibility", () => {
+      CreatePerson.numberCustomField.setValue(validNumberInput)
+      // make default invisible fields invisible again, amber color does that
+      CreatePerson.amberButton.click()
+      CreatePerson.numberCustomFieldContainer.waitForExist({ reverse: true })
+      // make visible
+      CreatePerson.greenButton.click()
+      CreatePerson.numberCustomFieldContainer.waitForExist()
+
+      expect(CreatePerson.numberCustomField.getValue()).be.equal(
+        validNumberInput
+      )
+    })
+
+    it("Should not persist previous invalid data when toggling field's visibility", () => {
+      CreatePerson.numberCustomField.setValue(inValidNumberInput)
+      // Actually see the validation warning
+      CreatePerson.numberCustomFieldHelpText.waitForExist()
+      // make invisible
+      CreatePerson.amberButton.click()
+      CreatePerson.numberCustomFieldContainer.waitForExist({ reverse: true })
+      // make visible
+      CreatePerson.greenButton.click()
+      CreatePerson.numberCustomFieldContainer.waitForExist()
+
+      expect(CreatePerson.numberCustomField.getValue()).not.be.equal(
+        inValidNumberInput
+      )
+      expect(CreatePerson.numberCustomField.getValue()).to.equal("")
+    })
+
+    it("Should validate visible field", () => {
+      CreatePerson.numberCustomField.setValue(inValidNumberInput)
+      CreatePerson.numberCustomFieldHelpText.waitForExist()
+    })
+
+    it("Should not validate invisible field so we can submit the form", () => {
+      // make invisible
+      CreatePerson.amberButton.click()
+      CreatePerson.numberCustomFieldContainer.waitForExist({ reverse: true })
+      CreatePerson.submitForm()
+      CreatePerson.waitForAlertSuccessToLoad()
     })
   })
 
   describe("For task's custom fields", () => {
     it("Should open create new task page", () => {
-      CreateTask.openAsAdminUser()
+      CreateTask.openAsAdmin()
       CreateTask.form.waitForExist()
       CreateTask.form.waitForDisplayed()
     })

--- a/client/tests/webdriver/specs/customFields.spec.js
+++ b/client/tests/webdriver/specs/customFields.spec.js
@@ -18,11 +18,25 @@ const REQUIRED_TASK_FIELDS = {
 }
 
 describe("When working with custom fields for different anet objects", () => {
+  // ------------------------------ REPORT CUSTOM FIELDS -----------------------------------------
   describe("For report's custom fields", () => {
     it("Should open a create new report page", () => {
       CreateReport.openAsAdminUser()
       CreateReport.form.waitForExist()
       CreateReport.form.waitForDisplayed()
+    })
+
+    it("Should not show default invisible fields", () => {
+      // both of these fields invisible at first
+      CreateReport.fieldsToggledVisibilityByTrainButton.forEach(invisField => {
+        expect(invisField.isExisting()).to.equal(false)
+      })
+
+      CreateReport.fieldsNotToggledVisibilityByTrainButton.forEach(
+        invisField => {
+          expect(invisField.isExisting()).to.equal(false)
+        }
+      )
     })
 
     it("Should toggle the correct invisible fields", () => {
@@ -135,6 +149,9 @@ describe("When working with custom fields for different anet objects", () => {
       CreatePerson.defaultInvisibleCustomFields.forEach(field => {
         expect(field.isExisting()).to.eq(false)
       })
+      // Date field is invisible by default
+      CreatePerson.addObjectButton.click()
+      CreatePerson.objectDateField.waitForExist({ reverse: true })
     })
 
     it("Should toggle correct invisible fields", () => {
@@ -144,7 +161,6 @@ describe("When working with custom fields for different anet objects", () => {
         field.waitForExist()
       })
       // Also it toggles array_of_objects date field
-      CreatePerson.addObjectButton.click()
       CreatePerson.objectDateField.waitForExist()
     })
 
@@ -192,7 +208,7 @@ describe("When working with custom fields for different anet objects", () => {
       CreatePerson.waitForAlertSuccessToLoad()
     })
   })
-
+  // ------------------------------ TASK CUSTOM FIELDS -----------------------------------------
   describe("For task's custom fields", () => {
     it("Should open create new task page", () => {
       CreateTask.openAsAdmin()

--- a/client/tests/webdriver/specs/customFields.spec.js
+++ b/client/tests/webdriver/specs/customFields.spec.js
@@ -1,0 +1,40 @@
+import { expect } from "chai"
+import CreateReport from "../pages/createReport.page"
+
+describe("When working with custom fields for different anet objects", () => {
+  describe("On a new report form", () => {
+    it("Should open a create new report page", () => {
+      CreateReport.openAsAdminUser()
+      CreateReport.form.waitForExist()
+      CreateReport.form.waitForDisplayed()
+    })
+
+    it("It should toggle the correct invisible fields", () => {
+      CreateReport.getEngagementTypesButtonByName("train").waitForExist()
+      CreateReport.getEngagementTypesButtonByName("train").waitForDisplayed()
+      CreateReport.getEngagementTypesButtonByName("train").click()
+      CreateReport.fieldsToggledVisibilityByTrainButton.forEach(
+        nowVisisbleField => {
+          nowVisisbleField.waitForExist()
+          nowVisisbleField.waitForDisplayed()
+        }
+      )
+
+      CreateReport.fieldsNotToggledVisibilityByTrainButton.forEach(
+        stillInvisField => {
+          expect(stillInvisField.isExisting()).to.equal(false)
+        }
+      )
+    })
+    it("Toggling visibility of a field should persist previous data", () => {
+      CreateReport.numberTrainedField.setValue("10")
+      CreateReport.getEngagementTypesButtonByName("train").click()
+      CreateReport.numberTrainedFormGroup.waitForExist({ reverse: true })
+
+      CreateReport.getEngagementTypesButtonByName("train").click()
+      CreateReport.numberTrainedFormGroup.waitForExist()
+
+      expect(CreateReport.numberTrainedField.getValue()).to.equal("10")
+    })
+  })
+})

--- a/client/tests/webdriver/specs/customFields.spec.js
+++ b/client/tests/webdriver/specs/customFields.spec.js
@@ -77,7 +77,7 @@ describe("When working with custom fields for different anet objects", () => {
       )
     })
 
-    it("Should not persist previous invalid data when toggling field's visibility", () => {
+    it("Should persist previous invalid data when toggling field's visibility", () => {
       CreateReport.numberTrainedField.setValue(INVALID_NUMBER_INPUT)
       CreateReport.numberTrainedHelpText.waitForExist()
       // Actually see the validation warning
@@ -94,10 +94,9 @@ describe("When working with custom fields for different anet objects", () => {
       trainButton.click()
       CreateReport.numberTrainedFormGroup.waitForExist()
 
-      expect(CreateReport.numberTrainedField.getValue()).not.be.equal(
+      expect(CreateReport.numberTrainedField.getValue()).to.equal(
         INVALID_NUMBER_INPUT
       )
-      expect(CreateReport.numberTrainedField.getValue()).to.be.equal("")
     })
 
     it("Should validate visible field", () => {
@@ -224,7 +223,7 @@ describe("When working with custom fields for different anet objects", () => {
       )
     })
 
-    it("Should not persist previous invalid data when toggling field's visibility", () => {
+    it("Should persist previous invalid data when toggling field's visibility", () => {
       CreatePerson.numberCustomField.setValue(INVALID_NUMBER_INPUT)
       // Actually see the validation warning
       CreatePerson.numberCustomFieldHelpText.waitForExist()
@@ -235,10 +234,9 @@ describe("When working with custom fields for different anet objects", () => {
       CreatePerson.greenButton.click()
       CreatePerson.numberCustomFieldContainer.waitForExist()
 
-      expect(CreatePerson.numberCustomField.getValue()).not.be.equal(
+      expect(CreatePerson.numberCustomField.getValue()).to.equal(
         INVALID_NUMBER_INPUT
       )
-      expect(CreatePerson.numberCustomField.getValue()).to.equal("")
     })
 
     it("Should validate visible field", () => {

--- a/client/tests/webdriver/specs/customFields.spec.js
+++ b/client/tests/webdriver/specs/customFields.spec.js
@@ -69,7 +69,37 @@ describe("When working with custom fields for different anet objects", () => {
       expect(CreateReport.numberTrainedField.getValue()).not.be.equal(
         inValidInput
       )
-      expect(CreateReport.numberTrainedField.getValue()).not.be.equal("")
+      expect(CreateReport.numberTrainedField.getValue()).to.be.equal("")
+    })
+
+    it("Should validate visible field", () => {
+      CreateReport.numberTrainedField.setValue(inValidInput)
+      CreateReport.numberTrainedHelpText.waitForExist()
+      CreateReport.submitForm()
+      CreateReport.waitForAlertToLoad()
+
+      expect(CreateReport.alert.getText()).to.include(
+        "Number trained must be greater than or equal to 1"
+      )
+    })
+
+    it("Should not validate invisible field", () => {
+      CreateReport.editButton.click()
+      CreateReport.form.waitForExist()
+      CreateReport.form.waitForDisplayed()
+
+      const button = CreateReport.getEngagementTypesButtonByName(
+        TESTED_BUTTON_NAME
+      )
+      // make the trained number field invisible
+      button.click()
+
+      CreateReport.submitForm()
+      CreateReport.waitForAlertToLoad()
+
+      expect(CreateReport.alert.getText()).to.not.include(
+        "Number trained must be greater than or equal to 1"
+      )
     })
   })
 

--- a/client/tests/webdriver/specs/customFields.spec.js
+++ b/client/tests/webdriver/specs/customFields.spec.js
@@ -143,6 +143,9 @@ describe("When working with custom fields for different anet objects", () => {
       CreatePerson.defaultInvisibleCustomFields.forEach(field => {
         field.waitForExist()
       })
+      // Also it toggles array_of_objects date field
+      CreatePerson.addObjectButton.click()
+      CreatePerson.objectDateField.waitForExist()
     })
 
     it("Should persist previous valid data when toggling field's visibility", () => {


### PR DESCRIPTION
Over time, custom fields' components became too convoluted to work with it, this PR simplifies some of the logic and fixes number of bugs. 

Fixed bugs:

- Submitting report form sometimes would prompt "unsaved changes" 
- Navigating away from a form not touched would prompt "unsaved changes"
- Report Sensitive Information field causes render unnecessarily, fixed by initializing correctly
- Fix random report test failings as the "unsaved changes" prompt would sometimes fail those tests.

Also: 

- There were no Task creation tests, as a side bonus, customFields' tests also create tasks in the process.

Closes #3160 , closes #3315 

#### User changes
- Users will see less buggy forms

#### Super User changes
-

#### Admin changes
-

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [X] Described the user behavior in PR body
  - [X] Referenced/updated all related issues
  - [X] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [X] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [X] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [X] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
