### PR TITLE
Add a back to draft capability for published reports

### DIFF
--- a/anet-dictionary.yml
+++ b/anet-dictionary.yml
@@ -4,7 +4,6 @@ VERSION_CHANGED_MSG: "There is a new version of ANET, click here to load the new
 SUPPORT_EMAIL_ADDR: support@example.com
 
 engagementsIncludeTimeAndDuration: true
-canUnpublishReports: true
 
 dateFormats:
   email:
@@ -198,6 +197,7 @@ fields:
               height: 200px
 
   report:
+    canUnpublishReports: true
     intent: Engagement purpose
     atmosphere: Atmospherics
     atmosphereDetails: Atmospherics details

--- a/anet-dictionary.yml
+++ b/anet-dictionary.yml
@@ -4,6 +4,7 @@ VERSION_CHANGED_MSG: "There is a new version of ANET, click here to load the new
 SUPPORT_EMAIL_ADDR: support@example.com
 
 engagementsIncludeTimeAndDuration: true
+canUnpublishReports: true
 
 dateFormats:
   email:

--- a/client/src/components/ConfirmDestructive.js
+++ b/client/src/components/ConfirmDestructive.js
@@ -4,8 +4,9 @@ import React from "react"
 import { Button } from "react-bootstrap"
 import Confirm from "react-confirm-bootstrap"
 
-const ConfirmDelete = ({
-  onConfirmDelete,
+const ConfirmDestructive = ({
+  onConfirm,
+  operation,
   objectType,
   objectDisplay,
   bsStyle,
@@ -13,16 +14,16 @@ const ConfirmDelete = ({
   children,
   ...otherProps
 }) => {
-  const confirmDeleteText = `Yes, I am sure that I want to delete ${objectType} ${objectDisplay}`
-  const title = `Confirm to delete ${objectType}`
-  const body = `Are you sure you want to delete this ${objectType}? This cannot be undone.`
+  const confirmText = `Yes, I am sure that I want to ${operation} ${objectType} ${objectDisplay}`
+  const title = `Confirm to ${operation} ${objectType}`
+  const body = `Are you sure you want to ${operation} this ${objectType}? This cannot be undone.`
 
   return (
     <Confirm
-      onConfirm={onConfirmDelete}
+      onConfirm={onConfirm}
       title={title}
       body={body}
-      confirmText={confirmDeleteText}
+      confirmText={confirmText}
       cancelText="No, I am not entirely sure at this point"
       dialogClassName="react-confirm-bootstrap-modal"
       confirmBSStyle="primary"
@@ -34,13 +35,17 @@ const ConfirmDelete = ({
     </Confirm>
   )
 }
-ConfirmDelete.propTypes = {
-  onConfirmDelete: PropTypes.func,
-  objectType: PropTypes.string,
-  objectDisplay: PropTypes.string,
+ConfirmDestructive.propTypes = {
+  onConfirm: PropTypes.func.isRequired,
+  objectType: PropTypes.string.isRequired,
+  operation: PropTypes.string.isRequired,
+  objectDisplay: PropTypes.string.isRequired,
   bsStyle: PropTypes.string,
   buttonLabel: PropTypes.string,
   children: PropTypes.node
 }
+ConfirmDestructive.defaultProps = {
+  operation: "delete"
+}
 
-export default ConfirmDelete
+export default ConfirmDestructive

--- a/client/src/components/RelatedObjectNoteModal.js
+++ b/client/src/components/RelatedObjectNoteModal.js
@@ -1,5 +1,5 @@
 import API from "api"
-import ConfirmDelete from "components/ConfirmDelete"
+import ConfirmDestructive from "components/ConfirmDestructive"
 import * as FieldHelper from "components/FieldHelper"
 import Messages from "components/Messages"
 import Model, {
@@ -106,8 +106,8 @@ const RelatedObjectNoteModal = ({
                   Cancel
                 </Button>
                 {_isEmpty(relatedObjects) && onDelete && (
-                  <ConfirmDelete
-                    onConfirmDelete={() => onDelete(note.uuid)}
+                  <ConfirmDestructive
+                    onConfirm={() => onDelete(note.uuid)}
                     objectType="note"
                     objectDisplay={"#" + note.uuid}
                     bsStyle="warning"

--- a/client/src/components/RelatedObjectNotes.js
+++ b/client/src/components/RelatedObjectNotes.js
@@ -4,7 +4,7 @@ import { IconNames } from "@blueprintjs/icons"
 import API from "api"
 import { gql } from "apollo-boost"
 import AppContext from "components/AppContext"
-import ConfirmDelete from "components/ConfirmDelete"
+import ConfirmDestructive from "components/ConfirmDestructive"
 import { parseHtmlWithLinkTo } from "components/editor/LinkAnet"
 import LinkTo from "components/LinkTo"
 import Messages from "components/Messages"
@@ -216,8 +216,8 @@ const RelatedObjectNotes = ({
                         onSuccess={hideEditRelatedObjectNoteModal}
                         onDelete={hideDeleteRelatedObjectNoteModal}
                       />
-                      <ConfirmDelete
-                        onConfirmDelete={() => deleteNote(note.uuid)}
+                      <ConfirmDestructive
+                        onConfirm={() => deleteNote(note.uuid)}
                         objectType="note"
                         objectDisplay={"#" + note.uuid}
                         title="Delete note"
@@ -225,7 +225,7 @@ const RelatedObjectNotes = ({
                         bsStyle="primary"
                       >
                         <img src={REMOVE_ICON} height={14} alt="Delete" />
-                      </ConfirmDelete>
+                      </ConfirmDestructive>
                     </>
                   )}
                 </Panel.Heading>

--- a/client/src/components/ReportWorkflow.js
+++ b/client/src/components/ReportWorkflow.js
@@ -13,6 +13,7 @@ const ACTION_TYPE_DETAILS = {
   REJECT: { text: "Changes requested", cssClass: "btn-danger rejected" },
   SUBMIT: { text: "Submitted", cssClass: "btn-pending submitted" },
   PUBLISH: { text: "Published", cssClass: "btn-success published" },
+  UNPUBLISH: { text: "Unpublished", cssClass: "btn-danger unpublished" },
   null: { text: "Pending", cssClass: "btn-pending default" }
 }
 

--- a/client/src/components/assessments/PeriodicAssessmentResults.js
+++ b/client/src/components/assessments/PeriodicAssessmentResults.js
@@ -3,7 +3,7 @@ import { IconNames } from "@blueprintjs/icons"
 import API from "api"
 import { gql } from "apollo-boost"
 import AssessmentModal from "components/assessments/AssessmentModal"
-import ConfirmDelete from "components/ConfirmDelete"
+import ConfirmDestructive from "components/ConfirmDestructive"
 import { ReadonlyCustomFields } from "components/CustomFields"
 import LinkTo from "components/LinkTo"
 import Model, { NOTE_TYPE } from "components/Model"
@@ -79,8 +79,8 @@ const PeriodicAssessment = ({
               >
                 <Icon icon={IconNames.EDIT} />
               </Button>
-              <ConfirmDelete
-                onConfirmDelete={() => deleteNote(note.uuid)}
+              <ConfirmDestructive
+                onConfirm={() => deleteNote(note.uuid)}
                 objectType="note"
                 objectDisplay={"#" + note.uuid}
                 title="Delete assessment"
@@ -88,7 +88,7 @@ const PeriodicAssessment = ({
                 bsStyle="primary"
               >
                 <img src={REMOVE_ICON} height={14} alt="Delete" />
-              </ConfirmDelete>
+              </ConfirmDestructive>
               <AssessmentModal
                 showModal={showAssessmentModalKey === note.uuid}
                 note={note}

--- a/client/src/pages/Home.js
+++ b/client/src/pages/Home.js
@@ -7,7 +7,7 @@ import {
 import API from "api"
 import { gql } from "apollo-boost"
 import AppContext from "components/AppContext"
-import ConfirmDelete from "components/ConfirmDelete"
+import ConfirmDestructive from "components/ConfirmDestructive"
 import Fieldset from "components/Fieldset"
 import GuidedTour from "components/GuidedTour"
 import Messages from "components/Messages"
@@ -347,8 +347,8 @@ const SavedSearches = ({ setSearchQuery, pageDispatchers }) => {
             <Button style={{ marginRight: 12 }} onClick={showSearch}>
               Show Search
             </Button>
-            <ConfirmDelete
-              onConfirmDelete={onConfirmDelete}
+            <ConfirmDestructive
+              onConfirm={onConfirmDelete}
               objectType="search"
               objectDisplay={selectedSearch.name}
               bsStyle="danger"

--- a/client/src/pages/positions/Show.js
+++ b/client/src/pages/positions/Show.js
@@ -3,7 +3,7 @@ import API from "api"
 import { gql } from "apollo-boost"
 import AppContext from "components/AppContext"
 import AssignPersonModal from "components/AssignPersonModal"
-import ConfirmDelete from "components/ConfirmDelete"
+import ConfirmDestructive from "components/ConfirmDestructive"
 import { ReadonlyCustomFields } from "components/CustomFields"
 import EditAssociatedPositionsModal from "components/EditAssociatedPositionsModal"
 import * as FieldHelper from "components/FieldHelper"
@@ -302,8 +302,8 @@ const PositionShow = ({ pageDispatchers }) => {
             {canDelete && (
               <div className="submit-buttons">
                 <div>
-                  <ConfirmDelete
-                    onConfirmDelete={onConfirmDelete}
+                  <ConfirmDestructive
+                    onConfirm={onConfirmDelete}
                     objectType="position"
                     objectDisplay={"#" + position.uuid}
                     bsStyle="warning"

--- a/client/src/pages/reports/Form.js
+++ b/client/src/pages/reports/Form.js
@@ -12,7 +12,7 @@ import {
 import AdvancedSingleSelect from "components/advancedSelectWidget/AdvancedSingleSelect"
 import AppContext from "components/AppContext"
 import InstantAssessmentsContainerField from "components/assessments/InstantAssessmentsContainerField"
-import ConfirmDelete from "components/ConfirmDelete"
+import ConfirmDestructive from "components/ConfirmDestructive"
 import CustomDateInput from "components/CustomDateInput"
 import {
   CustomFieldsContainer,
@@ -1081,8 +1081,8 @@ const ReportForm = ({
                     </div>
                   )}
                   {canDelete && (
-                    <ConfirmDelete
-                      onConfirmDelete={() => onConfirmDelete(values, resetForm)}
+                    <ConfirmDestructive
+                      onConfirm={() => onConfirmDelete(values, resetForm)}
                       objectType="report"
                       objectDisplay={values.uuid}
                       bsStyle="warning"

--- a/client/src/pages/reports/Show.js
+++ b/client/src/pages/reports/Show.js
@@ -332,8 +332,8 @@ const ReportShow = ({ setSearchQuery, pageDispatchers }) => {
       Position.isEqual(member, currentUser.position)
     )
   const canRequestChanges = canApprove || (report.isApproved() && isAdmin)
-  // Approved reports for not future engagements may be published by an admin user
-  const canPublish = !report.isFuture() && report.isApproved() && isAdmin
+  // Approved reports may be published by an admin user
+  const canPublish = report.isApproved() && isAdmin
   // Warn admins when they try to approve their own report
   const warnApproveOwnReport = canApprove && isAuthor
 
@@ -475,18 +475,16 @@ const ReportShow = ({ setSearchQuery, pageDispatchers }) => {
             {report.isApproved() && (
               <Fieldset style={{ textAlign: "center" }}>
                 <h4 className="text-danger">This {reportType} is APPROVED.</h4>
-                {!report.isFuture() && (
-                  <p>
-                    This report has been approved and will be automatically
-                    published to the ANET community in{" "}
-                    {moment(report.getReportApprovedAt())
-                      .add(
-                        Settings.reportWorkflow.nbOfHoursQuarantineApproved,
-                        "hours"
-                      )
-                      .toNow(true)}
-                  </p>
-                )}
+                <p>
+                  This report has been approved and will be automatically
+                  published to the ANET community in{" "}
+                  {moment(report.getReportApprovedAt())
+                    .add(
+                      Settings.reportWorkflow.nbOfHoursQuarantineApproved,
+                      "hours"
+                    )
+                    .toNow(true)}
+                </p>
                 {canPublish && (
                   <p>
                     You can also {renderPublishButton(!isValid)} it immediately.

--- a/client/src/pages/reports/Show.js
+++ b/client/src/pages/reports/Show.js
@@ -241,16 +241,12 @@ const GQL_EMAIL_REPORT = gql`
 `
 const GQL_SUBMIT_REPORT = gql`
   mutation($uuid: String!) {
-    submitReport(uuid: $uuid) {
-      uuid
-    }
+    submitReport(uuid: $uuid)
   }
 `
 const GQL_PUBLISH_REPORT = gql`
   mutation($uuid: String!) {
-    publishReport(uuid: $uuid) {
-      uuid
-    }
+    publishReport(uuid: $uuid)
   }
 `
 const GQL_ADD_REPORT_COMMENT = gql`
@@ -262,16 +258,12 @@ const GQL_ADD_REPORT_COMMENT = gql`
 `
 const GQL_REJECT_REPORT = gql`
   mutation($uuid: String!, $comment: CommentInput!) {
-    rejectReport(uuid: $uuid, comment: $comment) {
-      uuid
-    }
+    rejectReport(uuid: $uuid, comment: $comment)
   }
 `
 const GQL_APPROVE_REPORT = gql`
   mutation($uuid: String!, $comment: CommentInput!) {
-    approveReport(uuid: $uuid, comment: $comment) {
-      uuid
-    }
+    approveReport(uuid: $uuid, comment: $comment)
   }
 `
 

--- a/client/src/pages/reports/Show.js
+++ b/client/src/pages/reports/Show.js
@@ -8,7 +8,7 @@ import API from "api"
 import { gql } from "apollo-boost"
 import AppContext from "components/AppContext"
 import InstantAssessmentsContainerField from "components/assessments/InstantAssessmentsContainerField"
-import ConfirmDelete from "components/ConfirmDelete"
+import ConfirmDestructive from "components/ConfirmDestructive"
 import { ReadonlyCustomFields } from "components/CustomFields"
 import { parseHtmlWithLinkTo } from "components/editor/LinkAnet"
 import * as FieldHelper from "components/FieldHelper"
@@ -794,8 +794,8 @@ const ReportShow = ({ setSearchQuery, pageDispatchers }) => {
             {currentUser.isAdmin() && (
               <div className="submit-buttons">
                 <div>
-                  <ConfirmDelete
-                    onConfirmDelete={onConfirmDelete}
+                  <ConfirmDestructive
+                    onConfirm={onConfirmDelete}
                     objectType="report"
                     objectDisplay={"#" + uuid}
                     bsStyle="warning"

--- a/client/src/pages/reports/Show.js
+++ b/client/src/pages/reports/Show.js
@@ -798,18 +798,19 @@ const ReportShow = ({ setSearchQuery, pageDispatchers }) => {
 
             {currentUser.isAdmin() && (
               <div className="submit-buttons">
-                {report.isPublished() && Settings.canUnpublishReports && (
-                  <div>
-                    <ConfirmDestructive
-                      onConfirm={onConfirmUnpublish}
-                      objectType="report"
-                      operation="unpublish"
-                      objectDisplay={"#" + uuid}
-                      bsStyle="warning"
-                      buttonLabel={`Unpublish ${reportType}`}
-                      className="pull-left"
-                    />
-                  </div>
+                {report.isPublished() &&
+                  Settings.fields.report.canUnpublishReports && (
+                    <div>
+                      <ConfirmDestructive
+                        onConfirm={onConfirmUnpublish}
+                        objectType="report"
+                        operation="unpublish"
+                        objectDisplay={"#" + uuid}
+                        bsStyle="warning"
+                        buttonLabel={`Unpublish ${reportType}`}
+                        className="pull-left"
+                      />
+                    </div>
                 )}
                 <div>
                   <ConfirmDestructive

--- a/client/src/pages/reports/Show.js
+++ b/client/src/pages/reports/Show.js
@@ -229,6 +229,11 @@ const GQL_DELETE_REPORT = gql`
     deleteReport(uuid: $uuid)
   }
 `
+const GQL_UNPUBLISH_REPORT = gql`
+  mutation($uuid: String!) {
+    unpublishReport(uuid: $uuid)
+  }
+`
 const GQL_EMAIL_REPORT = gql`
   mutation($uuid: String!, $email: AnetEmailInput!) {
     emailReport(uuid: $uuid, email: $email)
@@ -793,6 +798,19 @@ const ReportShow = ({ setSearchQuery, pageDispatchers }) => {
 
             {currentUser.isAdmin() && (
               <div className="submit-buttons">
+                {report.isPublished() && Settings.canUnpublishReports && (
+                  <div>
+                    <ConfirmDestructive
+                      onConfirm={onConfirmUnpublish}
+                      objectType="report"
+                      operation="unpublish"
+                      objectDisplay={"#" + uuid}
+                      bsStyle="warning"
+                      buttonLabel={`Unpublish ${reportType}`}
+                      className="pull-left"
+                    />
+                  </div>
+                )}
                 <div>
                   <ConfirmDestructive
                     onConfirm={onConfirmDelete}
@@ -843,6 +861,19 @@ const ReportShow = ({ setSearchQuery, pageDispatchers }) => {
         </div>
       )
     }
+  }
+  function onConfirmUnpublish() {
+    API.mutation(GQL_UNPUBLISH_REPORT, { uuid })
+      .then(data => {
+        history.push("/", {
+          success: `${reportTypeUpperFirst} unpublished`
+        })
+      })
+      .catch(error => {
+        setSaveSuccess(null)
+        setSaveError(error)
+        jumpToTop()
+      })
   }
 
   function onConfirmDelete() {

--- a/client/tests/webdriver/baseSpecs/printReport.spec.js
+++ b/client/tests/webdriver/baseSpecs/printReport.spec.js
@@ -6,7 +6,9 @@ import ShowReport from "../pages/showReport.page"
 describe("Show print report page", () => {
   beforeEach("Open the show report page", () => {
     MyReports.open()
-    ShowReport.openAsAdminUser(MyReports.reportWithAssessmentsUrl)
+    ShowReport.openAsAdminUser(
+      MyReports.getReportUrl("A test report from Arthur")
+    )
     ShowReport.compactViewButton.click()
     ShowReport.compactView.waitForExist()
     ShowReport.compactView.waitForDisplayed()

--- a/client/tests/webdriver/baseSpecs/showReport.spec.js
+++ b/client/tests/webdriver/baseSpecs/showReport.spec.js
@@ -5,7 +5,9 @@ import ShowReport from "../pages/showReport.page"
 describe("Show report page", () => {
   beforeEach("Open the show report page", () => {
     MyReports.open()
-    ShowReport.openAsAdminUser(MyReports.reportWithAssessmentsUrl)
+    ShowReport.openAsAdminUser(
+      MyReports.getReportUrl("A test report from Arthur")
+    )
   })
   describe("When on the show page of a report with assessments", () => {
     it("We should see a table of tasks instant assessments related to the current report", () => {

--- a/client/tests/webdriver/baseSpecs/unpublishReport.spec.js
+++ b/client/tests/webdriver/baseSpecs/unpublishReport.spec.js
@@ -1,0 +1,18 @@
+import { expect } from "chai"
+import MyReports from "../pages/myReports.page"
+import EditReport from "../pages/report/editReport.page"
+import ShowReport from "../pages/report/showReport.page"
+
+describe("When unpublishing a report", () => {
+  beforeEach("Open the show report page", () => {
+    MyReports.open()
+    MyReports.openAsAdminUser(
+      MyReports.getReportUrl("A test report to be unpublished from Arthur")
+    )
+  })
+  it("Should unpublish the report successfully", () => {
+    const unpublishedReportUuid = ShowReport.uuid
+    EditReport.unpublishReport(unpublishedReportUuid)
+    expect(EditReport.alertSuccess.getText()).to.equal("Report unpublished")
+  })
+})

--- a/client/tests/webdriver/customFieldsSpecs/showTask.spec.js
+++ b/client/tests/webdriver/customFieldsSpecs/showTask.spec.js
@@ -6,7 +6,9 @@ import ShowTask from "../pages/showTask.page"
 describe("Show task page", () => {
   beforeEach("Open the show task page", () => {
     MyReports.open()
-    ShowReport.openAsAdminUser(MyReports.reportWithAssessmentsUrl)
+    ShowReport.openAsAdminUser(
+      MyReports.getReportUrl("A test report from Arthur")
+    )
     ShowTask.openAsAdminUser(ShowReport.task12BUrl)
   })
 

--- a/client/tests/webdriver/pages/myReports.page.js
+++ b/client/tests/webdriver/pages/myReports.page.js
@@ -7,12 +7,12 @@ class MyReports extends Page {
     super.openAsAdminUser(PAGE_URL)
   }
 
-  get reportWithAssessmentsUrl() {
+  getReportUrl(urlText) {
     const tableTab = browser.$(
       "#published-reports .report-collection div header div button[value='table']"
     )
     tableTab.click()
-    return $("*=A test report from Arthur").getAttribute("href")
+    return $(`*=${urlText}`).getAttribute("href")
   }
 }
 

--- a/client/tests/webdriver/pages/report/editReport.page.js
+++ b/client/tests/webdriver/pages/report/editReport.page.js
@@ -13,6 +13,10 @@ class EditReport extends Page {
     )
   }
 
+  get unpublishButton() {
+    return browser.$('//button[text()="Unpublish report"]')
+  }
+
   get alertSuccess() {
     return browser.$(".alert-success")
   }
@@ -20,6 +24,12 @@ class EditReport extends Page {
   confirmDeleteButton(uuid) {
     return browser.$(
       `//div[@class="modal-footer"]//button[text()="Yes, I am sure that I want to delete report ${uuid}"]`
+    )
+  }
+
+  confirmUnpublishButton(uuid) {
+    return browser.$(
+      `//div[@class="modal-footer"]//button[text()="Yes, I am sure that I want to unpublish report #${uuid}"]`
     )
   }
 
@@ -31,6 +41,17 @@ class EditReport extends Page {
     this.confirmDeleteButton(uuid).waitForClickable()
     browser.pause(300) // wait for modal animation to finish
     this.confirmDeleteButton(uuid).click()
+    this.waitForAlertSuccessToLoad()
+  }
+
+  unpublishReport(uuid) {
+    this.unpublishButton.click()
+    browser.pause(300) // wait for modal animation to finish
+    this.confirmUnpublishButton(uuid).waitForExist()
+    this.confirmUnpublishButton(uuid).waitForDisplayed()
+    this.confirmUnpublishButton(uuid).waitForClickable()
+    browser.pause(300) // wait for modal animation to finish
+    this.confirmUnpublishButton(uuid).click()
     this.waitForAlertSuccessToLoad()
   }
 

--- a/insertBaseData-mssql.sql
+++ b/insertBaseData-mssql.sql
@@ -708,6 +708,22 @@ INSERT INTO reportTasks (taskUuid, reportUuid)
 INSERT INTO reportTasks (taskUuid, reportUuid)
   VALUES ((SELECT uuid from tasks where shortName = '1.2.B'), @reportUuid);
 
+SET @reportUuid = lower(newid());
+INSERT INTO reports (uuid, createdAt, updatedAt, locationUuid, intent, text, nextSteps, keyOutcomes, state, engagementDate, atmosphere, advisorOrganizationUuid, principalOrganizationUuid)
+	VALUES (@reportUuid, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, (SELECT uuid from locations where name='General Hospital'), 'A test report to be unpublished from Arthur', '',
+	'I need to edit this report so unpublish it please','have reports in organizations', 2, DATEADD (minute, 1, CURRENT_TIMESTAMP), 0,
+	(SELECT uuid FROM organizations where shortName = 'ANET Administrators'), (SELECT uuid FROM organizations WHERE longName LIKE 'Ministry of Interior'));
+INSERT INTO reportPeople (personUuid, reportUuid, isPrimary, isAuthor)
+	VALUES ((SELECT uuid FROM people where emailAddress='hunter+arthur@example.com'), @reportUuid, 1, 1);
+INSERT INTO reportPeople (personUuid, reportUuid, isPrimary)
+	VALUES ((SELECT uuid FROM people where emailAddress='hunter+shardul@example.com'), @reportUuid, 1);
+INSERT INTO reportTasks (taskUuid, reportUuid)
+	VALUES ((SELECT uuid from tasks where shortName = '1.1.B'), @reportUuid);
+INSERT INTO reportTasks (taskUuid, reportUuid)
+  VALUES ((SELECT uuid from tasks where shortName = '1.2.A'), @reportUuid);
+INSERT INTO reportTasks (taskUuid, reportUuid)
+  VALUES ((SELECT uuid from tasks where shortName = '1.2.B'), @reportUuid);
+
 -- Release all of the reports right now, so they show up in the rollup.
 UPDATE reports SET releasedAt = reports.createdAt WHERE state = 2 OR state = 4;
 

--- a/src/main/java/mil/dds/anet/beans/ReportAction.java
+++ b/src/main/java/mil/dds/anet/beans/ReportAction.java
@@ -16,7 +16,7 @@ import mil.dds.anet.views.UuidFetcher;
 public class ReportAction extends AbstractAnetBean {
 
   public enum ActionType {
-    APPROVE, REJECT, SUBMIT, PUBLISH
+    APPROVE, REJECT, SUBMIT, PUBLISH, UNPUBLISH
   }
 
   // annotated below
@@ -30,7 +30,7 @@ public class ReportAction extends AbstractAnetBean {
   ActionType type;
   @GraphQLQuery
   @GraphQLInputField
-  private boolean planned; // only meaningful when type is APPROVE or PUBLISH
+  private boolean planned;
 
   @Override
   @JsonIgnore

--- a/src/main/java/mil/dds/anet/database/ReportDao.java
+++ b/src/main/java/mil/dds/anet/database/ReportDao.java
@@ -249,8 +249,8 @@ public class ReportDao extends AnetBaseDao<Report, ReportSearchQuery> {
   }
 
   @InTransaction
-  public void updateToDraftState(Report r) {
-    getDbHandle().createUpdate(
+  public int updateToDraftState(Report r) {
+    return getDbHandle().createUpdate(
         "/* UpdateFutureEngagementToDraft */ UPDATE reports SET state = :state , \"approvalStepUuid\" = NULL "
             + "WHERE uuid = :reportUuid")
         .bind("state", DaoUtils.getEnumId(ReportState.DRAFT)).bind("reportUuid", r.getUuid())

--- a/src/main/java/mil/dds/anet/resources/ReportResource.java
+++ b/src/main/java/mil/dds/anet/resources/ReportResource.java
@@ -337,7 +337,7 @@ public class ReportResource {
   }
 
   @GraphQLMutation(name = "submitReport")
-  public Report submitReport(@GraphQLRootContext Map<String, Object> context,
+  public int submitReport(@GraphQLRootContext Map<String, Object> context,
       @GraphQLArgument(name = "uuid") String uuid) {
     Person user = DaoUtils.getUserFromContext(context);
     final Report r = dao.getByUuid(uuid);
@@ -388,7 +388,7 @@ public class ReportResource {
 
     AnetAuditLogger.log("report {} submitted by author {}", r.getUuid(), user.getUuid());
     // GraphQL mutations *have* to return something, we return the report
-    return r;
+    return numRows;
   }
 
   static class ReportComment {
@@ -402,7 +402,7 @@ public class ReportResource {
   }
 
   @GraphQLMutation(name = "approveReport")
-  public Report approveReport(@GraphQLRootContext Map<String, Object> context,
+  public int approveReport(@GraphQLRootContext Map<String, Object> context,
       @GraphQLArgument(name = "uuid") String uuid,
       @GraphQLArgument(name = "comment") Comment comment) {
     Person approver = DaoUtils.getUserFromContext(context);
@@ -442,11 +442,11 @@ public class ReportResource {
 
     AnetAuditLogger.log("Report {} approved by {}", r.getUuid(), approver);
     // GraphQL mutations *have* to return something
-    return r;
+    return numRows;
   }
 
   @GraphQLMutation(name = "rejectReport")
-  public Report rejectReport(@GraphQLRootContext Map<String, Object> context,
+  public int rejectReport(@GraphQLRootContext Map<String, Object> context,
       @GraphQLArgument(name = "uuid") String uuid,
       @GraphQLArgument(name = "comment") Comment reason) {
     Person approver = DaoUtils.getUserFromContext(context);
@@ -503,7 +503,7 @@ public class ReportResource {
     sendReportRejectEmail(r, approver, reason1);
     AnetAuditLogger.log("report {} has requested changes by {}", r.getUuid(), approver);
     // GraphQL mutations *have* to return something
-    return r;
+    return numRows;
   }
 
   private void sendReportRejectEmail(Report r, Person rejector, Comment rejectionComment) {
@@ -519,7 +519,7 @@ public class ReportResource {
   }
 
   @GraphQLMutation(name = "publishReport")
-  public Report publishReport(@GraphQLRootContext Map<String, Object> context,
+  public int publishReport(@GraphQLRootContext Map<String, Object> context,
       @GraphQLArgument(name = "uuid") String uuid) {
     Person user = DaoUtils.getUserFromContext(context);
     final Report r = dao.getByUuid(uuid);
@@ -542,7 +542,7 @@ public class ReportResource {
 
     AnetAuditLogger.log("report {} published by admin {}", r.getUuid(), user);
     // GraphQL mutations *have* to return something
-    return r;
+    return numRows;
   }
 
   @GraphQLMutation(name = "unpublishReport")

--- a/src/main/java/mil/dds/anet/resources/ReportResource.java
+++ b/src/main/java/mil/dds/anet/resources/ReportResource.java
@@ -529,8 +529,8 @@ public class ReportResource {
     logger.debug("Attempting to publish report {}, which has advisor org {} and primary advisor {}",
         r, r.getAdvisorOrg(), r.getPrimaryAdvisor());
 
-    // Only admin may publish a report, and only for non future engagements
-    if (!AuthUtils.isAdmin(user) || r.isFutureEngagement()) {
+    // Only admin may publish a report
+    if (!AuthUtils.isAdmin(user)) {
       logger.info("User {} cannot publish report UUID {}", user, r.getUuid());
       throw new WebApplicationException("You cannot publish this report", Status.FORBIDDEN);
     }

--- a/src/main/resources/anet-schema.yml
+++ b/src/main/resources/anet-schema.yml
@@ -270,6 +270,12 @@ properties:
     default: false
     title: Whether engagements also include a time and a duration
     description: Used for report engagements; if set to `true`, you might also want to supply dateFormats.forms.inputWithTime and dateFormats.forms.longWithTime
+  canUnpublishReports:
+    type: boolean
+    default: false
+    title: Whether reports can be unpublished
+    description: Used for reports; if set to `true`, admins can change report state from published to draft
+
 
   dateFormats:
     type: object

--- a/src/main/resources/anet-schema.yml
+++ b/src/main/resources/anet-schema.yml
@@ -270,12 +270,6 @@ properties:
     default: false
     title: Whether engagements also include a time and a duration
     description: Used for report engagements; if set to `true`, you might also want to supply dateFormats.forms.inputWithTime and dateFormats.forms.longWithTime
-  canUnpublishReports:
-    type: boolean
-    default: false
-    title: Whether reports can be unpublished
-    description: Used for reports; if set to `true`, admins can change report state from published to draft
-
 
   dateFormats:
     type: object
@@ -440,6 +434,11 @@ properties:
         additionalProperties: false
         required: [intent,atmosphere,atmosphereDetails,cancelled,nextSteps,reportText]
         properties:
+          canUnpublishReports:
+            type: boolean
+            default: false
+            title: Whether reports can be unpublished
+            description: Used for reports; if set to `true`, admins can change report state from published to draft
           intent:
             type: string
             title: The label for a report's intent

--- a/src/test/java/mil/dds/anet/test/integration/db/FutureEngagementWorkerTest.java
+++ b/src/test/java/mil/dds/anet/test/integration/db/FutureEngagementWorkerTest.java
@@ -161,7 +161,7 @@ public class FutureEngagementWorkerTest extends AbstractResourceTest {
         getFutureDate(), null, Lists.newArrayList(advisor, principal)));
 
     // Submit the report
-    authorMutationExecutor.submitReport("{ uuid }", draftReport.getUuid());
+    authorMutationExecutor.submitReport("", draftReport.getUuid());
     // This planned report gets approved automatically
     final Report submittedReport = testReportState(draftReport.getUuid(), ReportState.APPROVED);
 
@@ -182,7 +182,7 @@ public class FutureEngagementWorkerTest extends AbstractResourceTest {
     final Report redraftedReport = testReportDraft(updatedReport.getUuid());
 
     // Submit the report
-    authorMutationExecutor.submitReport("{ uuid }", redraftedReport.getUuid());
+    authorMutationExecutor.submitReport("", redraftedReport.getUuid());
     // This should send an email to the approver
     expectedIds.add("hunter+jacob");
     // State should be PENDING_APPROVAL

--- a/src/test/resources/anet.graphql
+++ b/src/test/resources/anet.graphql
@@ -246,7 +246,7 @@ enum LocationSearchSortBy {
 """Mutation root"""
 type Mutation {
   addComment(comment: CommentInput, uuid: String): Comment
-  approveReport(comment: CommentInput, uuid: String): Report
+  approveReport(comment: CommentInput, uuid: String): Int!
   clearCache: String
   createAuthorizationGroup(authorizationGroup: AuthorizationGroupInput): AuthorizationGroup
   createLocation(location: LocationInput): Location
@@ -267,12 +267,12 @@ type Mutation {
   mergeLocations(loserUuid: String, winnerLocation: LocationInput): Location
   mergePeople(copyPosition: Boolean = false, loserUuid: String, winnerUuid: String): Int
   mergePositions(loserUuid: String, winnerPosition: PositionInput): Position
-  publishReport(uuid: String): Report
+  publishReport(uuid: String): Int!
   putPersonInPosition(person: PersonInput, uuid: String): Int
-  rejectReport(comment: CommentInput, uuid: String): Report
+  rejectReport(comment: CommentInput, uuid: String): Int!
   reloadDictionary: String
   saveAdminSettings(settings: [AdminSettingInput]): Int
-  submitReport(uuid: String): Report
+  submitReport(uuid: String): Int!
   unpublishReport(uuid: String): Int
   updateAssociatedPosition(position: PositionInput): Int
   updateAuthorizationGroup(authorizationGroup: AuthorizationGroupInput): Int

--- a/src/test/resources/anet.graphql
+++ b/src/test/resources/anet.graphql
@@ -3,6 +3,7 @@ enum ActionType {
   PUBLISH
   REJECT
   SUBMIT
+  UNPUBLISH
 }
 
 type Activity {
@@ -272,6 +273,7 @@ type Mutation {
   reloadDictionary: String
   saveAdminSettings(settings: [AdminSettingInput]): Int
   submitReport(uuid: String): Report
+  unpublishReport(uuid: String): Int
   updateAssociatedPosition(position: PositionInput): Int
   updateAuthorizationGroup(authorizationGroup: AuthorizationGroupInput): Int
   updateLocation(location: LocationInput): Int

--- a/testDictionaries/no-custom-fields.yml
+++ b/testDictionaries/no-custom-fields.yml
@@ -3,6 +3,7 @@ VERSION_CHANGED_MSG: "There is a new version of ANET, click here to load the new
 SUPPORT_EMAIL_ADDR: support@example.com
 
 engagementsIncludeTimeAndDuration: true
+canUnpublishReports: true
 
 dateFormats:
   email:

--- a/testDictionaries/no-custom-fields.yml
+++ b/testDictionaries/no-custom-fields.yml
@@ -3,7 +3,6 @@ VERSION_CHANGED_MSG: "There is a new version of ANET, click here to load the new
 SUPPORT_EMAIL_ADDR: support@example.com
 
 engagementsIncludeTimeAndDuration: true
-canUnpublishReports: true
 
 dateFormats:
   email:
@@ -149,6 +148,7 @@ fields:
       placeholder: Search for a position...
 
   report:
+    canUnpublishReports: true
     intent: Engagement purpose
     atmosphere: Atmospherics
     atmosphereDetails: Atmospherics details


### PR DESCRIPTION
Admins now can unpublish reports from the client-side using the **Unpublish Report** button at the bottom of the report page. This function needs to be enabled in the `anet-dictionary.yml` by setting `canUnpublishReports` to `true`.

Closes #3480 

#### User changes
- none

#### Super User changes
- none

#### Admin changes
- If enabled in the dictionary, admins can unpublish (i.e. put back to draft) published reports.
- Note that admins can now also manually publish future engagement reports that have been approved (previously they couldn't, and these would only get automatically published after the quarantine period).

#### System admin changes
- [x] anet.yml or anet-dictionary.yml needs change
  If admins should be able to unpublish reports, add this setting to the dictionary:
  ```
  fields:
    report:
      canUnpublishReports: true
  ```
- [ ] db needs migration
- [ ] documentation has changed
- [x] graphql schema has changed
  There's a new GraphQL mutation, `unpublishReport`

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [x] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here