### PR TITLE
Migrate to @blueprintjs/popover2

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -102,6 +102,7 @@
     "@apollo/react-hooks": "3.1.5",
     "@blueprintjs/core": "3.38.2",
     "@blueprintjs/datetime": "3.20.4",
+    "@blueprintjs/popover2": "0.2.0",
     "@emotion/react": "11.1.5",
     "@emotion/styled": "11.1.5",
     "@fullcalendar/core": "4.4.2",

--- a/client/src/components/AdvancedSearch.js
+++ b/client/src/components/AdvancedSearch.js
@@ -1,11 +1,6 @@
-import {
-  Classes,
-  Menu,
-  MenuItem,
-  Popover,
-  PopoverInteractionKind,
-  Position as PopoverPosition
-} from "@blueprintjs/core"
+import { Classes, Menu, MenuItem } from "@blueprintjs/core"
+import { Popover2, Popover2InteractionKind } from "@blueprintjs/popover2"
+import "@blueprintjs/popover2/lib/css/blueprint-popover2.css"
 import { resetPagination, SEARCH_OBJECT_LABELS, setSearchQuery } from "actions"
 import ButtonToggleGroup from "components/ButtonToggleGroup"
 import RemoveButton from "components/RemoveButton"
@@ -191,15 +186,19 @@ const AdvancedSearch = ({
                     "No additional filters available"
                   )
                 ) : (
-                  <Popover
+                  <Popover2
                     content={advancedSearchMenuContent}
                     captureDismiss
-                    interactionKind={PopoverInteractionKind.CLICK}
+                    interactionKind={Popover2InteractionKind.CLICK}
                     usePortal={false}
-                    position={PopoverPosition.RIGHT}
+                    autoFocus={true}
+                    enforceFocus={true}
+                    placement="right"
                     modifiers={{
                       preventOverflow: {
-                        boundariesElement: "viewport"
+                        options: {
+                          rootBoundary: "viewport"
+                        }
                       },
                       flip: {
                         enabled: false
@@ -209,7 +208,7 @@ const AdvancedSearch = ({
                     <Button bsStyle="link" id="addFilterDropdown">
                       + Add {filters.length > 0 && "another"} filter
                     </Button>
-                  </Popover>
+                  </Popover2>
                 )}
               </div>
               <div

--- a/client/src/components/BlueprintOverrides.css
+++ b/client/src/components/BlueprintOverrides.css
@@ -10,7 +10,7 @@
 	content: "to";
 	margin-right: 5px;
 }
-.bp3-transition-container {
+.bp3-popover2-transition-container {
 	/* Make sure it is on top of the advanced search popup */
 	z-index: 1070 !important;
 }

--- a/client/src/components/PlanningConflictForPerson.js
+++ b/client/src/components/PlanningConflictForPerson.js
@@ -1,13 +1,10 @@
-import {
-  Button,
-  Callout,
-  Icon,
-  Intent,
-  Spinner,
-  Tooltip
-} from "@blueprintjs/core"
+import { Button, Callout, Icon, Intent, Spinner } from "@blueprintjs/core"
 import { IconNames } from "@blueprintjs/icons"
-import { Popover2, Popover2InteractionKind } from "@blueprintjs/popover2"
+import {
+  Popover2,
+  Popover2InteractionKind,
+  Tooltip2
+} from "@blueprintjs/popover2"
 import "@blueprintjs/popover2/lib/css/blueprint-popover2.css"
 import API from "api"
 import { gql } from "apollo-boost"
@@ -49,20 +46,20 @@ const BasePlanningConflictForPerson = ({ person, report, iconOnly }) => {
 
   if (loading) {
     return (
-      <Tooltip content="Checking for planning conflicts...">
+      <Tooltip2 content="Checking for planning conflicts...">
         <Spinner intent={Intent.WARNING} size={20} />
-      </Tooltip>
+      </Tooltip2>
     )
   }
 
   if (error) {
     return (
-      <Tooltip
+      <Tooltip2
         content="Error occured while checking for planning conflicts!"
         intent={Intent.DANGER}
       >
         <Icon icon={IconNames.ERROR} intent={Intent.DANGER} />
-      </Tooltip>
+      </Tooltip2>
     )
   }
 

--- a/client/src/components/PlanningConflictForPerson.js
+++ b/client/src/components/PlanningConflictForPerson.js
@@ -3,12 +3,12 @@ import {
   Callout,
   Icon,
   Intent,
-  Popover,
-  PopoverInteractionKind,
   Spinner,
   Tooltip
 } from "@blueprintjs/core"
 import { IconNames } from "@blueprintjs/icons"
+import { Popover2, Popover2InteractionKind } from "@blueprintjs/popover2"
+import "@blueprintjs/popover2/lib/css/blueprint-popover2.css"
 import API from "api"
 import { gql } from "apollo-boost"
 import LinkTo from "components/LinkTo"
@@ -79,7 +79,11 @@ const BasePlanningConflictForPerson = ({ person, report, iconOnly }) => {
   }
 
   return (
-    <Popover
+    <Popover2
+      interactionKind={Popover2InteractionKind.CLICK}
+      usePortal={false}
+      autoFocus={false}
+      enforceFocus={false}
       content={
         <Callout
           title={`${person.toString()} has ${
@@ -99,18 +103,16 @@ const BasePlanningConflictForPerson = ({ person, report, iconOnly }) => {
           ))}
         </Callout>
       }
-      target={
-        <Button icon={IconNames.WARNING_SIGN} intent={Intent.WARNING} minimal>
-          {!iconOnly && (
-            <>
-              {conflictingReports.length}&nbsp;
-              {pluralize("conflict", conflictingReports.length)}
-            </>
-          )}
-        </Button>
-      }
-      interactionKind={PopoverInteractionKind.CLICK}
-    />
+    >
+      <Button icon={IconNames.WARNING_SIGN} intent={Intent.WARNING} minimal>
+        {!iconOnly && (
+          <>
+            {conflictingReports.length}&nbsp;
+            {pluralize("conflict", conflictingReports.length)}
+          </>
+        )}
+      </Button>
+    </Popover2>
   )
 }
 

--- a/client/src/components/PlanningConflictForReport.js
+++ b/client/src/components/PlanningConflictForReport.js
@@ -1,5 +1,7 @@
-import { Icon, Intent, Spinner, Tooltip } from "@blueprintjs/core"
+import { Icon, Intent, Spinner } from "@blueprintjs/core"
 import { IconNames } from "@blueprintjs/icons"
+import { Tooltip2 } from "@blueprintjs/popover2"
+import "@blueprintjs/popover2/lib/css/blueprint-popover2.css"
 import styled from "@emotion/styled"
 import API from "api"
 import { gql } from "apollo-boost"
@@ -58,7 +60,7 @@ const PlanningConflictForReport = ({ report, text, largeIcon }) => {
 
   if (error) {
     return (
-      <Tooltip
+      <Tooltip2
         content="An error occured while checking planning conflicts!"
         intent={Intent.DANGER}
       >
@@ -67,7 +69,7 @@ const PlanningConflictForReport = ({ report, text, largeIcon }) => {
           intent={Intent.DANGER}
           iconSize={Icon.SIZE_STANDARD}
         />
-      </Tooltip>
+      </Tooltip2>
     )
   }
 
@@ -84,7 +86,7 @@ const PlanningConflictForReport = ({ report, text, largeIcon }) => {
 
   return (
     <ReportConflictIconBox className="reportConflictIcon">
-      <Tooltip
+      <Tooltip2
         content={
           <ReportConflictTooltipContainer className="reportConflictTooltipContainer">
             <div>
@@ -106,7 +108,7 @@ const PlanningConflictForReport = ({ report, text, largeIcon }) => {
           iconSize={largeIcon ? Icon.SIZE_LARGE : Icon.SIZE_STANDARD}
           style={{ margin: "0 5px" }}
         />
-      </Tooltip>
+      </Tooltip2>
       {text}
     </ReportConflictIconBox>
   )

--- a/client/src/components/SearchBar.js
+++ b/client/src/components/SearchBar.js
@@ -1,4 +1,5 @@
-import { Popover, PopoverInteractionKind, Position } from "@blueprintjs/core"
+import { Popover2, Popover2InteractionKind } from "@blueprintjs/popover2"
+import "@blueprintjs/popover2/lib/css/blueprint-popover2.css"
 import { resetPagination, SEARCH_OBJECT_LABELS, setSearchQuery } from "actions"
 import AdvancedSearch from "components/AdvancedSearch"
 import {
@@ -20,15 +21,17 @@ export const SearchPopover = ({
   children
 }) => {
   return (
-    <Popover
+    <Popover2
       isOpen={isOpen}
       onInteraction={isOpen => setIsOpen(isOpen)}
       boundary="window"
       captureDismiss
       content={popoverContent}
-      interactionKind={PopoverInteractionKind.CLICK}
-      position={Position.BOTTOM_LEFT}
+      interactionKind={Popover2InteractionKind.CLICK_TARGET_ONLY}
+      placement="bottom-start"
       usePortal={false}
+      autoFocus={true}
+      enforceFocus={false}
       modifiers={{
         preventOverflow: {
           enabled: false
@@ -42,7 +45,7 @@ export const SearchPopover = ({
       }}
     >
       {children}
-    </Popover>
+    </Popover2>
   )
 }
 

--- a/client/src/components/advancedSelectWidget/AdvancedSelect.js
+++ b/client/src/components/advancedSelectWidget/AdvancedSelect.js
@@ -1,4 +1,5 @@
-import { Popover, PopoverInteractionKind, Position } from "@blueprintjs/core"
+import { Popover2, Popover2InteractionKind } from "@blueprintjs/popover2"
+import "@blueprintjs/popover2/lib/css/blueprint-popover2.css"
 import API from "api"
 import { gql } from "apollo-boost"
 import * as FieldHelper from "components/FieldHelper"
@@ -296,11 +297,10 @@ const AdvancedSelect = ({
     <>
       {!(disabled && renderSelectedWithDelete) && (
         <>
-          <div id={`${fieldName}-popover`}>
+          <div id={`${fieldName}-popover`} className="advanced-select-popover">
             <InputGroup>
-              <Popover
-                className="advanced-select-popover"
-                popoverClassName="bp3-popover-content-sizing"
+              <Popover2
+                popoverClassName="bp3-popover2-content-sizing"
                 content={
                   <Row className="border-between">
                     <FilterAsNav
@@ -350,10 +350,12 @@ const AdvancedSelect = ({
                 isOpen={showOverlay}
                 captureDismiss
                 disabled={disabled}
-                interactionKind={PopoverInteractionKind.CLICK}
+                interactionKind={Popover2InteractionKind.CLICK}
                 onInteraction={handleInteraction}
                 usePortal={false}
-                position={Position.BOTTOM}
+                autoFocus={false}
+                enforceFocus={false}
+                placement="bottom"
                 modifiers={{
                   preventOverflow: {
                     enabled: false
@@ -377,7 +379,7 @@ const AdvancedSelect = ({
                   }}
                   disabled={disabled}
                 />
-              </Popover>
+              </Popover2>
               {extraAddon && <InputGroup.Addon>{extraAddon}</InputGroup.Addon>}
               {addon && (
                 <FieldHelper.FieldAddon fieldId={fieldName} addon={addon} />

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -860,20 +860,20 @@ header.searchPagination {
 	font-size: 0.8em;
 }
 
-.advanced-select-popover .bp3-popover-content-sizing {
+.advanced-select-popover .bp3-popover2-content-sizing {
 	width: 100% !important;
 }
 
-.advanced-select-popover span.bp3-popover-target {
+.advanced-select-popover span.bp3-popover2-target {
 	display: block;
 	width: 100%;
 }
 
-.advanced-select-popover .bp3-transition-container {
-	top: 35px !important;
+.advanced-select-popover .bp3-popover2-transition-container {
+	top: 50px !important;
 }
 
-.advanced-select-popover .bp3-popover-content {
+.advanced-select-popover .bp3-popover2-content {
 	min-width: 400px;
 	max-width: 90vw !important;
 }

--- a/client/src/pages/locations/GeoLocation.js
+++ b/client/src/pages/locations/GeoLocation.js
@@ -1,5 +1,9 @@
-import { AnchorButton, Tooltip } from "@blueprintjs/core"
-import { Popover2, Popover2InteractionKind } from "@blueprintjs/popover2"
+import { AnchorButton } from "@blueprintjs/core"
+import {
+  Popover2,
+  Popover2InteractionKind,
+  Tooltip2
+} from "@blueprintjs/popover2"
 import "@blueprintjs/popover2/lib/css/blueprint-popover2.css"
 import * as FieldHelper from "components/FieldHelper"
 import { Field } from "formik"
@@ -299,7 +303,7 @@ const CoordinateActionButtons = ({
 }) => {
   return (
     <Col sm={3} style={{ padding: "4px 8px" }}>
-      <Tooltip content="Clear coordinates">
+      <Tooltip2 content="Clear coordinates">
         <AnchorButton
           minimal
           icon="delete"
@@ -308,7 +312,7 @@ const CoordinateActionButtons = ({
           onClick={onClear}
           disabled={isSubmitting || disabled}
         />
-      </Tooltip>
+      </Tooltip2>
       <AllFormatsInfo coordinates={coordinates} inForm />
     </Col>
   )
@@ -368,7 +372,7 @@ const AllFormatsInfo = ({ coordinates, inForm }) => {
         </div>
       }
     >
-      <Tooltip content="Display all coordinate formats">
+      <Tooltip2 content="Display all coordinate formats">
         <AnchorButton
           style={{ marginLeft: "8px" }}
           id="gloc-info-btn"
@@ -377,7 +381,7 @@ const AllFormatsInfo = ({ coordinates, inForm }) => {
           intent="primary"
           outlined={inForm}
         />
-      </Tooltip>
+      </Tooltip2>
     </Popover2>
   )
 }

--- a/client/src/pages/locations/GeoLocation.js
+++ b/client/src/pages/locations/GeoLocation.js
@@ -1,10 +1,6 @@
-import {
-  AnchorButton,
-  Popover,
-  PopoverInteractionKind,
-  Position,
-  Tooltip
-} from "@blueprintjs/core"
+import { AnchorButton, Tooltip } from "@blueprintjs/core"
+import { Popover2, Popover2InteractionKind } from "@blueprintjs/popover2"
+import "@blueprintjs/popover2/lib/css/blueprint-popover2.css"
 import * as FieldHelper from "components/FieldHelper"
 import { Field } from "formik"
 import {
@@ -302,7 +298,7 @@ const CoordinateActionButtons = ({
   disabled
 }) => {
   return (
-    <Col sm={2} style={{ padding: "4px 8px" }}>
+    <Col sm={3} style={{ padding: "4px 8px" }}>
       <Tooltip content="Clear coordinates">
         <AnchorButton
           minimal
@@ -338,7 +334,12 @@ const AllFormatsInfo = ({ coordinates, inForm }) => {
     return null
   }
   return (
-    <Popover
+    <Popover2
+      placement="right"
+      interactionKind={Popover2InteractionKind.CLICK}
+      usePortal={false}
+      autoFocus={false}
+      enforceFocus={false}
       content={
         <div style={{ padding: "8px" }}>
           <Table style={{ margin: 0 }}>
@@ -366,22 +367,18 @@ const AllFormatsInfo = ({ coordinates, inForm }) => {
           </Table>
         </div>
       }
-      target={
-        <Tooltip content="Display all coordinate formats">
-          <AnchorButton
-            style={{ marginLeft: "8px" }}
-            id="gloc-info-btn"
-            minimal
-            icon="info-sign"
-            intent="primary"
-            outlined={inForm}
-          />
-        </Tooltip>
-      }
-      position={Position.RIGHT}
-      interactionKind={PopoverInteractionKind.CLICK_TARGET_ONLY}
-      usePortal={false}
-    />
+    >
+      <Tooltip content="Display all coordinate formats">
+        <AnchorButton
+          style={{ marginLeft: "8px" }}
+          id="gloc-info-btn"
+          minimal
+          icon="info-sign"
+          intent="primary"
+          outlined={inForm}
+        />
+      </Tooltip>
+    </Popover2>
   )
 }
 

--- a/client/tests/webdriver/pages/advancedSearch.js
+++ b/client/tests/webdriver/pages/advancedSearch.js
@@ -38,7 +38,7 @@ class AdvancedSearch {
   }
 
   get addFilterPopover() {
-    return this.addFilterButtonText.$(".bp3-popover-content")
+    return this.addFilterButtonText.$(".bp3-popover2-content")
   }
 }
 

--- a/client/tests/webdriver/pages/location/createNewLocation.page.js
+++ b/client/tests/webdriver/pages/location/createNewLocation.page.js
@@ -34,7 +34,7 @@ class CreateNewLocation extends Page {
   // parent of MGRS table data => tr
   get allFormatsPopoverLat() {
     return this.form
-      .$(".bp3-popover-content table")
+      .$(".bp3-popover2-content table")
       .$("td*=Latitude")
       .$("..")
       .$("span:first-child")
@@ -42,7 +42,7 @@ class CreateNewLocation extends Page {
 
   get allFormatsPopoverLng() {
     return this.form
-      .$(".bp3-popover-content table")
+      .$(".bp3-popover2-content table")
       .$("td*=Latitude")
       .$("..")
       .$("span:nth-child(3)")
@@ -51,7 +51,7 @@ class CreateNewLocation extends Page {
   get allFormatsPopoverMGRS() {
     // parent of MGRS table data => tr
     return this.form
-      .$(".bp3-popover-content table")
+      .$(".bp3-popover2-content table")
       .$("td*=MGRS")
       .$("..")
       .$("span:first-child")

--- a/client/tests/webdriver/pages/location/editLocation.page.js
+++ b/client/tests/webdriver/pages/location/editLocation.page.js
@@ -23,7 +23,7 @@ class EditLocation extends Page {
   // parent of MGRS table data => tr
   get allFormatsPopoverLat() {
     return browser
-      .$(".bp3-popover-content table")
+      .$(".bp3-popover2-content table")
       .$("td*=Latitude")
       .$("..")
       .$("span:first-child")
@@ -31,7 +31,7 @@ class EditLocation extends Page {
 
   get allFormatsPopoverLng() {
     return browser
-      .$(".bp3-popover-content table")
+      .$(".bp3-popover2-content table")
       .$("td*=Latitude")
       .$("..")
       .$("span:nth-child(3)")
@@ -40,7 +40,7 @@ class EditLocation extends Page {
   get allFormatsPopoverMGRS() {
     // parent of MGRS table data => tr
     return browser
-      .$(".bp3-popover-content table")
+      .$(".bp3-popover2-content table")
       .$("td*=MGRS")
       .$("..")
       .$("span:first-child")

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -1412,6 +1412,18 @@
     classnames "^2.2"
     tslib "~1.13.0"
 
+"@blueprintjs/popover2@0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@blueprintjs/popover2/-/popover2-0.2.0.tgz#4712d98e0187c343e835dbe5c7fd0dfd29d2d64b"
+  integrity sha512-BvT6fuL+3hsHuOYXYdNwpNiOCCA4m0H7BD3TmpULo8+Vzw+BP5xHyB7Q1EPxJf8OqNNfSCO+oR+6WsPgzk6rXA==
+  dependencies:
+    "@blueprintjs/core" "^3.38.2"
+    "@popperjs/core" "^2.5.4"
+    classnames "^2.2"
+    dom4 "^2.1.5"
+    react-popper "^2.2.4"
+    tslib "~1.13.0"
+
 "@cnakazawa/watch@^1.0.3":
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/@cnakazawa/watch/-/watch-1.0.4.tgz#f864ae85004d0fcab6f50be9141c4da368d1656a"


### PR DESCRIPTION
Migrate Popover and Tooltip to the new Popover2 and Tooltip2.

Closes NCI-Agency/anet#3410

#### User changes
- In addition to the changed library underneath (which should be mostly invisible to the user, with the exception of some slightly improved positioning of pop-ups), it is now also possible to change the search text while building up search filters. Previously, clicking in the text box (or anywhere else outside the filter pop-up for that matter) while adding filters would dismiss the filter pop-up, which removed any changes to the filters. Starting with this version, dismissing the filter pop-up (without applying the changes) should now be done by clicking the Cancel button in the filter pop-up or by clicking on the textual representation of the current filter (just underneath the search text input).

#### Super User changes
- none

#### Admin changes
- none

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [x] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here