### PR TITLE
Update jsonpath-plus

### DIFF
--- a/anet-dictionary.yml
+++ b/anet-dictionary.yml
@@ -235,7 +235,7 @@ fields:
       trainingEvent:
         type: enum
         label: Training event
-        visibleWhen: $[?(@.multipleButtons && @.multipleButtons.indexOf('train') != -1)]
+        visibleWhen: $[?(@ && @.multipleButtons && @.multipleButtons.indexOf('train') != -1)]
         choices:
           YES:
             label: "Yes"
@@ -250,13 +250,13 @@ fields:
           - type: integer
           - type: min
             params: [1]
-        visibleWhen: $[?(@.multipleButtons && @.multipleButtons.indexOf('train') != -1)]
+        visibleWhen: $[?(@ && @.multipleButtons && @.multipleButtons.indexOf('train') != -1)]
       levelTrained:
         type: special_field
         widget: likertScale
         label: Level trained
         helpText: Basic / Intermediate / Advanced
-        visibleWhen: $[?(@.multipleButtons && @.multipleButtons.indexOf('train') != -1)]
+        visibleWhen: $[?(@ && @.multipleButtons && @.multipleButtons.indexOf('train') != -1)]
         levels:
           - color: lightGray
             endValue: 3
@@ -270,11 +270,11 @@ fields:
       trainingDate:
         type: date
         label: Training date
-        visibleWhen: $[?(@.multipleButtons && @.multipleButtons.indexOf('train') != -1)]
+        visibleWhen: $[?(@ && @.multipleButtons && @.multipleButtons.indexOf('train') != -1)]
       systemProcess:
         type: enum
         label: System / process
-        visibleWhen: $[?(@.multipleButtons && (@.multipleButtons.indexOf('advise') != -1 || @.multipleButtons.indexOf('assist') != -1 || @.multipleButtons.indexOf('other') != -1))]
+        visibleWhen: $[?(@ && @.multipleButtons && (@.multipleButtons.indexOf('advise') != -1 || @.multipleButtons.indexOf('assist') != -1 || @.multipleButtons.indexOf('other') != -1))]
         choices:
           YES:
             label: System
@@ -287,7 +287,7 @@ fields:
         validations:
           - type: required
             params: [You must provide the text field]
-        visibleWhen: $[?(@.multipleButtons && (@.multipleButtons.indexOf('advise') != -1 || @.multipleButtons.indexOf('assist') != -1 || @.multipleButtons.indexOf('other') != -1))]
+        visibleWhen: $[?(@ && @.multipleButtons && (@.multipleButtons.indexOf('advise') != -1 || @.multipleButtons.indexOf('assist') != -1 || @.multipleButtons.indexOf('other') != -1))]
       itemsAgreed:
         type: array_of_objects
         label: Items Agreed To
@@ -305,7 +305,7 @@ fields:
           dueDate:
             type: date
             label: Due date
-        visibleWhen: $[?(@.multipleButtons && @.multipleButtons.indexOf('advise') != -1)]
+        visibleWhen: $[?(@ && @.multipleButtons && @.multipleButtons.indexOf('advise') != -1)]
       assetsUsed:
         type: array_of_objects
         label: Assets used to assist
@@ -321,7 +321,7 @@ fields:
             type: number
             typeError: Qty must be a number
             label: Qty
-        visibleWhen: $[?(@.multipleButtons && (@.multipleButtons.indexOf('assist') != -1 || @.multipleButtons.indexOf('other') != -1))]
+        visibleWhen: $[?(@ && @.multipleButtons && (@.multipleButtons.indexOf('assist') != -1 || @.multipleButtons.indexOf('other') != -1))]
 
   person:
     firstName: First name
@@ -435,7 +435,7 @@ fields:
         componentClass: textarea
         style:
           height: 200px
-        visibleWhen: $[?(@.colourOptions === 'GREEN')]
+        visibleWhen: $[?(@ && @.colourOptions === 'GREEN')]
       numberFieldName:
         type: number
         typeError: Number field must be a number
@@ -448,7 +448,7 @@ fields:
             params: [5]
           - type: max
             params: [100]
-        visibleWhen: $[?((@.colourOptions === 'GREEN')||(@.colourOptions === 'RED'))]
+        visibleWhen: $[?(@ && (@.colourOptions === 'GREEN' || @.colourOptions === 'RED'))]
       nlt:
         type: date
         label: Not later than date
@@ -473,7 +473,7 @@ fields:
             type: date
             label: Object date
             helpText: Help text for object date field
-            visibleWhen: $[?(@.colourOptions === 'GREEN')]
+            visibleWhen: $[?(@ && @.colourOptions === 'GREEN')]
 
   location:
     format: LAT_LON
@@ -516,7 +516,7 @@ fields:
         componentClass: textarea
         style:
           height: 200px
-        visibleWhen: $[?(@.colourOptions === 'GREEN')]
+        visibleWhen: $[?(@ && @.colourOptions === 'GREEN')]
       numberFieldName:
         type: number
         typeError: Number field must be a number
@@ -529,7 +529,7 @@ fields:
             params: [5]
           - type: max
             params: [100]
-        visibleWhen: $[?((@.colourOptions === 'GREEN')||(@.colourOptions === 'RED'))]
+        visibleWhen: $[?(@ && (@.colourOptions === 'GREEN' || @.colourOptions === 'RED'))]
       nlt:
         type: date
         label: Not later than date
@@ -554,7 +554,7 @@ fields:
             type: date
             label: Object date
             helpText: Help text for object date field
-            visibleWhen: $[?(@.colourOptions === 'GREEN')]
+            visibleWhen: $[?(@ && @.colourOptions === 'GREEN')]
 
   position:
     name: 'Position Name'
@@ -597,7 +597,7 @@ fields:
         componentClass: textarea
         style:
           height: 200px
-        visibleWhen: $[?(@.colourOptions === 'GREEN')]
+        visibleWhen: $[?(@ && @.colourOptions === 'GREEN')]
       numberFieldName:
         type: number
         typeError: Number field must be a number
@@ -610,7 +610,7 @@ fields:
             params: [5]
           - type: max
             params: [100]
-        visibleWhen: $[?((@.colourOptions === 'GREEN')||(@.colourOptions === 'RED'))]
+        visibleWhen: $[?(@ && (@.colourOptions === 'GREEN' || @.colourOptions === 'RED'))]
       nlt:
         type: date
         label: Not later than date
@@ -635,7 +635,7 @@ fields:
             type: date
             label: Object date
             helpText: Help text for object date field
-            visibleWhen: $[?(@.colourOptions === 'GREEN')]
+            visibleWhen: $[?(@ && @.colourOptions === 'GREEN')]
 
   organization:
     shortName: Name
@@ -679,7 +679,7 @@ fields:
         componentClass: textarea
         style:
           height: 200px
-        visibleWhen: $[?(@.colourOptions === 'GREEN')]
+        visibleWhen: $[?(@ && @.colourOptions === 'GREEN')]
       numberFieldName:
         type: number
         typeError: Number field must be a number
@@ -692,7 +692,7 @@ fields:
             params: [5]
           - type: max
             params: [100]
-        visibleWhen: $[?((@.colourOptions === 'GREEN')||(@.colourOptions === 'RED'))]
+        visibleWhen: $[?(@ && (@.colourOptions === 'GREEN' || @.colourOptions === 'RED'))]
       nlt:
         type: date
         label: Not later than date
@@ -717,7 +717,7 @@ fields:
             type: date
             label: Object date
             helpText: Help text for object date field
-            visibleWhen: $[?(@.colourOptions === 'GREEN')]
+            visibleWhen: $[?(@ && @.colourOptions === 'GREEN')]
 
   advisor:
 

--- a/client/package.json
+++ b/client/package.json
@@ -134,7 +134,7 @@
     "graphql": "15.5.0",
     "hopscotch": "0.3.1",
     "html-react-parser": "1.2.4",
-    "jsonpath-plus": "5.0.3",
+    "jsonpath-plus": "5.0.4",
     "leaflet": "1.6.0",
     "leaflet-defaulticon-compatibility": "0.1.1",
     "leaflet-geosearch": "3.2.1",

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -10886,10 +10886,10 @@ jsonfile@^6.0.1:
   optionalDependencies:
     graceful-fs "^4.1.6"
 
-jsonpath-plus@5.0.3:
-  version "5.0.3"
-  resolved "https://registry.yarnpkg.com/jsonpath-plus/-/jsonpath-plus-5.0.3.tgz#502f0fc953d0f92428b2c2357c0c6809a803ec36"
-  integrity sha512-RDvpzY21CmKTvEfxuGqQmPqRTuzNOim7L+/TcsdBM8jguI5ok38t0p2eKr9GAsVkazrTyylpMZV/hKSQCWqx9g==
+jsonpath-plus@5.0.4:
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/jsonpath-plus/-/jsonpath-plus-5.0.4.tgz#3b8ce2ea6904ee6c6750ed027fe8df31789b62e3"
+  integrity sha512-w3pI3PewtwIrrGRCFvTkCkKu8IrOwjsqoYRxvxuXQjPB0udEtAuBY0B6/SEztsxMmuIHVHGFQ0knVnTCPW9qYw==
 
 jsprim@^1.2.2:
   version "1.4.1"


### PR DESCRIPTION
Update the jsonpath-plus dependency.

#### User changes
- none

#### Super User changes
- none

#### Admin changes
- none

#### System admin changes
- [x] anet.yml or anet-dictionary.yml needs change
  Due to a change in jsonpath-plus, expressions that were previously written in the dictionary as:
  ```
         visibleWhen: $[?(@.colourOptions === 'GREEN')]
         …
         visibleWhen: $[?((@.colourOptions === 'GREEN')||(@.colourOptions === 'RED'))]
         …
         visibleWhen: $[?(@.multipleButtons && @.multipleButtons.indexOf('train') != -1)]
  ```
  will need to be rewritten to:
  ```
          visibleWhen: $[?(@ && @.colourOptions === 'GREEN')]
          …
          visibleWhen: $[?(@ && (@.colourOptions === 'GREEN' || @.colourOptions === 'RED'))]
          …
          visibleWhen: $[?(@ && @.multipleButtons && @.multipleButtons.indexOf('train') != -1)]
  ```
  (i.e. prepend `@ &&` to the condition) else you will get errors on the client-side.
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [ ] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here