### PR TITLE
Remove automaticallyInactivateUsers.ignoredDomainNames from the dictionary

### DIFF
--- a/anet-dictionary.yml
+++ b/anet-dictionary.yml
@@ -681,7 +681,6 @@ imagery:
 
 automaticallyInactivateUsers:
   emailRemindersDaysPrior: [15, 30, 45]
-  ignoredDomainNames: []
   checkIntervalInSecs: 86400  # 60 * 60 * 24
 
 dashboards:

--- a/src/main/java/mil/dds/anet/utils/Utils.java
+++ b/src/main/java/mil/dds/anet/utils/Utils.java
@@ -387,68 +387,36 @@ public class Utils {
   public static boolean isEmailWhitelisted(final String email,
       final List<String> whitelistDomainNames) {
     try {
-      return isLogonDomainInList(email, whitelistDomainNames);
+      return isEmailDomainInList(email, whitelistDomainNames);
     } catch (IllegalArgumentException e) {
       logger.error("Failed to process email: {}", email);
       return false;
     }
   }
 
-  /**
-   * Checks whether a domain user name is allowed according to a list of whitelisted domains.
-   * 
-   * More info: https://docs.microsoft.com/en-us/windows/win32/secauthn/user-name-formats
-   * 
-   * @param domainUserName The domain user name to check
-   * @param ignoredDomainNames The list of ignored domain user names (wildcards allowed)
-   * @return Whether the domain user name is ignored
-   */
-  public static boolean isDomainUserNameIgnored(final String domainUserName,
-      final List<String> ignoredDomainNames) {
-    try {
-      return isLogonDomainInList(domainUserName, ignoredDomainNames);
-    } catch (IllegalArgumentException e) {
-      logger.error("Failed to process domain user name: {}", domainUserName);
-      return true;
-    }
-  }
-
-  private static boolean isLogonDomainInList(final String logon, final List<String> list)
+  private static boolean isEmailDomainInList(final String email, final List<String> list)
       throws IllegalArgumentException {
-
-    final String wildcard = "*";
-
-    // Separator for 'User Principal Name' format
-    final String upnSeparator = "@";
-
-    // Separator for 'Down-Level Logon Name' format
-    final String dlSeparator = "\\";
-
-    if (isEmptyOrNull(logon) || isEmptyOrNull(list)) {
+    if (isEmptyOrNull(email) || isEmptyOrNull(list)) {
       return false;
     }
 
-    // Logon has no domain
-    if (!logon.contains(upnSeparator) && !logon.contains(dlSeparator)) {
+    final String domainSeparator = "@";
+    if (!email.contains(domainSeparator)) {
+      // Email has no domain
       return false;
     }
 
-    // Find out the format
-    boolean isDownLevelFormat = logon.contains(dlSeparator);
-
-    final String[] splittedLogon =
-        logon.trim().split(isDownLevelFormat ? dlSeparator + "\\" : upnSeparator);
-
-    // A logon (domain user name or email) is expected to have two parts: username<separator>domain
-    if (splittedLogon.length != 2) {
-      throw new IllegalArgumentException("Malformed logon: " + logon);
+    final String[] splittedEmail = email.trim().split(domainSeparator);
+    if (splittedEmail.length != 2) {
+      // Email is expected to have two parts: username@domain
+      throw new IllegalArgumentException("Malformed email: " + email);
     }
 
-    // Find the domain name depending on the format
-    final String domainName =
-        (isDownLevelFormat ? splittedLogon[0] : splittedLogon[1]).toLowerCase();
+    // Find the domain name
+    final String domainName = splittedEmail[1].toLowerCase();
 
     // Compile a list of regex patterns we want to use to filter and then find any match
+    final String wildcard = "*";
     return list.stream().map(domain -> domainToRegexPattern(domain, wildcard))
         .anyMatch(domainPattern -> domainPattern.matcher(domainName).matches());
   }

--- a/src/main/resources/anet-schema.yml
+++ b/src/main/resources/anet-schema.yml
@@ -843,12 +843,6 @@ properties:
           type: integer
           title: The list of days prior to account inactivation. An email will be sent to the user with a warning.
           description: Days to send a warning prior to account inactivation.
-      ignoredDomainNames:
-        type: array
-        items:
-          type: string
-          title: The list of ignored (email) domain names. These will not be affected by auto-inactivation or be sent email warnings.
-          description: Valid email domain names for this ANET instance; may contain wildcards.
       checkIntervalInSecs:
         type: integer
         minimum: 0

--- a/src/test/java/mil/dds/anet/test/emails/AccountDeactivationWorkerTest.java
+++ b/src/test/java/mil/dds/anet/test/emails/AccountDeactivationWorkerTest.java
@@ -51,8 +51,6 @@ public class AccountDeactivationWorkerTest {
 
     when(config.getDictionaryEntry("automaticallyInactivateUsers.emailRemindersDaysPrior"))
         .thenReturn(Arrays.asList(15, 30, 45));
-    when(config.getDictionaryEntry("automaticallyInactivateUsers.ignoredDomainNames"))
-        .thenReturn(Arrays.asList("ignored_domain", "*.ignored", "ignored.domain"));
     when(config.getDictionaryEntry("automaticallyInactivateUsers.checkIntervalInSecs"))
         .thenReturn("60");
 

--- a/src/test/java/mil/dds/anet/utils/UtilsTest.java
+++ b/src/test/java/mil/dds/anet/utils/UtilsTest.java
@@ -161,31 +161,10 @@ public class UtilsTest {
   }
 
   @Test
-  public void testIgnoredDomainNames() {
-
-    final List<String> ignoredDomainNames =
-        Arrays.asList("ignored_domain", "*.ignored", "ignored.domain");
-
-    assertThat(Utils.isDomainUserNameIgnored("user@ignored_domain", ignoredDomainNames)).isTrue();
-    assertThat(Utils.isDomainUserNameIgnored("ignored_domain\\user", ignoredDomainNames)).isTrue();
-    assertThat(Utils.isDomainUserNameIgnored("user@test.ignored", ignoredDomainNames)).isTrue();
-    assertThat(Utils.isDomainUserNameIgnored("test.ignored\\user", ignoredDomainNames)).isTrue();
-    assertThat(Utils.isDomainUserNameIgnored("user@test.ignored.not", ignoredDomainNames))
-        .isFalse();
-    assertThat(Utils.isDomainUserNameIgnored("not_ignored_domain\\user", ignoredDomainNames))
-        .isFalse();
-    assertThat(Utils.isDomainUserNameIgnored("ignored_domain", ignoredDomainNames)).isFalse();
-    assertThat(Utils.isDomainUserNameIgnored("user@ignored.domain", ignoredDomainNames)).isTrue();
-    assertThat(Utils.isDomainUserNameIgnored("ignored_domain@user", ignoredDomainNames)).isFalse();
-    assertThat(Utils.isDomainUserNameIgnored("user\\ignored_domain", ignoredDomainNames)).isFalse();
-  }
-
-  @Test
   public void testAllDomains() throws Exception {
 
     final List<String> ignoredDomainNames = Arrays.asList("*");
 
-    assertThat(Utils.isDomainUserNameIgnored("user@domain", ignoredDomainNames)).isTrue();
     assertThat(Utils.isEmailWhitelisted("user@domain", ignoredDomainNames)).isTrue();
   }
 
@@ -193,15 +172,11 @@ public class UtilsTest {
   public void testMalformed() {
     final List<String> ignoredDomainNames = Arrays.asList("ignored_domain");
 
-    assertThat(Utils.isDomainUserNameIgnored("user@domain@domain", ignoredDomainNames)).isTrue();
-    assertThat(Utils.isEmailWhitelisted("domain\\domain\\user", ignoredDomainNames)).isFalse();
+    assertThat(Utils.isEmailWhitelisted("domain\\user", ignoredDomainNames)).isFalse();
   }
 
   @Test
   public void testEmpty() {
-    final List<String> ignoredDomainNames = Arrays.asList("ignored_domain");
-
-    assertThat(Utils.isDomainUserNameIgnored("", ignoredDomainNames)).isFalse();
-    assertThat(Utils.isEmailWhitelisted("domain\\user", Arrays.asList())).isFalse();
+    assertThat(Utils.isEmailWhitelisted("user@domain", Arrays.asList())).isFalse();
   }
 }


### PR DESCRIPTION
It was unused, and furthermore no longer works when Keycloak does the authentication (it only provides the plain username, no Windows domain).

#### System admin changes
- [x] `anet-dictionary.yml` needs change: `automaticallyInactivateUsers.ignoredDomainNames` should be removed