### PR TITLE
Show absolute date/time on notes instead of relative

### DIFF
--- a/client/src/components/RelatedObjectNotes.js
+++ b/client/src/components/RelatedObjectNotes.js
@@ -23,6 +23,7 @@ import { Button, Panel } from "react-bootstrap"
 import ReactDOM from "react-dom"
 import NotificationBadge from "react-notification-badge"
 import REMOVE_ICON from "resources/delete.png"
+import Settings from "settings"
 import utils from "utils"
 import "./BlueprintOverrides.css"
 
@@ -158,7 +159,9 @@ const RelatedObjectNotes = ({
           }}
         >
           {notes.map(note => {
-            const updatedAt = moment(note.updatedAt).fromNow()
+            const updatedAt = moment(note.updatedAt).format(
+              Settings.dateFormats.forms.displayShort.withTime
+            )
             const byMe = Person.isEqual(currentUser, note.author)
             const canEdit =
               note.type !== NOTE_TYPE.PARTNER_ASSESSMENT &&


### PR DESCRIPTION
Previously, notes in the side-panel would show a relative date/time such as "4 hours ago". Now, the date/time is shown as absolute (formatted as defined in the dictionary by the `dateFormats.forms.displayShort.withTime` key), e.g. "23 March 2021 @ 09:34".

Closes NCI-Agency/anet#3501

#### User changes
- Notes in the side-panel are now shown with an absolute date/time.

#### Super User changes
- none

#### Admin changes
- none

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [ ] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here