### PR TITLE
Show absolute date/time on periodic assessments and report comments

### DIFF
--- a/client/src/components/assessments/PeriodicAssessmentResults.js
+++ b/client/src/components/assessments/PeriodicAssessmentResults.js
@@ -20,6 +20,7 @@ import React, { useState } from "react"
 import { Button, Panel } from "react-bootstrap"
 import { toast } from "react-toastify"
 import REMOVE_ICON from "resources/delete.png"
+import Settings from "settings"
 
 const GQL_DELETE_NOTE = gql`
   mutation($uuid: String!) {
@@ -58,7 +59,11 @@ const PeriodicAssessment = ({
         }}
       >
         <>
-          <i>{moment(note.updatedAt).fromNow()}</i>{" "}
+          <i>
+            {moment(note.updatedAt).format(
+              Settings.dateFormats.forms.displayShort.withTime
+            )}
+          </i>{" "}
           <LinkTo
             modelType="Person"
             model={note.author}

--- a/client/src/pages/reports/Show.js
+++ b/client/src/pages/reports/Show.js
@@ -744,7 +744,10 @@ const ReportShow = ({ setSearchQuery, pageDispatchers }) => {
                         )}
                       >
                         {" "}
-                        {createdAt.fromNow()}:{" "}
+                        {createdAt.format(
+                          Settings.dateFormats.forms.displayShort.withTime
+                        )}
+                        :{" "}
                       </span>
                       "{comment.text}"
                     </p>


### PR DESCRIPTION
Previously, periodic assessments and report comments would show a relative date/time such as "4 hours ago". Now, the date/time is shown as absolute (formatted as defined in the dictionary by the `dateFormats.forms.displayShort.withTime` key), e.g. "1 April 2021 @ 08:08".

Closes NCI-Agency/anet#3526

#### User changes
- Periodic assessments and report comments are now shown with an absolute date/time.

#### Super User changes
- None

#### Admin changes
- None

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [ ] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here