### PR TITLE
Fix aggregation function modifying the Settings

### DIFF
--- a/client/src/components/aggregations/utils.js
+++ b/client/src/components/aggregations/utils.js
@@ -1,4 +1,5 @@
 import _clone from "lodash/clone"
+import _cloneDeep from "lodash/cloneDeep"
 import _isEmpty from "lodash/isEmpty"
 import { Person, Report } from "models"
 import moment from "moment"
@@ -87,15 +88,15 @@ export const countPerValueAggregation = (fieldName, fieldConfig, data) => {
     return counter
   }, {})
   const legendColors = _clone(CHART_COLORS)
-  const legend = fieldConfig?.choices || {}
+  const legend = _cloneDeep(fieldConfig?.choices || {})
   const legendKeys = !_isEmpty(legend)
-    ? Object.entries(legend)
-    : Object.entries(counters)
+    ? Object.keys(legend)
+    : Object.keys(counters)
   legendKeys.forEach(
-    ([key, val]) =>
+    key =>
       (legend[key] = {
-        label: val?.label || key,
-        color: val?.color || legendColors.shift()
+        label: legend[key]?.label || key,
+        color: legend[key]?.color || legendColors.shift()
       })
   )
   legend.null = { label: "Unspecified", color: "#bbbbbb" }


### PR DESCRIPTION
This aggregation function was modifying the global `Settings` object causing some different behavior for reports' custom fields as an example, which it shouldn't do. Also revert the Object.entries as it is not useful

Example of the bug:
- Open a fresh new ANET application
- Go to Create New Report : See that there are 4 engagement types with no colors
- Go to a page with aggregation widgets ( Example: Any Person Page)
- Go to Create New Report again: See that there 5 engagement types with colors.


#### User changes
- Users will not get inconsistent looking forms. 

#### Super User changes
-

#### Admin changes
-

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [X] Described the user behavior in PR body
  - [ ] Referenced/updated all related issues
  - [ ] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [X] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [X] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
