### PR TITLE
Fix report search for "pending approval of"

### DIFF
--- a/client/tests/webdriver/baseSpecs/homeTiles.spec.js
+++ b/client/tests/webdriver/baseSpecs/homeTiles.spec.js
@@ -1,0 +1,12 @@
+import { expect } from "chai"
+import Home from "../pages/home.page"
+
+describe("When checking the home page tiles", () => {
+  it("Should see correct number of pendingApprovalOf reports count when logged in as Arthur", () => {
+    Home.openAsAdminUser()
+    Home.homeTilesContainer.waitForExist()
+    Home.homeTilesContainer.waitForDisplayed()
+    // Depends on test data
+    expect(Home.pendingMyApprovalOfCount.getText()).to.eq("2")
+  })
+})

--- a/client/tests/webdriver/pages/home.page.js
+++ b/client/tests/webdriver/pages/home.page.js
@@ -23,6 +23,16 @@ class Home extends Page {
     return browser.$("#searchBarInput")
   }
 
+  get homeTilesContainer() {
+    return browser.$("fieldset.home-tile-row")
+  }
+
+  get pendingMyApprovalOfCount() {
+    return browser
+      .$('//button[contains(text(), "Reports pending my approval")]')
+      .$("h1")
+  }
+
   get submitSearch() {
     return browser.$("#topbar #searchBarSubmit")
   }

--- a/src/main/java/mil/dds/anet/search/mssql/MssqlReportSearcher.java
+++ b/src/main/java/mil/dds/anet/search/mssql/MssqlReportSearcher.java
@@ -25,7 +25,8 @@ public class MssqlReportSearcher extends AbstractReportSearcher {
   @Override
   public CompletableFuture<AnetBeanList<Report>> runSearch(Map<String, Object> context,
       Set<String> subFields, ReportSearchQuery query) {
-    buildQuery(subFields, query);
+    final ReportSearchQuery modifiedQuery = getQueryForPostProcessing(query);
+    buildQuery(subFields, modifiedQuery);
     outerQb.addSelectClause("*");
     outerQb.addTotalCount();
     outerQb.addFromClause("( " + qb.build() + " ) l");
@@ -33,7 +34,7 @@ public class MssqlReportSearcher extends AbstractReportSearcher {
     outerQb.addListArgs(qb.getListArgs());
     addOrderByClauses((AbstractSearchQueryBuilder<Report, ReportSearchQuery>) outerQb, query);
     return postProcessResults(context, query,
-        (outerQb).buildAndRun(getDbHandle(), query, new ReportMapper()));
+        (outerQb).buildAndRun(getDbHandle(), modifiedQuery, new ReportMapper()));
   }
 
   @Override

--- a/src/main/java/mil/dds/anet/search/pg/PostgresqlReportSearcher.java
+++ b/src/main/java/mil/dds/anet/search/pg/PostgresqlReportSearcher.java
@@ -25,9 +25,10 @@ public class PostgresqlReportSearcher extends AbstractReportSearcher {
   @Override
   public CompletableFuture<AnetBeanList<Report>> runSearch(Map<String, Object> context,
       Set<String> subFields, ReportSearchQuery query) {
-    buildQuery(subFields, query);
+    final ReportSearchQuery modifiedQuery = getQueryForPostProcessing(query);
+    buildQuery(subFields, modifiedQuery);
     return postProcessResults(context, query,
-        qb.buildAndRun(getDbHandle(), query, new ReportMapper()));
+        qb.buildAndRun(getDbHandle(), modifiedQuery, new ReportMapper()));
   }
 
   @Override

--- a/src/test/java/mil/dds/anet/test/resources/TaskApprovalTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/TaskApprovalTest.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.common.collect.Lists;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -453,8 +454,13 @@ public class TaskApprovalTest extends AbstractResourceTest {
 
     // Someone from EF 1.1
     final Person approver2 = getPersonFromDb("ELIZAWELL, Elizabeth");
-    updatedTask.getApprovalSteps().add(getApprovalStep(approver2, isPlanned, true));
-    updatedTask.getTaskedOrganizations().add(approver2.getPosition().getOrganization());
+    final List<ApprovalStep> approvalSteps = new ArrayList<>(updatedTask.getApprovalSteps());
+    approvalSteps.add(getApprovalStep(approver2, isPlanned, true));
+    updatedTask.setApprovalSteps(approvalSteps);
+    final List<Organization> taskedOrganizations =
+        new ArrayList<>(updatedTask.getTaskedOrganizations());
+    taskedOrganizations.add(approver2.getPosition().getOrganization());
+    updatedTask.setTaskedOrganizations(taskedOrganizations);
     final Task updatedTask2 = updateTask(updatedTask);
     final Report report3 = submitReport(text + "3", author, approver2, updatedTask2, isPlanned,
         ReportState.PENDING_APPROVAL);


### PR DESCRIPTION
Make sure the Home tile for "Reports pending my approval", and report search results for "pending approval of", show the correct number of results.

Closes NCI-Agency/anet#3442

#### User changes
- The Home tile for "Reports pending my approval", and report search results for "pending approval of", will show the correct number of results again.

#### Super User changes
- none

#### Admin changes
- none

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [x] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here