### PR TITLE
Fix missing duration info on report emails

### DIFF
--- a/src/main/resources/emails/approvalNeeded.ftlh
+++ b/src/main/resources/emails/approvalNeeded.ftlh
@@ -126,6 +126,12 @@ Dear ${approvalStepName},
   <strong>Engagement date and location:</strong> ${(engagementDateFormatter.format(report.engagementDate))!} @ ${(report.loadLocation(context).get().name)!}
 </div>
 
+<#if engagementsIncludeTimeAndDuration>
+  <div>
+    <strong>Duration (minutes):</strong> ${(report.duration)!}
+  </div>
+</#if>
+
 <#assign tasks = (report.loadTasks(context).get())!>
 <#list tasks as task>
 <div class="row">

--- a/src/main/resources/emails/emailReport.ftlh
+++ b/src/main/resources/emails/emailReport.ftlh
@@ -276,7 +276,7 @@ ${sender.name} sent you a report from ANET:
           <label for="duration" class="col-sm-2 control-label">Duration (minutes)</label>
           <div class="col-sm-7">
             <div id="duration" class="form-control-static">
-              ${duration!}
+              ${(report.duration)!}
             </div>
           </div>
         </div>


### PR DESCRIPTION
Duration information of a report wasn't shown in the sent emails. This PR fixes the issue by including the duration information in the email templates.
Closes #3335 

#### User changes
- Users will see report's duration information on the emails they recieve.

#### Super User changes
-

#### Admin changes
-

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [X] Described the user behavior in PR body
  - [X] Referenced/updated all related issues
  - [X] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [X] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [X] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
