### PR TITLE
Fix yupDate conversion

### DIFF
--- a/client/src/components/CustomDateInput.js
+++ b/client/src/components/CustomDateInput.js
@@ -60,8 +60,14 @@ const CustomDateInput = ({
       rightElement={rightElement}
       value={value && moment(value).toDate()}
       onChange={onChange}
-      formatDate={date => moment(date).format(inputFormat)}
-      parseDate={str => moment(str, dateFormats, true).toDate()}
+      formatDate={date => {
+        const dt = moment(date)
+        return dt.isValid() ? dt.format(inputFormat) : ""
+      }}
+      parseDate={str => {
+        const dt = moment(str, dateFormats, true)
+        return dt.isValid() ? dt.toDate() : false
+      }}
       placeholder={inputFormat}
       maxDate={moment().add(20, "years").endOf("year").toDate()}
       canClearSelection={false}

--- a/client/src/components/Model.js
+++ b/client/src/components/Model.js
@@ -127,11 +127,16 @@ export const ASSESSMENTS_RELATED_OBJECT_TYPE = {
 }
 
 export const yupDate = yup.date().transform(function(value, originalValue) {
-  if (this.isType(value)) {
+  if (
+    this.isType(value) &&
+    (this.isType(originalValue)
+      ? value === originalValue
+      : value.getTime() === originalValue)
+  ) {
     return value
   }
   const newValue = moment(originalValue)
-  return newValue.isValid() ? newValue.toDate() : value
+  return newValue.isValid() ? newValue.toDate() : null
 })
 
 export const CUSTOM_FIELD_TYPE = {


### PR DESCRIPTION
Fix conversion of timestamps < `1000000000` (Sep  9 2001 01:46:40 UTC) which would get parsed by Yup as a date string waaaay into the future.
Check whether the converted result is actually the same date, and if not, do our own conversion.

Closes NCI-Agency/anet#3428

#### User changes
- Engagement dates before Sep 9 2001 should work properly again.

#### Super User changes
- none

#### Admin changes
- none

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here