### PR TITLE
Fix future engagement worker

### DIFF
--- a/src/main/java/mil/dds/anet/beans/ApprovalStep.java
+++ b/src/main/java/mil/dds/anet/beans/ApprovalStep.java
@@ -137,4 +137,8 @@ public class ApprovalStep extends AbstractAnetBean {
     return clone;
   }
 
+  public static boolean isPlanningStep(ApprovalStep step) {
+    return step != null && ApprovalStepType.PLANNING_APPROVAL.equals(step.getType());
+  }
+
 }

--- a/src/main/java/mil/dds/anet/database/ReportDao.java
+++ b/src/main/java/mil/dds/anet/database/ReportDao.java
@@ -837,6 +837,7 @@ public class ReportDao extends AnetBaseDao<Report, ReportSearchQuery> {
     action.setReportUuid(r.getUuid());
     action.setPersonUuid(user.getUuid());
     action.setType(ActionType.SUBMIT);
+    action.setPlanned(r.isFutureEngagement());
     engine.getReportActionDao().insert(action);
 
     if (r.isFutureEngagement() && Utils.isEmptyOrNull(steps)) {
@@ -870,6 +871,7 @@ public class ReportDao extends AnetBaseDao<Report, ReportSearchQuery> {
     // User could be null when the publication action is being done automatically by a worker
     action.setPersonUuid(DaoUtils.getUuid(user));
     action.setType(ActionType.APPROVE);
+    action.setPlanned(ApprovalStep.isPlanningStep(step));
     AnetObjectEngine.getInstance().getReportActionDao().insert(action);
 
     // Update the report

--- a/src/main/java/mil/dds/anet/resources/ReportResource.java
+++ b/src/main/java/mil/dds/anet/resources/ReportResource.java
@@ -492,7 +492,7 @@ public class ReportResource {
     }
 
     // Write the rejection action
-    ReportAction rejection = new ReportAction();
+    final ReportAction rejection = new ReportAction();
     rejection.setReportUuid(r.getUuid());
     if (step != null) {
       // Step is null when an approved report is being rejected by an admin
@@ -500,6 +500,7 @@ public class ReportResource {
     }
     rejection.setPersonUuid(approver.getUuid());
     rejection.setType(ActionType.REJECT);
+    rejection.setPlanned(ApprovalStep.isPlanningStep(step) || r.isFutureEngagement());
     engine.getReportActionDao().insert(rejection);
 
     // Update the report

--- a/src/main/java/mil/dds/anet/resources/ReportResource.java
+++ b/src/main/java/mil/dds/anet/resources/ReportResource.java
@@ -398,39 +398,9 @@ public class ReportResource {
       throw new WebApplicationException("Missing engagement date", Status.BAD_REQUEST);
     }
 
-    // Get all the approval steps for this report
-    final List<ApprovalStep> steps = r.computeApprovalSteps(engine.getContext(), engine).join();
-
-    // Write the submission action
-    final ReportAction action = new ReportAction();
-    action.setReportUuid(r.getUuid());
-    action.setPersonUuid(user.getUuid());
-    action.setType(ActionType.SUBMIT);
-    engine.getReportActionDao().insert(action);
-
-    if (r.isFutureEngagement() && Utils.isEmptyOrNull(steps)) {
-      // Future engagements without planning approval chain will be approved directly
-      // Write the approval action
-      final ReportAction approval = new ReportAction();
-      approval.setReportUuid(r.getUuid());
-      approval.setPersonUuid(user.getUuid());
-      approval.setType(ActionType.APPROVE);
-      approval.setPlanned(true); // so the FutureEngagementWorker can find this
-      engine.getReportActionDao().insert(approval);
-      r.setState(ReportState.APPROVED);
-    } else {
-      // Push the report into the first step of this workflow
-      r.setApprovalStep(steps.get(0));
-      r.setState(ReportState.PENDING_APPROVAL);
-    }
-    final int numRows = dao.update(r, user);
-    if (numRows != 1) {
+    final int numRows = dao.submit(r, user);
+    if (numRows == 0) {
       throw new WebApplicationException("No records updated", Status.BAD_REQUEST);
-    }
-
-    if (!Utils.isEmptyOrNull(steps)) {
-      dao.sendApprovalNeededEmail(r, steps.get(0));
-      logger.info("Putting report {} into step {}", r.getUuid(), steps.get(0).getUuid());
     }
 
     AnetAuditLogger.log("report {} submitted by author {}", r.getUuid(), user.getUuid());

--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -3655,4 +3655,118 @@
 			<column name="customFields" type="${long_text_type}" />
 		</addColumn>
 	</changeSet>
+
+	<changeSet id="set-planned-reportActions" author="gjvoosten">
+		<!-- any report action linked to a planning step is itself planned -->
+		<sql dbms="postgresql">
+		<![CDATA[
+			UPDATE "reportActions"
+			SET planned = true
+			WHERE "approvalStepUuid" IN (
+				SELECT uuid
+				FROM "approvalSteps"
+				WHERE type = 0
+			)
+			AND "createdAt" >= '2021-01-01';
+		]]>
+		</sql>
+		<sql dbms="mssql">
+		<![CDATA[
+			UPDATE "reportActions"
+			SET planned = 1
+			WHERE "approvalStepUuid" IN (
+				SELECT uuid
+				FROM "approvalSteps"
+				WHERE type = 0
+			)
+			AND "createdAt" >= '2021-01-01';
+		]]>
+		</sql>
+
+		<!-- any report submit action directly followed by a planned action is itself planned -->
+		<sql dbms="postgresql">
+		<![CDATA[
+			UPDATE "reportActions"
+			SET planned = true
+			WHERE "createdAt" IN (
+				SELECT ra2."createdAt"
+				FROM "reportActions" ra
+				LEFT JOIN LATERAL (
+					SELECT ra2.*
+					FROM "reportActions" ra2
+					WHERE ra2."reportUuid" = ra."reportUuid"
+					AND ra2."createdAt" < ra."createdAt"
+					ORDER BY ra2."createdAt" DESC
+					LIMIT 1
+				) ra2 ON TRUE
+				WHERE ra2.type = 2
+				AND ra.planned = true
+			)
+			AND "createdAt" >= '2021-01-01';
+		]]>
+		</sql>
+		<sql dbms="mssql">
+		<![CDATA[
+			UPDATE "reportActions"
+			SET planned = 1
+			WHERE "createdAt" IN (
+				SELECT ra2."createdAt"
+				FROM "reportActions" ra
+				OUTER APPLY (
+					SELECT TOP(1) ra2.*
+					FROM "reportActions" ra2
+					WHERE ra2."reportUuid" = ra."reportUuid"
+					AND ra2."createdAt" < ra."createdAt"
+					ORDER BY ra2."createdAt" DESC
+				) ra2
+				WHERE ra2.type = 2
+				AND ra.planned = 1
+			)
+			AND "createdAt" >= '2021-01-01';
+		]]>
+		</sql>
+
+		<!-- any report publish action directly preceded by a planned action is itself planned -->
+		<sql dbms="postgresql">
+		<![CDATA[
+			UPDATE "reportActions"
+			SET planned = true
+			WHERE "createdAt" IN (
+				SELECT ra2."createdAt"
+				FROM "reportActions" ra
+				LEFT JOIN LATERAL (
+					SELECT ra2.*
+					FROM "reportActions" ra2
+					WHERE ra2."reportUuid" = ra."reportUuid"
+					AND ra2."createdAt" > ra."createdAt"
+					ORDER BY ra2."createdAt"
+					LIMIT 1
+				) ra2 ON TRUE
+				WHERE ra2.type = 3
+				AND ra.planned = true
+			);
+		]]>
+		</sql>
+		<sql dbms="mssql">
+		<![CDATA[
+			UPDATE "reportActions"
+			SET planned = 1
+			WHERE "createdAt" IN (
+				SELECT ra2."createdAt"
+				FROM "reportActions" ra
+				OUTER APPLY (
+					SELECT TOP(1) ra2.*
+					FROM "reportActions" ra2
+					WHERE ra2."reportUuid" = ra."reportUuid"
+					AND ra2."createdAt" > ra."createdAt"
+					ORDER BY ra2."createdAt"
+				) ra2
+				WHERE ra2.type = 3
+				AND ra.planned = 1
+			)
+			AND "createdAt" >= '2021-01-01';
+		]]>
+		</sql>
+	</changeSet>
+
 </databaseChangeLog>

--- a/src/test/java/mil/dds/anet/test/integration/db/FutureEngagementWorkerTest.java
+++ b/src/test/java/mil/dds/anet/test/integration/db/FutureEngagementWorkerTest.java
@@ -21,10 +21,9 @@ import mil.dds.anet.beans.Organization;
 import mil.dds.anet.beans.Person;
 import mil.dds.anet.beans.Report;
 import mil.dds.anet.beans.Report.ReportState;
-import mil.dds.anet.beans.ReportAction;
-import mil.dds.anet.beans.ReportAction.ActionType;
 import mil.dds.anet.beans.ReportPerson;
 import mil.dds.anet.config.AnetConfiguration;
+import mil.dds.anet.database.EmailDao;
 import mil.dds.anet.database.ReportDao;
 import mil.dds.anet.test.beans.PersonTest;
 import mil.dds.anet.test.integration.config.AnetTestConfiguration;
@@ -43,6 +42,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(TestApp.class)
 public class FutureEngagementWorkerTest extends AbstractResourceTest {
+
   private final static List<String> expectedIds = new ArrayList<>();
   private final static List<String> unexpectedIds = new ArrayList<>();
 
@@ -101,11 +101,11 @@ public class FutureEngagementWorkerTest extends AbstractResourceTest {
   @Test
   public void reportsOK() {
     final AnetObjectEngine engine = AnetObjectEngine.getInstance();
-    final Report report = createTestReport("reportsOK_1");
+    final Report report = createTestReport("reportsOK_1", true, true, true);
     engine.getReportDao().update(report);
-    final Report report2 = createTestReport("reportsOK_2");
+    final Report report2 = createTestReport("reportsOK_2", true, true, true);
     engine.getReportDao().update(report2);
-    final Report report3 = createTestReport("reportsOK_3");
+    final Report report3 = createTestReport("reportsOK_3", true, true, true);
     engine.getReportDao().update(report3);
 
     expectedIds.add("reportsOK_1");
@@ -123,7 +123,7 @@ public class FutureEngagementWorkerTest extends AbstractResourceTest {
   @Test
   public void testReportDueInFuture() {
     final AnetObjectEngine engine = AnetObjectEngine.getInstance();
-    final Report report = createTestReport("testReportDueInFuture_1");
+    final Report report = createTestReport("testReportDueInFuture_1", true, true, true);
     report.setEngagementDate(Instant.now().plus(Duration.ofDays(2L)));
     engine.getReportDao().update(report);
 
@@ -135,7 +135,7 @@ public class FutureEngagementWorkerTest extends AbstractResourceTest {
   @Test
   public void testReportDueEndToday() {
     final AnetObjectEngine engine = AnetObjectEngine.getInstance();
-    final Report report = createTestReport("testReportDueEndToday_1");
+    final Report report = createTestReport("testReportDueEndToday_1", true, true, true);
     report.setEngagementDate(Instant.now());
     engine.getReportDao().update(report);
 
@@ -151,13 +151,12 @@ public class FutureEngagementWorkerTest extends AbstractResourceTest {
   public void testGH3304() {
     // Create a draft report
     final AnetObjectEngine engine = AnetObjectEngine.getInstance();
+    final ReportDao reportDao = engine.getReportDao();
     final Person author = getRegularUser();
     final ReportPerson advisor = PersonTest.personToPrimaryReportAuthor(author);
     final ReportPerson principal = PersonTest.personToPrimaryReportPerson(getSteveSteveson());
-    final Report report = TestBeans.getTestReport(null, Lists.newArrayList(advisor, principal));
-    report.setState(ReportState.DRAFT);
-    report.setEngagementDate(Instant.now().plus(1, ChronoUnit.HOURS));
-    final Report draftReport = engine.getReportDao().insert(report);
+    final Report draftReport = reportDao.insert(TestBeans.getTestReport("testGH3304",
+        getFutureDate(), null, Lists.newArrayList(advisor, principal)));
 
     // Submit the report
     graphQLHelper.updateObject(author, "submitReport", "uuid", "uuid", "String",
@@ -169,8 +168,8 @@ public class FutureEngagementWorkerTest extends AbstractResourceTest {
     testFutureEngagementWorker(0);
 
     // Move the engagementDate from future to past to simulate time passing
-    submittedReport.setEngagementDate(Instant.now().minus(1, ChronoUnit.HOURS));
-    engine.getReportDao().update(submittedReport);
+    submittedReport.setEngagementDate(getPastDate());
+    reportDao.update(submittedReport);
     // State shouldn't have changed
     final Report updatedReport = testReportState(submittedReport.getUuid(), ReportState.APPROVED);
 
@@ -202,26 +201,25 @@ public class FutureEngagementWorkerTest extends AbstractResourceTest {
     checkApprovalStepType(ApprovalStepType.REPORT_APPROVAL, false, "2");
   }
 
-  private void checkApprovalStepType(final ApprovalStepType type, final boolean isExpected,
+  private void checkApprovalStepType(final ApprovalStepType type, final boolean isFuture,
       final String id) {
     final String fullId = "checkApprovalStepType_" + id;
-    if (isExpected) {
+    if (isFuture) {
       expectedIds.add(fullId);
     } else {
       unexpectedIds.add(fullId);
     }
 
     final AnetObjectEngine engine = AnetObjectEngine.getInstance();
-    final Report report = createTestReport(fullId);
-    final ApprovalStep as = report.getApprovalStep();
-    as.setType(type);
-    engine.getApprovalStepDao().insert(as);
+    final Report report = createTestReport(fullId, false, false, isFuture);
+    final ApprovalStep as = createApprovalStep(type);
     report.setApprovalStep(as);
+    report.setAdvisorOrgUuid(as.getRelatedObjectUuid());
     engine.getReportDao().update(report);
 
-    testFutureEngagementWorker(isExpected ? 1 : 0);
+    testFutureEngagementWorker(isFuture ? 1 : 0);
 
-    if (isExpected) {
+    if (isFuture) {
       // Report should be draft now
       testReportDraft(report.getUuid());
     }
@@ -247,7 +245,7 @@ public class FutureEngagementWorkerTest extends AbstractResourceTest {
     }
 
     final AnetObjectEngine engine = AnetObjectEngine.getInstance();
-    final Report report = createTestReport(fullId);
+    final Report report = createTestReport(fullId, true, true, true);
     report.setState(state);
     engine.getReportDao().update(report);
 
@@ -262,43 +260,29 @@ public class FutureEngagementWorkerTest extends AbstractResourceTest {
   @Test
   public void testApprovalStepReport() {
     final AnetObjectEngine engine = AnetObjectEngine.getInstance();
-    final Report report = createTestReport("testApprovalStepReport_1");
-    final ApprovalStep step = report.getApprovalStep();
-    step.setType(ApprovalStepType.REPORT_APPROVAL);
-    engine.getApprovalStepDao().insert(step);
+    final Report report = createTestReport("testApprovalStepReport_1", true, true, true);
+
+    expectedIds.add("testApprovalStepReport_1");
+
+    testFutureEngagementWorker(1);
+
+    // Report should be draft now
+    testReportDraft(report.getUuid());
+    // Edit it & submit
+    final ApprovalStep step = createApprovalStep(ApprovalStepType.REPORT_APPROVAL);
     report.setApprovalStep(step);
+    report.setAdvisorOrgUuid(step.getRelatedObjectUuid());
     engine.getReportDao().update(report);
-
-    // Report in approve step
-    final ReportAction ra = new ReportAction();
-    ra.setReport(report);
-    ra.setStep(step);
-    ra.setType(ActionType.APPROVE);
-    ra.setCreatedAt(Instant.now());
-    engine.getReportActionDao().insert(ra);
-
-    unexpectedIds.add("testApprovalStepReport_1");
+    engine.getReportDao().submit(report, report.loadAuthors(engine.getContext()).join().get(0));
+    testReportState(report.getUuid(), ReportState.PENDING_APPROVAL);
 
     testFutureEngagementWorker(0);
+    testReportState(report.getUuid(), ReportState.PENDING_APPROVAL);
   }
 
   @Test
   public void testPlanningApprovalStepReport() {
-    final AnetObjectEngine engine = AnetObjectEngine.getInstance();
-    final Report report = createTestReport("testPlanningApprovalStepReport_1");
-    final ApprovalStep step = report.getApprovalStep();
-    step.setType(ApprovalStepType.PLANNING_APPROVAL);
-    engine.getApprovalStepDao().insert(step);
-    report.setApprovalStep(step);
-    engine.getReportDao().update(report);
-
-    // Report in planning approve step
-    final ReportAction ra = new ReportAction();
-    ra.setReport(report);
-    ra.setStep(step);
-    ra.setType(ActionType.APPROVE);
-    ra.setCreatedAt(Instant.now());
-    engine.getReportActionDao().insert(ra);
+    final Report report = createTestReport("testPlanningApprovalStepReport_1", true, false, true);
 
     expectedIds.add("testPlanningApprovalStepReport_1");
 
@@ -310,18 +294,8 @@ public class FutureEngagementWorkerTest extends AbstractResourceTest {
 
   @Test
   public void testAutomaticallyApprovedReport() {
-    final AnetObjectEngine engine = AnetObjectEngine.getInstance();
-    final Report report = createTestReport("testAutomaticallyApprovedReport_1");
-    report.setApprovalStep(null);
-    engine.getReportDao().update(report);
-
     // Report in automatic approve step (no planning workflow)
-    final ReportAction ra = new ReportAction();
-    ra.setReport(report);
-    ra.setType(ActionType.APPROVE);
-    ra.setPlanned(true);
-    ra.setCreatedAt(Instant.now());
-    engine.getReportActionDao().insert(ra);
+    final Report report = createTestReport("testAutomaticallyApprovedReport_1", false, true, true);
 
     expectedIds.add("testAutomaticallyApprovedReport_1");
 
@@ -333,12 +307,7 @@ public class FutureEngagementWorkerTest extends AbstractResourceTest {
 
   @Test
   public void testPublishedReport() {
-    final AnetObjectEngine engine = AnetObjectEngine.getInstance();
-    final int emailSize = engine.getEmailDao().getAll().size();
     final Report report = createPublishedTestReport("testPublishedReport_1");
-    // Should have sent 2 emails: approval and published
-    assertThat(engine.getEmailDao().getAll().size()).isEqualTo(emailSize + 2);
-    expectedIds.add("hunter+arthur");
     expectedIds.add("testPublishedReport_1");
     testFutureEngagementWorker(1);
     // Report should be draft now
@@ -377,47 +346,77 @@ public class FutureEngagementWorkerTest extends AbstractResourceTest {
     emails.forEach(e -> assertThat(unexpectedIds).doesNotContain(e.to.text.split("@")[0]));
   }
 
-  private Report createTestReport(final String toAdressId) {
-    final AnetObjectEngine engine = AnetObjectEngine.getInstance();
-    final ReportPerson author = PersonTest.personToReportAuthor(TestBeans.getTestPerson());
-    author.setEmailAddress(toAdressId + whitelistedEmail);
-    engine.getPersonDao().insert(author);
-
-    final Organization organization = TestBeans.getTestOrganization();
-    engine.getOrganizationDao().insert(organization);
-
-    final ApprovalStep approvalStep = TestBeans.getTestApprovalStep(organization);
-    approvalStep.setType(ApprovalStepType.PLANNING_APPROVAL);
-    engine.getApprovalStepDao().insertAtEnd(approvalStep);
-
-    final Report report = TestBeans.getTestReport(approvalStep, ImmutableList.of(author));
-    return engine.getReportDao().insert(report);
-  }
-
-  private Report createPublishedTestReport(final String toAdressId) {
+  private void setPastDate(final Report report) {
     final AnetObjectEngine engine = AnetObjectEngine.getInstance();
     final ReportDao reportDao = engine.getReportDao();
-    final Person author = engine.getPersonDao().insert(TestBeans.getTestPerson());
-    author.setEmailAddress(toAdressId + whitelistedEmail);
+    report.setEngagementDate(getPastDate());
+    reportDao.update(report);
+  }
 
-    final Organization organization =
-        engine.getOrganizationDao().insert(TestBeans.getTestOrganization());
+  private Report createTestReport(final String toAddressId, final boolean addApprovalStep,
+      final boolean approve, final boolean setPastDate) {
+    final AnetObjectEngine engine = AnetObjectEngine.getInstance();
+    final ReportDao reportDao = engine.getReportDao();
 
-    final ApprovalStep as = TestBeans.getTestApprovalStep(organization);
-    as.setType(ApprovalStepType.PLANNING_APPROVAL);
-    final ApprovalStep approvalStep = engine.getApprovalStepDao().insertAtEnd(as);
+    final ReportPerson author = PersonTest.personToReportAuthor(TestBeans.getTestPerson());
+    author.setEmailAddress(toAddressId + whitelistedEmail);
+    engine.getPersonDao().insert(author);
 
-    final Report report = TestBeans.getTestReport(approvalStep,
-        ImmutableList.of(PersonTest.personToReportAuthor(author)));
-    report.setState(ReportState.DRAFT);
-    final Report testReport = engine.getReportDao().insert(report);
+    ApprovalStep approvalStep = null;
+    if (addApprovalStep) {
+      approvalStep = createApprovalStep(ApprovalStepType.PLANNING_APPROVAL);
+    }
+
+    final Report report = reportDao.insert(TestBeans.getTestReport(toAddressId, getFutureDate(),
+        approvalStep, ImmutableList.of(author)));
     // Submit this report
-    reportDao.submit(testReport, author);
-    // Approve this report
-    reportDao.approve(testReport, null, approvalStep);
+    reportDao.submit(report, author);
+
+    if (approvalStep != null && approve) {
+      // Approve this report
+      reportDao.approve(report, null, approvalStep);
+    }
+
+    if (setPastDate) {
+      setPastDate(report);
+    }
+    return report;
+  }
+
+  private ApprovalStep createApprovalStep(final ApprovalStepType type) {
+    final AnetObjectEngine engine = AnetObjectEngine.getInstance();
+    final Organization organization = TestBeans.getTestOrganization();
+    engine.getOrganizationDao().insert(organization);
+    final ApprovalStep approvalStep = TestBeans.getTestApprovalStep(organization);
+    approvalStep.setType(type);
+    engine.getApprovalStepDao().insertAtEnd(approvalStep);
+    return approvalStep;
+  }
+
+  private Report createPublishedTestReport(final String toAddressId) {
+    final AnetObjectEngine engine = AnetObjectEngine.getInstance();
+    final ReportDao reportDao = engine.getReportDao();
+    final EmailDao emailDao = engine.getEmailDao();
+
+    final Report report = createTestReport(toAddressId, true, true, false);
+
     // Publish this report
-    reportDao.publish(testReport, null);
-    return testReport;
+    final int emailSize = emailDao.getAll().size();
+    reportDao.publish(report, null);
+    // Should have sent email for publication
+    assertThat(emailDao.getAll().size()).isEqualTo(emailSize + 1);
+    expectedIds.add(toAddressId);
+
+    setPastDate(report);
+    return report;
+  }
+
+  private Instant getFutureDate() {
+    return Instant.now().plus(1, ChronoUnit.HOURS);
+  }
+
+  private Instant getPastDate() {
+    return Instant.now().minus(1, ChronoUnit.HOURS);
   }
 
 }

--- a/src/test/java/mil/dds/anet/test/integration/db/ReportPublicationWorkerTest.java
+++ b/src/test/java/mil/dds/anet/test/integration/db/ReportPublicationWorkerTest.java
@@ -206,10 +206,10 @@ public class ReportPublicationWorkerTest {
     emails.forEach(e -> assertThat(unexpectedIds).doesNotContain(e.to.text.split("@")[0]));
   }
 
-  private static Report createTestReport(final String toAdressId) {
+  private static Report createTestReport(final String toAddressId) {
     final AnetObjectEngine engine = AnetObjectEngine.getInstance();
     final ReportPerson author = PersonTest.personToReportAuthor(TestBeans.getTestPerson());
-    author.setEmailAddress(toAdressId + whitelistedEmail);
+    author.setEmailAddress(toAddressId + whitelistedEmail);
     engine.getPersonDao().insert(author);
 
     final Organization organization = TestBeans.getTestOrganization();
@@ -219,7 +219,9 @@ public class ReportPublicationWorkerTest {
     approvalStep.setType(ApprovalStepType.PLANNING_APPROVAL);
     engine.getApprovalStepDao().insertAtEnd(approvalStep);
 
-    final Report report = TestBeans.getTestReport(approvalStep, ImmutableList.of(author));
+    final Report report =
+        TestBeans.getTestReport(toAddressId, null, approvalStep, ImmutableList.of(author));
+    report.setState(ReportState.APPROVED);
     engine.getReportDao().insert(report);
     return report;
   }

--- a/src/test/java/mil/dds/anet/test/integration/utils/TestBeans.java
+++ b/src/test/java/mil/dds/anet/test/integration/utils/TestBeans.java
@@ -51,16 +51,21 @@ public class TestBeans {
     return as;
   }
 
-  public static Report getTestReport(ApprovalStep approvalStep, List<ReportPerson> reportPeople) {
-    Report r = new Report();
-    r.setState(ReportState.APPROVED);
-    r.setIntent("test_dummy");
+  public static Report getTestReport(String reportText, Instant engagementDate,
+      ApprovalStep approvalStep, List<ReportPerson> reportPeople) {
+    final String s = "test_dummy: " + reportText;
+    final Report r = new Report();
+    r.setState(ReportState.DRAFT);
+    r.setIntent(s);
     r.setAtmosphere(Atmosphere.NEUTRAL);
     r.setApprovalStep(approvalStep);
+    if (approvalStep != null) {
+      r.setAdvisorOrgUuid(approvalStep.getRelatedObjectUuid());
+    }
     r.setReportPeople(reportPeople);
-    r.setReportText("test_dummy");
-    r.setNextSteps("test_dummy");
-    r.setEngagementDate(Instant.now());
+    r.setReportText(s);
+    r.setNextSteps(s);
+    r.setEngagementDate(engagementDate == null ? Instant.now() : engagementDate);
     r.setDuration(60);
     return r;
   }


### PR DESCRIPTION
Fix the problem where planned engagements would get into PUBLISHED state and would never become DRAFT again when the engagement date has come.

#### User changes
- Planned engagements should no longer get 'stuck'.

#### Super User changes
- none

#### Admin changes
- none

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [x] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [ ] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [x] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [x] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here