### PR TITLE
Refactor recent users & activities

### DIFF
--- a/client/src/pages/admin/Index.js
+++ b/client/src/pages/admin/Index.js
@@ -217,7 +217,9 @@ const AdminIndex = ({ pageDispatchers }) => {
   function clearCache() {
     setActionLoading(true)
     return API.query(CLEAR_CACHE, {})
-      .then(result => toast.success(result?.clearCache))
+      .then(result =>
+        toast.success(result?.clearCache, { toastId: "success-clear-cache" })
+      )
       .catch(handleError)
       .finally(() => setActionLoading(false))
   }
@@ -225,7 +227,11 @@ const AdminIndex = ({ pageDispatchers }) => {
   function reloadDictionary() {
     setActionLoading(true)
     return API.query(RELOAD_DICTIONARY, {})
-      .then(result => toast.success(result?.reloadDictionary))
+      .then(result =>
+        toast.success(result?.reloadDictionary, {
+          toastId: "success-reload-dictionary"
+        })
+      )
       .catch(handleError)
       .finally(() => setActionLoading(false))
   }
@@ -251,7 +257,9 @@ const AdminIndex = ({ pageDispatchers }) => {
         }))
         setRecentUsers(users)
         setLastLoaded(moment())
-        toast.success("User activities & recent users are loaded succesfully")
+        toast.success("User activities & recent users are loaded succesfully", {
+          toastId: "success-load-recent"
+        })
       })
       .catch(handleError)
       .finally(() => setActionLoading(false))

--- a/client/src/pages/admin/UserActivityTable.js
+++ b/client/src/pages/admin/UserActivityTable.js
@@ -1,6 +1,9 @@
+import LinkTo from "components/LinkTo"
+import moment from "moment"
 import PropTypes from "prop-types"
 import React from "react"
 import { Alert, Table } from "react-bootstrap"
+import Settings from "settings"
 import "./UserActivityTable.css"
 
 const UserActivityTable = ({ text, values }) => {
@@ -37,8 +40,14 @@ const UserActivityTable = ({ text, values }) => {
             return (
               <tr key={ua.listKey}>
                 <td>{idx + 1}</td>
-                <td className="nobr">{ua.time}</td>
-                <td className="nobr">{ua.user}</td>
+                <td className="nobr">
+                  {moment(ua.time).format(
+                    Settings.dateFormats.forms.displayShort.withTime
+                  )}
+                </td>
+                <td className="nobr">
+                  <LinkTo modelType="Person" model={ua.user} />
+                </td>
                 <td>{ua.ip}</td>
                 <td>{ua.request}</td>
               </tr>

--- a/src/main/java/mil/dds/anet/beans/Person.java
+++ b/src/main/java/mil/dds/anet/beans/Person.java
@@ -7,8 +7,8 @@ import io.leangen.graphql.annotations.GraphQLQuery;
 import io.leangen.graphql.annotations.GraphQLRootContext;
 import java.security.Principal;
 import java.time.Instant;
-import java.util.ArrayList;
 import java.util.Base64;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -78,7 +78,7 @@ public class Person extends AbstractCustomizableAnetBean
   @GraphQLInputField
   private String code;
 
-  private List<Map<String, String>> userActivities;
+  private LinkedList<Map<String, Object>> userActivities;
 
   @Override
   public String getName() {
@@ -307,15 +307,15 @@ public class Person extends AbstractCustomizableAnetBean
   }
 
   @JsonIgnore
-  public List<Map<String, String>> getUserActivities() {
+  public LinkedList<Map<String, Object>> getUserActivities() {
     if (userActivities == null) {
-      return new ArrayList<>();
+      return new LinkedList<>();
     }
-    return new ArrayList<>(userActivities);
+    return new LinkedList<>(userActivities);
   }
 
   @JsonIgnore
-  public void setUserActivities(List<Map<String, String>> userActivities) {
+  public void setUserActivities(LinkedList<Map<String, Object>> userActivities) {
     this.userActivities = userActivities;
   }
 

--- a/src/main/java/mil/dds/anet/database/PersonDao.java
+++ b/src/main/java/mil/dds/anet/database/PersonDao.java
@@ -7,6 +7,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.net.URISyntaxException;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -59,7 +60,7 @@ public class PersonDao extends AnetBaseDao<Person, PersonSearchQuery> {
 
   private static final String EHCACHE_CONFIG = "/ehcache-config.xml";
   private static final String DOMAIN_USERS_CACHE = "domainUsersCache";
-  private static final int ACTIVITY_LOG_LIMIT = 100;
+  private static final int ACTIVITY_LOG_LIMIT = 10;
 
   private Cache<String, Person> domainUsersCache;
 
@@ -218,14 +219,14 @@ public class PersonDao extends AnetBaseDao<Person, PersonSearchQuery> {
     return people;
   }
 
-  public void logActivitiesByDomainUsername(String domainUsername, Map<String, String> activity) {
+  public void logActivitiesByDomainUsername(String domainUsername, Map<String, Object> activity) {
     final Person person = domainUsersCache.get(domainUsername);
     if (person != null) {
-      final List<Map<String, String>> activities = person.getUserActivities();
-      if (activities.size() >= ACTIVITY_LOG_LIMIT) {
-        activities.clear();
+      final LinkedList<Map<String, Object>> activities = person.getUserActivities();
+      while (activities.size() >= ACTIVITY_LOG_LIMIT) {
+        activities.removeLast();
       }
-      activities.add(activity);
+      activities.addFirst(activity);
       person.setUserActivities(activities);
       domainUsersCache.replace(domainUsername, person);
     }


### PR DESCRIPTION
Replace user's domainUsername in the lists of recent users and activities in the admin view with a LinkTo to the person.
Only show the 10 most recent activities for a user (instead of 100).
Format the time according to the setting in the dictionary.
Also use specific toastId's so we don't show the same message more than once.
Suppress warnings about serialVersionUID.

Closes NCI-Agency/anet#3327

#### User changes
- none

#### Super User changes
- none

#### Admin changes
- In the recent users & activities, a link to the person is shown instead of the domainUsername.
- Only the 10 most recent activities of a user are shown (instead of 100).
- Time is now formatted according to the setting in the dictionary.

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here