### PR TITLE
Use correct label for principal organization identificationCode field

### DIFF
--- a/client/src/models/Organization.js
+++ b/client/src/models/Organization.js
@@ -149,7 +149,7 @@ export default class Organization extends Model {
   static toIdentificationCodeString(organization) {
     return organization.type === Organization.TYPE.PRINCIPAL_ORG
       ? `${organization.shortName} \\ ${
-        Settings.fields.advisor.org.identificationCode.label
+        Settings.fields.principal.org.identificationCode.label
       }: ${organization.identificationCode || "Not specified"}`
       : `${organization.shortName} ${organization.longName} ${
         organization.identificationCode || ""


### PR DESCRIPTION
Fixes using wrong dictionary entry in commit b4bbd6e8f6571513ba0ea3aa476861d559109370

Relates to NCI-Agency/anet#363

#### User changes
- The code was using the advisor organization label for the identificationCode field for principal organizations; this fixes that by using the correct label.

#### Super User changes
- None

#### Admin changes
- None

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
- [x] Described the user behavior in PR body
- [x] Referenced/updated all related issues
- [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
- [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
- [ ] Added and/or updated unit tests
- [ ] Added and/or updated e2e tests
- [ ] Added and/or updated data migrations
- [ ] Updated documentation
- [x] Resolved all build errors and warnings
- [ ] Opened debt issues for anything not resolved here