### PR TITLE
Remove partner assessments, add conditional questions

### DIFF
--- a/anet-dictionary.yml
+++ b/anet-dictionary.yml
@@ -518,7 +518,7 @@ fields:
         - recurrence: quarterly
           questions:
             test1:
-              # TODO: test: $.position.[?(@.identificationCode && /^(Z|z)/.test(@.identificationCode))]
+              test: $.subject.position.organization.[?(@property === "identificationCode" && @.match(/^Z/i))]
               type: enum
               label: Test question 1
               choices:
@@ -532,7 +532,7 @@ fields:
                   label: three
                   color: '#ff8279'
             test2:
-              # TODO: test: $.position.[?(@.identificationCode && /^(Z|z)/.test(@.identificationCode))]
+              test: $.subject.position.organization.[?(@property === "identificationCode" && @.match(/^Z/i))]
               type: enum
               label: Test question 2
               choices:
@@ -546,7 +546,7 @@ fields:
                   label: five
                   color: '#c2ffb3'
             test3:
-              # TODO: test: $.position.[?(@.identificationCode && /^(Z|z)/.test(@.identificationCode))]
+              test: $.subject.position.organization.[?(@property === "identificationCode" && @.match(/^Z/i))]
               type: enum
               label: Test question 3
               choices:
@@ -560,7 +560,6 @@ fields:
                   label: three
                   color: '#ff8279'
             text:
-              # TODO: test: $.position.[?(@.identificationCode && /^(Z|z)/.test(@.identificationCode))]
               type: special_field
               label: Text
               widget: richTextEditor

--- a/anet-dictionary.yml
+++ b/anet-dictionary.yml
@@ -581,6 +581,30 @@ fields:
                 "3":
                   label: high
                   color: '#ff8279'
+            question2:
+              test: $.subject.position.organization.[?(@property === "identificationCode" && @.match(/^P/i))]
+              type: enumset
+              label: Attendee from P org
+              choices:
+                yes:
+                  label: P
+                  color: '#ff0000'
+            question3:
+              test: $.subject.position.organization.[?(@property === "identificationCode" && @.match(/^Z/i))]
+              type: enumset
+              label: Attendee from Z org
+              choices:
+                yes:
+                  label: Z
+                  color: '#00ff00'
+            question4:
+              test: $.relatedObject.[?(@property === "atmosphere" && @ === "POSITIVE")]
+              type: enumset
+              label: Report had POSITIVE atmosphere
+              choices:
+                yes:
+                  label: 👍
+                  color: '#0000ff'
 
     position:
       name: Afghan Tashkil

--- a/anet-dictionary.yml
+++ b/anet-dictionary.yml
@@ -514,51 +514,11 @@ fields:
     person:
       name: Afghan Partner
       countries: [Afghanistan]
-      assessment:
-        questions:
-          - id: test1
-            test: $.position.[?(@.identificationCode && /^(Z|z)/.test(@.identificationCode))]
-            label: Test question 1
-            choice:
-              - value: "1"
-                label: one
-                color: '#c2ffb3'
-              - value: "2"
-                label: two
-                color: '#ffe396'
-              - value: "3"
-                label: three
-                color: '#ff8279'
-          - id: test2
-            test: $.position.[?(@.identificationCode && /^(Z|z)/.test(@.identificationCode))]
-            label: Test question 2
-            choice:
-              - value: "3"
-                label: three
-                color: '#ff8279'
-              - value: "4"
-                label: four
-                color: '#ffe396'
-              - value: "5"
-                label: five
-                color: '#c2ffb3'
-          - id: test3
-            test: $.position.[?(@.identificationCode && /^(Z|z)/.test(@.identificationCode))]
-            label: Test question 3
-            choice:
-              - value: "1"
-                label: one
-                color: '#c2ffb3'
-              - value: "2"
-                label: two
-                color: '#ff8279'
-              - value: "3"
-                label: three
-                color: '#ff8279'
       assessments:
         - recurrence: quarterly
           questions:
             test1:
+              # TODO: test: $.position.[?(@.identificationCode && /^(Z|z)/.test(@.identificationCode))]
               type: enum
               label: Test question 1
               choices:
@@ -572,6 +532,7 @@ fields:
                   label: three
                   color: '#ff8279'
             test2:
+              # TODO: test: $.position.[?(@.identificationCode && /^(Z|z)/.test(@.identificationCode))]
               type: enum
               label: Test question 2
               choices:
@@ -585,6 +546,7 @@ fields:
                   label: five
                   color: '#c2ffb3'
             test3:
+              # TODO: test: $.position.[?(@.identificationCode && /^(Z|z)/.test(@.identificationCode))]
               type: enum
               label: Test question 3
               choices:
@@ -597,6 +559,13 @@ fields:
                 "3":
                   label: three
                   color: '#ff8279'
+            text:
+              # TODO: test: $.position.[?(@.identificationCode && /^(Z|z)/.test(@.identificationCode))]
+              type: special_field
+              label: Text
+              widget: richTextEditor
+              style:
+                height: 100px
         - recurrence: once
           relatedObjectType: report
           questions:

--- a/anet.yml
+++ b/anet.yml
@@ -148,15 +148,7 @@ logging:
     "io.dropwizard.assets.*": TRACE
     "waffle.servlet.NegotiateSecurityFilter": TRACE
     "mil.dds.anet.auth.AnetAuthenticationFilter": TRACE
-    "mil.dds.anet.threads": DEBUG
-    "mil.dds.anet.resources.TestingResource":
-      level: INFO
-      appenders:
-        - type: file
-          currentLogFilename: ./logs/testingLogger.log
-          archivedLogFilenamePattern: ./logs/testingLogger-%d.log.zip
-          archivedFileCount: 2
-          logFormat: '[%d{yyyy-MM-dd HH:mm:ss.SSS,UTC}] %p %c: %m%n'
+    "mil.dds.anet": DEBUG
     "mil.dds.anet.utils.AnetAuditLogger":
       level: INFO
       appenders:

--- a/client/src/components/CustomFields.js
+++ b/client/src/components/CustomFields.js
@@ -753,6 +753,7 @@ export const getFieldPropsFromFieldConfig = fieldConfig => {
     helpText,
     validations,
     visibleWhen,
+    test,
     objectFields,
     ...fieldProps
   } = fieldConfig

--- a/client/src/components/FieldHelper.js
+++ b/client/src/components/FieldHelper.js
@@ -364,7 +364,10 @@ const ButtonToggleGroupField = ({
           }
           let { label, value, color, style, ...props } = button
           if (color) {
-            if (field.value === value) {
+            if (
+              field.value === value ||
+              (Array.isArray(field.value) && field.value.includes(value))
+            ) {
               style = { ...style, backgroundColor: color }
             }
             style = { ...style, borderColor: color, borderWidth: "2px" }

--- a/client/src/components/Model.js
+++ b/client/src/components/Model.js
@@ -602,8 +602,8 @@ export default class Model {
     return false
   }
 
-  static filterAssessmentConfig(assessmentConfig, subject) {
-    const testValue = { subject }
+  static filterAssessmentConfig(assessmentConfig, subject, relatedObject) {
+    const testValue = { subject, relatedObject }
     const filteredAssessmentConfig = {}
     if (!_isEmpty(assessmentConfig)) {
       Object.entries(assessmentConfig)

--- a/client/src/components/Model.js
+++ b/client/src/components/Model.js
@@ -1,5 +1,6 @@
 import API from "api"
 import { gql } from "apollo-boost"
+import { JSONPath } from "jsonpath-plus"
 import _forEach from "lodash/forEach"
 import _isEmpty from "lodash/isEmpty"
 import moment from "moment"
@@ -524,7 +525,8 @@ export default class Model {
 
   static getInstantAssessmentsDetailsForEntities(
     entities,
-    assessmentsParentField
+    assessmentsParentField,
+    relatedObject
   ) {
     const assessmentsConfig = {}
     const assessmentsSchemaShape = {}
@@ -598,6 +600,22 @@ export default class Model {
     }
     // if we didn't early return, there is no pending assessment
     return false
+  }
+
+  static filterAssessmentConfig(assessmentConfig, subject) {
+    const testValue = { subject }
+    const filteredAssessmentConfig = {}
+    if (!_isEmpty(assessmentConfig)) {
+      Object.entries(assessmentConfig)
+        .filter(
+          ([key, question]) =>
+            !question.test || !_isEmpty(JSONPath(question.test, testValue))
+        )
+        .forEach(([key, question]) => {
+          filteredAssessmentConfig[key] = question
+        })
+    }
+    return filteredAssessmentConfig
   }
 
   static populateCustomFields(entity) {

--- a/client/src/components/RelatedObjectNoteModal.js
+++ b/client/src/components/RelatedObjectNoteModal.js
@@ -23,8 +23,7 @@ const RelatedObjectNoteModal = ({
   showModal,
   onCancel,
   onSuccess,
-  onDelete,
-  questions
+  onDelete
 }) => {
   const yupSchema = yup.object().shape({
     type: yup.string().required(),
@@ -78,26 +77,6 @@ const RelatedObjectNoteModal = ({
                   }}
                 >
                   <Messages error={error} />
-                  {note.type === NOTE_TYPE.PARTNER_ASSESSMENT && (
-                    <>
-                      {questions.map(question => (
-                        <React.Fragment key={question.id}>
-                          <p>{question.label}</p>
-                          <Field
-                            name={question.id}
-                            label=""
-                            component={FieldHelper.RadioButtonToggleGroupField}
-                            buttons={question.choice}
-                            onChange={value => {
-                              setFieldValue(question.id, value)
-                            }}
-                          />
-                          <br />
-                          <br />
-                        </React.Fragment>
-                      ))}
-                    </>
-                  )}
                   <Field
                     name="text"
                     value={noteText}
@@ -201,8 +180,7 @@ RelatedObjectNoteModal.propTypes = {
   showModal: PropTypes.bool,
   onCancel: PropTypes.func.isRequired,
   onSuccess: PropTypes.func.isRequired,
-  onDelete: PropTypes.func,
-  questions: PropTypes.array
+  onDelete: PropTypes.func
 }
 
 export default RelatedObjectNoteModal

--- a/client/src/components/RelatedObjectNotes.js
+++ b/client/src/components/RelatedObjectNotes.js
@@ -5,7 +5,6 @@ import API from "api"
 import { gql } from "apollo-boost"
 import AppContext from "components/AppContext"
 import ConfirmDelete from "components/ConfirmDelete"
-import Pie from "components/graphs/Pie"
 import { parseHtmlWithLinkTo } from "components/editor/LinkAnet"
 import LinkTo from "components/LinkTo"
 import Messages from "components/Messages"
@@ -14,7 +13,6 @@ import Model, {
   NOTE_TYPE
 } from "components/Model"
 import RelatedObjectNoteModal from "components/RelatedObjectNoteModal"
-import { JSONPath } from "jsonpath-plus"
 import _isEmpty from "lodash/isEmpty"
 import _isEqualWith from "lodash/isEqualWith"
 import { Person } from "models"
@@ -25,7 +23,6 @@ import { Button, Panel } from "react-bootstrap"
 import ReactDOM from "react-dom"
 import NotificationBadge from "react-notification-badge"
 import REMOVE_ICON from "resources/delete.png"
-import Settings from "settings"
 import utils from "utils"
 import "./BlueprintOverrides.css"
 
@@ -47,7 +44,6 @@ export const EXCLUDED_ASSESSMENT_FIELDS = [
 const RelatedObjectNotes = ({
   notesElemId,
   relatedObject,
-  relatedObjectValue,
   notes: notesProp
 }) => {
   const { currentUser } = useContext(AppContext)
@@ -81,38 +77,6 @@ const RelatedObjectNotes = ({
     const noNotes = _isEmpty(notes)
     const nrNotes = noNotes ? 0 : notes.length
     const badgeLabel = nrNotes > 10 ? "10+" : null
-    const questions =
-      relatedObject &&
-      Settings.fields.principal.person.assessment &&
-      relatedObject.relatedObjectType === Person.relatedObjectType &&
-      relatedObjectValue.role === Person.ROLE.PRINCIPAL
-        ? Settings.fields.principal.person.assessment.questions.filter(
-          question =>
-            !question.test ||
-              !_isEmpty(JSONPath(question.test, relatedObjectValue))
-        )
-        : []
-    const partnerAssessments = notes.filter(
-      note => note.type === NOTE_TYPE.PARTNER_ASSESSMENT
-    )
-    const partnerAssessmentsSummary = partnerAssessments.reduce(
-      (counters, assessment) => {
-        const assessmentJson = utils.parseJsonSafe(assessment.text)
-
-        questions.forEach(question => {
-          if (!counters[question.id]) {
-            counters[question.id] = {}
-          }
-          const counter = counters[question.id]
-          if (assessmentJson[question.id]) {
-            counter[assessmentJson[question.id]] =
-              ++counter[assessmentJson[question.id]] || 1
-          }
-        })
-        return counters
-      },
-      {}
-    )
 
     return hidden ? (
       <div style={{ minWidth: 50, padding: 5, marginRight: 15 }}>
@@ -169,17 +133,6 @@ const RelatedObjectNotes = ({
           >
             Post new note
           </Button>
-          {questions.length > 0 && (
-            <Button
-              bsStyle="primary"
-              style={{ margin: "5px" }}
-              onClick={() =>
-                showRelatedObjectNoteModal("new", NOTE_TYPE.PARTNER_ASSESSMENT)
-              }
-            >
-              Assess Person
-            </Button>
-          )}
         </div>
         <br />
         <RelatedObjectNoteModal
@@ -188,7 +141,6 @@ const RelatedObjectNotes = ({
             noteRelatedObjects: [{ ...relatedObject }]
           }}
           currentObject={relatedObject}
-          questions={questions}
           showModal={showRelatedObjectNoteModalKey === "new"}
           onCancel={cancelRelatedObjectNoteModal}
           onSuccess={hideNewRelatedObjectNoteModal}
@@ -197,52 +149,6 @@ const RelatedObjectNotes = ({
           <div>
             <i>No notes</i>
           </div>
-        )}
-
-        {partnerAssessments.length > 0 && questions.length > 0 && (
-          <Panel bsStyle="primary" style={{ width: "100%" }}>
-            <Panel.Heading>
-              Summary of <b>{partnerAssessments.length}</b> assessments for{" "}
-              {relatedObjectValue.rank} {relatedObjectValue.name}
-            </Panel.Heading>
-            <Panel.Body>
-              {questions.map(question => (
-                <React.Fragment key={question.id}>
-                  {question.label}
-                  <br />
-                  <Pie
-                    width={70}
-                    height={70}
-                    data={partnerAssessmentsSummary[question.id]}
-                    label={Object.values(
-                      partnerAssessmentsSummary[question.id]
-                    ).reduce((acc, cur) => acc + cur, 0)}
-                    segmentFill={entity => {
-                      const matching = question.choice.filter(
-                        choice => choice.value === entity.data.key
-                      )
-                      return matching.length > 0 ? matching[0].color : "#bbbbbb"
-                    }}
-                    segmentLabel={d => d.data.value}
-                  />
-
-                  <br />
-                  {question.choice.map(choice => (
-                    <React.Fragment key={choice.value}>
-                      <span style={{ backgroundColor: choice.color }}>
-                        {choice.label} :
-                        <b>
-                          {partnerAssessmentsSummary[question.id][choice.value]}
-                        </b>{" "}
-                      </span>
-                    </React.Fragment>
-                  ))}
-                  <br />
-                  <br />
-                </React.Fragment>
-              ))}
-            </Panel.Body>
-          </Panel>
         )}
 
         <div
@@ -255,6 +161,7 @@ const RelatedObjectNotes = ({
             const updatedAt = moment(note.updatedAt).fromNow()
             const byMe = Person.isEqual(currentUser, note.author)
             const canEdit =
+              note.type !== NOTE_TYPE.PARTNER_ASSESSMENT &&
               note.type !== NOTE_TYPE.ASSESSMENT &&
               (byMe || currentUser.isAdmin())
             const isJson = note.type !== NOTE_TYPE.FREE_TEXT
@@ -301,7 +208,6 @@ const RelatedObjectNotes = ({
                       <RelatedObjectNoteModal
                         note={note}
                         currentObject={relatedObject}
-                        questions={questions}
                         showModal={showRelatedObjectNoteModalKey === note.uuid}
                         onCancel={cancelRelatedObjectNoteModal}
                         onSuccess={hideEditRelatedObjectNoteModal}
@@ -344,7 +250,7 @@ const RelatedObjectNotes = ({
                       <>
                         <h4>
                           <u>
-                            <b>Partner assessment</b>
+                            <b>Old-style partner assessment</b>
                           </u>
                         </h4>
                         {Object.keys(jsonFields)
@@ -450,12 +356,7 @@ const RelatedObjectNotes = ({
 RelatedObjectNotes.propTypes = {
   notesElemId: PropTypes.string.isRequired,
   notes: PropTypes.arrayOf(Model.notePropType),
-  relatedObject: Model.relatedObjectPropType,
-  relatedObjectValue: PropTypes.shape({
-    role: PropTypes.string.isRequired,
-    rank: PropTypes.string.isRequired,
-    name: PropTypes.string.isRequired
-  })
+  relatedObject: Model.relatedObjectPropType
 }
 RelatedObjectNotes.defaultProps = {
   notesElemId: "notes-view",

--- a/client/src/components/assessments/AssessmentResultsTable.js
+++ b/client/src/components/assessments/AssessmentResultsTable.js
@@ -3,6 +3,7 @@ import { InstantAssessmentsRow } from "components/assessments/InstantAssessmentR
 import { PeriodicAssessmentsRows } from "components/assessments/PeriodicAssessmentResults"
 import Fieldset from "components/Fieldset"
 import LinkTo from "components/LinkTo"
+import Model from "components/Model"
 import PeriodsNavigation from "components/PeriodsNavigation"
 import _isEmpty from "lodash/isEmpty"
 import {
@@ -113,10 +114,14 @@ const AssessmentResultsTable = ({
     ?.map(s => s.getInstantAssessmentConfig())
     .filter(mc => !_isEmpty(mc))
   const { assessmentConfig } = entity.getPeriodicAssessmentDetails(recurrence)
+  const filteredAssessmentConfig = Model.filterAssessmentConfig(
+    assessmentConfig,
+    entity
+  )
   const showAssessmentResults =
     !_isEmpty(entityInstantAssessmentConfig) ||
     !_isEmpty(subEntitiesInstantAssessmentConfig) ||
-    !_isEmpty(assessmentConfig)
+    !_isEmpty(filteredAssessmentConfig)
   return (
     <>
       {showAssessmentResults && (

--- a/client/src/components/assessments/AssessmentResultsTable.js
+++ b/client/src/components/assessments/AssessmentResultsTable.js
@@ -41,10 +41,7 @@ const EntityAssessmentResults = ({
   if (!entity) {
     return null
   }
-  const instantAssessmentConfig = Model.filterAssessmentConfig(
-    entity.getInstantAssessmentConfig(),
-    entity // TODO: add relatedObject?
-  )
+  const instantAssessmentConfig = entity.getInstantAssessmentConfig()
   const { periods } = periodsConfig
   const dataPerPeriod = []
   periods.forEach(period =>
@@ -112,17 +109,9 @@ const AssessmentResultsTable = ({
   if (_isEmpty(periodsConfig?.periods)) {
     return null
   }
-  const entityInstantAssessmentConfig = Model.filterAssessmentConfig(
-    entity.getInstantAssessmentConfig(),
-    entity // TODO: add relatedObject?
-  )
+  const entityInstantAssessmentConfig = entity.getInstantAssessmentConfig()
   const subEntitiesInstantAssessmentConfig = subEntities
-    ?.map(s =>
-      Model.filterAssessmentConfig(
-        s.getInstantAssessmentConfig(),
-        s // TODO: add relatedObject?
-      )
-    )
+    ?.map(s => s.getInstantAssessmentConfig())
     .filter(mc => !_isEmpty(mc))
   const { assessmentConfig } = entity.getPeriodicAssessmentDetails(recurrence)
   const filteredAssessmentConfig = Model.filterAssessmentConfig(

--- a/client/src/components/assessments/AssessmentResultsTable.js
+++ b/client/src/components/assessments/AssessmentResultsTable.js
@@ -41,7 +41,10 @@ const EntityAssessmentResults = ({
   if (!entity) {
     return null
   }
-  const instantAssessmentConfig = entity.getInstantAssessmentConfig()
+  const instantAssessmentConfig = Model.filterAssessmentConfig(
+    entity.getInstantAssessmentConfig(),
+    entity // TODO: add relatedObject?
+  )
   const { periods } = periodsConfig
   const dataPerPeriod = []
   periods.forEach(period =>
@@ -109,9 +112,17 @@ const AssessmentResultsTable = ({
   if (_isEmpty(periodsConfig?.periods)) {
     return null
   }
-  const entityInstantAssessmentConfig = entity.getInstantAssessmentConfig()
+  const entityInstantAssessmentConfig = Model.filterAssessmentConfig(
+    entity.getInstantAssessmentConfig(),
+    entity // TODO: add relatedObject?
+  )
   const subEntitiesInstantAssessmentConfig = subEntities
-    ?.map(s => s.getInstantAssessmentConfig())
+    ?.map(s =>
+      Model.filterAssessmentConfig(
+        s.getInstantAssessmentConfig(),
+        s // TODO: add relatedObject?
+      )
+    )
     .filter(mc => !_isEmpty(mc))
   const { assessmentConfig } = entity.getPeriodicAssessmentDetails(recurrence)
   const filteredAssessmentConfig = Model.filterAssessmentConfig(

--- a/client/src/components/assessments/InstantAssessmentsContainerField.js
+++ b/client/src/components/assessments/InstantAssessmentsContainerField.js
@@ -12,7 +12,7 @@ import { Table } from "react-bootstrap"
 const InstantAssessmentsContainerField = ({
   entityType,
   entities,
-  entitiesInstantAssessmentsConfig,
+  relatedObject,
   parentFieldName,
   formikProps,
   readonly
@@ -22,12 +22,12 @@ const InstantAssessmentsContainerField = ({
     <Table condensed responsive>
       <tbody>
         {entities.map(entity => {
-          const entityInstantAssessmentConfig = !_isEmpty(
-            entitiesInstantAssessmentsConfig
+          const entityInstantAssessmentConfig = Model.filterAssessmentConfig(
+            entity.getInstantAssessmentConfig(),
+            entity,
+            relatedObject
           )
-            ? entitiesInstantAssessmentsConfig[entity.uuid]
-            : entity.getInstantAssessmentConfig()
-          if (!entityInstantAssessmentConfig) {
+          if (_isEmpty(entityInstantAssessmentConfig)) {
             return null
           }
           return (
@@ -64,7 +64,7 @@ const InstantAssessmentsContainerField = ({
 InstantAssessmentsContainerField.propTypes = {
   entityType: PropTypes.func.isRequired,
   entities: PropTypes.arrayOf(PropTypes.instanceOf(Model)),
-  entitiesInstantAssessmentsConfig: PropTypes.object,
+  relatedObject: PropTypes.object,
   parentFieldName: PropTypes.string.isRequired,
   formikProps: PropTypes.shape({
     setFieldTouched: PropTypes.func,

--- a/client/src/components/assessments/PeriodicAssessmentResults.js
+++ b/client/src/components/assessments/PeriodicAssessmentResults.js
@@ -144,7 +144,11 @@ export const PeriodicAssessmentsRows = ({
     assessmentConfig,
     assessmentYupSchema
   } = entity.getPeriodicAssessmentDetails(recurrence)
-  if (_isEmpty(assessmentConfig)) {
+  const filteredAssessmentConfig = Model.filterAssessmentConfig(
+    assessmentConfig,
+    entity
+  )
+  if (_isEmpty(filteredAssessmentConfig)) {
     return null
   }
 
@@ -181,7 +185,7 @@ export const PeriodicAssessmentsRows = ({
                       note={note}
                       assessment={assessment}
                       assessmentYupSchema={assessmentYupSchema}
-                      assessmentConfig={assessmentConfig}
+                      assessmentConfig={filteredAssessmentConfig}
                       entity={entity}
                       period={periods[index]}
                       recurrence={recurrence}
@@ -228,7 +232,7 @@ export const PeriodicAssessmentsRows = ({
                       assessmentYupSchema={assessmentYupSchema}
                       recurrence={recurrence}
                       assessmentPeriod={period}
-                      assessmentConfig={assessmentConfig}
+                      assessmentConfig={filteredAssessmentConfig}
                       onSuccess={() => {
                         setShowAssessmentModalKey(null)
                         onUpdateAssessment()

--- a/client/src/models/Person.js
+++ b/client/src/models/Person.js
@@ -157,7 +157,7 @@ export default class Person extends Model {
     .concat(Model.yupSchema)
 
   static autocompleteQuery =
-    "uuid, name, rank, role, status, endOfTourDate, avatar(size: 32), position { uuid, name, type, code, status, organization { uuid, shortName }, location {uuid, name} }"
+    "uuid name rank role status endOfTourDate avatar(size: 32) position { uuid name type code status organization { uuid shortName identificationCode } location { uuid name } }"
 
   static autocompleteQueryWithNotes = `${this.autocompleteQuery} ${GRAPHQL_NOTES_FIELDS}`
 

--- a/client/src/models/Report.js
+++ b/client/src/models/Report.js
@@ -1,5 +1,6 @@
 import Model, {
   createCustomFieldsSchema,
+  DEFAULT_CUSTOM_FIELDS_PARENT,
   NOTE_TYPE,
   REPORT_RELATED_OBJECT_TYPE,
   REPORT_STATE_PUBLISHED,
@@ -592,6 +593,22 @@ export default class Report extends Model {
           ? " - HH:mm"
           : " >>> " + Report.getEngagementDateFormat()
       )
+    )
+  }
+
+  static getCleanReport(values) {
+    // Strip notes and any synthetic fields from a report
+    return Object.without(
+      new Report(values),
+      "notes",
+      "reportTags",
+      "showSensitiveInfo",
+      "authors",
+      DEFAULT_CUSTOM_FIELDS_PARENT,
+      Report.TASKS_ASSESSMENTS_PARENT_FIELD,
+      Report.ATTENDEES_ASSESSMENTS_PARENT_FIELD,
+      Report.TASKS_ASSESSMENTS_UUIDS_FIELD,
+      Report.ATTENDEES_ASSESSMENTS_UUIDS_FIELD
     )
   }
 }

--- a/client/src/pages/people/Edit.js
+++ b/client/src/pages/people/Edit.js
@@ -116,7 +116,6 @@ const PersonEdit = ({ pageDispatchers }) => {
             relatedObject: person
           }
         }
-        relatedObjectValue={person}
       />
       <PersonForm
         initialValues={person}

--- a/client/src/pages/people/Show.js
+++ b/client/src/pages/people/Show.js
@@ -197,7 +197,6 @@ const PersonShow = ({ pageDispatchers }) => {
                   relatedObject: person
                 }
               }
-              relatedObjectValue={person}
             />
             <Messages error={stateError} success={stateSuccess} />
             <Form className="form-horizontal" method="post">

--- a/client/src/pages/reports/Compact.js
+++ b/client/src/pages/reports/Compact.js
@@ -112,6 +112,7 @@ const GQL_GET_REPORT = gql`
           organization {
             uuid
             shortName
+            identificationCode
           }
           location {
             uuid

--- a/client/src/pages/reports/Compact.js
+++ b/client/src/pages/reports/Compact.js
@@ -14,7 +14,7 @@ import { ReadonlyCustomFields } from "components/CustomFields"
 import { parseHtmlWithLinkTo } from "components/editor/LinkAnet"
 import Fieldset from "components/Fieldset"
 import LinkTo from "components/LinkTo"
-import { DEFAULT_CUSTOM_FIELDS_PARENT } from "components/Model"
+import Model, { DEFAULT_CUSTOM_FIELDS_PARENT } from "components/Model"
 import {
   mapPageDispatchersToProps,
   PageDispatchersPropType,
@@ -429,7 +429,11 @@ const CompactReportView = ({ pageDispatchers }) => {
       <table>
         <tbody>
           {report.tasks.map(task => {
-            const taskInstantAssessmentConfig = task.getInstantAssessmentConfig()
+            const taskInstantAssessmentConfig = Model.filterAssessmentConfig(
+              task.getInstantAssessmentConfig(),
+              task,
+              report
+            )
             // return only name and objective if no assessment
             return (
               <CompactRow
@@ -481,7 +485,11 @@ const CompactReportView = ({ pageDispatchers }) => {
       <table>
         <tbody>
           {attendees.map(attendee => {
-            const attendeeInstantAssessmentConfig = attendee.getInstantAssessmentConfig()
+            const attendeeInstantAssessmentConfig = Model.filterAssessmentConfig(
+              attendee.getInstantAssessmentConfig(),
+              attendee,
+              report
+            )
             const renderOrgName =
               prevDiffOrgName !== attendee.position?.organization?.shortName
             prevDiffOrgName = renderOrgName

--- a/client/src/pages/reports/Edit.js
+++ b/client/src/pages/reports/Edit.js
@@ -67,6 +67,7 @@ const GQL_GET_REPORT = gql`
           organization {
             uuid
             shortName
+            identificationCode
           }
           location {
             uuid

--- a/client/src/pages/reports/Form.js
+++ b/client/src/pages/reports/Form.js
@@ -435,6 +435,11 @@ const ReportForm = ({
         )
         const isFutureEngagement = Report.isFuture(values.engagementDate)
         const hasAssessments = values.engagementDate && !isFutureEngagement
+        let relatedObject
+        if (hasAssessments) {
+          relatedObject = Report.getCleanReport(values)
+        }
+
         return (
           <div className="report-form">
             <NavigationWarning isBlocking={dirty} />
@@ -1050,7 +1055,7 @@ const ReportForm = ({
                     <InstantAssessmentsContainerField
                       entityType={Person}
                       entities={values.reportPeople?.filter(rp => rp.attendee)}
-                      relatedObject={values}
+                      relatedObject={relatedObject}
                       parentFieldName={
                         Report.ATTENDEES_ASSESSMENTS_PARENT_FIELD
                       }
@@ -1070,7 +1075,7 @@ const ReportForm = ({
                     <InstantAssessmentsContainerField
                       entityType={Task}
                       entities={values.tasks}
-                      relatedObject={values}
+                      relatedObject={relatedObject}
                       parentFieldName={Report.TASKS_ASSESSMENTS_PARENT_FIELD}
                       formikProps={{
                         setFieldTouched,
@@ -1347,20 +1352,11 @@ const ReportForm = ({
 
   function save(values, sendEmail) {
     const report = Object.without(
-      new Report(values),
-      "notes",
+      Report.getCleanReport(values),
       "cancelled",
-      "reportTags",
-      "showSensitiveInfo",
-      "authors",
       "reportPeople",
       "tasks",
-      "customFields", // initial JSON from the db
-      DEFAULT_CUSTOM_FIELDS_PARENT,
-      Report.TASKS_ASSESSMENTS_PARENT_FIELD,
-      Report.ATTENDEES_ASSESSMENTS_PARENT_FIELD,
-      Report.TASKS_ASSESSMENTS_UUIDS_FIELD,
-      Report.ATTENDEES_ASSESSMENTS_UUIDS_FIELD
+      "customFields" // initial JSON from the db
     )
     if (Report.isFuture(values.engagementDate)) {
       // Empty fields which should not be set for future reports.

--- a/client/src/pages/reports/Form.js
+++ b/client/src/pages/reports/Form.js
@@ -1050,9 +1050,7 @@ const ReportForm = ({
                     <InstantAssessmentsContainerField
                       entityType={Person}
                       entities={values.reportPeople?.filter(rp => rp.attendee)}
-                      entitiesInstantAssessmentsConfig={
-                        attendeesInstantAssessmentsConfig
-                      }
+                      relatedObject={values}
                       parentFieldName={
                         Report.ATTENDEES_ASSESSMENTS_PARENT_FIELD
                       }
@@ -1072,9 +1070,7 @@ const ReportForm = ({
                     <InstantAssessmentsContainerField
                       entityType={Task}
                       entities={values.tasks}
-                      entitiesInstantAssessmentsConfig={
-                        tasksInstantAssessmentsConfig
-                      }
+                      relatedObject={values}
                       parentFieldName={Report.TASKS_ASSESSMENTS_PARENT_FIELD}
                       formikProps={{
                         setFieldTouched,

--- a/client/src/pages/reports/Show.js
+++ b/client/src/pages/reports/Show.js
@@ -371,9 +371,11 @@ const ReportShow = ({ setSearchQuery, pageDispatchers }) => {
 
   // Get initial tasks/people instant assessments values
   const hasAssessments = report.engagementDate && !report.isFuture()
+  let relatedObject
   if (hasAssessments) {
     report = Object.assign(report, report.getTasksEngagementAssessments())
     report = Object.assign(report, report.getAttendeesEngagementAssessments())
+    relatedObject = Report.getCleanReport(report)
   }
 
   return (
@@ -695,7 +697,7 @@ const ReportShow = ({ setSearchQuery, pageDispatchers }) => {
                     <InstantAssessmentsContainerField
                       entityType={Person}
                       entities={values.reportPeople?.filter(rp => rp.attendee)}
-                      relatedObject={report}
+                      relatedObject={relatedObject}
                       parentFieldName={
                         Report.ATTENDEES_ASSESSMENTS_PARENT_FIELD
                       }
@@ -713,7 +715,7 @@ const ReportShow = ({ setSearchQuery, pageDispatchers }) => {
                     <InstantAssessmentsContainerField
                       entityType={Task}
                       entities={values.tasks}
-                      relatedObject={report}
+                      relatedObject={relatedObject}
                       parentFieldName={Report.TASKS_ASSESSMENTS_PARENT_FIELD}
                       formikProps={{
                         values

--- a/client/src/pages/reports/Show.js
+++ b/client/src/pages/reports/Show.js
@@ -694,6 +694,7 @@ const ReportShow = ({ setSearchQuery, pageDispatchers }) => {
                     <InstantAssessmentsContainerField
                       entityType={Person}
                       entities={values.reportPeople?.filter(rp => rp.attendee)}
+                      relatedObject={report}
                       parentFieldName={
                         Report.ATTENDEES_ASSESSMENTS_PARENT_FIELD
                       }
@@ -711,6 +712,7 @@ const ReportShow = ({ setSearchQuery, pageDispatchers }) => {
                     <InstantAssessmentsContainerField
                       entityType={Task}
                       entities={values.tasks}
+                      relatedObject={report}
                       parentFieldName={Report.TASKS_ASSESSMENTS_PARENT_FIELD}
                       formikProps={{
                         values

--- a/client/src/pages/reports/Show.js
+++ b/client/src/pages/reports/Show.js
@@ -122,6 +122,7 @@ const GQL_GET_REPORT = gql`
           organization {
             uuid
             shortName
+            identificationCode
           }
           location {
             uuid

--- a/client/tests/webdriver/customFieldsSpecs/customFields.spec.js
+++ b/client/tests/webdriver/customFieldsSpecs/customFields.spec.js
@@ -1,4 +1,5 @@
 import { expect } from "chai"
+import { v4 as uuidv4 } from "uuid"
 import CreatePerson from "../pages/createNewPerson.page"
 import CreateTask from "../pages/createNewTask.page"
 import CreateReport from "../pages/createReport.page"
@@ -262,7 +263,9 @@ describe("When working with custom fields for different anet objects", () => {
       CreateTask.form.waitForExist()
       CreateTask.form.waitForDisplayed()
       // Fill other required fields so that we can test custom field validation
-      CreateTask.shortName.setValue(REQUIRED_TASK_FIELDS.shortName)
+      CreateTask.shortName.setValue(
+        `${REQUIRED_TASK_FIELDS.shortName} ${uuidv4()}`
+      )
     })
 
     it("Should be able to see assessment fields", () => {

--- a/client/tests/webdriver/customFieldsSpecs/notifications.spec.js
+++ b/client/tests/webdriver/customFieldsSpecs/notifications.spec.js
@@ -4,7 +4,7 @@ import Home from "../pages/home.page"
 
 describe("Home page", () => {
   describe("When checking the notification numbers", () => {
-    it("Should see that Erin has 1 counterpart with pending assessment and no tasks with pending assessments", () => {
+    it("Should see that Erin has 1 counterpart and no tasks with pending assessments", () => {
       Home.open()
       Home.myCounterpartsLink.waitForDisplayed()
       Home.myTasksLink.waitForDisplayed()
@@ -12,18 +12,29 @@ describe("Home page", () => {
       // eslint-disable-next-line no-unused-expressions
       expect(Home.myTasksNotifications.isExisting()).to.be.false
     })
-    it("Should see that Jack has no counterparts with pending assessment", () => {
-      Home.open("/", "jack")
+    it("Should see that Bob has no counterparts and 1 task with pending assessments", () => {
+      Home.open("/", "bob")
       Home.myCounterpartsLink.waitForDisplayed()
       Home.myTasksLink.waitForDisplayed()
       // eslint-disable-next-line no-unused-expressions
       expect(Home.myCounterpartsNotifications.isExisting()).to.be.false
+      expect(Home.myTasksNotifications.getText()).to.equal("1")
     })
-    it("Should see that Jack has 1 task with pending assessments", () => {
+    it("Should see that Jack has 1 counterpart and 1 task with pending assessments", () => {
       Home.open("/", "jack")
       Home.myCounterpartsLink.waitForDisplayed()
       Home.myTasksLink.waitForDisplayed()
+      expect(Home.myCounterpartsNotifications.getText()).to.equal("1")
       expect(Home.myTasksNotifications.getText()).to.equal("1")
+    })
+    it("Should see that Nick has no counterparts and no tasks with pending assessments", () => {
+      Home.open("/", "nick")
+      Home.myCounterpartsLink.waitForDisplayed()
+      Home.myTasksLink.waitForDisplayed()
+      /* eslint-disable no-unused-expressions */
+      expect(Home.myCounterpartsNotifications.isExisting()).to.be.false
+      expect(Home.myTasksNotifications.isExisting()).to.be.false
+      /* eslint-enable no-unused-expressions */
     })
   })
 })

--- a/client/tests/webdriver/customFieldsSpecs/pendingAssessments.spec.js
+++ b/client/tests/webdriver/customFieldsSpecs/pendingAssessments.spec.js
@@ -1,28 +1,284 @@
-// Note: number of assessments are based on the base data, if that changes, change this test as well
 import { expect } from "chai"
+import moment from "moment"
+import AssessmentsSection from "../pages/assessments.page"
+import CreateReport from "../pages/report/createReport.page"
 import MyCounterparts from "../pages/myCounterparts.page"
 import MyTasks from "../pages/myTasks.page"
 
+const SHORT_WAIT_MS = 1000
+
+// Note: number of assessments are based on the base data, if that changes, change this test as well
 describe("In my counterparts page", () => {
-  describe("When Erin is checking the content of the page", () => {
-    it("Should see 1 counterpart in the table of pending my counterparts that have pending assessments", () => {
+  describe("When Erin is checking the contents of the page", () => {
+    it("Should see 1 counterpart in the table of pending my counterparts that has pending assessments", () => {
       MyCounterparts.open()
       MyCounterparts.myPendingCounterparts.waitForDisplayed()
       const myPendingCounterpartsItems = MyCounterparts.myPendingCounterpartsContent.$$(
         "tr"
       )
       expect(myPendingCounterpartsItems).to.have.length(1)
+      MyCounterparts.getMyPendingCounterpart(
+        "CIV TOPFERNESS, Christopf"
+      ).click()
+    })
+    it("Should be able to add a quarterly assessment with 4 questions for the counterpart", () => {
+      AssessmentsSection.getAssessmentsSection("quarterly").waitForDisplayed()
+      const newAssessmentButton = AssessmentsSection.getNewAssessmentButton(
+        "quarterly"
+      )
+      newAssessmentButton.waitForDisplayed()
+      newAssessmentButton.click()
+      const modalContent = AssessmentsSection.modalContent
+      modalContent.waitForDisplayed()
+      AssessmentsSection.modalTitle.waitForDisplayed()
+      /* eslint-disable no-unused-expressions */
+      expect(
+        AssessmentsSection.getModalAssessmentQuestion("test1").isExisting()
+      ).to.be.true
+      expect(
+        AssessmentsSection.getModalAssessmentQuestion("test2").isExisting()
+      ).to.be.true
+      expect(
+        AssessmentsSection.getModalAssessmentQuestion("test3").isExisting()
+      ).to.be.true
+      expect(AssessmentsSection.getModalAssessmentQuestion("text").isExisting())
+        .to.be.true
+      /* eslint-enable no-unused-expressions */
+      const cancelButton = AssessmentsSection.modalCancelButton
+      cancelButton.waitForDisplayed()
+      cancelButton.click()
+      modalContent.waitForDisplayed({ reverse: true, timeout: SHORT_WAIT_MS })
+    })
+  })
+
+  describe("When Jack is checking the contents of the page", () => {
+    it("Should see 1 counterpart in the table of pending my counterparts that has pending assessments", () => {
+      MyCounterparts.openAs("jack")
+      MyCounterparts.myPendingCounterparts.waitForDisplayed()
+      const myPendingCounterpartsItems = MyCounterparts.myPendingCounterpartsContent.$$(
+        "tr"
+      )
+      expect(myPendingCounterpartsItems).to.have.length(1)
+      MyCounterparts.getMyPendingCounterpart("Maj ROGWELL, Roger").click()
+    })
+    it("Should be able to add a quarterly assessment with 1 question for the counterpart", () => {
+      AssessmentsSection.getAssessmentsSection("quarterly").waitForDisplayed()
+      const newAssessmentButton = AssessmentsSection.getNewAssessmentButton(
+        "quarterly"
+      )
+      newAssessmentButton.waitForDisplayed()
+      newAssessmentButton.click()
+      const modalContent = AssessmentsSection.modalContent
+      modalContent.waitForDisplayed()
+      AssessmentsSection.modalTitle.waitForDisplayed()
+      /* eslint-disable no-unused-expressions */
+      expect(
+        AssessmentsSection.getModalAssessmentQuestion("test1").isExisting()
+      ).to.be.false
+      expect(
+        AssessmentsSection.getModalAssessmentQuestion("test2").isExisting()
+      ).to.be.false
+      expect(
+        AssessmentsSection.getModalAssessmentQuestion("test3").isExisting()
+      ).to.be.false
+      expect(AssessmentsSection.getModalAssessmentQuestion("text").isExisting())
+        .to.be.true
+      /* eslint-enable no-unused-expressions */
+      const cancelButton = AssessmentsSection.modalCancelButton
+      cancelButton.waitForDisplayed()
+      cancelButton.click()
+      modalContent.waitForDisplayed({ reverse: true, timeout: SHORT_WAIT_MS })
     })
   })
 })
 
 describe("In my tasks page", () => {
-  describe("When Erin is checking the content of the page", () => {
+  describe("When Erin is checking the contents of the page", () => {
     it("Should see an empty table of my tasks that have pending assessments", () => {
       MyTasks.open()
       MyTasks.myPendingTasks.waitForDisplayed()
       // eslint-disable-next-line no-unused-expressions
       expect(MyTasks.myPendingTasksContent.isExisting()).to.be.false
+    })
+  })
+
+  describe("When Jack is checking the contents of the page", () => {
+    it("Should see 1 task in the table of my tasks that has pending assessments", () => {
+      MyTasks.openAs("jack")
+      MyTasks.myPendingTasks.waitForDisplayed()
+      const myPendingTasks = MyTasks.myPendingTasksContent.$$("tr")
+      expect(myPendingTasks).to.have.length(1)
+      MyTasks.getMyPendingTask("2.B").click()
+    })
+    it("Should be able to add a monthly assessment with 2 questions for the task", () => {
+      AssessmentsSection.getAssessmentsSection("monthly").waitForDisplayed()
+      const newAssessmentButton = AssessmentsSection.getNewAssessmentButton(
+        "monthly"
+      )
+      newAssessmentButton.waitForDisplayed()
+      newAssessmentButton.click()
+      const modalContent = AssessmentsSection.modalContent
+      modalContent.waitForDisplayed()
+      AssessmentsSection.modalTitle.waitForDisplayed()
+      /* eslint-disable no-unused-expressions */
+      expect(
+        AssessmentsSection.getModalAssessmentQuestion("issues").isExisting()
+      ).to.be.true
+      expect(
+        AssessmentsSection.getModalAssessmentQuestion("status").isExisting()
+      ).to.be.true
+      /* eslint-enable no-unused-expressions */
+      const cancelButton = AssessmentsSection.modalCancelButton
+      cancelButton.waitForDisplayed()
+      cancelButton.click()
+      modalContent.waitForDisplayed({ reverse: true, timeout: SHORT_WAIT_MS })
+    })
+    it("Should be able to add a weekly assessment with 1 question for the task", () => {
+      AssessmentsSection.getAssessmentsSection("weekly").waitForDisplayed()
+      const newAssessmentButton = AssessmentsSection.getNewAssessmentButton(
+        "weekly"
+      )
+      newAssessmentButton.waitForDisplayed()
+      newAssessmentButton.click()
+      const modalContent = AssessmentsSection.modalContent
+      modalContent.waitForDisplayed()
+      AssessmentsSection.modalTitle.waitForDisplayed()
+      /* eslint-disable no-unused-expressions */
+      expect(
+        AssessmentsSection.getModalAssessmentQuestion("issues").isExisting()
+      ).to.be.true
+      expect(
+        AssessmentsSection.getModalAssessmentQuestion("status").isExisting()
+      ).to.be.false
+      /* eslint-enable no-unused-expressions */
+      const cancelButton = AssessmentsSection.modalCancelButton
+      cancelButton.waitForDisplayed()
+      cancelButton.click()
+      modalContent.waitForDisplayed({ reverse: true, timeout: SHORT_WAIT_MS })
+    })
+  })
+})
+
+describe("In new report page", () => {
+  describe("When Selena is creating a new report", () => {
+    it("Should not show assessments without an engagement date", () => {
+      const report = {
+        intent: "instant assessment test",
+        engagementDate: moment().startOf("day")
+      }
+      CreateReport.openAs("selena")
+      /* eslint-disable no-unused-expressions */
+      expect(CreateReport.attendeesAssessments.isExisting()).to.be.false
+      expect(CreateReport.tasksAssessments.isExisting()).to.be.false
+      CreateReport.fillForm(report)
+      expect(CreateReport.attendeesAssessments.isExisting()).to.be.true
+      expect(CreateReport.tasksAssessments.isExisting()).to.be.true
+      /* eslint-enable no-unused-expressions */
+    })
+    it("Should be able to add instant assessments for tasks", () => {
+      const report = {
+        tasks: ["1.2.A"]
+      }
+      CreateReport.fillForm(report)
+      const taskAssessmentRows = CreateReport.taskAssessmentRows
+      expect(taskAssessmentRows).to.have.length(2)
+      for (let i = 0; i < 2; i += 2) {
+        const task = taskAssessmentRows[i]
+        const assessment = taskAssessmentRows[i + 1]
+        const questions = assessment.$$("td > div")
+        switch (task.getText()) {
+          case "1.2.A":
+            expect(questions).to.have.length(3)
+            expect(questions[0].getAttribute("id")).to.match(/\.question1$/)
+            expect(questions[1].getAttribute("id")).to.match(/\.question2$/)
+            expect(questions[2].getAttribute("id")).to.match(/\.question3$/)
+            break
+          default:
+            expect.fail("unexpected task")
+            break
+        }
+      }
+    })
+    it("Should be able to add instant assessments for attendees", () => {
+      const report = {
+        principals: [
+          "Maj ROGWELL, Roger",
+          "LtCol STEVESON, Steve",
+          "CIV HUNTMAN, Hunter"
+        ]
+      }
+      CreateReport.fillForm(report)
+      const attendeeAssessmentRows = CreateReport.attendeeAssessmentRows
+      expect(attendeeAssessmentRows).to.have.length(6)
+      for (let i = 0; i < 6; i += 2) {
+        const attendee = attendeeAssessmentRows[i]
+        const assessment = attendeeAssessmentRows[i + 1]
+        const questions = assessment.$$("td > div")
+        switch (attendee.getText()) {
+          case "Maj ROGWELL, Roger":
+            expect(questions).to.have.length(2)
+            expect(questions[1].getAttribute("id")).to.match(/\.question2$/)
+            break
+          case "LtCol STEVESON, Steve":
+            expect(questions).to.have.length(2)
+            expect(questions[1].getAttribute("id")).to.match(/\.question3$/)
+            break
+          case "CIV HUNTMAN, Hunter":
+            expect(questions).to.have.length(1)
+            break
+          default:
+            expect.fail("unexpected attendee")
+            break
+        }
+        expect(questions[0].getAttribute("id")).to.match(/\.question1$/)
+      }
+    })
+    it("Should have an additional question for positive atmosphere", () => {
+      CreateReport.positiveAtmosphere.click()
+      const attendeeAssessmentRows = CreateReport.attendeeAssessmentRows
+      expect(attendeeAssessmentRows).to.have.length(6)
+      for (let i = 0; i < 6; i += 2) {
+        const attendee = attendeeAssessmentRows[i]
+        const assessment = attendeeAssessmentRows[i + 1]
+        const questions = assessment.$$("td > div")
+        switch (attendee.getText()) {
+          case "Maj ROGWELL, Roger":
+            expect(questions).to.have.length(3)
+            break
+          case "LtCol STEVESON, Steve":
+            expect(questions).to.have.length(3)
+            break
+          case "CIV HUNTMAN, Hunter":
+            expect(questions).to.have.length(2)
+            break
+          default:
+            expect.fail("unexpected attendee")
+            break
+        }
+        expect(questions[questions.length - 1].getAttribute("id")).to.match(
+          /\.question4$/
+        )
+      }
+    })
+    it("Should be able to cancel/delete the report", () => {
+      if (!CreateReport.deleteButton.isExisting()) {
+        // Cancel the report
+        CreateReport.cancelButton.click()
+      } else {
+        // Delete it
+        CreateReport.deleteButton.waitForExist()
+        CreateReport.deleteButton.waitForDisplayed()
+        CreateReport.deleteButton.click()
+        // Confirm delete
+        browser.pause(SHORT_WAIT_MS) // wait for the modal to slide in (transition is 300 ms)
+        CreateReport.confirmButton.waitForExist()
+        CreateReport.confirmButton.waitForDisplayed()
+        CreateReport.confirmButton.click()
+        browser.pause(SHORT_WAIT_MS) // wait for the modal to slide out (transition is 300 ms)
+        // Report should be deleted
+        CreateReport.waitForAlertToLoad()
+        expect(CreateReport.alert.getText()).to.include("Report deleted")
+      }
     })
   })
 })

--- a/client/tests/webdriver/pages/assessments.page.js
+++ b/client/tests/webdriver/pages/assessments.page.js
@@ -1,0 +1,31 @@
+import Page from "./page"
+
+class AssessmentsSection extends Page {
+  getAssessmentsSection(recurrence) {
+    return browser.$(`#entity-assessments-results-${recurrence}`)
+  }
+
+  getNewAssessmentButton(recurrence) {
+    return this.getAssessmentsSection(recurrence).$(
+      "table.assessments-table tr button"
+    )
+  }
+
+  get modalContent() {
+    return browser.$("div.modal-content")
+  }
+
+  get modalTitle() {
+    return this.modalContent.$("h4.modal-title")
+  }
+
+  get modalCancelButton() {
+    return this.modalContent.$('//button[text()="Cancel"]')
+  }
+
+  getModalAssessmentQuestion(key) {
+    return this.modalContent.$(`[id="fg-entityAssessment.${key}"]`)
+  }
+}
+
+export default new AssessmentsSection()

--- a/client/tests/webdriver/pages/createFutureReport.page.js
+++ b/client/tests/webdriver/pages/createFutureReport.page.js
@@ -38,14 +38,6 @@ class CreateFutureReport extends CreateReport {
     return this.attendeesFieldValue.$(`tbody tr:nth-child(${n})`)
   }
 
-  get attendeesAssessments() {
-    return browser.$("#attendees-engagement-assessments")
-  }
-
-  getAttendeeAssessment(name) {
-    return this.attendeesAssessments.$(`//td/a[text()="${name}"]`)
-  }
-
   get tasksFieldFormGroup() {
     return browser.$(`div[id="fg-${tskId}"]`)
   }
@@ -70,14 +62,6 @@ class CreateFutureReport extends CreateReport {
 
   getTasksFieldValueRow(n) {
     return this.tasksFieldValue.$(`tbody tr:nth-child(${n})`)
-  }
-
-  get tasksAssessments() {
-    return browser.$("#tasks-engagement-assessments")
-  }
-
-  getTaskAssessment(shortName) {
-    return this.tasksAssessments.$(`//td/a[text()="${shortName}"]`)
   }
 
   get deleteButton() {

--- a/client/tests/webdriver/pages/createReport.page.js
+++ b/client/tests/webdriver/pages/createReport.page.js
@@ -36,6 +36,10 @@ export class CreateReport extends Page {
     return browser.$("#duration")
   }
 
+  get positiveAtmosphere() {
+    return browser.$("#positiveAtmos")
+  }
+
   getCustomFieldFormGroup(id) {
     return browser.$(`div[id="fg-${id}"]`)
   }
@@ -177,12 +181,40 @@ export class CreateReport extends Page {
     return this.testMultiReferenceFieldValue.$(`tbody tr:nth-child(${n})`)
   }
 
+  get attendeesAssessments() {
+    return browser.$("#attendees-engagement-assessments")
+  }
+
+  get attendeeAssessmentRows() {
+    return this.attendeesAssessments.$$("tr")
+  }
+
+  getAttendeeAssessment(name) {
+    return this.attendeesAssessments.$(`//td/a[text()="${name}"]`)
+  }
+
+  get tasksAssessments() {
+    return browser.$("#tasks-engagement-assessments")
+  }
+
+  get taskAssessmentRows() {
+    return this.tasksAssessments.$$("tr")
+  }
+
+  getTaskAssessment(shortName) {
+    return this.tasksAssessments.$(`//td/a[text()="${shortName}"]`)
+  }
+
   get submitButton() {
     return browser.$("#formBottomSubmit")
   }
 
   get editButton() {
     return browser.$('//a[text()="Edit"]')
+  }
+
+  get cancelButton() {
+    return browser.$('//button[text()="Cancel"]')
   }
 
   get deleteButton() {
@@ -197,6 +229,10 @@ export class CreateReport extends Page {
 
   open(pathName = PAGE_URL, credentials = Page.DEFAULT_CREDENTIALS.user) {
     super.open(pathName, credentials)
+  }
+
+  openAs(user) {
+    super.open(PAGE_URL, user)
   }
 
   openAsAdminUser() {
@@ -222,7 +258,9 @@ export class CreateReport extends Page {
   }
 
   submitForm() {
+    this.submitButton.waitForClickable()
     this.submitButton.click()
+    this.submitButton.waitForExist({ reverse: true })
   }
 }
 

--- a/client/tests/webdriver/pages/myCounterparts.page.js
+++ b/client/tests/webdriver/pages/myCounterparts.page.js
@@ -7,6 +7,10 @@ class MyTasks extends Page {
     super.open(PAGE_URL)
   }
 
+  openAs(user) {
+    super.open(PAGE_URL, user)
+  }
+
   openAsSuperUser() {
     super.openAsSuperUser(PAGE_URL)
   }
@@ -20,11 +24,15 @@ class MyTasks extends Page {
   }
 
   get myPendingCounterparts() {
-    return browser.$("#my-counterparts-with-pending-assessments").$("tbody")
+    return browser.$("#my-counterparts-with-pending-assessments")
   }
 
   get myPendingCounterpartsContent() {
     return browser.$("#my-counterparts-with-pending-assessments").$("tbody")
+  }
+
+  getMyPendingCounterpart(name) {
+    return this.myPendingCounterpartsContent.$(`//a[text()="${name}"]`)
   }
 }
 

--- a/client/tests/webdriver/pages/myTasks.page.js
+++ b/client/tests/webdriver/pages/myTasks.page.js
@@ -7,6 +7,10 @@ class MyTasks extends Page {
     super.open(PAGE_URL)
   }
 
+  openAs(user) {
+    super.open(PAGE_URL, user)
+  }
+
   openAsOnboardUser() {
     super.openAsOnboardUser(PAGE_URL)
   }
@@ -25,6 +29,10 @@ class MyTasks extends Page {
 
   get myPendingTasksContent() {
     return browser.$("#my-tasks-with-pending-assessments").$("tbody")
+  }
+
+  getMyPendingTask(name) {
+    return this.myPendingTasksContent.$(`//a[contains(text(), "${name}")]`)
   }
 }
 

--- a/src/main/java/mil/dds/anet/MaintenanceCommand.java
+++ b/src/main/java/mil/dds/anet/MaintenanceCommand.java
@@ -1,10 +1,33 @@
 package mil.dds.anet;
 
+import static mil.dds.anet.threads.PendingAssessmentsNotificationWorker.NOTE_PERIOD_START;
+import static mil.dds.anet.threads.PendingAssessmentsNotificationWorker.NOTE_RECURRENCE;
+import static mil.dds.anet.threads.PendingAssessmentsNotificationWorker.PRINCIPAL_PERSON_ASSESSMENTS;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.dropwizard.Application;
 import io.dropwizard.cli.EnvironmentCommand;
 import io.dropwizard.setup.Environment;
 import java.lang.invoke.MethodHandles;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import mil.dds.anet.beans.Note;
+import mil.dds.anet.beans.Note.NoteType;
 import mil.dds.anet.config.AnetConfiguration;
+import mil.dds.anet.database.NoteDao;
+import mil.dds.anet.database.mappers.MapperUtils;
+import mil.dds.anet.threads.PendingAssessmentsNotificationWorker.AssessmentDates;
+import mil.dds.anet.threads.PendingAssessmentsNotificationWorker.Recurrence;
+import mil.dds.anet.utils.DaoUtils;
+import mil.dds.anet.utils.Utils;
 import net.sourceforge.argparse4j.impl.Arguments;
 import net.sourceforge.argparse4j.inf.Namespace;
 import net.sourceforge.argparse4j.inf.Subparser;
@@ -15,6 +38,7 @@ public class MaintenanceCommand extends EnvironmentCommand<AnetConfiguration> {
 
   private static final Logger logger =
       LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+  private static final ObjectMapper mapper = MapperUtils.getDefaultMapper();
 
   public MaintenanceCommand(Application<AnetConfiguration> application) {
     super(application, "maintenance", "Various helpful maintenance commands for the ANET Database");
@@ -29,6 +53,9 @@ public class MaintenanceCommand extends EnvironmentCommand<AnetConfiguration> {
         .required(false)
         .help("Delete dangling notes (either report assessments for reports that have been deleted,"
             + " or notes pointing to objects that no longer exist)");
+    subparser.addArgument("-mpa", "--migratePartnerAssessments").action(Arguments.storeTrue())
+        .required(false)
+        .help("Migrate old-style partner assessments to new-style periodic assessments");
 
     super.configure(subparser);
   }
@@ -46,6 +73,10 @@ public class MaintenanceCommand extends EnvironmentCommand<AnetConfiguration> {
       deleteDanglingNotes(engine);
     }
 
+    if (Boolean.TRUE.equals(namespace.getBoolean("migratePartnerAssessments"))) {
+      migratePartnerAssessments(engine, configuration);
+    }
+
     System.exit(0);
   }
 
@@ -57,5 +88,103 @@ public class MaintenanceCommand extends EnvironmentCommand<AnetConfiguration> {
   private void deleteDanglingNotes(AnetObjectEngine engine) {
     logger.info("Deleting dangling assessments and notes");
     engine.getNoteDao().deleteDanglingNotes();
+  }
+
+  private void migratePartnerAssessments(final AnetObjectEngine engine,
+      final AnetConfiguration configuration) {
+    logger.info("Migrating old-style partner assessments");
+    final Map<String, Object> assessmentConfig = getAssessmentConfig(configuration);
+    final String recurrence = getAssessmentRecurrence(assessmentConfig);
+    final Set<String> questions = getAssessmentQuestions(assessmentConfig);
+
+    final NoteDao noteDao = engine.getNoteDao();
+    for (final Note note : getPartnerAssessmentNotes(noteDao)) {
+      final JsonNode partnerAssessment;
+      try {
+        partnerAssessment = Utils.parseJsonSafe(note.getText());
+      } catch (JsonProcessingException e) {
+        logger.error("Invalid JSON in note {}, leaving note as-is for later inspection", note);
+        continue;
+      }
+
+      if (partnerAssessment == null || !partnerAssessment.isObject()) {
+        logger.error("Can't handle note {}, leaving note as-is for later inspection", note);
+        continue;
+      }
+
+      final ObjectNode objectNode = (ObjectNode) partnerAssessment;
+      for (final Iterator<Map.Entry<String, JsonNode>> entryIter = objectNode.fields(); entryIter
+          .hasNext();) {
+        final Map.Entry<String, JsonNode> entry = entryIter.next();
+        if (!entry.getValue().isValueNode() || !questions.contains(entry.getKey())) {
+          // Unknown prop, remove
+          logger.warn("Removing unknown prop {} from note {}", entry.getKey(), note);
+          entryIter.remove();
+        }
+      }
+
+      try {
+        // Update the note with the new data
+        objectNode.put(NOTE_RECURRENCE, recurrence);
+        objectNode.put(NOTE_PERIOD_START, getPeriodStart(recurrence, note.getCreatedAt()));
+        note.setText(mapper.writeValueAsString(objectNode));
+        note.setType(NoteType.ASSESSMENT);
+        noteDao.updateNoteTypeAndText(note);
+      } catch (JsonProcessingException e) {
+        logger.error("Can't update JSON of note {}, leaving note as-is for later inspection", note);
+      }
+    }
+
+    final List<Note> remainingPartnerAssessmentNotes = getPartnerAssessmentNotes(noteDao);
+    if (remainingPartnerAssessmentNotes.isEmpty()) {
+      logger.info("Migrated all old-style partner assessments");
+    } else {
+      final int nr = remainingPartnerAssessmentNotes.size();
+      logger.warn(nr == 1 ? "The following old-style partner assessment was not migrated:"
+          : "The following {} old-style partner assessments were not migrated:", nr);
+      for (final Note note : remainingPartnerAssessmentNotes) {
+        logger.warn("- note {}", note);
+      }
+    }
+  }
+
+  private List<Note> getPartnerAssessmentNotes(final NoteDao noteDao) {
+    return noteDao.getNotesByType(NoteType.PARTNER_ASSESSMENT);
+  }
+
+  private Map<String, Object> getAssessmentConfig(final AnetConfiguration configuration) {
+    @SuppressWarnings("unchecked")
+    final List<Map<String, Object>> assessmentsConfig =
+        (List<Map<String, Object>>) configuration.getDictionaryEntry(PRINCIPAL_PERSON_ASSESSMENTS);
+    if (assessmentsConfig != null) {
+      for (final Map<String, Object> assessmentConfig : assessmentsConfig) {
+        // Find the first recurring assessment definition
+        final String recurrence = getAssessmentRecurrence(assessmentConfig);
+        if (!"once".equals(recurrence)) {
+          logger.info("Will change partner assessments to {} periodic assessments", recurrence);
+          return assessmentConfig;
+        }
+      }
+    }
+    throw new IllegalArgumentException(
+        "No recurring assessment definition found in the dictionary under \""
+            + PRINCIPAL_PERSON_ASSESSMENTS + "\"");
+  }
+
+  private String getAssessmentRecurrence(final Map<String, Object> assessmentConfig) {
+    return (String) assessmentConfig.get("recurrence");
+  }
+
+  private Set<String> getAssessmentQuestions(final Map<String, Object> assessmentConfig) {
+    @SuppressWarnings("unchecked")
+    final Map<String, Object> questions = (Map<String, Object>) assessmentConfig.get("questions");
+    return new HashSet<>(questions.keySet());
+  }
+
+  public static String getPeriodStart(final String recurrence, final Instant instant) {
+    final AssessmentDates assessmentDates =
+        new AssessmentDates(instant, Recurrence.valueOfRecurrence(recurrence));
+    return DateTimeFormatter.ISO_LOCAL_DATE
+        .format(assessmentDates.getNotificationDate().atZone(DaoUtils.getServerNativeZoneId()));
   }
 }

--- a/src/main/java/mil/dds/anet/MaintenanceCommand.java
+++ b/src/main/java/mil/dds/anet/MaintenanceCommand.java
@@ -77,7 +77,10 @@ public class MaintenanceCommand extends EnvironmentCommand<AnetConfiguration> {
       migratePartnerAssessments(engine, configuration);
     }
 
-    System.exit(0);
+    if (!configuration.isTestMode()) {
+      // Only exit when not in testMode, or the Command tests won't run
+      System.exit(0);
+    }
   }
 
   private void clearEmptyBiographies(AnetObjectEngine engine) {

--- a/src/main/java/mil/dds/anet/beans/Note.java
+++ b/src/main/java/mil/dds/anet/beans/Note.java
@@ -17,7 +17,10 @@ import mil.dds.anet.views.UuidFetcher;
 public class Note extends AbstractAnetBean {
 
   public static enum NoteType {
-    FREE_TEXT, CHANGE_RECORD, PARTNER_ASSESSMENT, ASSESSMENT
+    FREE_TEXT, CHANGE_RECORD, // -
+    @Deprecated
+    PARTNER_ASSESSMENT, // Should no longer be used but remain in place to keep the correct values
+    ASSESSMENT
   }
 
   @GraphQLQuery

--- a/src/main/java/mil/dds/anet/resources/PositionResource.java
+++ b/src/main/java/mil/dds/anet/resources/PositionResource.java
@@ -103,7 +103,7 @@ public class PositionResource {
           }, oldPositionUuid -> {
             dao.deletePositionAssociation(DaoUtils.getUuid(pos), oldPositionUuid);
           });
-      AnetAuditLogger.log("Person {} associations changed to {} by {}", current,
+      AnetAuditLogger.log("Position {} associations changed to {} by {}", current,
           pos.getAssociatedPositions(), user);
       // GraphQL mutations *have* to return something
       return 1;

--- a/src/main/java/mil/dds/anet/threads/PendingAssessmentsNotificationWorker.java
+++ b/src/main/java/mil/dds/anet/threads/PendingAssessmentsNotificationWorker.java
@@ -198,15 +198,15 @@ public class PendingAssessmentsNotificationWorker extends AbstractWorker {
   }
 
   // Dictionary lookup keys we use
-  private static final String PRINCIPAL_PERSON_ASSESSMENTS = "fields.principal.person.assessments";
-  private static final String TASK_SUB_LEVEL_ASSESSMENTS = "fields.task.subLevel.assessments";
-  private static final String TASK_TOP_LEVEL_ASSESSMENTS = "fields.task.topLevel.assessments";
+  public static final String PRINCIPAL_PERSON_ASSESSMENTS = "fields.principal.person.assessments";
+  public static final String TASK_SUB_LEVEL_ASSESSMENTS = "fields.task.subLevel.assessments";
+  public static final String TASK_TOP_LEVEL_ASSESSMENTS = "fields.task.topLevel.assessments";
   // JSON fields in task.customFields we use
-  private static final String TASK_ASSESSMENTS = "assessments";
-  private static final String TASK_RECURRENCE = "recurrence";
+  public static final String TASK_ASSESSMENTS = "assessments";
+  public static final String TASK_RECURRENCE = "recurrence";
   // JSON fields in note.text we use
-  private static final String NOTE_RECURRENCE = "__recurrence";
-  private static final String NOTE_PERIOD_START = "__periodStart";
+  public static final String NOTE_RECURRENCE = "__recurrence";
+  public static final String NOTE_PERIOD_START = "__periodStart";
 
   private final PositionDao positionDao;
   private final TaskDao taskDao;

--- a/src/main/resources/anet-schema.yml
+++ b/src/main/resources/anet-schema.yml
@@ -69,6 +69,8 @@ $defs:
     additionalProperties: false
     required: [type]
     properties:
+      test:
+        type: string
       type:
         title: value type field
         type: string

--- a/src/main/resources/anet-schema.yml
+++ b/src/main/resources/anet-schema.yml
@@ -630,41 +630,6 @@ properties:
                   type: string
                   title: The list of possible countries
                   description: Used in the UI where a country can be selected for a person inside a principal organization.
-              assessment:
-                type: object
-                additionalProperties: false
-                required: [questions]
-                properties:
-                  questions:
-                    type: array
-                    uniqueItems: true
-                    minItems: 1
-                    items:
-                      type: object
-                      additionalProperties: false
-                      required: [id,label,choice]
-                      properties:
-                        id:
-                          type: string
-                        test:
-                          type: string
-                        label:
-                          type: string
-                        choice:
-                          type: array
-                          uniqueItems: true
-                          minItems: 1
-                          items:
-                            type: object
-                            additionalProperties: false
-                            required: [value,label]
-                            properties:
-                              value:
-                                type: string
-                              label:
-                                type: string
-                              color:
-                                type: string
               assessments:
                 type: array
                 items:

--- a/src/test/java/mil/dds/anet/test/beans/PersonTest.java
+++ b/src/test/java/mil/dds/anet/test/beans/PersonTest.java
@@ -22,37 +22,6 @@ public class PersonTest extends BeanTester<Person> {
   final File DEFAULT_AVATAR =
       new File(PersonTest.class.getResource("/assets/default_avatar.png").getFile());
 
-  public static Person getJackJacksonStub() {
-    final Person person = new Person();
-    person.setName("JACKSON, Jack");
-    person.setEmailAddress("hunter+foobar@example.com");
-    person.setPhoneNumber("123-456-78960");
-    person.setRank("OF-9");
-    person.setStatus(Person.Status.ACTIVE);
-    person.setRole(Role.ADVISOR);
-    person.setBiography("this is a sample biography");
-    person.setDomainUsername("jack");
-    person.setGender("Male");
-    person.setCountry("United States of America");
-    person.setEndOfTourDate(
-        ZonedDateTime.of(2017, 6, 30, 0, 0, 0, 0, DaoUtils.getServerNativeZoneId()).toInstant());
-    return person;
-  }
-
-  public static Person getSteveStevesonStub() {
-    Person person = new Person();
-    person.setName("STEVESON, Steve");
-    person.setEmailAddress("hunter+steve@example.com");
-    person.setPhoneNumber("+011-258-32895");
-    person.setRank("LtCol");
-    person.setStatus(Person.Status.ACTIVE);
-    person.setRole(Role.PRINCIPAL);
-    person.setBiography("this is a sample person who could be a Principal!");
-    person.setGender("Male");
-    person.setCountry("Afghanistan");
-    return person;
-  }
-
   @Test
   public void serializesToJson() throws Exception {
     serializesToJson(getJackJacksonStub(), "testJson/people/jack.json");
@@ -96,6 +65,76 @@ public class PersonTest extends BeanTester<Person> {
 
     assertThat(imageBinary.getWidth()).isEqualTo(32);
     assertThat(imageBinary.getHeight()).isEqualTo(32);
+  }
+
+  public static Person getChristopfTopferness() {
+    final Person person = new Person();
+    person.setName("TOPFERNESS, Christopf");
+    person.setEmailAddress("hunter+christopf@example.com");
+    person.setPhoneNumber("+1-422222222");
+    person.setRank("CIV");
+    person.setStatus(Person.Status.ACTIVE);
+    person.setRole(Role.PRINCIPAL);
+    person.setBiography("Christopf works in the MoD Office");
+    person.setGender("Male");
+    person.setCountry("Afghanistan");
+    return person;
+  }
+
+  public static Person getHunterHuntman() {
+    final Person person = new Person();
+    person.setName("HUNTMAN, Hunter");
+    person.setEmailAddress("hunter+hunter@example.com");
+    person.setPhoneNumber("+1-412-9314");
+    person.setRank("CIV");
+    person.setStatus(Person.Status.ACTIVE);
+    person.setRole(Role.PRINCIPAL);
+    person.setGender("Male");
+    return person;
+  }
+
+  public static Person getShardulSharton() {
+    final Person person = new Person();
+    person.setName("SHARTON, Shardul");
+    person.setEmailAddress("hunter+shardul@example.com");
+    person.setPhoneNumber("+99-9999-9999");
+    person.setRank("CIV");
+    person.setStatus(Person.Status.INACTIVE);
+    person.setRole(Role.PRINCIPAL);
+    person.setGender("Male");
+    person.setCountry("Italy");
+    return person;
+  }
+
+  public static Person getJackJacksonStub() {
+    final Person person = new Person();
+    person.setName("JACKSON, Jack");
+    person.setEmailAddress("hunter+foobar@example.com");
+    person.setPhoneNumber("123-456-78960");
+    person.setRank("OF-9");
+    person.setStatus(Person.Status.ACTIVE);
+    person.setRole(Role.ADVISOR);
+    person.setBiography("this is a sample biography");
+    person.setDomainUsername("jack");
+    person.setGender("Male");
+    person.setCountry("United States of America");
+    person.setEndOfTourDate(
+        ZonedDateTime.of(2017, 6, 30, 0, 0, 0, 0, DaoUtils.getServerNativeZoneId()).toInstant());
+    return person;
+  }
+
+  public static Person getSteveStevesonStub() {
+    Person person = new Person();
+    person.setName("STEVESON, Steve");
+    person.setEmailAddress("hunter+steve@example.com");
+    person.setPhoneNumber("+011-258-32895");
+    person.setRank("LtCol");
+    person.setStatus(Person.Status.ACTIVE);
+    person.setRole(Role.PRINCIPAL);
+    person.setBiography("this is a sample person who could be a Principal!");
+    person.setGender("Male");
+    person.setCountry("Afghanistan");
+    return person;
   }
 
   public static Person getRogerRogwell() {
@@ -272,7 +311,5 @@ public class PersonTest extends BeanTester<Person> {
       System.out.println("A equals B");
     }
   }
-
-
 
 }

--- a/src/test/java/mil/dds/anet/test/integration/commands/MaintenanceCommandTest.java
+++ b/src/test/java/mil/dds/anet/test/integration/commands/MaintenanceCommandTest.java
@@ -1,0 +1,144 @@
+package mil.dds.anet.test.integration.commands;
+
+import static mil.dds.anet.threads.PendingAssessmentsNotificationWorker.NOTE_PERIOD_START;
+import static mil.dds.anet.threads.PendingAssessmentsNotificationWorker.NOTE_RECURRENCE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.dropwizard.Application;
+import io.dropwizard.cli.Cli;
+import io.dropwizard.setup.Bootstrap;
+import io.dropwizard.util.JarLocation;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import mil.dds.anet.AnetObjectEngine;
+import mil.dds.anet.MaintenanceCommand;
+import mil.dds.anet.beans.Note;
+import mil.dds.anet.beans.Note.NoteType;
+import mil.dds.anet.beans.NoteRelatedObject;
+import mil.dds.anet.config.AnetConfiguration;
+import mil.dds.anet.database.NoteDao;
+import mil.dds.anet.database.PersonDao;
+import mil.dds.anet.test.integration.utils.TestApp;
+import mil.dds.anet.test.resources.AbstractResourceTest;
+import mil.dds.anet.utils.Utils;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(TestApp.class)
+public class MaintenanceCommandTest extends AbstractResourceTest {
+  private static NoteDao noteDao;
+  private static List<Note> testAssessments;
+
+  @BeforeAll
+  public static void setUpClass() throws Exception {
+    noteDao = AnetObjectEngine.getInstance().getNoteDao();
+    testAssessments = createTestAssessments();
+    final Application<AnetConfiguration> newApplication = TestApp.app.newApplication();
+    final Bootstrap<AnetConfiguration> bootstrap = new Bootstrap<>(newApplication);
+    newApplication.initialize(bootstrap);
+    final Cli cli =
+        new Cli(new JarLocation(newApplication.getClass()), bootstrap, System.out, System.err);
+    cli.run("maintenance", "-mpa", "anet.yml");
+  }
+
+  @AfterAll
+  public static void tearDownClass() throws Exception {
+    deleteTestAssessments(testAssessments);
+  }
+
+  @Test
+  public void testPartnerAssessments() throws Exception {
+    final List<Note> remainingPartnerAssessments =
+        noteDao.getNotesByType(NoteType.PARTNER_ASSESSMENT);
+    checkPartnerAssessment(testAssessments.get(0), remainingPartnerAssessments);
+    checkPartnerAssessment(testAssessments.get(1), remainingPartnerAssessments);
+    checkPartnerAssessment(testAssessments.get(2), remainingPartnerAssessments);
+  }
+
+  @Test
+  public void testPeriodicAssessments() throws Exception {
+    final List<Note> periodicAssessments = noteDao.getNotesByType(NoteType.ASSESSMENT);
+    checkPeriodicAssessment(testAssessments.get(3), periodicAssessments);
+    checkPeriodicAssessment(testAssessments.get(4), periodicAssessments);
+  }
+
+  private void checkPartnerAssessment(Note note, List<Note> remainingPartnerAssessments) {
+    final Optional<Note> found = remainingPartnerAssessments.stream()
+        .filter(pa -> pa.getUuid().equals(note.getUuid())).findFirst();
+    assertThat(found).isPresent();
+    // Note should be unchanged
+    assertThat(found.get()).isEqualTo(note);
+  }
+
+  private void checkPeriodicAssessment(Note note, List<Note> periodicAssessments) {
+    final Optional<Note> found =
+        periodicAssessments.stream().filter(pa -> pa.getUuid().equals(note.getUuid())).findFirst();
+    assertThat(found).isPresent();
+    final Note periodicAssessment = found.get();
+    assertThat(periodicAssessment.getType()).isEqualTo(NoteType.ASSESSMENT);
+    try {
+      final JsonNode jsonNode = Utils.parseJsonSafe(periodicAssessment.getText());
+      assertThat(jsonNode).isNotNull();
+      assertThat(jsonNode.isObject()).isTrue();
+      final ObjectNode objectNode = (ObjectNode) jsonNode;
+      assertThat(objectNode.has(NOTE_RECURRENCE)).isTrue();
+      final JsonNode recurrence = objectNode.get(NOTE_RECURRENCE);
+      assertThat(recurrence.isTextual()).isTrue();
+      assertThat(recurrence.asText()).isNotEmpty();
+      assertThat(objectNode.has(NOTE_PERIOD_START)).isTrue();
+      final JsonNode periodStart = objectNode.get(NOTE_PERIOD_START);
+      assertThat(periodStart.isTextual()).isTrue();
+      assertThat(periodStart.asText()).isNotEmpty();
+      assertThat(periodStart.asText()).isEqualTo(MaintenanceCommand
+          .getPeriodStart(recurrence.asText(), periodicAssessment.getCreatedAt()));
+      // Unknown prop should be removed
+      assertThat(objectNode.has("test")).isFalse();
+    } catch (JsonProcessingException e) {
+      fail("Invalid JSON in periodic assessment {}", periodicAssessment);
+    }
+  }
+
+  private static List<Note> createTestAssessments() {
+    final List<Note> partnerAssessments = new ArrayList<>();
+    // null
+    partnerAssessments.add(createTestAssessment(null));
+    // no JSON
+    partnerAssessments.add(createTestAssessment("text"));
+    // not a JSON object
+    partnerAssessments.add(createTestAssessment("\"test\": }"));
+    // invalid but parsed into a JSON object
+    partnerAssessments.add(createTestAssessment("{ \"test\":"));
+    // valid JSON object
+    partnerAssessments.add(createTestAssessment(
+        "{ \"test1\":\"3\", \"test2\":\"3\", \"test3\":\"3\", \"text\": \"sample text\" }"));
+    return partnerAssessments;
+  }
+
+  private static Note createTestAssessment(String text) {
+    final Note testNote = new Note();
+    testNote.setAuthor(admin);
+    testNote.setType(NoteType.PARTNER_ASSESSMENT);
+    testNote.setText(text);
+    final NoteRelatedObject testNro = new NoteRelatedObject();
+    testNro.setRelatedObjectType(PersonDao.TABLE_NAME);
+    testNro.setRelatedObjectUuid(admin.getUuid());
+    testNote.setNoteRelatedObjects(Collections.singletonList(testNro));
+    final Note partnerAssessment = noteDao.insert(testNote);
+    assertThat(partnerAssessment.getUuid()).isNotNull();
+    return partnerAssessment;
+  }
+
+  private static void deleteTestAssessments(List<Note> partnerAssessments) {
+    for (final Note note : partnerAssessments) {
+      assertThat(noteDao.delete(note.getUuid())).isEqualTo(1);
+    }
+  }
+}

--- a/src/test/java/mil/dds/anet/test/resources/AbstractResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/AbstractResourceTest.java
@@ -146,35 +146,47 @@ public abstract class AbstractResourceTest {
     return erin;
   }
 
-  public Person getJackJackson() {
+  public static Person getChristopfTopferness() {
+    return findOrPutPersonInDb(PersonTest.getChristopfTopferness());
+  }
+
+  public static Person getHunterHuntman() {
+    return findOrPutPersonInDb(PersonTest.getHunterHuntman());
+  }
+
+  public static Person getJackJackson() {
     return findOrPutPersonInDb(PersonTest.getJackJacksonStub());
   }
 
-  public Person getSteveSteveson() {
+  public static Person getShardulSharton() {
+    return findOrPutPersonInDb(PersonTest.getShardulSharton());
+  }
+
+  public static Person getSteveSteveson() {
     return findOrPutPersonInDb(PersonTest.getSteveStevesonStub());
   }
 
-  public Person getRogerRogwell() {
+  public static Person getRogerRogwell() {
     return findOrPutPersonInDb(PersonTest.getRogerRogwell());
   }
 
-  public Person getElizabethElizawell() {
+  public static Person getElizabethElizawell() {
     return findOrPutPersonInDb(PersonTest.getElizabethElizawell());
   }
 
-  public Person getNickNicholson() {
+  public static Person getNickNicholson() {
     return findOrPutPersonInDb(PersonTest.getNickNicholson());
   }
 
-  public Person getBobBobtown() {
+  public static Person getBobBobtown() {
     return findOrPutPersonInDb(PersonTest.getBobBobtown());
   }
 
-  public Person getAndrewAnderson() {
+  public static Person getAndrewAnderson() {
     return findOrPutPersonInDb(PersonTest.getAndrewAnderson());
   }
 
-  public Organization createOrganizationWithUuid(String uuid) {
+  public static Organization createOrganizationWithUuid(String uuid) {
     final Organization ao = new Organization();
     ao.setUuid(uuid);
     return ao;

--- a/src/test/java/mil/dds/anet/test/resources/PositionResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/PositionResourceTest.java
@@ -184,8 +184,9 @@ public class PositionResourceTest extends AbstractResourceTest {
     prinPos.setOrganization(orgs.getList().get(0));
     prinPos.setStatus(Position.Status.ACTIVE);
 
-    Person principal = getRogerRogwell();
-    assertThat(principal.getUuid()).isNotNull();
+    final Person roger = getRogerRogwell();
+    final Position rogersOldPosition = roger.getPosition();
+    assertThat(roger.getUuid()).isNotNull();
     String tashkilUuid = graphQLHelper.createObject(admin, "createPosition", "position",
         "PositionInput", prinPos, new TypeReference<GraphQlResponse<Position>>() {});
     assertThat(tashkilUuid).isNotNull();
@@ -196,7 +197,7 @@ public class PositionResourceTest extends AbstractResourceTest {
     // put the principal in a tashkil
     variables = new HashMap<>();
     variables.put("uuid", tashkil.getUuid());
-    variables.put("person", principal);
+    variables.put("person", roger);
     nrUpdated = graphQLHelper.updateObject(admin,
         "mutation ($uuid: String!, $person: PersonInput!) { payload: putPersonInPosition (uuid: $uuid, person: $person) }",
         variables);
@@ -270,6 +271,20 @@ public class PositionResourceTest extends AbstractResourceTest {
         new TypeReference<GraphQlResponse<Position>>() {});
     assertThat(currPos.getPerson()).isNotNull();
     assertThat(currPos.getPersonUuid()).isEqualTo(jack.getUuid());
+
+    // Put roger back in his old position
+    variables = new HashMap<>();
+    variables.put("uuid", rogersOldPosition.getUuid());
+    variables.put("person", roger);
+    nrUpdated = graphQLHelper.updateObject(admin,
+        "mutation ($uuid: String!, $person: PersonInput!) { payload: putPersonInPosition (uuid: $uuid, person: $person) }",
+        variables);
+    assertThat(nrUpdated).isEqualTo(1);
+
+    currPos = graphQLHelper.getObjectById(admin, "position", FIELDS, rogersOldPosition.getUuid(),
+        new TypeReference<GraphQlResponse<Position>>() {});
+    assertThat(currPos.getPerson()).isNotNull();
+    assertThat(currPos.getPersonUuid()).isEqualTo(roger.getUuid());
   }
 
   @Test

--- a/testDictionaries/no-custom-fields.yml
+++ b/testDictionaries/no-custom-fields.yml
@@ -269,51 +269,11 @@ fields:
     person:
       name: Afghan Partner
       countries: [Afghanistan]
-      assessment:
-        questions:
-          - id: test1
-            test: $.position.[?(@.identificationCode && /^(Z|z)/.test(@.identificationCode))]
-            label: Test question 1
-            choice:
-              - value: "1"
-                label: one
-                color: '#c2ffb3'
-              - value: "2"
-                label: two
-                color: '#ffe396'
-              - value: "3"
-                label: three
-                color: '#ff8279'
-          - id: test2
-            test: $.position.[?(@.identificationCode && /^(Z|z)/.test(@.identificationCode))]
-            label: Test question 2
-            choice:
-              - value: "3"
-                label: three
-                color: '#ff8279'
-              - value: "4"
-                label: four
-                color: '#ffe396'
-              - value: "5"
-                label: five
-                color: '#c2ffb3'
-          - id: test3
-            test: $.position.[?(@.identificationCode && /^(Z|z)/.test(@.identificationCode))]
-            label: Test question 3
-            choice:
-              - value: "1"
-                label: one
-                color: '#c2ffb3'
-              - value: "2"
-                label: two
-                color: '#ff8279'
-              - value: "3"
-                label: three
-                color: '#ff8279'
       assessments:
         - recurrence: quarterly
           questions:
             test1:
+              test: $.subject.position.organization.[?(@property == "identificationCode" && @.match(/^Z/i))]
               type: enum
               label: Test question 1
               choices:
@@ -327,6 +287,7 @@ fields:
                   label: three
                   color: '#ff8279'
             test2:
+              test: $.subject.position.organization.[?(@property == "identificationCode" && @.match(/^Z/i))]
               type: enum
               label: Test question 2
               choices:
@@ -340,6 +301,7 @@ fields:
                   label: five
                   color: '#c2ffb3'
             test3:
+              test: $.subject.position.organization.[?(@property == "identificationCode" && @.match(/^Z/i))]
               type: enum
               label: Test question 3
               choices:
@@ -352,6 +314,12 @@ fields:
                 "3":
                   label: three
                   color: '#ff8279'
+            text:
+              type: special_field
+              label: Text
+              widget: richTextEditor
+              style:
+                height: 100px
         - recurrence: once
           relatedObjectType: report
           questions:
@@ -368,6 +336,30 @@ fields:
                 "3":
                   label: high
                   color: '#ff8279'
+            question2:
+              test: $.subject.position.organization.[?(@property == "identificationCode" && @.match(/^P/i))]
+              type: enumset
+              label: Attendee from P org
+              choices:
+                yes:
+                  label: P
+                  color: '#ff0000'
+            question3:
+              test: $.subject.position.organization.[?(@property == "identificationCode" && @.match(/^Z/i))]
+              type: enumset
+              label: Attendee from Z org
+              choices:
+                yes:
+                  label: Z
+                  color: '#00ff00'
+            question4:
+              test: $.relatedObject.[?(@property == "atmosphere" && @ == "POSITIVE")]
+              type: enumset
+              label: Report had POSITIVE atmosphere
+              choices:
+                yes:
+                  label: 👍
+                  color: '#0000ff'
 
     position:
       name: Afghan Tashkil


### PR DESCRIPTION
Remove old-style partner assessments, and add a maintenance command to migrate these to periodic assessments, possibly creating additional position associations between the advisor who created the partner assessment and the principal they assessed. Also introduce the possibility to add conditions to assessment questions (both periodic and with `recurrence: once`).

Closes NCI-Agency/anet#3339

#### User changes
- Old-style partner assessments (as shown in the Notes side-panel) will be migrated to periodic assessments (as shown on the assessed person's page). It is no longer possible to create partner assessments, these are now obsolete.
- When an advisor has assessed a principal, an association between the advisor's and principal's positions (a.k.a. counterpart) at the time of the assessment is added (if both positions still have active status).

#### Super User changes
- None.

#### Admin changes
- None.

#### System admin changes
A maintenance command has been added to migrate old-style partner assessments to periodic assessments for people. It can be run from the command-line like so:
```
anet.bat maintenance --migratePartnerAssessments anet.yml
```
Details about the results of the migration are written to the log; check those results to see if there were any problems, like partner assessments that couldn't be migrated for some reason. Newly added position associations are logged to the audit log.
Before running the migration, the ANET dictionary needs to updated. If it had an entry for partner assessments like this:
```
  principal:
    person:
      assessment:
        questions:
          - id: test1
            test: $.position.[?(@.identificationCode && /^(Z|z)/.test(@.identificationCode))]
            label: Test question 1
            choice:
              - value: "1"
                label: one
                color: '#c2ffb3'
              - value: "2"
                label: two
                color: '#ffe396'
              - value: "3"
                label: three
                color: '#ff8279'
          - id: test2
            test: $.position.[?(@.identificationCode && /^(Z|z)/.test(@.identificationCode))]
            label: Test question 2
            choice:
              - value: "3"
                label: three
                color: '#ff8279'
              - value: "4"
                label: four
                color: '#ffe396'
              - value: "5"
                label: five
                color: '#c2ffb3'
          - id: test3
            test: $.position.[?(@.identificationCode && /^(Z|z)/.test(@.identificationCode))]
            label: Test question 3
            choice:
              - value: "1"
                label: one
                color: '#c2ffb3'
              - value: "2"
                label: two
                color: '#ff8279'
              - value: "3"
                label: three
                color: '#ff8279'
```
it needs to be moved and edited like so:
```
  principal:
    person:
      assessments:
        - recurrence: quarterly
          questions:
            test1:
              test: $.subject.position.organization.[?(@property == "identificationCode" && @.match(/^Z/i))]
              type: enum
              label: Test question 1
              choices:
                "1":
                  label: one
                  color: '#c2ffb3'
                "2":
                  label: two
                  color: '#ffe396'
                "3":
                  label: three
                  color: '#ff8279'
            test2:
              test: $.subject.position.organization.[?(@property == "identificationCode" && @.match(/^Z/i))]
              type: enum
              label: Test question 2
              choices:
                "3":
                  label: three
                  color: '#ff8279'
                "4":
                  label: four
                  color: '#ffe396'
                "5":
                  label: five
                  color: '#c2ffb3'
            test3:
              test: $.subject.position.organization.[?(@property == "identificationCode" && @.match(/^Z/i))]
              type: enum
              label: Test question 3
              choices:
                "1":
                  label: one
                  color: '#c2ffb3'
                "2":
                  label: two
                  color: '#ff8279'
                "3":
                  label: three
                  color: '#ff8279'
            text:
              type: special_field
              label: Text
              widget: richTextEditor
              style:
                height: 100px
```
Set the `recurrence:` to whatever is required (in the example above it's set to `quarterly`).
The syntax for the new assessments is slightly different, e.g.:
```
        questions:
          - id: test1
```
should become:
```
          questions:
            test1:
```
and:
```
            choice:
              - value: "1"
```
should become:
```
              choices:
                "1":
```
Pay attention to the `test:` conditions, these have changed slightly too; the fields of the subject being assessed are now under `$.subject`. And since the old-style partner assessments always contained a `text` field, do not forget to add that last `text:` entry under the `questions:` (note: if previously all questions had the same `test:` condition, you might want to add that `test:` here too).

Regarding the `test:` conditions, these can also be applied to so-called _instant_ assessments, i.e. assessments with `recurrence: once` and `relatedObjectType: report`. The fields of the subject being assessed (e.g. person or task) are under `$.subject`, the fields of the related object (e.g. report) are under `$.relatedObject`. An example of such an instant assessment definition with conditions is:
```
  principal:
    person:
      assessments:
        - recurrence: once
          relatedObjectType: report
          questions:
            question1:
              type: enum
              label: Attendee involvement
              choices:
                "1":
                  label: low
                  color: '#c2ffb3'
                "2":
                  label: medium
                  color: '#ffe396'
                "3":
                  label: high
                  color: '#ff8279'
            question2:
              test: $.subject.position.organization.[?(@property == "identificationCode" && @.match(/^P/i))]
              type: enumset
              label: Attendee from P org
              choices:
                yes:
                  label: P
                  color: '#ff0000'
            question3:
              test: $.subject.position.organization.[?(@property == "identificationCode" && @.match(/^Z/i))]
              type: enumset
              label: Attendee from Z org
              choices:
                yes:
                  label: Z
                  color: '#00ff00'
            question4:
              test: $.relatedObject.[?(@property == "atmosphere" && @ == "POSITIVE")]
              type: enumset
              label: Report had POSITIVE atmosphere
              choices:
                yes:
                  label: 👍
                  color: '#0000ff'
```
Here, `question1` will be shown for all attending principals, `question2` only for those whose organization code starts with a `P` (or a lower-case `p`), `question3`  only for those whose organization code starts with a `Z` (or a lower-case `z`), and `question4` only if the report had a `POSITIVE` atmosphere.

- [x] anet.yml or anet-dictionary.yml needs change
- [x] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [x] Added and/or updated unit tests
  - [x] Added and/or updated e2e tests
  - [x] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here