### PR TITLE
Fix notes and map errors when merging positions

### DIFF
--- a/client/src/models/Position.js
+++ b/client/src/models/Position.js
@@ -139,6 +139,8 @@ export default class Position extends Model {
     location {
       uuid
       name
+      lat
+      lng
     }
     customFields
     ${GRAPHQL_NOTES_FIELDS}

--- a/client/src/pages/admin/MergePositions.js
+++ b/client/src/pages/admin/MergePositions.js
@@ -341,6 +341,7 @@ const MergePositions = ({ pageDispatchers }) => {
 
     const winnerPosition = Object.without(
       mergedPosition,
+      "notes",
       DEFAULT_CUSTOM_FIELDS_PARENT
     )
     API.mutation(GQL_MERGE_POSITION, {


### PR DESCRIPTION
Admins can merge positions with related notes and can see the correct locations on the map.

Relates to #2995 

#### User changes
- None

#### Super User changes
- None

#### Admin changes
- Admins don't get errors when merging positions with `relatedObjectNotes` and can see the locations on the map.

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
