### PR TITLE
Refactor automaticallyInactivateUsers.ignoredDomainNames

### DIFF
--- a/src/main/java/mil/dds/anet/threads/AccountDeactivationWorker.java
+++ b/src/main/java/mil/dds/anet/threads/AccountDeactivationWorker.java
@@ -90,7 +90,7 @@ public class AccountDeactivationWorker extends AbstractWorker {
       final Integer nextWarning, final Instant now, final Instant lastRun,
       final List<String> ignoredDomainNames, final Integer warningIntervalInSecs) {
     if (person.getStatus() == Person.Status.INACTIVE
-        || Utils.isDomainUserNameIgnored(person.getDomainUsername(), ignoredDomainNames)) {
+        || Utils.isEmailIgnored(person.getEmailAddress(), ignoredDomainNames)) {
       // Skip inactive ANET users or users from ignored domains
       return;
     }

--- a/src/test/java/mil/dds/anet/utils/UtilsTest.java
+++ b/src/test/java/mil/dds/anet/utils/UtilsTest.java
@@ -166,18 +166,12 @@ public class UtilsTest {
     final List<String> ignoredDomainNames =
         Arrays.asList("ignored_domain", "*.ignored", "ignored.domain");
 
-    assertThat(Utils.isDomainUserNameIgnored("user@ignored_domain", ignoredDomainNames)).isTrue();
-    assertThat(Utils.isDomainUserNameIgnored("ignored_domain\\user", ignoredDomainNames)).isTrue();
-    assertThat(Utils.isDomainUserNameIgnored("user@test.ignored", ignoredDomainNames)).isTrue();
-    assertThat(Utils.isDomainUserNameIgnored("test.ignored\\user", ignoredDomainNames)).isTrue();
-    assertThat(Utils.isDomainUserNameIgnored("user@test.ignored.not", ignoredDomainNames))
-        .isFalse();
-    assertThat(Utils.isDomainUserNameIgnored("not_ignored_domain\\user", ignoredDomainNames))
-        .isFalse();
-    assertThat(Utils.isDomainUserNameIgnored("ignored_domain", ignoredDomainNames)).isFalse();
-    assertThat(Utils.isDomainUserNameIgnored("user@ignored.domain", ignoredDomainNames)).isTrue();
-    assertThat(Utils.isDomainUserNameIgnored("ignored_domain@user", ignoredDomainNames)).isFalse();
-    assertThat(Utils.isDomainUserNameIgnored("user\\ignored_domain", ignoredDomainNames)).isFalse();
+    assertThat(Utils.isEmailIgnored("user@ignored_domain", ignoredDomainNames)).isTrue();
+    assertThat(Utils.isEmailIgnored("user@test.ignored", ignoredDomainNames)).isTrue();
+    assertThat(Utils.isEmailIgnored("user@test.ignored.not", ignoredDomainNames)).isFalse();
+    assertThat(Utils.isEmailIgnored("user@not_ignored_domain", ignoredDomainNames)).isFalse();
+    assertThat(Utils.isEmailIgnored("user@ignored.domain", ignoredDomainNames)).isTrue();
+    assertThat(Utils.isEmailIgnored("ignored_domain@user", ignoredDomainNames)).isFalse();
   }
 
   @Test
@@ -185,7 +179,7 @@ public class UtilsTest {
 
     final List<String> ignoredDomainNames = Arrays.asList("*");
 
-    assertThat(Utils.isDomainUserNameIgnored("user@domain", ignoredDomainNames)).isTrue();
+    assertThat(Utils.isEmailIgnored("user@domain", ignoredDomainNames)).isTrue();
     assertThat(Utils.isEmailWhitelisted("user@domain", ignoredDomainNames)).isTrue();
   }
 
@@ -193,15 +187,15 @@ public class UtilsTest {
   public void testMalformed() {
     final List<String> ignoredDomainNames = Arrays.asList("ignored_domain");
 
-    assertThat(Utils.isDomainUserNameIgnored("user@domain@domain", ignoredDomainNames)).isTrue();
-    assertThat(Utils.isEmailWhitelisted("domain\\domain\\user", ignoredDomainNames)).isFalse();
+    assertThat(Utils.isEmailIgnored("user@domain@domain", ignoredDomainNames)).isTrue();
+    assertThat(Utils.isEmailWhitelisted("user@domain@domain", ignoredDomainNames)).isFalse();
   }
 
   @Test
   public void testEmpty() {
     final List<String> ignoredDomainNames = Arrays.asList("ignored_domain");
 
-    assertThat(Utils.isDomainUserNameIgnored("", ignoredDomainNames)).isFalse();
-    assertThat(Utils.isEmailWhitelisted("domain\\user", Arrays.asList())).isFalse();
+    assertThat(Utils.isEmailIgnored("", ignoredDomainNames)).isFalse();
+    assertThat(Utils.isEmailWhitelisted("user@domain", Arrays.asList())).isFalse();
   }
 }


### PR DESCRIPTION
Use the user's emailAddress when filtering out users that need to be automatically inactivated.
No longer use the domainUsername, as the domain part of that will in the future no longer be available.

#### System admin changes
- [x] `anet-dictionary.yml` needs change: if `automaticallyInactivateUsers.ignoredDomainNames` was used, change it to use email domains instead of Windows/AD domains
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [ ] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [x] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here