### PR TITLE
Pin yup version to v.0.31.0

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -19,7 +19,7 @@
       "allowedVersions": "/^.*\\.jre8$/"
     },
     {
-      "packageNames": ["autoprefixer", "draft-js", "leaflet", "react-tooltip"],
+      "packageNames": ["autoprefixer", "draft-js", "leaflet", "react-tooltip", "yup"],
       "packagePatterns": ["^@fullcalendar/"],
       "enabled": false
     }


### PR DESCRIPTION
After yup version update, there were a lot of bugs introduced in the newer versions. Lets wait for a stable version before trying to update this dependency. I did try to fix one of them here https://github.com/jquense/yup/pull/1177 but it is not included in the v.0... releases, from the looks of it, maintainer plans to do a major update for v.1... https://github.com/jquense/yup/tags


#### User changes
-

#### Super User changes
-

#### Admin changes
-

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [X] Described the user behavior in PR body
  - [X] Referenced/updated all related issues
  - [ ] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [X] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [ ] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
