### PR TITLE
Fix my counterparts tab not showing fields

### DIFF
--- a/client/src/pages/App.js
+++ b/client/src/pages/App.js
@@ -74,6 +74,22 @@ const GQL_GET_APP_DATA = gql`
             name
             rank
             avatar(size: 32)
+            position {
+              uuid
+              name
+              type
+              code
+              status
+              organization {
+                uuid
+                shortName
+                identificationCode
+              }
+              location {
+                uuid
+                name
+              }
+            }
             ${GRAPHQL_NOTIFICATIONS_NOTE_FIELDS}
           }
         }


### PR DESCRIPTION
My counterparts tab in the dropdown attendee search in the report form was missing some fields. The counterparts information was read from the currentUser object which was missing the fields. This adds the necessary fields to be fetched.

Closes #3453 

#### User changes
- Users will see the position/organization/location fields of their counterparts in the dropdown search in the report form.

#### Super User changes
-

#### Admin changes
-

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [X] Described the user behavior in PR body
  - [X] Referenced/updated all related issues
  - [X] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [X] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [X] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
