### PR TITLE
Provide a sensible default if fieldsConfig is not set

### DIFF
--- a/client/src/components/CustomFields.js
+++ b/client/src/components/CustomFields.js
@@ -661,7 +661,7 @@ const FIELD_COMPONENTS = {
 }
 
 export function getInvisibleFields(
-  fieldsConfig,
+  fieldsConfig = {},
   parentFieldName,
   formikValues,
   isArrayOfObjects = false


### PR DESCRIPTION
A dictionary entry like `fields.person.customFields` is optional, but the code would break if it was absent.

Fixes NCI-Agency/anet#3360

#### User changes
- none

#### Super User changes
- Person Edit/Create should work again for configurations that have no custom fields definition for person in the dictionary.

#### Admin changes
- Person Edit/Create should work again for configurations that have no custom fields definition for person in the dictionary.

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here