### PR TITLE
Fix "This is not me" onboarding

### DIFF
--- a/client/src/pages/people/Form.js
+++ b/client/src/pages/people/Form.js
@@ -566,7 +566,7 @@ const PersonForm = ({ edit, title, saveText, initialValues }) => {
 
   function onSubmitSuccess(response, values, form) {
     // reset the form to latest values
-    // to avoid unsaved changes propmt if it somehow becomes dirty
+    // to avoid unsaved changes prompt if it somehow becomes dirty
     form.resetForm({ values, isSubmitting: true })
     if (onSaveRedirectToHome) {
       localStorage.clear()
@@ -602,7 +602,7 @@ const PersonForm = ({ edit, title, saveText, initialValues }) => {
       "customFields", // initial JSON from the db
       DEFAULT_CUSTOM_FIELDS_PARENT
     )
-    if (values.isPendingVerification) {
+    if (values.pendingVerification) {
       person.pendingVerification = false
     }
     person.name = Person.fullName(


### PR DESCRIPTION
After taking over from a previous role-based account, users can choose "This is not me" and go through the onboarding process to provide information about themselves. Trying to save this information could fail with an error. This PR fixes that.

Fixes NCI-Agency/anet#3491

#### User changes
- Onboarding after selecting "This is not me" in the user's details works again.

#### Super User changes
- none

#### Admin changes
- none

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here