### PR TITLE
Fix parsing smtp config in anet.yml

### DIFF
--- a/src/main/java/mil/dds/anet/config/AnetConfiguration.java
+++ b/src/main/java/mil/dds/anet/config/AnetConfiguration.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.Set;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Positive;
 import mil.dds.anet.utils.AnetConstants;
 import mil.dds.anet.utils.Utils;
 import org.slf4j.Logger;
@@ -266,11 +267,12 @@ public class AnetConfiguration extends Configuration implements AssetsBundleConf
   public static class SmtpConfiguration {
     @NotNull
     private String hostname;
-    private Integer port = 587;
+    @Positive
+    private int port = 587;
     private String username;
     private String password;
-    private Boolean startTls = true;
-    private boolean disabled = false;
+    private boolean startTls = true;
+    private boolean disabled;
     private Integer nbOfHoursForStaleEmails;
     private String sslTrust;
 
@@ -282,11 +284,11 @@ public class AnetConfiguration extends Configuration implements AssetsBundleConf
       this.hostname = hostname;
     }
 
-    public Integer getPort() {
+    public int getPort() {
       return port;
     }
 
-    public void setPort(Integer port) {
+    public void setPort(int port) {
       this.port = port;
     }
 
@@ -306,11 +308,11 @@ public class AnetConfiguration extends Configuration implements AssetsBundleConf
       this.password = password;
     }
 
-    public Boolean getStartTls() {
+    public boolean getStartTls() {
       return startTls;
     }
 
-    public void setStartTls(Boolean startTls) {
+    public void setStartTls(boolean startTls) {
       this.startTls = startTls;
     }
 

--- a/src/main/java/mil/dds/anet/threads/AnetEmailWorker.java
+++ b/src/main/java/mil/dds/anet/threads/AnetEmailWorker.java
@@ -209,9 +209,9 @@ public class AnetEmailWorker extends AbstractWorker {
   private Properties getSmtpProps(SmtpConfiguration smtpConfig) {
     final Properties props = new Properties();
     props.put("mail.smtp.ssl.trust", smtpConfig.getSslTrust());
-    props.put("mail.smtp.starttls.enable", smtpConfig.getStartTls().toString());
+    props.put("mail.smtp.starttls.enable", Boolean.toString(smtpConfig.getStartTls()));
     props.put("mail.smtp.host", smtpConfig.getHostname());
-    props.put("mail.smtp.port", smtpConfig.getPort().toString());
+    props.put("mail.smtp.port", Integer.toString(smtpConfig.getPort()));
     if (hasUsername(smtpConfig)) {
       props.put("mail.smtp.auth", "true");
     }


### PR DESCRIPTION
Prevent NPE's when `port` or `startTls` settings are blank in `anet.yml`.

#### System admin changes
When `port` or `startTls` ar left blank in `anet.yml`, e.g.:
```
smtp:
  port: 
  startTls: 
```
ANET no longer exits with a NullPointerException.
A blank `startTls` will default to `false`, and a blank `port` will warn that the port has to be greater than 0.