### PR TITLE
Fix formCustomFields error when creating objects

### DIFF
--- a/client/src/components/EditAssociatedPositionsModal.js
+++ b/client/src/components/EditAssociatedPositionsModal.js
@@ -185,7 +185,7 @@ const EditAssociatedPositionsModal = ({
   }
 
   function save(values, form) {
-    const newPosition = new Position(values).getObjClientSideFieldsFiltered(
+    const newPosition = new Position(values).filterClientSideFields(
       "previousPeople",
       "person",
       "responsibleTasks"

--- a/client/src/components/EditAssociatedPositionsModal.js
+++ b/client/src/components/EditAssociatedPositionsModal.js
@@ -6,7 +6,7 @@ import AppContext from "components/AppContext"
 import * as FieldHelper from "components/FieldHelper"
 import LinkTo from "components/LinkTo"
 import Messages from "components/Messages"
-import Model, { DEFAULT_CUSTOM_FIELDS_PARENT } from "components/Model"
+import Model from "components/Model"
 import RemoveButton from "components/RemoveButton"
 import { FastField, Form, Formik } from "formik"
 import { Person, Position } from "models"
@@ -185,16 +185,10 @@ const EditAssociatedPositionsModal = ({
   }
 
   function save(values, form) {
-    const newPosition = Object.without(
-      new Position(values),
+    const newPosition = new Position(values).getObjClientSideFieldsFiltered(
       "previousPeople",
-      "person", // prevent any changes to person
-      "notes",
-      "responsibleTasks", // Only for querying
-      DEFAULT_CUSTOM_FIELDS_PARENT
-    )
-    newPosition.associatedPositions = values.associatedPositions?.map(ap =>
-      Object.without(ap, DEFAULT_CUSTOM_FIELDS_PARENT)
+      "person",
+      "responsibleTasks"
     )
     return API.mutation(GQL_UPDATE_ASSOCIATED_POSITION, {
       position: newPosition

--- a/client/src/components/Model.js
+++ b/client/src/components/Model.js
@@ -121,6 +121,7 @@ export const NOTE_TYPE = {
 
 export const DEFAULT_CUSTOM_FIELDS_PARENT = "formCustomFields"
 export const INVISIBLE_CUSTOM_FIELDS_FIELD = "invisibleCustomFields"
+export const NOTES_FIELD = "notes"
 
 export const ASSESSMENTS_RELATED_OBJECT_TYPE = {
   REPORT: "report"
@@ -688,5 +689,23 @@ export default class Model {
         note.type !== NOTE_TYPE.FREE_TEXT &&
         (note.customFields = utils.parseJsonSafe(note.text))
     )
+  }
+
+  static FILTERED_CLIENT_SIDE_FIELDS = [
+    NOTES_FIELD,
+    DEFAULT_CUSTOM_FIELDS_PARENT /* , others */
+  ]
+
+  static getObjClientSideFieldsFiltered(obj, ...additionalFields) {
+    // filter common fields here
+    return Object.without(
+      obj,
+      ...Model.FILTERED_CLIENT_SIDE_FIELDS,
+      ...additionalFields
+    )
+  }
+
+  getObjClientSideFieldsFiltered(...additionalFields) {
+    return Model.getObjClientSideFieldsFiltered(this, ...additionalFields)
   }
 }

--- a/client/src/components/Model.js
+++ b/client/src/components/Model.js
@@ -697,7 +697,6 @@ export default class Model {
   ]
 
   static getObjClientSideFieldsFiltered(obj, ...additionalFields) {
-    // filter common fields here
     return Object.without(
       obj,
       ...Model.FILTERED_CLIENT_SIDE_FIELDS,

--- a/client/src/components/Model.js
+++ b/client/src/components/Model.js
@@ -693,10 +693,10 @@ export default class Model {
 
   static FILTERED_CLIENT_SIDE_FIELDS = [
     NOTES_FIELD,
-    DEFAULT_CUSTOM_FIELDS_PARENT /* , others */
+    DEFAULT_CUSTOM_FIELDS_PARENT
   ]
 
-  static getObjClientSideFieldsFiltered(obj, ...additionalFields) {
+  static filterClientSideFields(obj, ...additionalFields) {
     return Object.without(
       obj,
       ...Model.FILTERED_CLIENT_SIDE_FIELDS,
@@ -704,7 +704,7 @@ export default class Model {
     )
   }
 
-  getObjClientSideFieldsFiltered(...additionalFields) {
-    return Model.getObjClientSideFieldsFiltered(this, ...additionalFields)
+  filterClientSideFields(...additionalFields) {
+    return Model.filterClientSideFields(this, ...additionalFields)
   }
 }

--- a/client/src/components/approvals/ApprovalsDefinition.js
+++ b/client/src/components/approvals/ApprovalsDefinition.js
@@ -5,7 +5,7 @@ import { ApproverOverlayRow } from "components/advancedSelectWidget/AdvancedSele
 import * as FieldHelper from "components/FieldHelper"
 import Fieldset from "components/Fieldset"
 import LinkTo from "components/LinkTo"
-import Model, { DEFAULT_CUSTOM_FIELDS_PARENT } from "components/Model"
+import Model from "components/Model"
 import RemoveButton from "components/RemoveButton"
 import { FastField, FieldArray } from "formik"
 import { Position } from "models"
@@ -199,7 +199,7 @@ const ApprovalsDefinition = ({
           component={FieldHelper.SpecialField}
           onChange={value => {
             value = value.map(position =>
-              Object.without(position, DEFAULT_CUSTOM_FIELDS_PARENT)
+              Position.getObjClientSideFieldsFiltered(position)
             ) // remove formCustomFields to prevent errors when sending data to server
             // validation will be done by setFieldValue
             setFieldTouched(`${fieldName}.${index}.approvers`, true, false) // onBlur doesn't work when selecting an option

--- a/client/src/components/approvals/ApprovalsDefinition.js
+++ b/client/src/components/approvals/ApprovalsDefinition.js
@@ -199,7 +199,7 @@ const ApprovalsDefinition = ({
           component={FieldHelper.SpecialField}
           onChange={value => {
             value = value.map(position =>
-              Position.getObjClientSideFieldsFiltered(position)
+              Position.filterClientSideFields(position)
             ) // remove formCustomFields to prevent errors when sending data to server
             // validation will be done by setFieldValue
             setFieldTouched(`${fieldName}.${index}.approvers`, true, false) // onBlur doesn't work when selecting an option

--- a/client/src/models/Location.js
+++ b/client/src/models/Location.js
@@ -221,4 +221,18 @@ export default class Location extends Model {
     }
     return this.name
   }
+
+  static FILTERED_CLIENT_SIDE_FIELDS = ["displayedCoordinate"]
+
+  static getObjClientSideFieldsFiltered(obj, ...additionalFields) {
+    return Model.getObjClientSideFieldsFiltered(
+      obj,
+      ...Location.FILTERED_CLIENT_SIDE_FIELDS,
+      ...additionalFields
+    )
+  }
+
+  getObjClientSideFieldsFiltered(...additionalFields) {
+    return Location.getObjClientSideFieldsFiltered(this, ...additionalFields)
+  }
 }

--- a/client/src/models/Location.js
+++ b/client/src/models/Location.js
@@ -224,15 +224,15 @@ export default class Location extends Model {
 
   static FILTERED_CLIENT_SIDE_FIELDS = ["displayedCoordinate"]
 
-  static getObjClientSideFieldsFiltered(obj, ...additionalFields) {
-    return Model.getObjClientSideFieldsFiltered(
+  static filterClientSideFields(obj, ...additionalFields) {
+    return Model.filterClientSideFields(
       obj,
       ...Location.FILTERED_CLIENT_SIDE_FIELDS,
       ...additionalFields
     )
   }
 
-  getObjClientSideFieldsFiltered(...additionalFields) {
-    return Location.getObjClientSideFieldsFiltered(this, ...additionalFields)
+  filterClientSideFields(...additionalFields) {
+    return Location.filterClientSideFields(this, ...additionalFields)
   }
 }

--- a/client/src/models/Position.js
+++ b/client/src/models/Position.js
@@ -199,4 +199,27 @@ export default class Position extends Model {
       return POSITIONS_ICON
     }
   }
+
+  static FILTERED_CLIENT_SIDE_FIELDS = [
+    /* fill if necessary */
+  ]
+
+  static getObjClientSideFieldsFiltered(obj, ...additionalFields) {
+    // filter commons first
+    if (obj.associatedPositions) {
+      obj.associatedPositions = obj.associatedPositions.map(ap =>
+        Position.getObjClientSideFieldsFiltered(ap)
+      )
+    }
+    // Also filter for position specific if there is any
+    return Model.getObjClientSideFieldsFiltered(
+      obj,
+      ...Position.FILTERED_CLIENT_SIDE_FIELDS,
+      ...additionalFields
+    )
+  }
+
+  getObjClientSideFieldsFiltered(...additionalFields) {
+    return Position.getObjClientSideFieldsFiltered(this, ...additionalFields)
+  }
 }

--- a/client/src/models/Position.js
+++ b/client/src/models/Position.js
@@ -201,25 +201,24 @@ export default class Position extends Model {
   }
 
   static FILTERED_CLIENT_SIDE_FIELDS = [
-    /* fill if necessary */
+    // Fill if necessary
   ]
 
-  static getObjClientSideFieldsFiltered(obj, ...additionalFields) {
-    // filter commons first
+  static filterClientSideFields(obj, ...additionalFields) {
+    // Filter formCustomFields in associatedPositions
     if (obj.associatedPositions) {
       obj.associatedPositions = obj.associatedPositions.map(ap =>
-        Position.getObjClientSideFieldsFiltered(ap)
+        Position.filterClientSideFields(ap)
       )
     }
-    // Also filter for position specific if there is any
-    return Model.getObjClientSideFieldsFiltered(
+    return Model.filterClientSideFields(
       obj,
       ...Position.FILTERED_CLIENT_SIDE_FIELDS,
       ...additionalFields
     )
   }
 
-  getObjClientSideFieldsFiltered(...additionalFields) {
-    return Position.getObjClientSideFieldsFiltered(this, ...additionalFields)
+  filterClientSideFields(...additionalFields) {
+    return Position.filterClientSideFields(this, ...additionalFields)
   }
 }

--- a/client/src/pages/admin/MergePositions.js
+++ b/client/src/pages/admin/MergePositions.js
@@ -339,10 +339,8 @@ const MergePositions = ({ pageDispatchers }) => {
     // serialize form custom fields before query, and remove unserialized field
     mergedPosition.customFields = customFieldsJSONString(mergedPosition)
 
-    const winnerPosition = Object.without(
-      mergedPosition,
-      "notes",
-      DEFAULT_CUSTOM_FIELDS_PARENT
+    const winnerPosition = Position.getObjClientSideFieldsFiltered(
+      mergedPosition
     )
     API.mutation(GQL_MERGE_POSITION, {
       loserUuid: loser.uuid,

--- a/client/src/pages/admin/MergePositions.js
+++ b/client/src/pages/admin/MergePositions.js
@@ -339,9 +339,7 @@ const MergePositions = ({ pageDispatchers }) => {
     // serialize form custom fields before query, and remove unserialized field
     mergedPosition.customFields = customFieldsJSONString(mergedPosition)
 
-    const winnerPosition = Position.getObjClientSideFieldsFiltered(
-      mergedPosition
-    )
+    const winnerPosition = Position.filterClientSideFields(mergedPosition)
     API.mutation(GQL_MERGE_POSITION, {
       loserUuid: loser.uuid,
       winnerPosition

--- a/client/src/pages/admin/authorizationgroup/Form.js
+++ b/client/src/pages/admin/authorizationgroup/Form.js
@@ -5,7 +5,7 @@ import { PositionOverlayRow } from "components/advancedSelectWidget/AdvancedSele
 import * as FieldHelper from "components/FieldHelper"
 import Fieldset from "components/Fieldset"
 import Messages from "components/Messages"
-import Model, { DEFAULT_CUSTOM_FIELDS_PARENT } from "components/Model"
+import Model from "components/Model"
 import NavigationWarning from "components/NavigationWarning"
 import { jumpToTop } from "components/Page"
 import PositionTable from "components/PositionTable"
@@ -233,15 +233,13 @@ const AuthorizationGroupForm = ({ edit, title, initialValues }) => {
       new AuthorizationGroup(values),
       "notes"
     )
-    authorizationGroup.positions = values.positions.map(pos => {
-      const p = Object.without(
+    authorizationGroup.positions = values.positions.map(pos =>
+      Position.getObjClientSideFieldsFiltered(
         pos,
         "previousPeople",
-        "customFields",
-        DEFAULT_CUSTOM_FIELDS_PARENT
+        "customFields"
       )
-      return p
-    })
+    )
     return API.mutation(
       edit ? GQL_UPDATE_AUTHORIZATION_GROUP : GQL_CREATE_AUTHORIZATION_GROUP,
       { authorizationGroup }

--- a/client/src/pages/admin/authorizationgroup/Form.js
+++ b/client/src/pages/admin/authorizationgroup/Form.js
@@ -234,11 +234,7 @@ const AuthorizationGroupForm = ({ edit, title, initialValues }) => {
       "notes"
     )
     authorizationGroup.positions = values.positions.map(pos =>
-      Position.getObjClientSideFieldsFiltered(
-        pos,
-        "previousPeople",
-        "customFields"
-      )
+      Position.filterClientSideFields(pos, "previousPeople", "customFields")
     )
     return API.mutation(
       edit ? GQL_UPDATE_AUTHORIZATION_GROUP : GQL_CREATE_AUTHORIZATION_GROUP,

--- a/client/src/pages/locations/Form.js
+++ b/client/src/pages/locations/Form.js
@@ -13,7 +13,7 @@ import Fieldset from "components/Fieldset"
 import GeoLocation from "components/GeoLocation"
 import Leaflet from "components/Leaflet"
 import Messages from "components/Messages"
-import Model, { DEFAULT_CUSTOM_FIELDS_PARENT } from "components/Model"
+import Model from "components/Model"
 import NavigationWarning from "components/NavigationWarning"
 import { jumpToTop } from "components/Page"
 import SimilarObjectsModal from "components/SimilarObjectsModal"
@@ -307,12 +307,8 @@ const LocationForm = ({ edit, title, initialValues }) => {
   }
 
   function save(values) {
-    const location = Object.without(
-      new Location(values),
-      "notes",
-      "displayedCoordinate",
-      "customFields", // initial JSON from the db
-      DEFAULT_CUSTOM_FIELDS_PARENT
+    const location = new Location(values).getObjClientSideFieldsFiltered(
+      "customFields"
     )
     location.customFields = customFieldsJSONString(values)
     return API.mutation(edit ? GQL_UPDATE_LOCATION : GQL_CREATE_LOCATION, {

--- a/client/src/pages/locations/Form.js
+++ b/client/src/pages/locations/Form.js
@@ -307,9 +307,7 @@ const LocationForm = ({ edit, title, initialValues }) => {
   }
 
   function save(values) {
-    const location = new Location(values).getObjClientSideFieldsFiltered(
-      "customFields"
-    )
+    const location = new Location(values).filterClientSideFields("customFields")
     location.customFields = customFieldsJSONString(values)
     return API.mutation(edit ? GQL_UPDATE_LOCATION : GQL_CREATE_LOCATION, {
       location

--- a/client/src/pages/positions/Form.js
+++ b/client/src/pages/positions/Form.js
@@ -16,7 +16,7 @@ import * as FieldHelper from "components/FieldHelper"
 import Fieldset from "components/Fieldset"
 import LinkTo from "components/LinkTo"
 import Messages from "components/Messages"
-import Model, { DEFAULT_CUSTOM_FIELDS_PARENT } from "components/Model"
+import Model from "components/Model"
 import NavigationWarning from "components/NavigationWarning"
 import { jumpToTop } from "components/Page"
 import SimilarObjectsModal from "components/SimilarObjectsModal"
@@ -400,14 +400,12 @@ const PositionForm = ({ edit, title, initialValues }) => {
   }
 
   function save(values, form) {
-    const position = Object.without(
-      new Position(values),
+    const position = new Position(values).getObjClientSideFieldsFiltered(
       "previousPeople",
-      "notes",
-      "customFields", // initial JSON from the db
-      "responsibleTasks", // Only for querying
-      DEFAULT_CUSTOM_FIELDS_PARENT
+      "customFields",
+      "responsibleTasks"
     )
+
     if (position.type !== Position.TYPE.PRINCIPAL) {
       position.type = position.permissions || Position.TYPE.ADVISOR
     }

--- a/client/src/pages/positions/Form.js
+++ b/client/src/pages/positions/Form.js
@@ -400,7 +400,7 @@ const PositionForm = ({ edit, title, initialValues }) => {
   }
 
   function save(values, form) {
-    const position = new Position(values).getObjClientSideFieldsFiltered(
+    const position = new Position(values).filterClientSideFields(
       "previousPeople",
       "customFields",
       "responsibleTasks"

--- a/client/src/pages/tasks/Form.js
+++ b/client/src/pages/tasks/Form.js
@@ -245,7 +245,7 @@ const TaskForm = ({ edit, title, initialValues }) => {
                   onChange={value => {
                     // validation will be done by setFieldValue
                     value = value.map(position =>
-                      Position.getObjClientSideFieldsFiltered(position)
+                      Position.filterClientSideFields(position)
                     )
                     setFieldTouched("responsiblePositions", true, false) // onBlur doesn't work when selecting an option
                     setFieldValue("responsiblePositions", value)

--- a/client/src/pages/tasks/Form.js
+++ b/client/src/pages/tasks/Form.js
@@ -244,6 +244,9 @@ const TaskForm = ({ edit, title, initialValues }) => {
                   dictProps={Settings.fields.task.responsiblePositions}
                   onChange={value => {
                     // validation will be done by setFieldValue
+                    value = value.map(position =>
+                      Position.getObjClientSideFieldsFiltered(position)
+                    )
                     setFieldTouched("responsiblePositions", true, false) // onBlur doesn't work when selecting an option
                     setFieldValue("responsiblePositions", value)
                   }}


### PR DESCRIPTION
Remove formCustomFields from position objects before sending them to the server to prevent errors.

Closes #3508 

#### User changes
- None

#### Super User changes
- Super Users can create locations, tasks, or organizations with engagement planning approval process and report publication approval process.

#### Admin changes
- Admins can create locations, tasks, or organizations with engagement planning approval process and report publication approval process.

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
