### PR TITLE
Re-enable IE 11 support

### DIFF
--- a/client/config/paths.js
+++ b/client/config/paths.js
@@ -35,5 +35,6 @@ module.exports = {
   testSrc: resolveApp("tests"),
   appNodeModules: resolveApp("node_modules"),
   ownNodeModules: resolveApp("node_modules"),
-  nodePaths: nodePaths
+  nodePaths: nodePaths,
+  platforms: resolveApp("platform")
 }

--- a/client/config/webpack.common.js
+++ b/client/config/webpack.common.js
@@ -36,7 +36,7 @@ const commonConfig = {
       },
       {
         test: /\.(m?js|jsx)$/,
-        include: [paths.appSrc, paths.testSrc],
+        include: [paths.appSrc, paths.testSrc, paths.platforms],
         use: [
           "thread-loader",
           {

--- a/client/config/webpack.common.js
+++ b/client/config/webpack.common.js
@@ -35,7 +35,7 @@ const commonConfig = {
         use: ["eslint-loader"]
       },
       {
-        test: /\.(js|jsx)$/,
+        test: /\.(m?js|jsx)$/,
         include: [paths.appSrc, paths.testSrc],
         use: [
           "thread-loader",
@@ -50,7 +50,7 @@ const commonConfig = {
         ]
       },
       {
-        test: /\.js$/,
+        test: /\.m?js$/,
         // Based on https://github.com/facebook/create-react-app/pull/3776
         include: /node_modules/,
         use: [
@@ -92,7 +92,7 @@ const commonConfig = {
 
 module.exports = {
   clientConfig: merge.merge(commonConfig, {
-    target: "web",
+    target: ["web", "es5"],
     resolve: {
       alias: { vm: "vm-browserify" }
     },


### PR DESCRIPTION
webpack's default behavior changed with the version 5, it needs extra target info and babel .mjs file transpilation (`html-react-parser` has a` index.mjs` file, which forces esm module syntax, which needs to be transpiled by `babel`)

Closes #3416 

#### User changes
- IE 11 users will be able to use ANET

#### Super User changes
-

#### Admin changes
-

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [X] Described the user behavior in PR body
  - [X] Referenced/updated all related issues
  - [X] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [X] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [X] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
