### PR TITLE
Fix KML and NVG exports

### DIFF
--- a/client/src/exportUtils.js
+++ b/client/src/exportUtils.js
@@ -142,11 +142,24 @@ const GQL_GET_REPORT_LIST = gql`
           rank
           role
         }
+        reportPeople {
+          uuid
+          name
+          rank
+          role
+        }
         primaryAdvisor {
           uuid
           name
           rank
           role
+          position {
+            uuid
+            organization {
+              uuid
+              shortName
+            }
+          }
         }
         primaryPrincipal {
           uuid

--- a/src/main/resources/stylesheets/kml.xslt
+++ b/src/main/resources/stylesheets/kml.xslt
@@ -12,8 +12,7 @@
                         </Icon>
                     </IconStyle>
                 </Style>
-                <xsl:apply-templates select="data/reportList/list/element[number(location/lat)=location/lat]" mode="report"/>
-                <xsl:apply-templates select="data/REPORTS/list/element[number(location/lat)=location/lat]" mode="report"/>
+                <xsl:apply-templates select="data/reports/list/element[number(location/lat)=location/lat]" mode="report"/>
                 <ScreenOverlay>
                     <name>ANET Legend </name>
                     <Icon>
@@ -31,7 +30,7 @@
     <xsl:template match="element" mode="report">
         <Placemark>
             <name>
-                <h1><xsl:value-of select="primaryAdvisor/name" />@<xsl:value-of select="primaryPrincipal/position/organization/longName"/></h1>
+                <h1><xsl:value-of select="primaryAdvisor/name" />@<xsl:value-of select="primaryAdvisor/position/organization/shortName"/></h1>
             </name>
             <description>
             <xsl:text disable-output-escaping="yes">&lt;![CDATA[</xsl:text>
@@ -42,7 +41,7 @@
                 <br/>
                 <h2>Attendees</h2>
                 <p>
-                    <xsl:apply-templates select="attendees/element" mode="attendee"/>
+                    <xsl:apply-templates select="reportPeople/element" mode="reportPerson"/>
                 </p>
                 <h2>Engagement Intent</h2>
                 <xsl:value-of select="intent"/>
@@ -55,7 +54,7 @@
         </Placemark>
     </xsl:template>
 
-    <xsl:template match="element" mode="attendee">
+    <xsl:template match="element" mode="reportPerson">
         <p>
             <xsl:value-of select="rank"/>  <xsl:text> </xsl:text>
             <xsl:value-of select="name"/>  <xsl:text> [</xsl:text>

--- a/src/main/resources/stylesheets/nvg.xslt
+++ b/src/main/resources/stylesheets/nvg.xslt
@@ -3,15 +3,14 @@
 
     <xsl:template match="/">
         <nvg xmlns="http://tide.act.nato.int/schemas/2008/10/nvg" version="1.4.0" classification="NOT CLASSIFIED">
-            <xsl:apply-templates select="data/reportList/list/element[number(location/lat)=location/lat]"/>
-            <xsl:apply-templates select="data/REPORTS/list/element[number(location/lat)=location/lat]"/>
+            <xsl:apply-templates select="data/reports/list/element[number(location/lat)=location/lat]"/>
         </nvg>
     </xsl:template>
 
     <xsl:template match="element">
         <point>
             <xsl:attribute name="label">
-                <xsl:value-of select="primaryAdvisor/name" />@<xsl:value-of select="primaryPrincipal/position/organization/longName" />
+                <xsl:value-of select="primaryAdvisor/name" />@<xsl:value-of select="primaryAdvisor/position/organization/shortName" />
             </xsl:attribute>
             <xsl:attribute name="x">
                 <xsl:value-of select="location/lng" />


### PR DESCRIPTION
Select the correct XML paths, and make sure the fields we use in the exports are retrieved by the GraphQL request.

#### User changes
- KML and NVG exports should show results again.

#### Super User changes
- none

#### Admin changes
- none

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [ ] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here