### PR TITLE
Fix state update after unmount in LinkAnetEntity

### DIFF
--- a/client/src/components/editor/LinkAnetEntity.js
+++ b/client/src/components/editor/LinkAnetEntity.js
@@ -8,11 +8,15 @@ const LinkAnetEntity = ({ type, uuid, children }) => {
   const [entity, setEntity] = useState()
 
   useEffect(() => {
+    let mounted = true
     const modelClass = Models[type]
     modelClass &&
       modelClass
         .fetchByUuid(uuid, GRAPHQL_ENTITY_FIELDS)
-        .then(data => setEntity(data))
+        .then(data => mounted && setEntity(data))
+    return () => {
+      mounted = false
+    }
   }, [type, uuid])
 
   return (


### PR DESCRIPTION
When LinkAnetEntity tries to fetch the entity data but gets unmounted, it does state update with late fetched data without a component which causes memory leaks.

Similar to #3187 

#### User changes
-

#### Super User changes
-

#### Admin changes
-

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [ ] Described the user behavior in PR body
  - [X] Referenced/updated all related issues
  - [ ] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [X] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [X] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
