### PR TITLE
Refactor rollup GraphQL schema to use Instant instead of Long

### DIFF
--- a/client/src/pages/rollup/Show.js
+++ b/client/src/pages/rollup/Show.js
@@ -41,8 +41,8 @@ import utils from "utils"
 
 const GQL_ROLLUP_GRAPH = gql`
   query(
-    $startDate: Long!
-    $endDate: Long!
+    $startDate: Instant!
+    $endDate: Instant!
     $principalOrganizationUuid: String
     $advisorOrganizationUuid: String
     $orgType: OrganizationType
@@ -65,8 +65,8 @@ const GQL_ROLLUP_GRAPH = gql`
 `
 const GQL_SHOW_ROLLUP_EMAIL = gql`
   query(
-    $startDate: Long!
-    $endDate: Long!
+    $startDate: Instant!
+    $endDate: Instant!
     $principalOrganizationUuid: String
     $advisorOrganizationUuid: String
     $orgType: OrganizationType
@@ -82,8 +82,8 @@ const GQL_SHOW_ROLLUP_EMAIL = gql`
 `
 const GQL_EMAIL_ROLLUP = gql`
   mutation(
-    $startDate: Long!
-    $endDate: Long!
+    $startDate: Instant!
+    $endDate: Instant!
     $email: AnetEmailInput!
     $principalOrganizationUuid: String
     $advisorOrganizationUuid: String

--- a/src/main/java/mil/dds/anet/resources/ReportResource.java
+++ b/src/main/java/mil/dds/anet/resources/ReportResource.java
@@ -663,14 +663,11 @@ public class ReportResource {
    *        reports will be by/about this org or a child org.
    */
   @GraphQLQuery(name = "rollupGraph")
-  public List<RollupGraph> getDailyRollupGraph(@GraphQLArgument(name = "startDate") Long start,
-      @GraphQLArgument(name = "endDate") Long end,
+  public List<RollupGraph> getDailyRollupGraph(@GraphQLArgument(name = "startDate") Instant start,
+      @GraphQLArgument(name = "endDate") Instant end,
       @GraphQLArgument(name = "orgType") OrganizationType orgType,
       @GraphQLArgument(name = "advisorOrganizationUuid") String advisorOrgUuid,
       @GraphQLArgument(name = "principalOrganizationUuid") String principalOrgUuid) {
-    Instant startDate = Instant.ofEpochMilli(start);
-    Instant endDate = Instant.ofEpochMilli(end);
-
     final List<RollupGraph> dailyRollupGraph;
 
     @SuppressWarnings("unchecked")
@@ -680,16 +677,16 @@ public class ReportResource {
         getOrgsByShortNames(nonReportingOrgsShortNames);
 
     if (principalOrgUuid != null) {
-      dailyRollupGraph = dao.getDailyRollupGraph(startDate, endDate, principalOrgUuid,
+      dailyRollupGraph = dao.getDailyRollupGraph(start, end, principalOrgUuid,
           OrganizationType.PRINCIPAL_ORG, nonReportingOrgs);
     } else if (advisorOrgUuid != null) {
-      dailyRollupGraph = dao.getDailyRollupGraph(startDate, endDate, advisorOrgUuid,
+      dailyRollupGraph = dao.getDailyRollupGraph(start, end, advisorOrgUuid,
           OrganizationType.ADVISOR_ORG, nonReportingOrgs);
     } else {
       if (orgType == null) {
         orgType = OrganizationType.ADVISOR_ORG;
       }
-      dailyRollupGraph = dao.getDailyRollupGraph(startDate, endDate, orgType, nonReportingOrgs);
+      dailyRollupGraph = dao.getDailyRollupGraph(start, end, orgType, nonReportingOrgs);
     }
 
     Collections.sort(dailyRollupGraph, getRollupGraphComparator());
@@ -698,15 +695,15 @@ public class ReportResource {
   }
 
   @GraphQLMutation(name = "emailRollup")
-  public Integer emailRollup(@GraphQLArgument(name = "startDate") Long start,
-      @GraphQLArgument(name = "endDate") Long end,
+  public Integer emailRollup(@GraphQLArgument(name = "startDate") Instant start,
+      @GraphQLArgument(name = "endDate") Instant end,
       @GraphQLArgument(name = "orgType") OrganizationType orgType,
       @GraphQLArgument(name = "advisorOrganizationUuid") String advisorOrgUuid,
       @GraphQLArgument(name = "principalOrganizationUuid") String principalOrgUuid,
       @GraphQLArgument(name = "email") AnetEmail email) {
     DailyRollupEmail action = new DailyRollupEmail();
-    action.setStartDate(Instant.ofEpochMilli(start));
-    action.setEndDate(Instant.ofEpochMilli(end));
+    action.setStartDate(start);
+    action.setEndDate(end);
     action.setComment(email.getComment());
     action.setAdvisorOrganizationUuid(advisorOrgUuid);
     action.setPrincipalOrganizationUuid(principalOrgUuid);
@@ -719,15 +716,15 @@ public class ReportResource {
   }
 
   @GraphQLQuery(name = "showRollupEmail")
-  public String showRollupEmail(@GraphQLArgument(name = "startDate") Long start,
-      @GraphQLArgument(name = "endDate") Long end,
+  public String showRollupEmail(@GraphQLArgument(name = "startDate") Instant start,
+      @GraphQLArgument(name = "endDate") Instant end,
       @GraphQLArgument(name = "orgType") OrganizationType orgType,
       @GraphQLArgument(name = "advisorOrganizationUuid") String advisorOrgUuid,
       @GraphQLArgument(name = "principalOrganizationUuid") String principalOrgUuid,
       @GraphQLArgument(name = "showText", defaultValue = "false") Boolean showReportText) {
     DailyRollupEmail action = new DailyRollupEmail();
-    action.setStartDate(Instant.ofEpochMilli(start));
-    action.setEndDate(Instant.ofEpochMilli(end));
+    action.setStartDate(start);
+    action.setEndDate(end);
     action.setChartOrgType(orgType);
     action.setAdvisorOrganizationUuid(advisorOrgUuid);
     action.setPrincipalOrganizationUuid(principalOrgUuid);

--- a/src/test/java/mil/dds/anet/test/resources/ReportsResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/ReportsResourceTest.java
@@ -1341,7 +1341,8 @@ public class ReportsResourceTest extends AbstractResourceTest {
     variables.put("startDate", startDate.toEpochMilli());
     variables.put("endDate", endDate.toEpochMilli());
     final List<RollupGraph> startGraph = graphQLHelper.getObjectList(admin,
-        "query ($startDate: Long!, $endDate: Long!) { payload: rollupGraph(startDate: $startDate, endDate: $endDate) { org {"
+        "query ($startDate: Instant!, $endDate: Instant!) {"
+            + " payload: rollupGraph(startDate: $startDate, endDate: $endDate) { org {"
             + ORGANIZATION_FIELDS + "} published cancelled } }",
         variables, new TypeReference<GraphQlResponse<List<RollupGraph>>>() {});
 
@@ -1387,7 +1388,8 @@ public class ReportsResourceTest extends AbstractResourceTest {
 
     // Check on the daily rollup graph now.
     final List<RollupGraph> endGraph = graphQLHelper.getObjectList(admin,
-        "query ($startDate: Long!, $endDate: Long!) { payload: rollupGraph(startDate: $startDate, endDate: $endDate) { org {"
+        "query ($startDate: Instant!, $endDate: Instant!) {"
+            + " payload: rollupGraph(startDate: $startDate, endDate: $endDate) { org {"
             + ORGANIZATION_FIELDS + "} published cancelled } }",
         variables, new TypeReference<GraphQlResponse<List<RollupGraph>>>() {});
 
@@ -1436,7 +1438,8 @@ public class ReportsResourceTest extends AbstractResourceTest {
     variables.put("startDate", startDate.toEpochMilli());
     variables.put("endDate", endDate.toEpochMilli());
     final List<RollupGraph> startGraph = graphQLHelper.getObjectList(elizabeth,
-        "query ($startDate: Long!, $endDate: Long!) { payload: rollupGraph(startDate: $startDate, endDate: $endDate) { org {"
+        "query ($startDate: Instant!, $endDate: Instant!) {"
+            + " payload: rollupGraph(startDate: $startDate, endDate: $endDate) { org {"
             + ORGANIZATION_FIELDS + "} published cancelled } }",
         variables, new TypeReference<GraphQlResponse<List<RollupGraph>>>() {});
 
@@ -1482,7 +1485,8 @@ public class ReportsResourceTest extends AbstractResourceTest {
 
     // Check on the daily rollup graph now.
     final List<RollupGraph> endGraph = graphQLHelper.getObjectList(elizabeth,
-        "query ($startDate: Long!, $endDate: Long!) { payload: rollupGraph(startDate: $startDate, endDate: $endDate) { org {"
+        "query ($startDate: Instant!, $endDate: Instant!) {"
+            + " payload: rollupGraph(startDate: $startDate, endDate: $endDate) { org {"
             + ORGANIZATION_FIELDS + "} published cancelled } }",
         variables, new TypeReference<GraphQlResponse<List<RollupGraph>>>() {});
 


### PR DESCRIPTION
These were the last places Long was still being used, so now we're using the scalar type Instant everywhere we mean it to be a timestamp.

#### User changes
- none

#### Super User changes
- none

#### Admin changes
- none

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [x] graphql schema has changed
   This changes the GraphQL schema from:
```
scalar Long

type Query {
  …
  emailRollup(orgType: OrganizationType, advisorOrganizationUuid: String, endDate: Long, principalOrganizationUuid: String, email: AnetEmailInput, startDate: Long): Int
  rollupGraph(orgType: OrganizationType, advisorOrganizationUuid: String, endDate: Long, principalOrganizationUuid: String, startDate: Long): [RollupGraph]
  showRollupEmail(orgType: OrganizationType, advisorOrganizationUuid: String, endDate: Long, showText: Boolean = false, principalOrganizationUuid: String, startDate: Long): String
  …
}
```
   to:
```
type Query {
  …
  emailRollup(orgType: OrganizationType, advisorOrganizationUuid: String, endDate: Instant, principalOrganizationUuid: String, email: AnetEmailInput, startDate: Instant): Int
  rollupGraph(orgType: OrganizationType, advisorOrganizationUuid: String, endDate: Instant, principalOrganizationUuid: String, startDate: Instant): [RollupGraph]
  showRollupEmail(orgType: OrganizationType, advisorOrganizationUuid: String, endDate: Instant, showText: Boolean = false, principalOrganizationUuid: String, startDate: Instant): String
  …
}
```
   [please note that `scalar Instant` is already defined in the schema as it's used elsewhere]

### Checklist
  - [x] Described the user behavior in PR body
  - [ ] Referenced/updated all related issues
  - [ ] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [x] Added and/or updated unit tests
  - [x] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here