### PR TITLE
Force super users to enter a location for advisor positions

### DIFF
--- a/client/src/models/Position.js
+++ b/client/src/models/Position.js
@@ -63,8 +63,24 @@ export default class Position extends Model {
           org => org && org.uuid
         ),
       person: yup.object().nullable().default({}),
-      location: yup.object().nullable().default({})
+      location: yup
+        .object()
+        .nullable()
+        .default(null)
+        .label("Location")
+        .when("type", (type, schema) =>
+          [
+            Position.TYPE.ADVISOR,
+            Position.TYPE.SUPER_USER,
+            Position.TYPE.ADMINISTRATOR
+          ].includes(type)
+            ? schema.required(
+              `Location is required for ${advisorPosition.name}`
+            )
+            : schema.nullable()
+        )
     })
+
     // not actually in the database, the database contains the JSON customFields
     .concat(Position.customFieldsSchema)
     .concat(Model.yupSchema)

--- a/client/tests/webdriver/baseSpecs/createNewPosition.spec.js
+++ b/client/tests/webdriver/baseSpecs/createNewPosition.spec.js
@@ -11,7 +11,7 @@ const SIMILAR_ADVISOR_POSITION_NAME = "EF 1.1 Advisor for Agriculture"
 
 describe("Create position page", () => {
   describe("When creating a position", () => {
-    it("Should show name and organization to be required when submitting empty form", () => {
+    it("Should show name, organization and location to be required when submitting empty form", () => {
       CreatePosition.openAsAdminUser()
       CreatePosition.form.waitForExist()
       CreatePosition.form.waitForDisplayed()
@@ -22,6 +22,20 @@ describe("Create position page", () => {
       CreatePosition.organizationHelpBlock.waitForExist()
       CreatePosition.organizationHelpBlock.waitForDisplayed()
 
+      CreatePosition.typeAdvisorButton.click()
+
+      expect(CreatePosition.positionNameHelpBlock.getText()).to.equal(
+        "Position name is required"
+      )
+      expect(CreatePosition.organizationHelpBlock.getText()).to.equal(
+        "Organization is required"
+      )
+      expect(CreatePosition.locationHelpBlock.getText()).to.equal(
+        "Location is required for NATO Billet"
+      )
+
+      CreatePosition.typePrincipalButton.click()
+
       expect(CreatePosition.positionNameHelpBlock.getText()).to.equal(
         "Position name is required"
       )
@@ -31,6 +45,7 @@ describe("Create position page", () => {
     })
 
     it("Should display possible duplicates with similar names", () => {
+      CreatePosition.typeAdvisorButton.click()
       CreatePosition.positionNameInput.setValue(SIMILAR_ADVISOR_POSITION_NAME)
       CreatePosition.duplicatesButton.waitForDisplayed()
       CreatePosition.duplicatesButton.click()
@@ -42,7 +57,8 @@ describe("Create position page", () => {
       expect(similar).to.equal("EF 1.1 Advisor for Agriculture")
     })
 
-    it("Should successfully create a position when required fields are filled", () => {
+    it("Should successfully create an advisor position when required fields are filled", () => {
+      CreatePosition.typeAdvisorButton.click()
       CreatePosition.positionNameInput.setValue("Test Position")
 
       CreatePosition.organizationInput.click()
@@ -50,6 +66,30 @@ describe("Create position page", () => {
       CreatePosition.waitForOrgAdvancedSelectToChange(ADMIN_ORG_COMPLETE)
       expect(CreatePosition.orgAdvancedSelectFirstItem.getText()).to.include(
         ADMIN_ORG_COMPLETE
+      )
+
+      CreatePosition.orgAdvancedSelectFirstItem.click()
+
+      CreatePosition.locationInput.click()
+      CreatePosition.locAdvancedSelectFirstItem.click()
+
+      CreatePosition.submitForm()
+      CreatePosition.waitForAlertSuccessToLoad()
+    })
+
+    it("Should successfully create a principle position when required fields are filled", () => {
+      CreatePosition.openAsAdminUser()
+      CreatePosition.form.waitForExist()
+      CreatePosition.form.waitForDisplayed()
+
+      CreatePosition.typePrincipalButton.click()
+      CreatePosition.positionNameInput.setValue("Test Position")
+
+      CreatePosition.organizationInput.click()
+      CreatePosition.organizationInput.setValue(PRINCIPAL_ORG)
+      CreatePosition.waitForOrgAdvancedSelectToChange(PRINCIPAL_ORG_COMPLETE)
+      expect(CreatePosition.orgAdvancedSelectFirstItem.getText()).to.include(
+        PRINCIPAL_ORG_COMPLETE
       )
 
       CreatePosition.orgAdvancedSelectFirstItem.click()

--- a/client/tests/webdriver/pages/createNewPosition.page.js
+++ b/client/tests/webdriver/pages/createNewPosition.page.js
@@ -52,6 +52,20 @@ class CreatePosition extends Page {
     )
   }
 
+  get locationInput() {
+    return browser.$("#location")
+  }
+
+  get locationHelpBlock() {
+    return browser.$("#fg-location .help-block")
+  }
+
+  get locAdvancedSelectFirstItem() {
+    return browser.$(
+      "#location-popover tbody tr:first-child td:nth-child(2) span"
+    )
+  }
+
   get alertSuccess() {
     return browser.$(".alert-success")
   }

--- a/insertBaseData-mssql.sql
+++ b/insertBaseData-mssql.sql
@@ -99,71 +99,74 @@ INSERT INTO people (uuid, name, status, role, emailAddress, phoneNumber, rank, b
 INSERT INTO people (uuid, name, status, role, emailAddress, phoneNumber, rank, biography, country, gender, createdAt, updatedAt)
 	VALUES (lower(newid()), 'SHARTON, Shardul', 1, 1, 'hunter+shardul@example.com', '+99-9999-9999', 'CIV', NULL, 'Italy', 'MALE', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
 
-INSERT INTO positions (uuid, name, type, status, currentPersonUuid, createdAt, updatedAt)
-	VALUES (lower(newid()), 'ANET Administrator', 3, 0, NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
-INSERT INTO positions (uuid, name, type, status, currentPersonUuid, createdAt, updatedAt)
-	VALUES (lower(newid()), 'EF 1 Manager', 2, 0, NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
-INSERT INTO positions (uuid, name, type, status, currentPersonUuid, createdAt, updatedAt)
-	VALUES (lower(newid()), 'EF 1.1 Advisor A', 0, 0, NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
-INSERT INTO positions (uuid, name, type, status, currentPersonUuid, createdAt, updatedAt)
-	VALUES (lower(newid()), 'EF 1.1 Advisor B', 0, 0, NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
-INSERT INTO positions (uuid, name, type, status, currentPersonUuid, createdAt, updatedAt)
-	VALUES (lower(newid()), 'EF 1.1 Advisor C', 0, 0, NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
-INSERT INTO positions (uuid, name, type, status, currentPersonUuid, createdAt, updatedAt)
-	VALUES (lower(newid()), 'EF 1.1 Advisor D', 0, 0, NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
-INSERT INTO positions (uuid, name, type, status, currentPersonUuid, createdAt, updatedAt)
-	VALUES (lower(newid()), 'EF 1.1 Advisor E', 0, 0, NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
-INSERT INTO positions (uuid, name, type, status, currentPersonUuid, createdAt, updatedAt)
-	VALUES (lower(newid()), 'EF 1.1 Advisor F', 0, 0, NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
-INSERT INTO positions (uuid, name, type, status, currentPersonUuid, createdAt, updatedAt)
-	VALUES (lower(newid()), 'EF 1.1 Advisor for Agriculture', 0, 0, NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
-INSERT INTO positions (uuid, name, type, status, currentPersonUuid, createdAt, updatedAt)
-	VALUES (lower(newid()), 'EF 1.1 Old Inactive Advisor', 0, 1, NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
-INSERT INTO positions (uuid, name, type, status, currentPersonUuid, createdAt, updatedAt)
-	VALUES (lower(newid()), 'EF 1.1 Advisor for Mining', 0, 0, NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
-INSERT INTO positions (uuid, name, type, status, currentPersonUuid, createdAt, updatedAt)
-	VALUES (lower(newid()), 'EF 1.1 Advisor for Space Issues', 0, 0, NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
-INSERT INTO positions (uuid, name, type, status, currentPersonUuid, createdAt, updatedAt)
-	VALUES (lower(newid()), 'EF 1.1 Advisor for Interagency Advising', 0, 0, NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
-INSERT INTO positions (uuid, name, type, status, currentPersonUuid, createdAt, updatedAt)
-	VALUES (lower(newid()), 'EF 1.1 SuperUser', 2, 0, NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
-INSERT INTO positions (uuid, name, type, status, currentPersonUuid, createdAt, updatedAt)
-	VALUES (lower(newid()), 'EF 1.2 Advisor', 0, 0, NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
-INSERT INTO positions (uuid, name, type, status, currentPersonUuid, createdAt, updatedAt)
-	VALUES (lower(newid()), 'EF 2.1 Advisor B', 0, 0, NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
-INSERT INTO positions (uuid, name, type, status, currentPersonUuid, createdAt, updatedAt)
-	VALUES (lower(newid()), 'EF 2.1 Advisor for Accounting', 0, 0, NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
-INSERT INTO positions (uuid, name, type, status, currentPersonUuid, createdAt, updatedAt)
-	VALUES (lower(newid()), 'EF 2.1 Advisor for Kites', 0, 0, NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
-INSERT INTO positions (uuid, name, type, status, currentPersonUuid, createdAt, updatedAt)
-	VALUES (lower(newid()), 'EF 2.1 SuperUser', 2, 0, NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
-INSERT INTO positions (uuid, name, type, status, currentPersonUuid, createdAt, updatedAt)
-	VALUES (lower(newid()), 'EF 2.2 Advisor C', 0, 0, NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
-INSERT INTO positions (uuid, name, type, status, currentPersonUuid, createdAt, updatedAt)
-	VALUES (lower(newid()), 'EF 2.2 Advisor D', 0, 0, NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
-INSERT INTO positions (uuid, name, type, status, currentPersonUuid, createdAt, updatedAt)
-	VALUES (lower(newid()), 'EF 2.2 Old and Inactive', 0, 1, NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
-INSERT INTO positions (uuid, name, type, status, currentPersonUuid, createdAt, updatedAt)
-	VALUES (lower(newid()), 'EF 2.2 Advisor Sewing Facilities', 0, 0, NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
-INSERT INTO positions (uuid, name, type, status, currentPersonUuid, createdAt, updatedAt)
-	VALUES (lower(newid()), 'EF 2.2 Advisor Local Kebabs', 0, 0, NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
-INSERT INTO positions (uuid, name, type, status, currentPersonUuid, createdAt, updatedAt)
-	VALUES (lower(newid()), 'EF 2.2 Super User', 2, 0, NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
-INSERT INTO positions (uuid, name, type, status, currentPersonUuid, createdAt, updatedAt)
-	VALUES (lower(newid()), 'EF 2.2 Final Reviewer', 2, 0, NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
-INSERT INTO positions (uuid, name, type, status, currentPersonUuid, createdAt, updatedAt)
-	VALUES (lower(newid()), 'EF 4.1 Advisor A', 0, 0, NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
-INSERT INTO positions (uuid, name, type, status, currentPersonUuid, createdAt, updatedAt)
-	VALUES (lower(newid()), 'EF 4.1 Advisor for Coffee', 0, 0, NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
-INSERT INTO positions (uuid, name, type, status, currentPersonUuid, createdAt, updatedAt)
-	VALUES (lower(newid()), 'EF 4.1 Advisor on Software Engineering', 0, 0, NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
-INSERT INTO positions (uuid, name, type, status, currentPersonUuid, createdAt, updatedAt)
-	VALUES (lower(newid()), 'EF 4.1 Advisor E', 0, 0, NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
-INSERT INTO positions (uuid, name, type, status, currentPersonUuid, createdAt, updatedAt)
-	VALUES (lower(newid()), 'EF 4.1 Advisor old - dont use', 0, 1, NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
-INSERT INTO positions (uuid, name, type, status, currentPersonUuid, createdAt, updatedAt)
-	VALUES (lower(newid()), 'EF 9 Advisor <empty>', 0, 0, NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+-- Create locations
+INSERT INTO locations (uuid, name, lat, lng, createdAt, updatedAt)
+	VALUES
+		(N'cc49bb27-4d8f-47a8-a9ee-af2b68b992ac', 'St Johns Airport', 47.613442, -52.740936, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+		(N'8c138750-91ce-41bf-9b4c-9f0ddc73608b', 'Murray''s Hotel', 47.561517, -52.708760, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+		(N'9c982685-5946-4dad-a7ee-0f5a12f5e170', 'Wishingwells Park', 47.560040, -52.736962, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+		(N'0855fb0a-995e-4a79-a132-4024ee2983ff', 'General Hospital', 47.571772, -52.741935, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+		(N'95446f93-249b-4aa9-b98a-7bd2c4680718', 'Portugal Cove Ferry Terminal', 47.626718, -52.857241, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+		(N'c8fdb53f-6f93-46fc-b0fa-f005c7b49667', 'Cabot Tower', 47.570010, -52.681770, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+		(N'c7a9f420-457a-490c-a810-b504c022cf1e', 'Fort Amherst', 47.563763, -52.680590, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+		(N'7339f9e3-99d1-497a-9e3b-1269c4c287fe', 'Harbour Grace Police Station', 47.705133, -53.214422, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+		(N'f2207d9b-204b-4cb5-874d-3fe6bc6f8acd', 'Conception Bay South Police Station', 47.526784, -52.954739, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+INSERT INTO locations (uuid, name, createdAt, updatedAt)
+	VALUES
+		(N'e0ff0d6c-e663-4639-a44d-b075bf1e690d', 'MoD Headquarters Kabul', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+		(N'5046a870-6c2a-40a7-9681-61a1d6eeaa07', 'MoI Headquarters Kabul', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+		(N'c15eb29e-2965-401e-9f36-6ac8b9cc3842', 'President''s Palace', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+		(N'0585f158-5121-46a2-b099-799fe980aa9c', 'Kabul Police Academy', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+		(N'053ab2ad-132a-4a62-8cbb-20827f50ec34', 'Police HQ Training Facility', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+		(N'e87f145b-32e9-47ec-a0f4-e0dcf18e8a8c', 'Kabul Hospital', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+		(N'6465dd40-9fec-41db-a3b9-652fa52c7d21', 'MoD Army Training Base 123', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+		(N'2a59dd78-0c29-4b3f-bc94-7c98ff80b197', 'MoD Location the Second', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+		(N'18c9be38-bf68-40e2-80d8-aac47f5ff7cf', 'MoI Office Building ABC', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+		(N'8a34768c-aa15-41e4-ab79-6cf2740d555e', 'MoI Training Center', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+		(N'9f364c59-953e-4c17-919c-648ea3a74e36', 'MoI Adminstrative Office', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+		(N'dfc3918d-c2e3-4308-b161-2445cde77b3f', 'MoI Senior Executive Suite', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+		(N'3652e114-ad16-43f0-b179-cc1bce6958d5', 'MoI Coffee Shop', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+		(N'5ac4078d-d445-416a-a93e-5941562359bb', 'MoI Herat Office', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+		(N'22b0137c-4d89-43eb-ac95-a9f68aba884f', 'MoI Jalalabad Office', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+		(N'60f4084f-3304-4cd5-89df-353edef07d18', 'MoI Kandahar Office', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+		(N'c136bf89-cc24-43a5-8f51-0f41dfc9ab77', 'MoI Mazar-i-Sharif', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+		(N'b0979678-0ed0-4b42-9b26-9976fcfa1b81', 'MoI Office Building ABC', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
 
+-- Create advisor positions
+INSERT INTO positions (uuid, name, type, status, currentPersonUuid, locationUuid, createdAt, updatedAt)
+	VALUES
+		(lower(newid()), 'ANET Administrator', 3, 0, NULL, 'c8fdb53f-6f93-46fc-b0fa-f005c7b49667', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+		(lower(newid()), 'EF 1 Manager', 2, 0, NULL, 'cc49bb27-4d8f-47a8-a9ee-af2b68b992ac', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+		(lower(newid()), 'EF 1.1 Advisor A', 0, 0, NULL, 'cc49bb27-4d8f-47a8-a9ee-af2b68b992ac', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+		(lower(newid()), 'EF 1.1 Advisor B', 0, 0, NULL, 'cc49bb27-4d8f-47a8-a9ee-af2b68b992ac', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+		(lower(newid()), 'EF 1.1 Advisor C', 0, 0, NULL, 'cc49bb27-4d8f-47a8-a9ee-af2b68b992ac', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+		(lower(newid()), 'EF 1.1 Advisor D', 0, 0, NULL, 'cc49bb27-4d8f-47a8-a9ee-af2b68b992ac', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+		(lower(newid()), 'EF 1.1 Advisor E', 0, 0, NULL, 'cc49bb27-4d8f-47a8-a9ee-af2b68b992ac', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+		(lower(newid()), 'EF 1.1 Advisor F', 0, 0, NULL, 'cc49bb27-4d8f-47a8-a9ee-af2b68b992ac', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+		(lower(newid()), 'EF 1.1 Advisor for Agriculture', 0, 0, NULL, 'cc49bb27-4d8f-47a8-a9ee-af2b68b992ac', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+		(lower(newid()), 'EF 1.1 Old Inactive Advisor', 0, 1, NULL, 'cc49bb27-4d8f-47a8-a9ee-af2b68b992ac', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+		(lower(newid()), 'EF 1.1 Advisor for Mining', 0, 0, NULL, 'cc49bb27-4d8f-47a8-a9ee-af2b68b992ac', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+		(lower(newid()), 'EF 1.1 Advisor for Space Issues', 0, 0, NULL, 'cc49bb27-4d8f-47a8-a9ee-af2b68b992ac', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+		(lower(newid()), 'EF 1.1 Advisor for Interagency Advising', 0, 0, NULL, 'cc49bb27-4d8f-47a8-a9ee-af2b68b992ac', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+		(lower(newid()), 'EF 1.1 SuperUser', 2, 0, NULL, 'cc49bb27-4d8f-47a8-a9ee-af2b68b992ac', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+		(lower(newid()), 'EF 1.2 Advisor', 0, 0, NULL, 'cc49bb27-4d8f-47a8-a9ee-af2b68b992ac', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+		(lower(newid()), 'EF 2.1 Advisor B', 0, 0, NULL, '8c138750-91ce-41bf-9b4c-9f0ddc73608b', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+		(lower(newid()), 'EF 2.1 Advisor for Accounting', 0, 0, NULL, '8c138750-91ce-41bf-9b4c-9f0ddc73608b', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+		(lower(newid()), 'EF 2.1 Advisor for Kites', 0, 0, NULL, '8c138750-91ce-41bf-9b4c-9f0ddc73608b', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+		(lower(newid()), 'EF 2.1 SuperUser', 2, 0, NULL, '8c138750-91ce-41bf-9b4c-9f0ddc73608b', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+		(lower(newid()), 'EF 2.2 Advisor C', 0, 0, NULL, '8c138750-91ce-41bf-9b4c-9f0ddc73608b', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+		(lower(newid()), 'EF 2.2 Advisor D', 0, 0, NULL, '8c138750-91ce-41bf-9b4c-9f0ddc73608b', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+		(lower(newid()), 'EF 2.2 Old and Inactive', 0, 1, NULL, '8c138750-91ce-41bf-9b4c-9f0ddc73608b', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+		(lower(newid()), 'EF 2.2 Advisor Sewing Facilities', 0, 0, NULL, '8c138750-91ce-41bf-9b4c-9f0ddc73608b', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+		(lower(newid()), 'EF 2.2 Advisor Local Kebabs', 0, 0, NULL, '8c138750-91ce-41bf-9b4c-9f0ddc73608b', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+		(lower(newid()), 'EF 2.2 Super User', 2, 0, NULL, '8c138750-91ce-41bf-9b4c-9f0ddc73608b', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+		(lower(newid()), 'EF 2.2 Final Reviewer', 2, 0, NULL, '8c138750-91ce-41bf-9b4c-9f0ddc73608b', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+		(lower(newid()), 'EF 4.1 Advisor A', 0, 0, NULL, 'c7a9f420-457a-490c-a810-b504c022cf1e', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+		(lower(newid()), 'EF 4.1 Advisor for Coffee', 0, 0, NULL, 'c7a9f420-457a-490c-a810-b504c022cf1e', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+		(lower(newid()), 'EF 4.1 Advisor on Software Engineering', 0, 0, NULL, 'c7a9f420-457a-490c-a810-b504c022cf1e', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+		(lower(newid()), 'EF 4.1 Advisor E', 0, 0, NULL, 'c7a9f420-457a-490c-a810-b504c022cf1e', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+		(lower(newid()), 'EF 4.1 Advisor old - dont use', 0, 1, NULL, 'c7a9f420-457a-490c-a810-b504c022cf1e', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+		(lower(newid()), 'EF 9 Advisor <empty>', 0, 0, NULL, '7339f9e3-99d1-497a-9e3b-1269c4c287fe', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
 
 -- Put Andrew in the EF 1 Manager Billet
 INSERT INTO peoplePositions (positionUuid, personUuid, createdAt)
@@ -432,62 +435,6 @@ INSERT INTO approvers (approvalStepUuid, positionUuid)
 	WHERE approvalSteps.name = 'Task Owner approval'
 	AND approvalSteps.type = 1;
 
--- Create locations
-INSERT INTO locations (uuid, name, lat, lng, createdAt, updatedAt)
-	VALUES (N'cc49bb27-4d8f-47a8-a9ee-af2b68b992ac', 'St Johns Airport', 47.613442, -52.740936, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
-INSERT INTO locations (uuid, name, lat, lng, createdAt, updatedAt)
-	VALUES (N'8c138750-91ce-41bf-9b4c-9f0ddc73608b', 'Murray''s Hotel', 47.561517, -52.708760, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
-INSERT INTO locations (uuid, name, lat, lng, createdAt, updatedAt)
-	VALUES (N'9c982685-5946-4dad-a7ee-0f5a12f5e170', 'Wishingwells Park', 47.560040, -52.736962, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
-INSERT INTO locations (uuid, name, lat, lng, createdAt, updatedAt)
-	VALUES (N'0855fb0a-995e-4a79-a132-4024ee2983ff', 'General Hospital', 47.571772, -52.741935, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
-INSERT INTO locations (uuid, name, lat, lng, createdAt, updatedAt)
-	VALUES (N'95446f93-249b-4aa9-b98a-7bd2c4680718', 'Portugal Cove Ferry Terminal', 47.626718, -52.857241, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
-INSERT INTO locations (uuid, name, lat, lng, createdAt, updatedAt)
-	VALUES (N'c8fdb53f-6f93-46fc-b0fa-f005c7b49667', 'Cabot Tower', 47.570010, -52.681770, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
-INSERT INTO locations (uuid, name, lat, lng, createdAt, updatedAt)
-	VALUES (N'c7a9f420-457a-490c-a810-b504c022cf1e', 'Fort Amherst', 47.563763, -52.680590, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
-INSERT INTO locations (uuid, name, lat, lng, createdAt, updatedAt)
-	VALUES (N'7339f9e3-99d1-497a-9e3b-1269c4c287fe', 'Harbour Grace Police Station', 47.705133, -53.214422, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
-INSERT INTO locations (uuid, name, lat, lng, createdAt, updatedAt)
-	VALUES (N'f2207d9b-204b-4cb5-874d-3fe6bc6f8acd', 'Conception Bay South Police Station', 47.526784, -52.954739, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
-INSERT INTO locations (uuid, name, createdAt, updatedAt)
-	VALUES (N'e0ff0d6c-e663-4639-a44d-b075bf1e690d', 'MoD Headquarters Kabul', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
-INSERT INTO locations (uuid, name, createdAt, updatedAt)
-	VALUES (N'5046a870-6c2a-40a7-9681-61a1d6eeaa07', 'MoI Headquarters Kabul', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
-INSERT INTO locations (uuid, name, createdAt, updatedAt)
-	VALUES (N'c15eb29e-2965-401e-9f36-6ac8b9cc3842', 'President''s Palace', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
-INSERT INTO locations (uuid, name, createdAt, updatedAt)
-	VALUES (N'0585f158-5121-46a2-b099-799fe980aa9c', 'Kabul Police Academy', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
-INSERT INTO locations (uuid, name, createdAt, updatedAt)
-	VALUES (N'053ab2ad-132a-4a62-8cbb-20827f50ec34', 'Police HQ Training Facility', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
-INSERT INTO locations (uuid, name, createdAt, updatedAt)
-	VALUES (N'e87f145b-32e9-47ec-a0f4-e0dcf18e8a8c', 'Kabul Hospital', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
-INSERT INTO locations (uuid, name, createdAt, updatedAt)
-	VALUES (N'6465dd40-9fec-41db-a3b9-652fa52c7d21', 'MoD Army Training Base 123', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
-INSERT INTO locations (uuid, name, createdAt, updatedAt)
-	VALUES (N'2a59dd78-0c29-4b3f-bc94-7c98ff80b197', 'MoD Location the Second', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
-INSERT INTO locations (uuid, name, createdAt, updatedAt)
-	VALUES (N'18c9be38-bf68-40e2-80d8-aac47f5ff7cf', 'MoI Office Building ABC', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
-INSERT INTO locations (uuid, name, createdAt, updatedAt)
-	VALUES (N'8a34768c-aa15-41e4-ab79-6cf2740d555e', 'MoI Training Center', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
-INSERT INTO locations (uuid, name, createdAt, updatedAt)
-	VALUES (N'9f364c59-953e-4c17-919c-648ea3a74e36', 'MoI Adminstrative Office', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
-INSERT INTO locations (uuid, name, createdAt, updatedAt)
-	VALUES (N'dfc3918d-c2e3-4308-b161-2445cde77b3f', 'MoI Senior Executive Suite', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
-INSERT INTO locations (uuid, name, createdAt, updatedAt)
-	VALUES (N'3652e114-ad16-43f0-b179-cc1bce6958d5', 'MoI Coffee Shop', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
-INSERT INTO locations (uuid, name, createdAt, updatedAt)
-	VALUES (N'5ac4078d-d445-416a-a93e-5941562359bb', 'MoI Herat Office', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
-INSERT INTO locations (uuid, name, createdAt, updatedAt)
-	VALUES (N'22b0137c-4d89-43eb-ac95-a9f68aba884f', 'MoI Jalalabad Office', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
-INSERT INTO locations (uuid, name, createdAt, updatedAt)
-	VALUES (N'60f4084f-3304-4cd5-89df-353edef07d18', 'MoI Kandahar Office', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
-INSERT INTO locations (uuid, name, createdAt, updatedAt)
-	VALUES (N'c136bf89-cc24-43a5-8f51-0f41dfc9ab77', 'MoI Mazar-i-Sharif', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
-INSERT INTO locations (uuid, name, createdAt, updatedAt)
-	VALUES (N'b0979678-0ed0-4b42-9b26-9976fcfa1b81', 'MoI Office Building ABC', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
-
 -- Create a location approval process for a location
 INSERT INTO approvalSteps (uuid, relatedObjectUuid, name, type)
     SELECT lower(newid()), (SELECT uuid FROM locations WHERE name = 'Portugal Cove Ferry Terminal'), 'Location approval', 1;
@@ -503,6 +450,7 @@ INSERT INTO organizations (uuid, shortName, longName, type, parentOrgUuid, creat
 	VALUES (lower(newid()), 'MOD-F', 'Ministry of Defense Finances', 1,
 	(SELECT uuid from organizations where shortName = 'MoD'), CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
 
+-- Create principal positions
 INSERT INTO positions (uuid, name, code, type, status, currentPersonUuid, organizationUuid, createdAt, updatedAt)
 	VALUES (N'879121d2-d265-4d26-8a2b-bd073caa474e', 'Minister of Defense', 'MOD-FO-00001', 1, 0, NULL, (SELECT uuid FROM organizations WHERE longName LIKE 'Ministry of Defense'), CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
 INSERT INTO positions (uuid, name, code, type, status, currentPersonUuid, organizationUuid, createdAt, updatedAt)

--- a/src/test/java/mil/dds/anet/test/resources/AbstractResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/AbstractResourceTest.java
@@ -161,6 +161,12 @@ public abstract class AbstractResourceTest {
     return stubQueryExecutor.me(PERSON_FIELDS);
   }
 
+  // Location in the test database
+  public static Location getGeneralHospital()
+      throws GraphQLRequestExecutionException, GraphQLRequestPreparationException {
+    return adminQueryExecutor.location("{ uuid }", "0855fb0a-995e-4a79-a132-4024ee2983ff");
+  }
+
   // Advisors in the test database
   public static Person getSuperUser() {
     final Person rebecca =

--- a/src/test/java/mil/dds/anet/test/resources/NoteResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/NoteResourceTest.java
@@ -45,9 +45,11 @@ public class NoteResourceTest extends AbstractResourceTest {
 
   private static final String NOTE_FIELDS = "{ uuid type text author { uuid }"
       + " noteRelatedObjects { noteUuid relatedObjectType relatedObjectUuid } }";
-  private static final String NOTES_FIELDS = "notes " + NOTE_FIELDS;
-  private static final String POSITION_FIELDS = "{ uuid name type status " + NOTES_FIELDS + " }";
-  private static final String REPORT_FIELDS = "{ uuid intent state " + NOTES_FIELDS + "}";
+  private static final String _NOTES_FIELDS = String.format("notes %1$s", NOTE_FIELDS);
+  private static final String POSITION_FIELDS = String.format(
+      "{ uuid name type status organization { uuid } location { uuid } %1$s }", _NOTES_FIELDS);
+  private static final String REPORT_FIELDS =
+      String.format("{ uuid intent state %1$s }", _NOTES_FIELDS);
 
   private static NoteCounterDao noteCounterDao;
 
@@ -64,7 +66,8 @@ public class NoteResourceTest extends AbstractResourceTest {
     final PositionInput testPositionInput = PositionInput.builder()
         .withName("a test position created by testDeleteDanglingPositionNote")
         .withType(PositionType.ADVISOR).withStatus(Status.INACTIVE)
-        .withOrganization(getOrganizationInput(admin.getPosition().getOrganization())).build();
+        .withOrganization(getOrganizationInput(admin.getPosition().getOrganization()))
+        .withLocation(getLocationInput(getGeneralHospital())).build();
     final Position testPosition =
         adminMutationExecutor.createPosition(POSITION_FIELDS, testPositionInput);
     assertThat(testPosition).isNotNull();

--- a/src/test/java/mil/dds/anet/test/resources/OrganizationResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/OrganizationResourceTest.java
@@ -60,6 +60,7 @@ public class OrganizationResourceTest extends AbstractResourceTest {
     // Create a position and put it in this AO
     final PositionInput b1Input = getPositionInput(TestData.getTestAdvisor());
     b1Input.setOrganization(getOrganizationInput(updated));
+    b1Input.setLocation(getLocationInput(getGeneralHospital()));
     b1Input.setCode(b1Input.getCode() + "_" + Instant.now().toEpochMilli());
     final Position createdPos = adminMutationExecutor.createPosition(POSITION_FIELDS, b1Input);
     assertThat(createdPos).isNotNull();

--- a/src/test/java/mil/dds/anet/test/resources/PersonResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/PersonResourceTest.java
@@ -125,9 +125,9 @@ public class PersonResourceTest extends AbstractResourceTest {
     Organization org = orgs.getList().stream()
         .filter(o -> o.getShortName().equalsIgnoreCase("EF 6")).findFirst().get();
 
-    final PositionInput newPosInput =
-        PositionInput.builder().withType(PositionType.ADVISOR).withName("Test Position")
-            .withOrganization(getOrganizationInput(org)).withStatus(Status.ACTIVE).build();
+    final PositionInput newPosInput = PositionInput.builder().withType(PositionType.ADVISOR)
+        .withName("Test Position").withOrganization(getOrganizationInput(org))
+        .withLocation(getLocationInput(getGeneralHospital())).withStatus(Status.ACTIVE).build();
     final Position newPos = adminMutationExecutor.createPosition(POSITION_FIELDS, newPosInput);
     assertThat(newPos).isNotNull();
     assertThat(newPos.getUuid()).isNotNull();
@@ -144,9 +144,9 @@ public class PersonResourceTest extends AbstractResourceTest {
 
     // Change this person w/ a new position, and ensure it gets changed.
 
-    final PositionInput newPos2Input =
-        PositionInput.builder().withType(PositionType.ADVISOR).withName("A Second Test Position")
-            .withOrganization(getOrganizationInput(org)).withStatus(Status.ACTIVE).build();
+    final PositionInput newPos2Input = PositionInput.builder().withType(PositionType.ADVISOR)
+        .withName("A Second Test Position").withOrganization(getOrganizationInput(org))
+        .withLocation(getLocationInput(getGeneralHospital())).withStatus(Status.ACTIVE).build();
     final Position newPos2 = adminMutationExecutor.createPosition(POSITION_FIELDS, newPos2Input);
     assertThat(newPos2).isNotNull();
     assertThat(newPos2.getUuid()).isNotNull();
@@ -318,6 +318,7 @@ public class PersonResourceTest extends AbstractResourceTest {
     final Organization ao = adminMutationExecutor.createOrganization("{ uuid }",
         TestData.createAdvisorOrganizationInput(true));
     testInput.setOrganization(getOrganizationInput(ao));
+    testInput.setLocation(getLocationInput(getGeneralHospital()));
 
     final Position created = adminMutationExecutor.createPosition(POSITION_FIELDS, testInput);
     assertThat(created).isNotNull();
@@ -387,9 +388,9 @@ public class PersonResourceTest extends AbstractResourceTest {
         .filter(o -> o.getShortName().equalsIgnoreCase("EF 6")).findFirst().get();
     assertThat(org.getUuid()).isNotNull();
 
-    final PositionInput newPosInput =
-        PositionInput.builder().withType(PositionType.ADVISOR).withName("Test Position")
-            .withOrganization(getOrganizationInput(org)).withStatus(Status.ACTIVE).build();
+    final PositionInput newPosInput = PositionInput.builder().withType(PositionType.ADVISOR)
+        .withName("Test Position").withOrganization(getOrganizationInput(org))
+        .withLocation(getLocationInput(getGeneralHospital())).withStatus(Status.ACTIVE).build();
     final Position retPos = adminMutationExecutor.createPosition(POSITION_FIELDS, newPosInput);
     assertThat(retPos).isNotNull();
     assertThat(retPos.getUuid()).isNotNull();

--- a/src/test/java/mil/dds/anet/test/resources/PositionResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/PositionResourceTest.java
@@ -43,8 +43,9 @@ public class PositionResourceTest extends AbstractResourceTest {
   private static final String _ORGANIZATION_FIELDS = "uuid shortName";
   private static final String _PERSON_FIELDS = "uuid name role";
   private static final String _POSITION_FIELDS = "uuid name code type status";
-  private static final String ORGANIZATION_FIELDS = String.format(
-      "{ %1$s positions { %2$s organization { uuid } } }", _ORGANIZATION_FIELDS, _POSITION_FIELDS);
+  private static final String ORGANIZATION_FIELDS =
+      String.format("{ %1$s positions { %2$s organization { uuid } location { uuid } } }",
+          _ORGANIZATION_FIELDS, _POSITION_FIELDS);
   private static final String PERSON_FIELDS =
       String.format("{ %1$s position { %2$s } }", _PERSON_FIELDS, _POSITION_FIELDS);
   private static final String FIELDS = String.format(
@@ -68,7 +69,8 @@ public class PositionResourceTest extends AbstractResourceTest {
         TestData.createAdvisorOrganizationInput(true));
     final PositionInput testInput = PositionInput.builder()
         .withName("A Test Position created by PositionResourceTest").withType(PositionType.ADVISOR)
-        .withStatus(Status.ACTIVE).withOrganization(getOrganizationInput(ao)).build();
+        .withStatus(Status.ACTIVE).withOrganization(getOrganizationInput(ao))
+        .withLocation(getLocationInput(getGeneralHospital())).build();
 
     Position created = adminMutationExecutor.createPosition(FIELDS, testInput);
     assertThat(created).isNotNull();
@@ -255,6 +257,7 @@ public class PositionResourceTest extends AbstractResourceTest {
     final PositionInput testInput = TestData.createPositionInput();
     testInput.setCode(testInput.getCode() + "_" + Instant.now().toEpochMilli());
     testInput.setOrganization(getOrganizationInput(orgs.getList().get(0)));
+    testInput.setLocation(getLocationInput(getGeneralHospital()));
     final Position created = adminMutationExecutor.createPosition(FIELDS, testInput);
     assertThat(created).isNotNull();
     assertThat(created.getUuid()).isNotNull();
@@ -519,7 +522,8 @@ public class PositionResourceTest extends AbstractResourceTest {
     // Create a new position and move prin2 there on CREATE.
     final PositionInput pos2Input =
         PositionInput.builder().withName("Created by PositionTest").withType(PositionType.PRINCIPAL)
-            .withOrganization(getOrganizationInput(orgs.getList().get(0))).withStatus(Status.ACTIVE)
+            .withOrganization(getOrganizationInput(orgs.getList().get(0)))
+            .withLocation(getLocationInput(getGeneralHospital())).withStatus(Status.ACTIVE)
             .withPerson(getPersonInput(prin2)).build();
 
     final Position pos2 = adminMutationExecutor.createPosition(FIELDS, pos2Input);
@@ -595,7 +599,8 @@ public class PositionResourceTest extends AbstractResourceTest {
     final PositionInput newPositionInput =
         PositionInput.builder().withName("A Test Position not related to the user's organization")
             .withType(PositionType.ADVISOR).withStatus(Status.ACTIVE)
-            .withOrganization(getOrganizationInput(ao)).build();
+            .withOrganization(getOrganizationInput(ao))
+            .withLocation(getLocationInput(getGeneralHospital())).build();
     final Position newPosition = adminMutationExecutor.createPosition(FIELDS, newPositionInput);
 
     // try to update the new position (not related to the user's organization)

--- a/src/test/java/mil/dds/anet/test/resources/ReportsResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/ReportsResourceTest.java
@@ -145,7 +145,8 @@ public class ReportsResourceTest extends AbstractResourceTest {
 
     final PositionInput approver1PosInput = PositionInput.builder()
         .withName("Test Approver 1 Position").withOrganization(getOrganizationInput(advisorOrg))
-        .withType(PositionType.SUPER_USER).withStatus(Status.ACTIVE).build();
+        .withLocation(getLocationInput(getGeneralHospital())).withType(PositionType.SUPER_USER)
+        .withStatus(Status.ACTIVE).build();
     Position approver1Pos =
         adminMutationExecutor.createPosition(POSITION_FIELDS, approver1PosInput);
     assertThat(approver1Pos).isNotNull();
@@ -156,7 +157,8 @@ public class ReportsResourceTest extends AbstractResourceTest {
 
     final PositionInput approver2PosInput = PositionInput.builder()
         .withName("Test Approver 2 Position").withOrganization(getOrganizationInput(advisorOrg))
-        .withType(PositionType.SUPER_USER).withStatus(Status.ACTIVE).build();
+        .withLocation(getLocationInput(getGeneralHospital())).withType(PositionType.SUPER_USER)
+        .withStatus(Status.ACTIVE).build();
     final Position approver2Pos =
         adminMutationExecutor.createPosition(POSITION_FIELDS, approver2PosInput);
     assertThat(approver2Pos).isNotNull();
@@ -166,9 +168,9 @@ public class ReportsResourceTest extends AbstractResourceTest {
     assertThat(nrUpdated).isEqualTo(1);
 
     // Create a billet for the author
-    final PositionInput authorBilletInput =
-        PositionInput.builder().withName("A report writer").withType(PositionType.ADVISOR)
-            .withOrganization(getOrganizationInput(advisorOrg)).withStatus(Status.ACTIVE).build();
+    final PositionInput authorBilletInput = PositionInput.builder().withName("A report writer")
+        .withType(PositionType.ADVISOR).withOrganization(getOrganizationInput(advisorOrg))
+        .withLocation(getLocationInput(getGeneralHospital())).withStatus(Status.ACTIVE).build();
     final Position authorBillet =
         adminMutationExecutor.createPosition(POSITION_FIELDS, authorBilletInput);
     assertThat(authorBillet).isNotNull();
@@ -533,8 +535,9 @@ public class ReportsResourceTest extends AbstractResourceTest {
     assertThat(rejected).isNotNull();
 
     // Create billet for Author
-    final PositionInput billetInput = PositionInput.builder().withName("EF 1.1 new advisor")
-        .withType(PositionType.ADVISOR).withStatus(Status.ACTIVE).build();
+    final PositionInput billetInput =
+        PositionInput.builder().withName("EF 1.1 new advisor").withType(PositionType.ADVISOR)
+            .withLocation(getLocationInput(getGeneralHospital())).withStatus(Status.ACTIVE).build();
 
     // Put billet in EF 1.1
     final OrganizationSearchQueryInput queryOrgs = OrganizationSearchQueryInput.builder()


### PR DESCRIPTION
Closes #785 

#### User changes
- None

#### Super User changes
- Forced to enter location information for advisor positions

#### Admin changes
- Forced to enter location information for advisor positions

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [x] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here