### PR TITLE
Fix home page counter for 'reports pending my approval'

### DIFF
--- a/client/src/pages/Home.js
+++ b/client/src/pages/Home.js
@@ -12,9 +12,9 @@ import Fieldset from "components/Fieldset"
 import GuidedTour from "components/GuidedTour"
 import Messages from "components/Messages"
 import {
-  PageDispatchersPropType,
   jumpToTop,
   mapPageDispatchersToProps,
+  PageDispatchersPropType,
   useBoilerplate
 } from "components/Page"
 import SavedSearchTable from "components/SavedSearchTable"
@@ -66,10 +66,7 @@ const GQL_GET_REPORT_COUNT = gql`
 
 const HomeTile = ({ query, setSearchQuery, pageDispatchers }) => {
   const history = useHistory()
-  const reportQuery = Object.assign({}, query.query, {
-    // we're only interested in the totalCount, so just get at most one report
-    pageSize: 1
-  })
+  const reportQuery = Object.assign({}, query.query)
   const { loading, error, data } = API.useApiQuery(GQL_GET_REPORT_COUNT, {
     reportQuery
   })


### PR DESCRIPTION
Remove page size from home tile queries since we don't query the actual list anyway. Older version is working for other queries but not this one.
Maybe another root cause?

Closes #3442

#### User changes
- Users will see correct number of reports which needs approval from themselves.

#### Super User changes
-

#### Admin changes
-

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [X] Described the user behavior in PR body
  - [X] Referenced/updated all related issues
  - [X] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [X] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [X] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
