### PR TITLE
Filter out people pending verification from advanced search

### DIFF
--- a/client/src/components/SearchFilters.js
+++ b/client/src/components/SearchFilters.js
@@ -148,6 +148,9 @@ const advancedSelectFilterPersonProps = {
   overlayRenderRow: PersonDetailedOverlayRow,
   objectType: Person,
   valueKey: "name",
+  queryParams: {
+    pendingVerification: false
+  },
   fields: Person.autocompleteQuery,
   addon: PEOPLE_ICON
 }


### PR DESCRIPTION
Fixes NCI-Agency/anet#3267

#### User changes
- When adding an advanced search filter for people, not-yet-active profiles (without names, just uuid's) will no longer be shown.

#### Super User changes
- none

#### Admin changes
- none

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here