### PR TITLE
Fix editing associated positions

### DIFF
--- a/client/src/components/EditAssociatedPositionsModal.js
+++ b/client/src/components/EditAssociatedPositionsModal.js
@@ -6,7 +6,7 @@ import AppContext from "components/AppContext"
 import * as FieldHelper from "components/FieldHelper"
 import LinkTo from "components/LinkTo"
 import Messages from "components/Messages"
-import Model from "components/Model"
+import Model, { DEFAULT_CUSTOM_FIELDS_PARENT } from "components/Model"
 import RemoveButton from "components/RemoveButton"
 import { FastField, Form, Formik } from "formik"
 import { Person, Position } from "models"
@@ -187,12 +187,15 @@ const EditAssociatedPositionsModal = ({
   function save(values, form) {
     const newPosition = Object.without(
       new Position(values),
+      "previousPeople",
+      "person", // prevent any changes to person
       "notes",
-      "responsibleTasks" // Only for querying
+      "responsibleTasks", // Only for querying
+      DEFAULT_CUSTOM_FIELDS_PARENT
     )
-    newPosition.associatedPositions = values.associatedPositions
-    delete newPosition.previousPeople
-    delete newPosition.person // prevent any changes to person.
+    newPosition.associatedPositions = values.associatedPositions?.map(ap =>
+      Object.without(ap, DEFAULT_CUSTOM_FIELDS_PARENT)
+    )
     return API.mutation(GQL_UPDATE_ASSOCIATED_POSITION, {
       position: newPosition
     })


### PR DESCRIPTION
Prevent error about `formCustomFields` not defined for the input.

Fixes NCI-Agency/anet#3481

#### User changes
- none

#### Super User changes
- Super Users can assign associated positions again.

#### Admin changes
- Admins can assign associated positions again.

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here