### PR TITLE
Update GraphQL-SPQR

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -88,7 +88,7 @@ dependencies {
 	implementation 'ch.qos.logback:logback-access:1.2.3'
 	implementation 'com.github.waffle:waffle-jna:1.9.1'
 	implementation 'com.graphql-java:java-dataloader:2.2.3'
-	implementation 'io.leangen.graphql:spqr:0.10.1'
+	implementation 'io.leangen.graphql:spqr:0.11.1'
 	implementation 'com.googlecode.owasp-java-html-sanitizer:owasp-java-html-sanitizer:20200713.1'
 	implementation 'com.mikesamuel:json-sanitizer:1.2.2'
 

--- a/src/main/java/mil/dds/anet/graphql/DateTimeMapper.java
+++ b/src/main/java/mil/dds/anet/graphql/DateTimeMapper.java
@@ -2,8 +2,9 @@ package mil.dds.anet.graphql;
 
 import graphql.schema.GraphQLScalarType;
 import io.leangen.graphql.generator.BuildContext;
-import io.leangen.graphql.generator.OperationMapper;
+import io.leangen.graphql.generator.mapping.TypeMappingEnvironment;
 import io.leangen.graphql.generator.mapping.common.CachingMapper;
+import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.AnnotatedType;
 import java.time.Instant;
 
@@ -12,19 +13,19 @@ public class DateTimeMapper extends CachingMapper<GraphQLScalarType, GraphQLScal
   public static final GraphQLScalarType GraphQLInstant = GraphQlDateTimeType.getInstance();
 
   @Override
-  public GraphQLScalarType toGraphQLType(String typeName, AnnotatedType javaType,
-      OperationMapper operationMapper, BuildContext buildContext) {
+  protected GraphQLScalarType toGraphQLType(String typeName, AnnotatedType javaType,
+      TypeMappingEnvironment env) {
     return GraphQLInstant;
   }
 
   @Override
-  public GraphQLScalarType toGraphQLInputType(String typeName, AnnotatedType javaType,
-      OperationMapper operationMapper, BuildContext buildContext) {
-    return toGraphQLType(typeName, javaType, operationMapper, buildContext);
+  protected GraphQLScalarType toGraphQLInputType(String typeName, AnnotatedType javaType,
+      TypeMappingEnvironment env) {
+    return toGraphQLType(typeName, javaType, env);
   }
 
   @Override
-  public boolean supports(AnnotatedType type) {
+  public boolean supports(AnnotatedElement element, AnnotatedType type) {
     return type.getType() == Instant.class;
   }
 


### PR DESCRIPTION
The build shows messages like:
```
> Task :dbPrep
ANTLR Tool version 4.7.2 used for code generation does not match the current runtime version 4.8
ANTLR Runtime version 4.7.2 used for parser compilation does not match the current runtime version 4.8
ANTLR Tool version 4.7.2 used for code generation does not match the current runtime version 4.8
ANTLR Runtime version 4.7.2 used for parser compilation does not match the current runtime version 4.8
```
which is due to the fact that GraphQL SPQR updates GraphQL to 16.2 which declares an ANTLR 4.8 dependency, and jdbi3 declares ANTLR 4.7.2 (which ends up in its generated code). See https://github.com/jdbi/jdbi/issues/1798 and https://github.com/jdbi/jdbi/pull/1793

So this needs to wait on an update of JDBI.

Closes #

#### User changes
-

#### Super User changes
-

#### Admin changes
-

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [ ] Described the user behavior in PR body
  - [ ] Referenced/updated all related issues
  - [ ] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [ ] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [ ] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
