### PR TITLE
Notify users when there is new version of ANET or ANET server is down

### DIFF
--- a/anet-dictionary.yml
+++ b/anet-dictionary.yml
@@ -1,4 +1,6 @@
 # Do not forget to also edit testDictionaries/*.yml files if dictionary change can break stuff
+CONNECTION_ERROR_MSG: Connection to the server is lost
+VERSION_CHANGED_MSG: "There is a new version of ANET, click here to load the new version (CAUTION: save any unsaved changes first)"
 SUPPORT_EMAIL_ADDR: support@example.com
 
 engagementsIncludeTimeAndDuration: true

--- a/build.gradle
+++ b/build.gradle
@@ -148,6 +148,7 @@ processResources {
 		}
 	}
 }
+processResources.outputs.upToDateWhen{ false }
 
 def projectBranch = "git rev-parse --abbrev-ref HEAD".execute(null, projectDir);
 projectBranch.waitFor();

--- a/client/platform/utils.js
+++ b/client/platform/utils.js
@@ -1,12 +1,18 @@
-export function loadFileAjaxSync(filePath, mimeType) {
+export function loadFileAjaxSync(filePath, mimeType, body) {
   const xmlhttp = new XMLHttpRequest()
-  xmlhttp.open("GET", filePath, false)
-  if (mimeType !== null) {
-    if (xmlhttp.overrideMimeType) {
-      xmlhttp.overrideMimeType(mimeType)
+  if (body) {
+    xmlhttp.open("POST", filePath, false)
+    xmlhttp.setRequestHeader("Content-Type", mimeType)
+    xmlhttp.send(body)
+  } else {
+    xmlhttp.open("GET", filePath, false)
+    if (mimeType !== null) {
+      if (xmlhttp.overrideMimeType) {
+        xmlhttp.overrideMimeType(mimeType)
+      }
     }
+    xmlhttp.send()
   }
-  xmlhttp.send()
   if (xmlhttp.status === 200) {
     return xmlhttp.responseText
   } else {

--- a/client/platform/web-dev/settings.js
+++ b/client/platform/web-dev/settings.js
@@ -1,10 +1,9 @@
-import { gql } from "apollo-boost"
 import { loadFileAjaxSync } from "../utils"
 
 const Settings = JSON.parse(
   loadFileAjaxSync("/api/admin/dictionary", "application/json")
 )
-const GQL_GET_VERSION_INFO = gql`
+const GQL_GET_VERSION_INFO = `
   query {
     projectVersion
   }

--- a/client/platform/web-dev/settings.js
+++ b/client/platform/web-dev/settings.js
@@ -1,8 +1,21 @@
+import { gql } from "apollo-boost"
 import { loadFileAjaxSync } from "../utils"
 
 const Settings = JSON.parse(
   loadFileAjaxSync("/api/admin/dictionary", "application/json")
 )
-const Version = "Dev-Mode"
+const GQL_GET_VERSION_INFO = gql`
+  query {
+    projectVersion
+  }
+`
+
+const Version = JSON.parse(
+  loadFileAjaxSync(
+    "/graphql",
+    "application/json",
+    JSON.stringify({ query: GQL_GET_VERSION_INFO })
+  )
+).data.projectVersion
 
 export { Version, Settings as default }

--- a/client/src/api.js
+++ b/client/src/api.js
@@ -104,8 +104,8 @@ const API = {
       .catch(response => Promise.reject(API._handleError(response)))
   },
 
-  useApiQuery(query, variables) {
-    const results = useQuery(query, { variables })
+  useApiQuery(query, variables, others) {
+    const results = useQuery(query, { variables, ...others })
     results.error = results.error && API._handleError(results.error)
     return results
   },

--- a/client/src/components/SecurityBanner.js
+++ b/client/src/components/SecurityBanner.js
@@ -73,6 +73,7 @@ const ConnectionBanner = ({ connection }) => {
           window.location.reload()
           event.preventDefault()
         }}
+        style={{ color: "white" }}
       >
         {Settings.VERSION_CHANGED_MSG}
       </a>
@@ -88,6 +89,7 @@ const ConnectionBanner = ({ connection }) => {
 ConnectionBanner.propTypes = {
   connection: PropTypes.object.isRequired
 }
+
 export const CompactSecurityBanner = () => {
   const { appSettings } = useContext(AppContext)
   return (

--- a/client/src/components/SecurityBanner.js
+++ b/client/src/components/SecurityBanner.js
@@ -1,11 +1,17 @@
 import styled from "@emotion/styled"
 import AppContext from "components/AppContext"
 import LinkTo from "components/LinkTo"
+import PropTypes from "prop-types"
 import React, { useContext } from "react"
-import { Version } from "settings"
+import Settings, { Version } from "settings"
 
-const SETTING_KEY_TEXT = "SECURITY_BANNER_TEXT"
+export const SETTING_KEY_TEXT = "SECURITY_BANNER_TEXT"
 export const SETTING_KEY_COLOR = "SECURITY_BANNER_COLOR"
+
+const CONNECTION_INFO_COLORS = {
+  newVersion: "black",
+  error: "red"
+}
 
 const css = {
   zIndex: 101,
@@ -18,23 +24,27 @@ const aCss = {
 }
 
 const SecurityBanner = () => {
-  const { appSettings, currentUser } = useContext(AppContext)
+  const { appSettings, currentUser, connection } = useContext(AppContext)
+  const background = appSettings[SETTING_KEY_COLOR]
+
   return (
-    <div
-      className="banner"
-      style={{ ...css, background: appSettings[SETTING_KEY_COLOR] }}
-    >
-      {appSettings[SETTING_KEY_TEXT]} || {currentUser.name}{" "}
-      <LinkTo
-        modelType="Person"
-        model={currentUser}
-        style={aCss}
-        showIcon={false}
-      >
-        (edit)
-      </LinkTo>
-      <VersionBox>Version : {Version}</VersionBox>
-    </div>
+    <>
+      <div className="banner" style={{ ...css, background }}>
+        <>
+          {appSettings[SETTING_KEY_TEXT]} || {currentUser.name}{" "}
+          <LinkTo
+            modelType="Person"
+            model={currentUser}
+            style={aCss}
+            showIcon={false}
+          >
+            (edit)
+          </LinkTo>
+          <VersionBox>Version : {Version}</VersionBox>
+        </>
+      </div>
+      <ConnectionBanner connection={connection} />
+    </>
   )
 }
 
@@ -48,6 +58,36 @@ const VersionBox = styled.h6`
   }
 `
 
+const ConnectionBanner = ({ connection }) => {
+  let background = ""
+  let newBanner = ""
+  if (connection.error) {
+    background = CONNECTION_INFO_COLORS.error
+    newBanner = <>{Settings.CONNECTION_ERROR_MSG}</>
+  } else if (connection.newVersion) {
+    background = CONNECTION_INFO_COLORS.newVersion
+    newBanner = (
+      <a
+        href="/"
+        onClick={event => {
+          window.location.reload()
+          event.preventDefault()
+        }}
+      >
+        {Settings.VERSION_CHANGED_MSG}
+      </a>
+    )
+  }
+  return !newBanner ? null : (
+    <div className="banner" style={{ ...css, background }}>
+      {newBanner}
+    </div>
+  )
+}
+
+ConnectionBanner.propTypes = {
+  connection: PropTypes.object.isRequired
+}
 export const CompactSecurityBanner = () => {
   const { appSettings } = useContext(AppContext)
   return (

--- a/client/src/connectionUtils.js
+++ b/client/src/connectionUtils.js
@@ -35,9 +35,11 @@ export const useConnectionInfo = () => {
 
   useEffect(() => {
     // when there is a newVersion and location changed, automatically update ANET version
-    if (newVersion && pathname !== prevLocation.current) {
+    if (pathname !== prevLocation.current) {
       prevLocation.current = pathname
-      window.location.reload()
+      if (newVersion) {
+        window.location.reload()
+      }
     }
   }, [pathname, newVersion])
 

--- a/client/src/connectionUtils.js
+++ b/client/src/connectionUtils.js
@@ -1,0 +1,32 @@
+import API from "api"
+import { gql } from "apollo-boost"
+import { useEffect } from "react"
+import { Version } from "settings"
+
+const GQL_GET_VERSION_INFO = gql`
+  query {
+    projectVersion
+  }
+`
+
+const POLL_INTERVAL_IN_MS = 30_000 // milliseconds
+
+export const useConnectionInfo = () => {
+  const { error, data, stopPolling } = API.useApiQuery(
+    GQL_GET_VERSION_INFO,
+    {},
+    { pollInterval: POLL_INTERVAL_IN_MS }
+  )
+
+  useEffect(() => {
+    // stop it when we unmount, maybe Apollo does it maybe not
+    return () => stopPolling()
+  }, [stopPolling])
+
+  const newVersion = data?.projectVersion
+  return {
+    // if there is no error and the version doesn't match, we should notify version change
+    newVersion: !error && newVersion !== Version ? newVersion : null,
+    error: !!error
+  }
+}

--- a/client/src/pages/App.js
+++ b/client/src/pages/App.js
@@ -8,6 +8,7 @@ import {
   useBoilerplate
 } from "components/Page"
 import ResponsiveLayout from "components/ResponsiveLayout"
+import { useConnectionInfo } from "connectionUtils"
 import { Organization, Person } from "models"
 import {
   getNotifications,
@@ -130,8 +131,9 @@ const GQL_GET_APP_DATA = gql`
 const App = ({ pageDispatchers, pageProps }) => {
   const history = useHistory()
   const routerLocation = useLocation()
-  const { loading, error, data, refetch } = API.useApiQuery(GQL_GET_APP_DATA)
 
+  const { loading, error, data, refetch } = API.useApiQuery(GQL_GET_APP_DATA)
+  const connectionInfo = useConnectionInfo()
   const { done, result } = useBoilerplate({
     loading,
     error,
@@ -161,7 +163,8 @@ const App = ({ pageDispatchers, pageProps }) => {
         appSettings: appState.settings,
         currentUser: appState.currentUser,
         loadAppData: refetch,
-        notifications: appState.notifications
+        notifications: appState.notifications,
+        connection: { ...connectionInfo }
       }}
     >
       <ResponsiveLayout

--- a/client/tests/models/securityBanner.test.js
+++ b/client/tests/models/securityBanner.test.js
@@ -1,0 +1,50 @@
+import "@testing-library/jest-dom/extend-expect"
+import { render, screen } from "@testing-library/react"
+import React from "react"
+import { BrowserRouter } from "react-router-dom"
+import AppContext from "../../src/components/AppContext"
+import SecurityBanner, {
+  SETTING_KEY_COLOR,
+  SETTING_KEY_TEXT
+} from "../../src/components/SecurityBanner"
+
+const Wrapper = connection => {
+  const appSettings = {}
+  appSettings[SETTING_KEY_COLOR] = "green"
+  appSettings[SETTING_KEY_TEXT] = "DEMO USE ONLY"
+  const currentUser = {}
+  currentUser.name = "unit_test"
+  currentUser.uuid = "unit_test_uuid"
+
+  return (
+    <BrowserRouter>
+      <AppContext.Provider value={{ connection, appSettings, currentUser }}>
+        <SecurityBanner />
+      </AppContext.Provider>
+    </BrowserRouter>
+  )
+}
+
+describe("In the security banner", () => {
+  it("We should be able to see connection error message when there is an error", () => {
+    render(Wrapper({ error: true, newVersion: null }))
+    const errorMsg = screen.getByText(/Connection to the server/)
+    expect(errorMsg).toBeInTheDocument()
+  })
+  it("We should be able to see new version message when there is a new version", () => {
+    render(Wrapper({ error: false, newVersion: "UNIT_TEST_VERSION" }))
+    const versionMsg = screen.getByText(/There is a new version of ANET/)
+    expect(versionMsg).toBeInTheDocument()
+  })
+  it("We should be able to see normal banner text when no error and no new version", () => {
+    render(Wrapper({ error: false, newVersion: null }))
+    const normalBanner = screen.getByText(/DEMO USE ONLY/)
+    expect(normalBanner).toBeInTheDocument()
+
+    // Other notifications should dissappear
+    const errorMsg = screen.queryByText(/Connection to the server/)
+    expect(errorMsg).toBeNull()
+    const versionMsg = screen.queryByText(/There is a new version of ANET/)
+    expect(versionMsg).toBeNull()
+  })
+})

--- a/src/main/resources/anet-schema.yml
+++ b/src/main/resources/anet-schema.yml
@@ -246,8 +246,14 @@ $defs:
 #########################################################
 type: object
 additionalProperties: false
-required: [SUPPORT_EMAIL_ADDR, dateFormats, reportWorkflow, maxTextFieldLength, fields, pinned_ORGs, non_reporting_ORGs, domainNames, activeDomainNames, imagery]
+required: [CONNECTION_ERROR_MSG, VERSION_CHANGED_MSG, SUPPORT_EMAIL_ADDR, dateFormats, reportWorkflow, maxTextFieldLength, fields, pinned_ORGs, non_reporting_ORGs, domainNames, activeDomainNames, imagery]
 properties:
+  CONNECTION_ERROR_MSG:
+    type: string
+    description: Banner text when the connection is lost
+  VERSION_CHANGED_MSG:
+    type: string
+    description: Banner text when there is a new version of ANET
   SUPPORT_EMAIL_ADDR:
     type: string
     title: The support email address

--- a/testDictionaries/no-custom-fields.yml
+++ b/testDictionaries/no-custom-fields.yml
@@ -1,3 +1,5 @@
+CONNECTION_ERROR_MSG: Connection to the server is lost
+VERSION_CHANGED_MSG: "There is a new version of ANET, click here to load the new version (CAUTION: save any unsaved changes first)"
 SUPPORT_EMAIL_ADDR: support@example.com
 
 engagementsIncludeTimeAndDuration: true


### PR DESCRIPTION
I have implemented a polling mechanism from client-side for version data, if there is a new one, we notify new version info, if there is a polling error, we notify server/network down info.

The banner text at the top will be changed when a new version of ANET detected or server being down detected. Users will see a different banner text with different background color. This way, they can make sure they are on the latest version of ANET and they will not do any data losing action when server is down as well.


Closes #1164, closes #3020 

#### User changes
- A new ANET version and ANET server being down notifications under the top security banner

#### Super User changes
-

#### Admin changes
- Banner text messages can be changed from `anet-dictionary.yml`

`CONNECTION_ERROR_MSG`: Network / Server down message

`VERSION_CHANGED_MSG`: New version message, tell what user should do.

#### System admin changes
- [X] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [X] Described the user behavior in PR body
  - [X] Referenced/updated all related issues
  - [X] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [X] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [X] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [X] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
