### PR TITLE
Fix unused env variable at wdio script in package.json

### DIFF
--- a/anet-dictionary.yml
+++ b/anet-dictionary.yml
@@ -1,3 +1,4 @@
+# Do not forget to also edit testDictionaries/*.yml files if dictionary change can break stuff
 SUPPORT_EMAIL_ADDR: support@example.com
 
 engagementsIncludeTimeAndDuration: true

--- a/client/config/wdio.config.ie.js
+++ b/client/config/wdio.config.ie.js
@@ -7,7 +7,7 @@ const config = require("./wdio.config.js").config
 
 // override default wdio config for IE tests
 config.baseUrl = process.env.SERVER_URL
-config.specs = ["./tests/webdriver/specs/ie/*.spec.js"]
+config.specs = ["./tests/webdriver/ie/**/*.spec.js"]
 config.exclude = []
 
 const capabilities = config.capabilities[0]

--- a/client/config/wdio.config.js
+++ b/client/config/wdio.config.js
@@ -10,22 +10,21 @@ const config = {
 
   //
   // ==================
-  // Specify Test Files
+  // Specify Test Suites
   // ==================
   // Define which test specs should run. The pattern is relative to the directory
   // from which `wdio` was called. Notice that, if you are calling `wdio` from an
   // NPM script (see https://docs.npmjs.com/cli/run-script) then the current working
   // directory is where your package.json resides, so `wdio` will be called from there.
   //
-
   suites: {
-    base: ["./tests/webdriver/baseSpecs/*.spec.js"],
-    withCustomFields: ["./tests/webdriver/customFieldsSpecs/*.spec.js"],
-    noCustomFields: ["./tests/webdriver/noCustomFieldsSpecs/*.spec.js"]
+    // tests that <don't> depend on custom fields from dictionary
+    base: ["./tests/webdriver/baseSpecs/**/*.spec.js"],
+    // tests that depend on custom fields from dictionary
+    withCustomFields: ["./tests/webdriver/customFieldsSpecs/**/*.spec.js"],
+    // Specifically for testing when there is no custom field in dictionary
+    noCustomFields: ["./tests/webdriver/noCustomFieldsSpecs/**/*.spec.js"]
   },
-  // IE tests are excluded by default. They are exclusively included in IE dedicated config.
-  // Please see `wdio.config.ie.js` for details.
-  exclude: ["./tests/webdriver/specs/ie/*.spec.js"],
   //
   // ============
   // Capabilities

--- a/client/package.json
+++ b/client/package.json
@@ -188,7 +188,7 @@
     "test": "echo 'Run \"test-all\" to execute all client-side tests, or pick a specific test target: \"test-jest\", \"test-wdio\", \"test-wdio-ie\", \"test-e2e\".' ; exit 1",
     "test-all": "yarn run test-jest && yarn run test-wdio && yarn run test-wdio-ie && yarn run test-e2e",
     "test-e2e": "export SERVER_URL=${SERVER_URL:-'http://localhost:8180'} ; NODE_ENV=test node $(npm bin)/ava --config ava.config.js",
-    "test-wdio": "export SERVER_URL=${SERVER_URL:-'http://localhost:8180'} SUITE=${TEST_WDIO_SUITE:-withCustomFields}; NODE_ENV=test wdio --baseUrl ${SERVER_URL} ./config/wdio.config.js --suite base --suite ${TEST_WDIO_SUITE}",
+    "test-wdio": "export SERVER_URL=${SERVER_URL:-'http://localhost:8180'} SUITE=${TEST_WDIO_SUITE:-withCustomFields}; NODE_ENV=test wdio --baseUrl ${SERVER_URL} ./config/wdio.config.js --suite base --suite ${SUITE}",
     "test-jest": "export ANET_DICTIONARY=../${ANET_DICTIONARY_NAME:-anet-dictionary.yml} ; NODE_ENV=test jest --testPathPattern='tests/(actions|reducers|models|utils)'",
     "test-wdio-ie": "export SERVER_URL=${SERVER_URL:-'http://localhost:8180'} ; NODE_ENV=test node ./tests/util/wdio.ie.js",
     "test-all-noCF": "yarn run test-wdio-noCF",

--- a/client/tests/webdriver/ie/ie11RetiredBanner.spec.js
+++ b/client/tests/webdriver/ie/ie11RetiredBanner.spec.js
@@ -1,5 +1,5 @@
 import { expect } from "chai"
-import Home from "../../pages/home.page"
+import Home from "../pages/home.page"
 
 describe("Anet home page on IE 11", () => {
   it("should have the correct title", () => {


### PR DESCRIPTION
Causes custom fields related tests to not run. Missed in #3370, fixed here. Also done some refactoring / commenting

#### User changes
-

#### Super User changes
-

#### Admin changes
-

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [ ] Described the user behavior in PR body
  - [ ] Referenced/updated all related issues
  - [ ] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [ ] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [ ] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
