### PR TITLE
Enhance merge people for fine grained control

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -131,6 +131,10 @@ dependencies {
 
 	testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'
 	testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.1'
+
+	// Avoid "ERROR StatusLogger Log4j2 could not find a logging implementation.
+	// Please add log4j-core to the classpath. Using SimpleLogger to log to the console..."
+	runtimeOnly 'org.apache.logging.log4j:log4j-to-slf4j:2.14.1'
 }
 
 configurations.all {

--- a/build.gradle
+++ b/build.gradle
@@ -143,16 +143,20 @@ configurations.all {
 
 test {
 	useJUnitPlatform()
+	jacoco {
+		destinationFile = file("$buildDir/jacoco/test-${run.environment['DB_DRIVER']}.exec")
+	}
 }
 
 jacoco {
-	toolVersion = "0.8.6"
+	toolVersion = "0.8.7"
 }
 
 jacocoTestReport {
+	executionData.setFrom project.fileTree(dir: "$buildDir", include: "jacoco/test-*.exec")
 	reports {
 		xml.required = true
-		html.required = false
+		html.required = true
 	}
 }
 

--- a/client/src/components/PreviousPositions.js
+++ b/client/src/components/PreviousPositions.js
@@ -1,0 +1,50 @@
+import LinkTo from "components/LinkTo"
+import _isEmpty from "lodash/isEmpty"
+import moment from "moment"
+import PropTypes from "prop-types"
+import React from "react"
+import { Table } from "react-bootstrap"
+import Settings from "settings"
+
+function PreviousPositions({ history: previousPositions, action }) {
+  return _isEmpty(previousPositions) ? (
+    <em>No positions found</em>
+  ) : (
+    <Table id="previous-positions">
+      <thead>
+        <tr>
+          <th>Position</th>
+          <th>Dates</th>
+          {action && <th>Action</th>}
+        </tr>
+      </thead>
+      <tbody>
+        {previousPositions.map((pp, idx) => (
+          <tr key={idx} id={`previousPosition_${idx}`}>
+            <td>
+              <LinkTo modelType="Position" model={pp.position} />
+            </td>
+            <td>
+              {moment(pp.startTime).format(
+                Settings.dateFormats.forms.displayShort.date
+              )}{" "}
+              - &nbsp;
+              {pp.endTime &&
+                moment(pp.endTime).format(
+                  Settings.dateFormats.forms.displayShort.date
+                )}
+            </td>
+            {action && <td>{action(pp, idx)}</td>}
+          </tr>
+        ))}
+      </tbody>
+    </Table>
+  )
+}
+
+PreviousPositions.propTypes = {
+  history: PropTypes.array,
+  action: PropTypes.func
+}
+
+export default PreviousPositions

--- a/client/src/mergeUtils.js
+++ b/client/src/mergeUtils.js
@@ -6,15 +6,17 @@ import {
   DEFAULT_CUSTOM_FIELDS_PARENT,
   MODEL_TO_OBJECT_TYPE
 } from "components/Model"
+import RemoveButton from "components/RemoveButton"
 import _cloneDeep from "lodash/cloneDeep"
 import _escape from "lodash/escape"
 import _isEmpty from "lodash/isEmpty"
 import _set from "lodash/set"
 import { Location } from "models"
+import Person from "models/Person"
 import React, { useCallback, useReducer } from "react"
 import { Button } from "react-bootstrap"
 import { toast } from "react-toastify"
-import RemoveButton from "./components/RemoveButton"
+import Settings from "settings"
 
 export const MERGE_SIDES = {
   LEFT: "left",
@@ -181,7 +183,7 @@ const OBJECT_TYPE_TO_VALIDATOR = {
   [MODEL_TO_OBJECT_TYPE.AuthorizationGroup]: null,
   [MODEL_TO_OBJECT_TYPE.Location]: validForGeneral,
   [MODEL_TO_OBJECT_TYPE.Organization]: null,
-  [MODEL_TO_OBJECT_TYPE.Person]: () => true,
+  [MODEL_TO_OBJECT_TYPE.Person]: validForGeneral,
   [MODEL_TO_OBJECT_TYPE.Position]: validPositions,
   [MODEL_TO_OBJECT_TYPE.Report]: null,
   [MODEL_TO_OBJECT_TYPE.Task]: null
@@ -241,6 +243,37 @@ export function unassignedPerson(position1, position2, mergedPosition) {
     return true
   } else {
     return false
+  }
+}
+
+export function mergedPersonIsValid(mergedPerson) {
+  let msg
+  if (!mergedPerson.role) {
+    msg = "Merged person must have a role"
+  } else if (!mergedPerson.status) {
+    msg = "Merged person must have a status"
+  } else if (!mergedPerson.rank) {
+    msg = `Merged person must have a ${Settings.fields.person.rank}`
+  } else if (!mergedPerson.gender) {
+    msg = `Merged person must have a ${Settings.fields.person.gender}`
+  } else if (!mergedPerson.country) {
+    msg = `Merged person must have a ${Settings.fields.person.country}`
+  } else if (mergedPerson.role === Person.ROLE.ADVISOR) {
+    if (!mergedPerson.emailAddress) {
+      msg = `${
+        Settings.fields.person.emailAddress.label
+      } is required for ${Person.humanNameOfRole(Person.ROLE.ADVISOR)}`
+    } else if (!mergedPerson.endOfTourDate) {
+      msg = `${
+        Settings.fields.person.endOfTourDate
+      } is required for ${Person.humanNameOfRole(Person.ROLE.ADVISOR)}`
+    }
+  }
+  if (msg) {
+    toast(msg)
+    return false
+  } else {
+    return true
   }
 }
 

--- a/client/src/mergeUtils.js
+++ b/client/src/mergeUtils.js
@@ -181,7 +181,7 @@ const OBJECT_TYPE_TO_VALIDATOR = {
   [MODEL_TO_OBJECT_TYPE.AuthorizationGroup]: null,
   [MODEL_TO_OBJECT_TYPE.Location]: validForGeneral,
   [MODEL_TO_OBJECT_TYPE.Organization]: null,
-  [MODEL_TO_OBJECT_TYPE.Person]: null,
+  [MODEL_TO_OBJECT_TYPE.Person]: () => true,
   [MODEL_TO_OBJECT_TYPE.Position]: validPositions,
   [MODEL_TO_OBJECT_TYPE.Report]: null,
   [MODEL_TO_OBJECT_TYPE.Task]: null

--- a/client/src/mergeUtils.js
+++ b/client/src/mergeUtils.js
@@ -247,33 +247,53 @@ export function unassignedPerson(position1, position2, mergedPosition) {
 }
 
 export function mergedPersonIsValid(mergedPerson) {
-  let msg
+  const msg = []
   if (!mergedPerson.role) {
-    msg = "Merged person must have a role"
-  } else if (!mergedPerson.status) {
-    msg = "Merged person must have a status"
-  } else if (!mergedPerson.rank) {
-    msg = `Merged person must have a ${Settings.fields.person.rank}`
-  } else if (!mergedPerson.gender) {
-    msg = `Merged person must have a ${Settings.fields.person.gender}`
-  } else if (!mergedPerson.country) {
-    msg = `Merged person must have a ${Settings.fields.person.country}`
-  } else if (mergedPerson.role === Person.ROLE.ADVISOR) {
+    msg.push("Role")
+  }
+  if (!mergedPerson.status) {
+    msg.push("Status")
+  }
+  if (!mergedPerson.rank) {
+    msg.push(Settings.fields.person.rank)
+  }
+  if (!mergedPerson.gender) {
+    msg.push(Settings.fields.person.gender)
+  }
+  if (!mergedPerson.country) {
+    msg.push(Settings.fields.person.country)
+  }
+  if (mergedPerson.role === Person.ROLE.ADVISOR) {
     if (!mergedPerson.emailAddress) {
-      msg = `${
-        Settings.fields.person.emailAddress.label
-      } is required for ${Person.humanNameOfRole(Person.ROLE.ADVISOR)}`
-    } else if (!mergedPerson.endOfTourDate) {
-      msg = `${
-        Settings.fields.person.endOfTourDate
-      } is required for ${Person.humanNameOfRole(Person.ROLE.ADVISOR)}`
+      msg.push(
+        `${
+          Settings.fields.person.emailAddress.label
+        } for ${Person.humanNameOfRole(Person.ROLE.ADVISOR)} role`
+      )
+    }
+    if (!mergedPerson.endOfTourDate) {
+      msg.push(
+        `${Settings.fields.person.endOfTourDate} for ${Person.humanNameOfRole(
+          Person.ROLE.ADVISOR
+        )} role`
+      )
     }
   }
-  if (msg) {
-    toast(msg)
-    return false
-  } else {
+  if (_isEmpty(msg)) {
     return true
+  } else {
+    const msgContainer = (
+      <div>
+        <div>It is required to fill the following fields:</div>
+        <ul>
+          {msg.map((m, index) => (
+            <li key={index}>{m}</li>
+          ))}
+        </ul>
+      </div>
+    )
+    toast.warning(msgContainer)
+    return false
   }
 }
 

--- a/client/src/models/Person.js
+++ b/client/src/models/Person.js
@@ -177,10 +177,10 @@ export default class Person extends Model {
     name
     rank
     role
-    emailAddress
-    phoneNumber
     status
     pendingVerification
+    emailAddress
+    phoneNumber
     domainUsername
     biography
     country
@@ -196,6 +196,30 @@ export default class Person extends Model {
         uuid
         shortName
         identificationCode
+      }
+      associatedPositions {
+        uuid
+        name
+        type
+        person {
+          uuid
+          name
+          rank
+          role
+          avatar(size: 32)
+        }
+        organization {
+          uuid
+          shortName
+        }
+      }
+    }
+    previousPositions {
+      startTime
+      endTime
+      position {
+        uuid
+        name
       }
     }
     customFields

--- a/client/src/models/Person.js
+++ b/client/src/models/Person.js
@@ -220,6 +220,13 @@ export default class Person extends Model {
       position {
         uuid
         name
+        previousPeople {
+          startTime
+          endTime
+          person {
+            uuid
+          }
+        }
       }
     }
     customFields

--- a/client/src/models/Person.js
+++ b/client/src/models/Person.js
@@ -172,6 +172,36 @@ export default class Person extends Model {
   static autocompleteQuery =
     "uuid name rank role status endOfTourDate avatar(size: 32) position { uuid name type code status organization { uuid shortName identificationCode } location { uuid name } }"
 
+  static allFieldsQuery = `
+    uuid
+    name
+    rank
+    role
+    emailAddress
+    phoneNumber
+    status
+    pendingVerification
+    domainUsername
+    biography
+    country
+    gender
+    endOfTourDate
+    avatar(size: 256)
+    code
+    position {
+      uuid
+      name
+      type
+      organization {
+        uuid
+        shortName
+        identificationCode
+      }
+    }
+    customFields
+    ${GRAPHQL_NOTES_FIELDS}
+  `
+
   static autocompleteQueryWithNotes = `${this.autocompleteQuery} ${GRAPHQL_NOTES_FIELDS}`
 
   constructor(props) {

--- a/client/src/pages/admin/MergePeople.js
+++ b/client/src/pages/admin/MergePeople.js
@@ -152,7 +152,7 @@ const MergePeople = ({ pageDispatchers }) => {
             </div>
           )}
           {areAllSet(person1, person2, mergedPerson) && (
-            <>
+            <fieldset>
               <PersonField
                 label="Avatar"
                 value={
@@ -413,7 +413,7 @@ const MergePeople = ({ pageDispatchers }) => {
                     )
                   }
                 )}
-            </>
+            </fieldset>
           )}
         </Col>
         <Col md={4} id="right-merge-per-col">
@@ -525,7 +525,7 @@ const PersonColumn = ({ align, label, mergeState, dispatchMergeActions }) => {
         />
       </Form.Group>
       {areAllSet(person) && (
-        <>
+        <fieldset>
           <PersonField
             label="Avatar"
             fieldName="avatar"
@@ -860,7 +860,7 @@ const PersonColumn = ({ align, label, mergeState, dispatchMergeActions }) => {
                 )
               }
             )}
-        </>
+        </fieldset>
       )}
     </PersonCol>
   )

--- a/client/src/pages/admin/MergePeople.js
+++ b/client/src/pages/admin/MergePeople.js
@@ -49,9 +49,7 @@ import utils from "utils"
 
 const GQL_MERGE_PERSON = gql`
   mutation($loserUuid: String!, $winnerPerson: PersonInput!) {
-    mergePeople(loserUuid: $loserUuid, winnerPerson: $winnerPerson) {
-      uuid
-    }
+    mergePeople(loserUuid: $loserUuid, winnerPerson: $winnerPerson) 
   }
 `
 
@@ -446,8 +444,8 @@ const MergePeople = ({ pageDispatchers }) => {
       winnerPerson
     })
       .then(res => {
-        if (res.mergePeople) {
-          history.push(Person.pathFor({ uuid: res.mergePeople.uuid }), {
+        if (res) {
+          history.push(Person.pathFor({ uuid: mergedPerson.uuid }), {
             success: "People merged. Displaying merged Person below."
           })
         }

--- a/client/src/pages/admin/MergePeople.js
+++ b/client/src/pages/admin/MergePeople.js
@@ -7,6 +7,7 @@ import { PersonSimpleOverlayRow } from "components/advancedSelectWidget/Advanced
 import AdvancedSingleSelect from "components/advancedSelectWidget/AdvancedSingleSelect"
 import AvatarDisplayComponent from "components/AvatarDisplayComponent"
 import { customFieldsJSONString } from "components/CustomFields"
+import EditHistory from "components/EditHistory"
 import { parseHtmlWithLinkTo } from "components/editor/LinkAnet"
 import LinkTo from "components/LinkTo"
 import PersonField from "components/MergeField"
@@ -22,6 +23,7 @@ import {
   PageDispatchersPropType,
   useBoilerplate
 } from "components/Page"
+import PreviousPositions from "components/PreviousPositions"
 import useMergeObjects, {
   areAllSet,
   getActionButton,
@@ -210,6 +212,39 @@ const MergePeople = ({ pageDispatchers }) => {
                   dispatchMergeActions(setAMergedField("position", {}, null))
                 )}
                 fieldName="position"
+                mergeState={mergeState}
+                dispatchMergeActions={dispatchMergeActions}
+              />
+              <PersonField
+                label="Previous Positions"
+                value={
+                  <>
+                    <PreviousPositions
+                      history={mergedPerson.previousPositions}
+                    />
+                    <EditHistory
+                      history1={person1.previousPositions}
+                      history2={person2.previousPositions}
+                      initialHistory={mergedPerson.previousPositions}
+                      historyComp={PreviousPositions}
+                      currentlyOccupyingEntity={mergedPerson.position}
+                      historyEntityType="position"
+                      title="Pick and Choose positions and dates for Positions History"
+                      setHistory={history =>
+                        dispatchMergeActions(
+                          setAMergedField("previousPositions", history, null)
+                        )
+                      }
+                    />
+                  </>
+                }
+                align="column"
+                action={getClearButton(() =>
+                  dispatchMergeActions(
+                    setAMergedField("previousPositions", [], null)
+                  )
+                )}
+                fieldName="previousPositions"
                 mergeState={mergeState}
                 dispatchMergeActions={dispatchMergeActions}
               />
@@ -592,6 +627,28 @@ const PersonColumn = ({ align, label, mergeState, dispatchMergeActions }) => {
               align,
               mergeState,
               "position"
+            )}
+            mergeState={mergeState}
+            dispatchMergeActions={dispatchMergeActions}
+          />
+          <PersonField
+            label="Previous Positions"
+            fieldName="previousPositions"
+            value={<PreviousPositions history={person.previousPositions} />}
+            align={align}
+            action={getActionButton(
+              () => {
+                dispatchMergeActions(
+                  setAMergedField(
+                    "previousPositions",
+                    person.previousPositions,
+                    align
+                  )
+                )
+              },
+              align,
+              mergeState,
+              "previousPositions"
             )}
             mergeState={mergeState}
             dispatchMergeActions={dispatchMergeActions}

--- a/client/src/pages/admin/MergePeople.js
+++ b/client/src/pages/admin/MergePeople.js
@@ -25,6 +25,7 @@ import {
 } from "components/Page"
 import PreviousPositions from "components/PreviousPositions"
 import useMergeObjects, {
+  ALIGN_OPTIONS,
   areAllSet,
   getActionButton,
   getActivationButton,
@@ -32,6 +33,7 @@ import useMergeObjects, {
   getInfoButton,
   getOtherSide,
   mergedPersonIsValid,
+  MERGE_SIDES,
   selectAllFields,
   setAMergedField,
   setMergeable
@@ -49,7 +51,7 @@ import utils from "utils"
 
 const GQL_MERGE_PERSON = gql`
   mutation($loserUuid: String!, $winnerPerson: PersonInput!) {
-    mergePeople(loserUuid: $loserUuid, winnerPerson: $winnerPerson) 
+    mergePeople(loserUuid: $loserUuid, winnerPerson: $winnerPerson)
   }
 `
 
@@ -57,7 +59,7 @@ const MergePeople = ({ pageDispatchers }) => {
   const history = useHistory()
   const [saveError, setSaveError] = useState(null)
   const [showHistoryModal, setShowHistoryModal] = useState(false)
-  const [mergeState, dispatchMergeActions, mergeSides] = useMergeObjects(
+  const [mergeState, dispatchMergeActions] = useMergeObjects(
     MODEL_TO_OBJECT_TYPE.Person
   )
 
@@ -67,8 +69,8 @@ const MergePeople = ({ pageDispatchers }) => {
     pageDispatchers
   })
 
-  const person1 = mergeState[mergeSides[0]]
-  const person2 = mergeState[mergeSides[1]]
+  const person1 = mergeState[MERGE_SIDES.LEFT]
+  const person2 = mergeState[MERGE_SIDES.RIGHT]
   const mergedPerson = mergeState.merged
 
   return (
@@ -82,7 +84,7 @@ const MergePeople = ({ pageDispatchers }) => {
           <PersonColumn
             mergeState={mergeState}
             dispatchMergeActions={dispatchMergeActions}
-            align={mergeSides[0]}
+            align={ALIGN_OPTIONS.LEFT}
             label="Person 1"
           />
         </Col>
@@ -90,8 +92,10 @@ const MergePeople = ({ pageDispatchers }) => {
           <MidColTitle>
             {getActionButton(
               () =>
-                dispatchMergeActions(selectAllFields(person1, mergeSides[0])),
-              mergeSides[0],
+                dispatchMergeActions(
+                  selectAllFields(person1, MERGE_SIDES.LEFT)
+                ),
+              MERGE_SIDES.LEFT,
               mergeState,
               null,
               !areAllSet(person1, person2),
@@ -100,8 +104,10 @@ const MergePeople = ({ pageDispatchers }) => {
             <h4 style={{ margin: "0" }}>Merged Person</h4>
             {getActionButton(
               () =>
-                dispatchMergeActions(selectAllFields(person2, mergeSides[1])),
-              mergeSides[1],
+                dispatchMergeActions(
+                  selectAllFields(person2, MERGE_SIDES.RIGHT)
+                ),
+              MERGE_SIDES.RIGHT,
               mergeState,
               null,
               !areAllSet(person1, person2),
@@ -161,7 +167,7 @@ const MergePeople = ({ pageDispatchers }) => {
                     }}
                   />
                 }
-                align="center"
+                align={ALIGN_OPTIONS.CENTER}
                 action={getClearButton(() =>
                   dispatchMergeActions(setAMergedField("avatar", null, null))
                 )}
@@ -172,7 +178,7 @@ const MergePeople = ({ pageDispatchers }) => {
               <PersonField
                 label="Name"
                 value={mergedPerson.name}
-                align="center"
+                align={ALIGN_OPTIONS.CENTER}
                 action={getInfoButton("Name is required.")}
                 fieldName="name"
                 mergeState={mergeState}
@@ -181,7 +187,7 @@ const MergePeople = ({ pageDispatchers }) => {
               <PersonField
                 label="Domain username"
                 value={mergedPerson.domainUsername}
-                align="center"
+                align={ALIGN_OPTIONS.CENTER}
                 action={getClearButton(() =>
                   dispatchMergeActions(
                     setAMergedField("domainUsername", "", null)
@@ -194,7 +200,7 @@ const MergePeople = ({ pageDispatchers }) => {
               <PersonField
                 label="Role"
                 value={mergedPerson.role}
-                align="center"
+                align={ALIGN_OPTIONS.CENTER}
                 action={getInfoButton("Role is required.")}
                 fieldName="role"
                 mergeState={mergeState}
@@ -205,7 +211,7 @@ const MergePeople = ({ pageDispatchers }) => {
                 value={
                   <LinkTo modelType="Position" model={mergedPerson.position} />
                 }
-                align="center"
+                align={ALIGN_OPTIONS.CENTER}
                 action={getClearButton(() =>
                   dispatchMergeActions(setAMergedField("position", {}, null))
                 )}
@@ -242,7 +248,7 @@ const MergePeople = ({ pageDispatchers }) => {
                     />
                   </>
                 }
-                align="column"
+                align={ALIGN_OPTIONS.CENTER}
                 action={getClearButton(() =>
                   dispatchMergeActions(
                     setAMergedField("previousPositions", [], null)
@@ -255,7 +261,7 @@ const MergePeople = ({ pageDispatchers }) => {
               <PersonField
                 label="Status"
                 value={mergedPerson.status}
-                align="center"
+                align={ALIGN_OPTIONS.CENTER}
                 action={getActivationButton(
                   mergedPerson.status === Person.STATUS.ACTIVE,
                   () =>
@@ -277,7 +283,7 @@ const MergePeople = ({ pageDispatchers }) => {
               <PersonField
                 label={Settings.fields.person.emailAddress.label}
                 value={mergedPerson.emailAddress}
-                align="center"
+                align={ALIGN_OPTIONS.CENTER}
                 action={
                   mergedPerson.role === Person.ROLE.ADVISOR
                     ? getInfoButton(
@@ -296,7 +302,7 @@ const MergePeople = ({ pageDispatchers }) => {
               <PersonField
                 label={Settings.fields.person.phoneNumber}
                 value={mergedPerson.phoneNumber}
-                align="center"
+                align={ALIGN_OPTIONS.CENTER}
                 action={getClearButton(() =>
                   dispatchMergeActions(setAMergedField("phoneNumber", "", null))
                 )}
@@ -307,7 +313,7 @@ const MergePeople = ({ pageDispatchers }) => {
               <PersonField
                 label={Settings.fields.person.rank}
                 value={mergedPerson.rank}
-                align="center"
+                align={ALIGN_OPTIONS.CENTER}
                 action={getInfoButton(
                   `${Settings.fields.person.rank} is required.`
                 )}
@@ -318,7 +324,7 @@ const MergePeople = ({ pageDispatchers }) => {
               <PersonField
                 label={Settings.fields.person.gender}
                 value={mergedPerson.gender}
-                align="center"
+                align={ALIGN_OPTIONS.CENTER}
                 action={getInfoButton(
                   `${Settings.fields.person.gender} is required.`
                 )}
@@ -329,7 +335,7 @@ const MergePeople = ({ pageDispatchers }) => {
               <PersonField
                 label={Settings.fields.person.country}
                 value={mergedPerson.country}
-                align="center"
+                align={ALIGN_OPTIONS.CENTER}
                 action={getInfoButton(
                   `${Settings.fields.person.country} is required.`
                 )}
@@ -340,7 +346,7 @@ const MergePeople = ({ pageDispatchers }) => {
               <PersonField
                 label={Settings.fields.person.code}
                 value={mergedPerson.code}
-                align="center"
+                align={ALIGN_OPTIONS.CENTER}
                 action={getClearButton(() =>
                   dispatchMergeActions(setAMergedField("code", "", null))
                 )}
@@ -353,7 +359,7 @@ const MergePeople = ({ pageDispatchers }) => {
                 value={moment(mergedPerson.endOfTourDate).format(
                   Settings.dateFormats.forms.displayShort.date
                 )}
-                align="center"
+                align={ALIGN_OPTIONS.CENTER}
                 action={
                   mergedPerson.role === Person.ROLE.ADVISOR
                     ? getInfoButton(
@@ -372,7 +378,7 @@ const MergePeople = ({ pageDispatchers }) => {
               <PersonField
                 label="Biography"
                 value={parseHtmlWithLinkTo(mergedPerson.biography)}
-                align="center"
+                align={ALIGN_OPTIONS.CENTER}
                 action={getClearButton(() =>
                   dispatchMergeActions(setAMergedField("biography", "", null))
                 )}
@@ -390,7 +396,7 @@ const MergePeople = ({ pageDispatchers }) => {
                         key={fieldName}
                         label={fieldConfig.label || fieldName}
                         value={JSON.stringify(fieldValue)}
-                        align="center"
+                        align={ALIGN_OPTIONS.CENTER}
                         action={getClearButton(() =>
                           dispatchMergeActions(
                             setAMergedField(
@@ -414,7 +420,7 @@ const MergePeople = ({ pageDispatchers }) => {
           <PersonColumn
             mergeState={mergeState}
             dispatchMergeActions={dispatchMergeActions}
-            align={mergeSides[1]}
+            align={ALIGN_OPTIONS.RIGHT}
             label="Person 2"
           />
         </Col>

--- a/client/src/pages/admin/MergePeople.js
+++ b/client/src/pages/admin/MergePeople.js
@@ -58,7 +58,7 @@ const GQL_MERGE_PERSON = gql`
 const MergePeople = ({ pageDispatchers }) => {
   const history = useHistory()
   const [saveError, setSaveError] = useState(null)
-
+  const [showHistoryModal, setShowHistoryModal] = useState(false)
   const [mergeState, dispatchMergeActions, mergeSides] = useMergeObjects(
     MODEL_TO_OBJECT_TYPE.Person
   )
@@ -227,9 +227,15 @@ const MergePeople = ({ pageDispatchers }) => {
                       history2={person2.previousPositions}
                       initialHistory={mergedPerson.previousPositions}
                       historyComp={PreviousPositions}
+                      showModal={showHistoryModal}
+                      setShowModal={setShowHistoryModal}
                       currentlyOccupyingEntity={mergedPerson.position}
+                      parentEntityUuid1={person1.uuid}
+                      parentEntityUuid2={person2.uuid}
                       historyEntityType="position"
-                      title="Pick and Choose positions and dates for Positions History"
+                      parentEntityType="person"
+                      midColTitle="Merged Person History"
+                      mainTitle="Pick and Choose positions and dates for Positions History"
                       setHistory={history =>
                         dispatchMergeActions(
                           setAMergedField("previousPositions", history, null)
@@ -434,7 +440,7 @@ const MergePeople = ({ pageDispatchers }) => {
     }
     const loser = mergedPerson.uuid === person1.uuid ? person2 : person1
     mergedPerson.customFields = customFieldsJSONString(mergedPerson)
-    const winnerPerson = Person.filterClientSideFilters(mergedPerson)
+    const winnerPerson = Person.filterClientSideFields(mergedPerson)
     API.mutation(GQL_MERGE_PERSON, {
       loserUuid: loser.uuid,
       winnerPerson

--- a/client/src/pages/people/Show.js
+++ b/client/src/pages/people/Show.js
@@ -231,6 +231,7 @@ const PersonShow = ({ pageDispatchers }) => {
   const numberOfFieldsUnderAvatar = person.getNumberOfFieldsInLeftColumn() || 6
   const leftColumUnderAvatar = orderedFields.slice(0, numberOfFieldsUnderAvatar)
   const rightColum = orderedFields.slice(numberOfFieldsUnderAvatar)
+
   return (
     <Formik enableReinitialize initialValues={person}>
       {() => {

--- a/client/src/pages/people/Show.js
+++ b/client/src/pages/people/Show.js
@@ -28,6 +28,7 @@ import {
   SubscriptionIcon,
   useBoilerplate
 } from "components/Page"
+import PreviousPositions from "components/PreviousPositions"
 import RelatedObjectNotes, {
   GRAPHQL_NOTES_FIELDS
 } from "components/RelatedObjectNotes"
@@ -592,37 +593,7 @@ const PersonShow = ({ pageDispatchers }) => {
   }
 
   function getPrevPositionsHumanValue() {
-    return _isEmpty(person.previousPositions) ? (
-      <em>No positions found</em>
-    ) : (
-      <Table id="previous-positions">
-        <thead>
-          <tr>
-            <th>Position</th>
-            <th>Dates</th>
-          </tr>
-        </thead>
-        <tbody>
-          {person.previousPositions.map((pp, idx) => (
-            <tr key={idx} id={`previousPosition_${idx}`}>
-              <td>
-                <LinkTo modelType="Position" model={pp.position} />
-              </td>
-              <td>
-                {moment(pp.startTime).format(
-                  Settings.dateFormats.forms.displayShort.date
-                )}{" "}
-                - &nbsp;
-                {pp.endTime &&
-                  moment(pp.endTime).format(
-                    Settings.dateFormats.forms.displayShort.date
-                  )}
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </Table>
-    )
+    return <PreviousPositions history={person.previousPositions} />
   }
 
   function renderCounterparts(position) {

--- a/client/tests/webdriver/baseSpecs/mergePeople.spec.js
+++ b/client/tests/webdriver/baseSpecs/mergePeople.spec.js
@@ -1,0 +1,391 @@
+import { expect } from "chai"
+import moment from "moment"
+import MergePeople from "../pages/mergePeople.page"
+
+const EXAMPLE_PEOPLE = {
+  validLeft: {
+    search: "winner",
+    fullName: "CIV MERGED, Duplicate Winner",
+    name: "MERGED, Duplicate Winner",
+    role: "PRINCIPAL",
+    position: "Chief of Merge People Test 1",
+    status: "ACTIVE",
+    email: "merged+winner@example.com",
+    phone: "+1-234-5678",
+    rank: "CIV",
+    gender: "MALE",
+    nationality: "Afghanistan",
+    previousPositions: [
+      {
+        name: "Chief of Merge People Test 1",
+        date: `${moment().format("D MMMM YYYY")} -  `
+      }
+    ],
+    biography: "Winner is a test person who will be merged",
+    notes: ["Merge one person note", "A really nice person to work with"],
+    perUuid: "3cb2076c-5317-47fe-86ad-76f298993917",
+    posUuid: "885dd6bf-4647-4ef7-9bc4-4dd2826064bb"
+  },
+  validRight: {
+    search: "loser",
+    fullName: "CTR MERGED, Duplicate Loser",
+    name: "MERGED, Duplicate Loser",
+    role: "PRINCIPAL",
+    position: "Chief of Merge People Test 2",
+    status: "ACTIVE",
+    email: "merged+loser@example.com",
+    phone: "+1-876-5432",
+    rank: "CTR",
+    gender: "FEMALE",
+    nationality: "Afghanistan",
+    previousPositions: [
+      {
+        name: "Chief of Merge People Test 2",
+        date: `${moment().format("D MMMM YYYY")} -  `
+      }
+    ],
+    biography: "Loser is a test person who will be merged",
+    notes: ["Merge two person note"],
+    perUuid: "c725aef3-cdd1-4baf-ac72-f28219b234e9",
+    posUuid: "4dc40a27-19ae-4e03-a4f3-55b2c768725f"
+  }
+}
+
+describe("Merge people page", () => {
+  it("Should display fields values of the left person", () => {
+    // Open merge people page.
+    MergePeople.open()
+    MergePeople.title.waitForExist()
+    MergePeople.title.waitForDisplayed()
+
+    // Search and select a person from left person field.
+    MergePeople.leftPersonField.setValue(EXAMPLE_PEOPLE.validLeft.search)
+    MergePeople.waitForAdvancedSelectLoading(EXAMPLE_PEOPLE.validLeft.fullName)
+    MergePeople.firstItemFromAdvancedSelect.click()
+    browser.pause(500) // wait for the rendering of custom fields
+    // Check if the fields displayed properly after selecting a person from left side.
+    MergePeople.waitForColumnToChange(
+      EXAMPLE_PEOPLE.validLeft.name,
+      "left",
+      "Name"
+    )
+
+    expect(MergePeople.getColumnContent("left", "Name").getText()).to.eq(
+      EXAMPLE_PEOPLE.validLeft.name
+    )
+    expect(MergePeople.getColumnContent("left", "Role").getText()).to.eq(
+      EXAMPLE_PEOPLE.validLeft.role
+    )
+    expect(MergePeople.getColumnContent("left", "Position").getText()).to.eq(
+      EXAMPLE_PEOPLE.validLeft.position
+    )
+    expect(MergePeople.getPreviousPositions("left")).to.eql(
+      EXAMPLE_PEOPLE.validLeft.previousPositions
+    )
+    expect(MergePeople.getColumnContent("left", "Status").getText()).to.eq(
+      EXAMPLE_PEOPLE.validLeft.status
+    )
+    expect(MergePeople.getColumnContent("left", "Email").getText()).to.eq(
+      EXAMPLE_PEOPLE.validLeft.email
+    )
+    expect(MergePeople.getColumnContent("left", "Phone").getText()).to.eq(
+      EXAMPLE_PEOPLE.validLeft.phone
+    )
+    expect(MergePeople.getColumnContent("left", "Rank").getText()).to.eq(
+      EXAMPLE_PEOPLE.validLeft.rank
+    )
+    expect(MergePeople.getColumnContent("left", "Gender").getText()).to.eq(
+      EXAMPLE_PEOPLE.validLeft.gender
+    )
+    expect(MergePeople.getColumnContent("left", "Nationality").getText()).to.eq(
+      EXAMPLE_PEOPLE.validLeft.nationality
+    )
+    expect(MergePeople.getColumnContent("left", "Biography").getText()).to.eq(
+      EXAMPLE_PEOPLE.validLeft.biography
+    )
+  })
+  it("Should not allow to select the same people", () => {
+    MergePeople.rightPersonField.setValue(EXAMPLE_PEOPLE.validLeft.search)
+    MergePeople.waitForAdvancedSelectLoading(EXAMPLE_PEOPLE.validLeft.fullName)
+    MergePeople.firstItemFromAdvancedSelect.click()
+
+    MergePeople.samePositionsToast.waitForDisplayed()
+  })
+  it("Should display fields values of the right person", () => {
+    // Search and select a person from right person field.
+    MergePeople.rightPersonField.setValue(EXAMPLE_PEOPLE.validRight.search)
+    MergePeople.waitForAdvancedSelectLoading(EXAMPLE_PEOPLE.validRight.fullName)
+    MergePeople.firstItemFromAdvancedSelect.click()
+    browser.pause(500) // wait for the rendering of custom fields
+    // Check if the fields displayed properly after selecting a person from left side.
+    MergePeople.waitForColumnToChange(
+      EXAMPLE_PEOPLE.validRight.name,
+      "right",
+      "Name"
+    )
+
+    expect(MergePeople.getColumnContent("right", "Name").getText()).to.eq(
+      EXAMPLE_PEOPLE.validRight.name
+    )
+    expect(MergePeople.getColumnContent("right", "Role").getText()).to.eq(
+      EXAMPLE_PEOPLE.validRight.role
+    )
+    expect(MergePeople.getColumnContent("right", "Position").getText()).to.eq(
+      EXAMPLE_PEOPLE.validRight.position
+    )
+    expect(MergePeople.getPreviousPositions("right")).to.eql(
+      EXAMPLE_PEOPLE.validRight.previousPositions
+    )
+    expect(MergePeople.getColumnContent("right", "Status").getText()).to.eq(
+      EXAMPLE_PEOPLE.validRight.status
+    )
+    expect(MergePeople.getColumnContent("right", "Email").getText()).to.eq(
+      EXAMPLE_PEOPLE.validRight.email
+    )
+    expect(MergePeople.getColumnContent("right", "Phone").getText()).to.eq(
+      EXAMPLE_PEOPLE.validRight.phone
+    )
+    expect(MergePeople.getColumnContent("right", "Rank").getText()).to.eq(
+      EXAMPLE_PEOPLE.validRight.rank
+    )
+    expect(MergePeople.getColumnContent("right", "Gender").getText()).to.eq(
+      EXAMPLE_PEOPLE.validRight.gender
+    )
+    expect(
+      MergePeople.getColumnContent("right", "Nationality").getText()
+    ).to.eq(EXAMPLE_PEOPLE.validRight.nationality)
+    expect(MergePeople.getColumnContent("left", "Biography").getText()).to.eq(
+      EXAMPLE_PEOPLE.validLeft.biography
+    )
+  })
+  it("Should be able to select all fields from left person", () => {
+    MergePeople.getUseAllButton("left").click()
+    browser.pause(500) // wait for the rendering of custom fields
+    MergePeople.waitForColumnToChange(
+      EXAMPLE_PEOPLE.validLeft.name,
+      "mid",
+      "Name"
+    )
+
+    expect(MergePeople.getColumnContent("mid", "Name").getText()).to.eq(
+      EXAMPLE_PEOPLE.validLeft.name
+    )
+    expect(MergePeople.getColumnContent("mid", "Role").getText()).to.eq(
+      EXAMPLE_PEOPLE.validLeft.role
+    )
+    expect(MergePeople.getColumnContent("mid", "Position").getText()).to.eq(
+      EXAMPLE_PEOPLE.validLeft.position
+    )
+    expect(MergePeople.getPreviousPositions("mid")).to.eql(
+      EXAMPLE_PEOPLE.validLeft.previousPositions
+    )
+    expect(MergePeople.getColumnContent("mid", "Status").getText()).to.eq(
+      EXAMPLE_PEOPLE.validLeft.status
+    )
+    expect(MergePeople.getColumnContent("mid", "Email").getText()).to.eq(
+      EXAMPLE_PEOPLE.validLeft.email
+    )
+    expect(MergePeople.getColumnContent("mid", "Phone").getText()).to.eq(
+      EXAMPLE_PEOPLE.validLeft.phone
+    )
+    expect(MergePeople.getColumnContent("mid", "Rank").getText()).to.eq(
+      EXAMPLE_PEOPLE.validLeft.rank
+    )
+    expect(MergePeople.getColumnContent("mid", "Gender").getText()).to.eq(
+      EXAMPLE_PEOPLE.validLeft.gender
+    )
+    expect(MergePeople.getColumnContent("mid", "Nationality").getText()).to.eq(
+      EXAMPLE_PEOPLE.validLeft.nationality
+    )
+    expect(MergePeople.getColumnContent("mid", "Biography").getText()).to.eq(
+      EXAMPLE_PEOPLE.validLeft.biography
+    )
+  })
+  it("Should be able to select all fields from right person", () => {
+    MergePeople.getUseAllButton("right").click()
+    browser.pause(500) // wait for the rendering of custom fields
+    MergePeople.waitForColumnToChange(
+      EXAMPLE_PEOPLE.validRight.name,
+      "mid",
+      "Name"
+    )
+
+    expect(MergePeople.getColumnContent("mid", "Name").getText()).to.eq(
+      EXAMPLE_PEOPLE.validRight.name
+    )
+    expect(MergePeople.getColumnContent("mid", "Role").getText()).to.eq(
+      EXAMPLE_PEOPLE.validRight.role
+    )
+    expect(MergePeople.getColumnContent("mid", "Position").getText()).to.eq(
+      EXAMPLE_PEOPLE.validRight.position
+    )
+    expect(MergePeople.getPreviousPositions("mid")).to.eql(
+      EXAMPLE_PEOPLE.validRight.previousPositions
+    )
+    expect(MergePeople.getColumnContent("mid", "Status").getText()).to.eq(
+      EXAMPLE_PEOPLE.validRight.status
+    )
+    expect(MergePeople.getColumnContent("mid", "Email").getText()).to.eq(
+      EXAMPLE_PEOPLE.validRight.email
+    )
+    expect(MergePeople.getColumnContent("mid", "Phone").getText()).to.eq(
+      EXAMPLE_PEOPLE.validRight.phone
+    )
+    expect(MergePeople.getColumnContent("mid", "Rank").getText()).to.eq(
+      EXAMPLE_PEOPLE.validRight.rank
+    )
+    expect(MergePeople.getColumnContent("mid", "Gender").getText()).to.eq(
+      EXAMPLE_PEOPLE.validRight.gender
+    )
+    expect(MergePeople.getColumnContent("mid", "Nationality").getText()).to.eq(
+      EXAMPLE_PEOPLE.validRight.nationality
+    )
+    expect(MergePeople.getColumnContent("mid", "Biography").getText()).to.eq(
+      EXAMPLE_PEOPLE.validRight.biography
+    )
+  })
+  it("Should be able to select from both left and right side.", () => {
+    MergePeople.getSelectButton("left", "Name").click()
+    MergePeople.waitForColumnToChange(
+      EXAMPLE_PEOPLE.validLeft.name,
+      "mid",
+      "Name"
+    )
+    expect(MergePeople.getColumnContent("mid", "Name").getText()).to.eq(
+      EXAMPLE_PEOPLE.validLeft.name
+    )
+
+    MergePeople.getSelectButton("left", "Role").click()
+    MergePeople.waitForColumnToChange(
+      EXAMPLE_PEOPLE.validLeft.role,
+      "mid",
+      "Role"
+    )
+    expect(MergePeople.getColumnContent("mid", "Role").getText()).to.equal(
+      EXAMPLE_PEOPLE.validLeft.role
+    )
+
+    MergePeople.getSelectButton("left", "Position").click()
+    MergePeople.waitForColumnToChange(
+      EXAMPLE_PEOPLE.validLeft.position,
+      "mid",
+      "Position"
+    )
+    expect(MergePeople.getColumnContent("mid", "Position").getText()).to.equal(
+      EXAMPLE_PEOPLE.validLeft.position
+    )
+
+    MergePeople.getSelectButton("left", "Status").click()
+    MergePeople.waitForColumnToChange(
+      EXAMPLE_PEOPLE.validLeft.status,
+      "mid",
+      "Status"
+    )
+    expect(MergePeople.getColumnContent("mid", "Status").getText()).to.equal(
+      EXAMPLE_PEOPLE.validLeft.status
+    )
+
+    MergePeople.getSelectButton("left", "Email").click()
+    MergePeople.waitForColumnToChange(
+      EXAMPLE_PEOPLE.validLeft.email,
+      "mid",
+      "Email"
+    )
+    expect(MergePeople.getColumnContent("mid", "Email").getText()).to.equal(
+      EXAMPLE_PEOPLE.validLeft.email
+    )
+
+    MergePeople.getSelectButton("left", "Phone").click()
+    MergePeople.waitForColumnToChange(
+      EXAMPLE_PEOPLE.validLeft.phone,
+      "mid",
+      "Phone"
+    )
+    expect(MergePeople.getColumnContent("mid", "Phone").getText()).to.equal(
+      EXAMPLE_PEOPLE.validLeft.phone
+    )
+
+    MergePeople.getSelectButton("left", "Email").click()
+    MergePeople.waitForColumnToChange(
+      EXAMPLE_PEOPLE.validLeft.email,
+      "mid",
+      "Email"
+    )
+    expect(MergePeople.getColumnContent("mid", "Email").getText()).to.equal(
+      EXAMPLE_PEOPLE.validLeft.email
+    )
+
+    MergePeople.getSelectButton("left", "Rank").click()
+    MergePeople.waitForColumnToChange(
+      EXAMPLE_PEOPLE.validLeft.rank,
+      "mid",
+      "Rank"
+    )
+    expect(MergePeople.getColumnContent("mid", "Rank").getText()).to.equal(
+      EXAMPLE_PEOPLE.validLeft.rank
+    )
+
+    MergePeople.getSelectButton("left", "Gender").click()
+    MergePeople.waitForColumnToChange(
+      EXAMPLE_PEOPLE.validLeft.gender,
+      "mid",
+      "Gender"
+    )
+    expect(MergePeople.getColumnContent("mid", "Gender").getText()).to.equal(
+      EXAMPLE_PEOPLE.validLeft.gender
+    )
+
+    MergePeople.getSelectButton("left", "Nationality").click()
+    MergePeople.waitForColumnToChange(
+      EXAMPLE_PEOPLE.validLeft.nationality,
+      "mid",
+      "Nationality"
+    )
+    expect(
+      MergePeople.getColumnContent("mid", "Nationality").getText()
+    ).to.equal(EXAMPLE_PEOPLE.validLeft.nationality)
+
+    MergePeople.getSelectButton("left", "Biography").click()
+    MergePeople.waitForColumnToChange(
+      EXAMPLE_PEOPLE.validLeft.biography,
+      "mid",
+      "Biography"
+    )
+    expect(MergePeople.getColumnContent("mid", "Biography").getText()).to.equal(
+      EXAMPLE_PEOPLE.validLeft.biography
+    )
+
+    MergePeople.getSelectButton("left", "Previous Positions").click()
+    expect(MergePeople.getPreviousPositions("mid")).to.eql(
+      EXAMPLE_PEOPLE.validLeft.previousPositions
+    )
+  })
+  it("Should be able to merge both people when winner is left person", () => {
+    MergePeople.mergePeopleButton.click()
+    MergePeople.waitForSuccessAlert()
+  })
+  it("Should merge notes of the both people", () => {
+    MergePeople.showNotesButton.click()
+    // Wait for offcanvas to open
+    browser.pause(100)
+    expect(
+      MergePeople.areNotesExist([
+        ...EXAMPLE_PEOPLE.validLeft.notes,
+        ...EXAMPLE_PEOPLE.validRight.notes
+      ])
+    ).to.eq(true)
+  })
+  it("Should be able to delete the loser person", () => {
+    MergePeople.openPage(`/people/${EXAMPLE_PEOPLE.validRight.perUuid}`)
+    MergePeople.errorTitle.waitForExist()
+    expect(MergePeople.errorTitle.getText()).to.equal(
+      `User #${EXAMPLE_PEOPLE.validRight.perUuid} not found.`
+    )
+  })
+  it("Should remove the loser from its position and position history", () => {
+    MergePeople.openPage(`/positions/${EXAMPLE_PEOPLE.validRight.posUuid}`)
+    expect(MergePeople.unoccupiedPositionPersonMessage.getText()).to.equal(
+      "Chief of Merge People Test 2 is currently empty."
+    )
+  })
+})

--- a/client/tests/webdriver/pages/mergePeople.page.js
+++ b/client/tests/webdriver/pages/mergePeople.page.js
@@ -1,0 +1,154 @@
+import Page from "./page"
+
+const PATH = "/admin/mergePeople"
+
+class MergePeople extends Page {
+  open() {
+    super.openAsAdminUser(PATH)
+  }
+
+  openPage(path) {
+    super.openAsAdminUser(path)
+  }
+
+  get errorTitle() {
+    return browser.$("//h1")
+  }
+
+  get title() {
+    return browser.$('//h4[contains(text(),"Merge People")]')
+  }
+
+  get leftPersonField() {
+    return browser.$("#Person1")
+  }
+
+  get rightPersonField() {
+    return browser.$("#Person2")
+  }
+
+  get advancedSelectPopover() {
+    return browser.$(".bp3-popover2-content")
+  }
+
+  get personHeaderFromPopover() {
+    return browser.$('//table//th[contains(text(), "name")]')
+  }
+
+  get firstItemFromAdvancedSelect() {
+    return browser.$("table > tbody > tr:first-child > td:nth-child(2) > span")
+  }
+
+  get samePositionsToast() {
+    return browser.$('//div[text()="Please select different people"]')
+  }
+
+  get mergePeopleButton() {
+    return browser.$('//button[text()="Merge People"]')
+  }
+
+  get showNotesButton() {
+    return browser.$('button[title="Show notes"]')
+  }
+
+  get unoccupiedPositionPersonMessage() {
+    return browser.$("p.position-empty-message")
+  }
+
+  get noteCards() {
+    return browser.$$(".offcanvas .card")
+  }
+
+  getUseAllButton(side) {
+    const button = side === "left" ? "small:first-child" : "small:last-child"
+    return browser.$(`#mid-merge-per-col ${button} > button`)
+  }
+
+  getSelectButton(side, text) {
+    const buttonDiv = browser.$(
+      `//div[@id="${side}-merge-per-col"]//div[text()="${text}"]`
+    )
+    const button = buttonDiv.$("..").$("..")
+    return button.$("small > button")
+  }
+
+  getColumnContent(side, text) {
+    return browser.$(
+      `//div[@id="${side}-merge-per-col"]//div[text()="${text}"]/following-sibling::div`
+    )
+  }
+
+  getPreviousPositions(side) {
+    const previousPositionsElements = browser.$$(
+      `//div[@id="${side}-merge-per-col"]//div[text()="Previous Positions"]/following-sibling::div//table//tbody//tr`
+    )
+    const previousPositions = previousPositionsElements.map(elem => {
+      return {
+        name: elem.$$("td")[0].getText(),
+        date: elem.$$("td")[1].getText()
+      }
+    })
+    return previousPositions
+  }
+
+  waitForAdvancedSelectLoading(compareStr) {
+    this.advancedSelectPopover.waitForExist()
+    this.advancedSelectPopover.waitForDisplayed()
+    this.personHeaderFromPopover.waitForExist()
+    this.personHeaderFromPopover.waitForDisplayed()
+
+    browser.waitUntil(
+      () => {
+        return this.firstItemFromAdvancedSelect.getText() === compareStr
+      },
+      {
+        timeout: 5000,
+        timeoutMsg: "Couldn't find the searched person in time"
+      }
+    )
+  }
+
+  waitForColumnToChange(compareStr, side, text) {
+    const field = this.getColumnContent(side, text)
+
+    browser.waitUntil(
+      () => {
+        return field.getText() === compareStr
+      },
+      {
+        timeout: 5000,
+        timeoutMsg: "Couldn't set the person in time"
+      }
+    )
+  }
+
+  waitForSuccessAlert() {
+    browser.waitUntil(
+      () => {
+        return (
+          browser.$(".alert-success").getText() ===
+          "People merged. Displaying merged Person below."
+        )
+      },
+      {
+        timeout: 5000,
+        timeoutMsg: "Couldn't see the success alert in time"
+      }
+    )
+  }
+
+  areNotesExist(notes) {
+    let areExist = true
+    const allNoteTexts = this.noteCards.map(card =>
+      card.$$(".card-body > div")[1].getText()
+    )
+    notes.forEach(note => {
+      if (!allNoteTexts.includes(note)) {
+        areExist = false
+      }
+    })
+    return areExist
+  }
+}
+
+export default new MergePeople()

--- a/insertBaseData-mssql.sql
+++ b/insertBaseData-mssql.sql
@@ -96,6 +96,10 @@ INSERT INTO people (uuid, name, status, role, emailAddress, phoneNumber, rank, b
 	VALUES (lower(newid()), 'KYLESON, Kyle', 0, 1, 'kyleson+kyle@example.com', '+1-412-7324', 'CIV', 'Kyle is another test person we have in the database', 'Afghanistan', 'MALE', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
 INSERT INTO people (uuid, name, status, role, emailAddress, phoneNumber, rank, biography, country, gender, createdAt, updatedAt)
 	VALUES (lower(newid()), 'BEMERGED, Myposwill', 0, 1, 'bemerged+myposwill@example.com', '+1-412-7324', 'CIV', 'Myposwill is a test person whose position will be merged', 'Afghanistan', 'MALE', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+INSERT INTO people (uuid, name, status, role, emailAddress, phoneNumber, rank, biography, country, gender, createdAt, updatedAt)
+	VALUES ('3cb2076c-5317-47fe-86ad-76f298993917', 'MERGED, Duplicate Winner', 0, 1, 'merged+winner@example.com', '+1-234-5678', 'CIV', 'Winner is a test person who will be merged', 'Afghanistan', 'MALE', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+INSERT INTO people (uuid, name, status, role, emailAddress, phoneNumber, rank, biography, country, gender, createdAt, updatedAt)
+	VALUES ('c725aef3-cdd1-4baf-ac72-f28219b234e9', 'MERGED, Duplicate Loser', 0, 1, 'merged+loser@example.com', '+1-876-5432', 'CTR', 'Loser is a test person who will be merged', 'Afghanistan', 'FEMALE', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
 -- Super Users
 INSERT INTO people (uuid, name, status, role, emailAddress, phoneNumber, rank, biography, domainUsername, country, gender, endOfTourDate, createdAt, updatedAt)
 	VALUES (lower(newid()), 'BOBTOWN, Bob', 0, 0, 'hunter+bob@example.com', '+1-444-7324', 'CIV', 'Bob is a Super User in EF 1.1', 'bob', 'United States of America', 'MALE', DATEADD(year, 1, CURRENT_TIMESTAMP), CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
@@ -567,6 +571,10 @@ INSERT INTO positions (uuid, name, code, type, status, currentPersonUuid, organi
 	VALUES (N'25fe500c-3503-4ba8-a9a4-09b29b50c1f1', 'Merge One', 'MOD-M1-HQ-00001', 1, 0, NULL, (SELECT uuid FROM organizations WHERE longName LIKE 'Ministry of Defense'), CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
 INSERT INTO positions (uuid, name, code, type, status, currentPersonUuid, organizationUuid, createdAt, updatedAt)
 	VALUES (N'e87f0f60-ad13-4c1c-96f7-672c595b81c7', 'Merge Two', 'MOD-M2-HQ-00001', 1, 0, NULL, (SELECT uuid FROM organizations WHERE longName LIKE 'Ministry of Defense'), CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+INSERT INTO positions (uuid, name, code, type, status, currentPersonUuid, organizationUuid, createdAt, updatedAt)
+	VALUES (N'885dd6bf-4647-4ef7-9bc4-4dd2826064bb', 'Chief of Merge People Test 1', 'MOI-MPT1-HQ-00001', 1, 0, NULL, (SELECT uuid FROM organizations WHERE longName LIKE 'Ministry of Interior'), CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+INSERT INTO positions (uuid, name, code, type, status, currentPersonUuid, organizationUuid, createdAt, updatedAt)
+	VALUES (N'4dc40a27-19ae-4e03-a4f3-55b2c768725f', 'Chief of Merge People Test 2', 'MOI-MPT2-HQ-00001', 1, 0, NULL, (SELECT uuid FROM organizations WHERE longName LIKE 'Ministry of Interior'), CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
 
 -- Put Steve into a Tashkil and associate with the EF 1.1 Advisor A Billet
 INSERT INTO peoplePositions (positionUuid, personUuid, createdAt)
@@ -624,6 +632,15 @@ INSERT INTO positionRelationships (positionUuid_a, positionUuid_b, createdAt, up
 	((SELECT uuid FROM positions WHERE name='EF 1.1 Advisor C'), (SELECT uuid from positions WHERE name ='Merge One'), CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 0),
 	((SELECT uuid FROM positions WHERE name='EF 1.1 Advisor C'), (SELECT uuid from positions WHERE name ='Merge Two'), CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 0),
 	((SELECT uuid FROM positions WHERE name='EF 1.1 Advisor D'), (SELECT uuid from positions WHERE name ='Merge Two'), CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 0);
+
+-- Put Winner Duplicate in a Tashkil
+INSERT INTO peoplePositions (positionUuid, personUuid, createdAt)
+	VALUES ((SELECT uuid from positions where name = 'Chief of Merge People Test 1'), (SELECT uuid from people where emailAddress = 'merged+winner@example.com'), CURRENT_TIMESTAMP);
+UPDATE positions SET currentPersonUuid = (SELECT uuid from people where emailAddress = 'merged+winner@example.com') WHERE name = 'Chief of Merge People Test 1';
+-- Put Loser Duplicate in a Tashkil
+INSERT INTO peoplePositions (positionUuid, personUuid, createdAt)
+	VALUES ((SELECT uuid from positions where name = 'Chief of Merge People Test 2'), (SELECT uuid from people where emailAddress = 'merged+loser@example.com'), CURRENT_TIMESTAMP);
+UPDATE positions SET currentPersonUuid = (SELECT uuid from people where emailAddress = 'merged+loser@example.com') WHERE name = 'Chief of Merge People Test 2';
 
 UPDATE positions SET locationUuid = (SELECT uuid from LOCATIONS where name = 'Kabul Police Academy') WHERE name = 'Chief of Police';
 UPDATE positions SET locationUuid = (SELECT uuid from LOCATIONS where name = 'MoD Headquarters Kabul') WHERE name = 'Cost Adder - MoD';
@@ -1044,6 +1061,23 @@ INSERT INTO noteRelatedObjects (noteUuid, relatedObjectType, relatedObjectUuid)
 	SELECT @noteUuid, 'positions', p.uuid
 	FROM positions p
 	WHERE p.uuid = 'e87f0f60-ad13-4c1c-96f7-672c595b81c7';
+
+-- Add notes to the people that will be merged
+SET @noteUuid = lower(newid());
+INSERT INTO notes (uuid, authorUuid, type, text, createdAt, updatedAt)
+	VALUES (@noteUuid, @authorUuid, 0, 'Merge one person note', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+INSERT INTO noteRelatedObjects (noteUuid, relatedObjectType, relatedObjectUuid)
+	SELECT @noteUuid, 'people', p.uuid
+	FROM people p
+	WHERE p.uuid = '3cb2076c-5317-47fe-86ad-76f298993917';
+
+SET @noteUuid = lower(newid());
+INSERT INTO notes (uuid, authorUuid, type, text, createdAt, updatedAt)
+	VALUES (@noteUuid, @authorUuid, 0, 'Merge two person note', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+INSERT INTO noteRelatedObjects (noteUuid, relatedObjectType, relatedObjectUuid)
+	SELECT @noteUuid, 'people', p.uuid
+	FROM people p
+	WHERE p.uuid = 'c725aef3-cdd1-4baf-ac72-f28219b234e9';
 
 SET @authorUuid = (SELECT uuid FROM people WHERE name = 'ERINSON, Erin');
 SET @noteUuid = lower(newid());

--- a/src/main/java/mil/dds/anet/database/PersonDao.java
+++ b/src/main/java/mil/dds/anet/database/PersonDao.java
@@ -384,6 +384,9 @@ public class PersonDao extends AnetSubscribableObjectDao<Person, PersonSearchQue
     getDbHandle().createUpdate(String.format(sqlDel, DaoUtils.isMsSql() ? "FROM" : "USING"))
         .bind("winnerUuid", winnerUuid).bind("loserUuid", loserUuid).execute();
 
+    // update winner's fields
+    update(winner);
+
     // update report people, should now be unique
     updateForMerge("reportPeople", "personUuid", winnerUuid, loserUuid);
 
@@ -394,7 +397,9 @@ public class PersonDao extends AnetSubscribableObjectDao<Person, PersonSearchQue
     updateForMerge("comments", "authorUuid", winnerUuid, loserUuid);
 
     // update position history
-    updateForMerge("peoplePositions", "personUuid", winnerUuid, loserUuid);
+    deleteForMerge("peoplePositions", "personUuid", loserUuid);
+    updatePersonHistory(winner);
+
 
     // update note authors
     updateForMerge("notes", "authorUuid", winnerUuid, loserUuid);

--- a/src/main/java/mil/dds/anet/database/PersonDao.java
+++ b/src/main/java/mil/dds/anet/database/PersonDao.java
@@ -6,6 +6,7 @@ import java.lang.invoke.MethodHandles;
 import java.lang.reflect.InvocationTargetException;
 import java.net.URISyntaxException;
 import java.time.Instant;
+import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Deque;
@@ -351,6 +352,12 @@ public class PersonDao extends AnetSubscribableObjectDao<Person, PersonSearchQue
 
   @InTransaction
   public int mergePeople(Person winner, Person loser) {
+    final String winnerUuid = winner.getUuid();
+    final String loserUuid = loser.getUuid();
+
+    // Update the winner's fields
+    update(winner);
+
     // For reports where both winner and loser are in the reportPeople:
     // 1. set winner's isPrimary, isAttendee and is isAuthor flags to the logical OR of both
     final String sqlUpd = "WITH dups AS ( SELECT"
@@ -367,8 +374,6 @@ public class PersonDao extends AnetSubscribableObjectDao<Person, PersonSearchQue
         + " WHERE \"reportPeople\".\"reportUuid\" = dups.wreportuuid"
         + " AND \"reportPeople\".\"personUuid\" = dups.wpersonuuid";
     // MS SQL has no real booleans, so bitwise-or the 0/1 values in that case
-    final String winnerUuid = winner.getUuid();
-    final String loserUuid = loser.getUuid();
     getDbHandle().createUpdate(String.format(sqlUpd, DaoUtils.isMsSql() ? "|" : "OR"))
         .bind("winnerUuid", winnerUuid).bind("loserUuid", loserUuid).execute();
     // 2. delete the loser so we don't have duplicates
@@ -384,26 +389,39 @@ public class PersonDao extends AnetSubscribableObjectDao<Person, PersonSearchQue
     getDbHandle().createUpdate(String.format(sqlDel, DaoUtils.isMsSql() ? "FROM" : "USING"))
         .bind("winnerUuid", winnerUuid).bind("loserUuid", loserUuid).execute();
 
-    // update winner's fields
-    update(winner);
-
-    // update report people, should now be unique
+    // Update report people, should now be unique
     updateForMerge("reportPeople", "personUuid", winnerUuid, loserUuid);
 
-    // update approvals this person might have done
+    // Update approvals this person might have done
     updateForMerge("reportActions", "personUuid", winnerUuid, loserUuid);
 
-    // update comment authors
+    // Update comment authors
     updateForMerge("comments", "authorUuid", winnerUuid, loserUuid);
 
-    // update position history
+    // Remove winner and loser from (old) position
+    final LocalDateTime now = DaoUtils.asLocalDateTime(Instant.now());
+    getDbHandle()
+        .createUpdate("/* personMergePositionRemovePerson.update */ UPDATE positions "
+            + "SET \"currentPersonUuid\" = NULL, \"updatedAt\" = :updatedAt "
+            + "WHERE \"currentPersonUuid\" IN ( :winnerUuid, :loserUuid )")
+        .bind("updatedAt", now).bind("winnerUuid", winnerUuid).bind("loserUuid", loserUuid)
+        .execute();
+    // Set winner in (new) position
+    getDbHandle()
+        .createUpdate("/* personMergePositionAddPerson.update */ UPDATE positions "
+            + "SET \"currentPersonUuid\" = :personUuid, \"updatedAt\" = :updatedAt "
+            + "WHERE uuid = :positionUuid")
+        .bind("personUuid", winnerUuid).bind("updatedAt", now)
+        .bind("positionUuid", DaoUtils.getUuid(winner.getPosition())).execute();
+    // Remove loser from position history
     deleteForMerge("peoplePositions", "personUuid", loserUuid);
+    // Update position history with given input on winner
     updatePersonHistory(winner);
 
-    // update note authors
+    // Update note authors
     updateForMerge("notes", "authorUuid", winnerUuid, loserUuid);
 
-    // update notes
+    // Update notes
     updateM2mForMerge("noteRelatedObjects", "noteUuid", "relatedObjectUuid", winnerUuid, loserUuid);
 
     // Update customSensitiveInformation for winner
@@ -412,8 +430,9 @@ public class PersonDao extends AnetSubscribableObjectDao<Person, PersonSearchQue
     // Delete customSensitiveInformation for loser
     deleteForMerge("customSensitiveInformation", "relatedObjectUuid", loserUuid);
 
-    // finally, delete the person!
+    // Finally, delete loser
     final int nr = deleteForMerge("people", "uuid", loserUuid);
+
     // E.g. positions may have been updated, so evict from the cache
     evictFromCache(winner);
     evictFromCache(loser);
@@ -470,8 +489,10 @@ public class PersonDao extends AnetSubscribableObjectDao<Person, PersonSearchQue
     // Delete old history
     final int numRows = getDbHandle()
         .execute("DELETE FROM \"peoplePositions\"  WHERE \"personUuid\" = ?", personUuid);
-    // Add new history
-    if (p.getPreviousPositions() != null) {
+    if (Utils.isEmptyOrNull(p.getPreviousPositions())) {
+      updatePeoplePositions(DaoUtils.getUuid(p.getPosition()), personUuid, Instant.now(), null);
+    } else {
+      // Store the history as given
       for (final PersonPositionHistory history : p.getPreviousPositions()) {
         updatePeoplePositions(history.getPositionUuid(), personUuid, history.getStartTime(),
             history.getEndTime());

--- a/src/main/java/mil/dds/anet/database/PersonDao.java
+++ b/src/main/java/mil/dds/anet/database/PersonDao.java
@@ -400,7 +400,6 @@ public class PersonDao extends AnetSubscribableObjectDao<Person, PersonSearchQue
     deleteForMerge("peoplePositions", "personUuid", loserUuid);
     updatePersonHistory(winner);
 
-
     // update note authors
     updateForMerge("notes", "authorUuid", winnerUuid, loserUuid);
 
@@ -472,9 +471,11 @@ public class PersonDao extends AnetSubscribableObjectDao<Person, PersonSearchQue
     final int numRows = getDbHandle()
         .execute("DELETE FROM \"peoplePositions\"  WHERE \"personUuid\" = ?", personUuid);
     // Add new history
-    for (final PersonPositionHistory history : p.getPreviousPositions()) {
-      updatePeoplePositions(history.getPositionUuid(), personUuid, history.getStartTime(),
-          history.getEndTime());
+    if (p.getPreviousPositions() != null) {
+      for (final PersonPositionHistory history : p.getPreviousPositions()) {
+        updatePeoplePositions(history.getPositionUuid(), personUuid, history.getStartTime(),
+            history.getEndTime());
+      }
     }
     return numRows;
   }

--- a/src/main/java/mil/dds/anet/database/PositionDao.java
+++ b/src/main/java/mil/dds/anet/database/PositionDao.java
@@ -641,4 +641,14 @@ public class PositionDao extends AnetSubscribableObjectDao<Position, PositionSea
     }
     return numRows;
   }
+
+  public void setPersonInPositionWithNoRelationOperation(String personUuid, String positionUuid) {
+    getDbHandle()
+        .createUpdate("/* positionSetPerson.set1 */ UPDATE positions "
+            + "SET \"currentPersonUuid\" = :personUuid, \"updatedAt\" = :updatedAt "
+            + "WHERE uuid = :positionUuid")
+        .bind("personUuid", personUuid).bind("updatedAt", DaoUtils.asLocalDateTime(Instant.now()))
+        .bind("positionUuid", positionUuid).execute();
+
+  }
 }

--- a/src/main/java/mil/dds/anet/database/PositionDao.java
+++ b/src/main/java/mil/dds/anet/database/PositionDao.java
@@ -534,21 +534,12 @@ public class PositionDao extends AnetSubscribableObjectDao<Position, PositionSea
     // Update the winner's fields
     update(winner);
 
-    // Update position history with given input on winnerPosition
+    // Remove loser from position history
     deleteForMerge("peoplePositions", "positionUuid", loserUuid);
-    deleteForMerge("peoplePositions", "positionUuid", winnerUuid);
-    if (Utils.isEmptyOrNull(winner.getPreviousPeople())) {
-      AnetObjectEngine.getInstance().getPersonDao().updatePeoplePositions(winnerUuid,
-          winner.getPersonUuid(), Instant.now(), null);
-    } else {
-      // Store the history as given
-      for (final PersonPositionHistory pph : winner.getPreviousPeople()) {
-        AnetObjectEngine.getInstance().getPersonDao().updatePeoplePositions(winnerUuid,
-            pph.getPersonUuid(), pph.getStartTime(), pph.getEndTime());
-      }
-    }
+    // Update position history with given input on winner
+    updatePositionHistory(winner);
 
-    // Update positionRelationships with given input on winnerPosition
+    // Update positionRelationships with given input on winner
     final Set<String> existingApUuids =
         existingAssociatedPositions.stream().map(ap -> ap.getUuid()).collect(Collectors.toSet());
     // delete common relations of merging positions
@@ -629,25 +620,21 @@ public class PositionDao extends AnetSubscribableObjectDao<Position, PositionSea
   }
 
   @InTransaction
-  public int updatePositionPreviousPeople(Position pos) {
+  public int updatePositionHistory(Position pos) {
+    final PersonDao personDao = AnetObjectEngine.getInstance().getPersonDao();
     final String posUuid = pos.getUuid();
     // Delete old history
     final int numRows = getDbHandle()
         .execute("DELETE FROM \"peoplePositions\"  WHERE \"positionUuid\" = ?", posUuid);
-    // Add new history
-    for (final PersonPositionHistory history : pos.getPreviousPeople()) {
-      AnetObjectEngine.getInstance().getPersonDao().updatePeoplePositions(posUuid,
-          history.getPersonUuid(), history.getStartTime(), history.getEndTime());
+    if (Utils.isEmptyOrNull(pos.getPreviousPeople())) {
+      personDao.updatePeoplePositions(posUuid, pos.getPersonUuid(), Instant.now(), null);
+    } else {
+      // Add new history
+      for (final PersonPositionHistory history : pos.getPreviousPeople()) {
+        personDao.updatePeoplePositions(posUuid, history.getPersonUuid(), history.getStartTime(),
+            history.getEndTime());
+      }
     }
     return numRows;
-  }
-
-  public void setPersonInPositionWithNoRelationOperation(String personUuid, String positionUuid) {
-    getDbHandle()
-        .createUpdate("/* positionSetPerson.set1 */ UPDATE positions "
-            + "SET \"currentPersonUuid\" = :personUuid, \"updatedAt\" = :updatedAt "
-            + "WHERE uuid = :positionUuid")
-        .bind("personUuid", personUuid).bind("updatedAt", DaoUtils.asLocalDateTime(Instant.now()))
-        .bind("positionUuid", positionUuid).execute();
   }
 }

--- a/src/main/java/mil/dds/anet/database/PositionDao.java
+++ b/src/main/java/mil/dds/anet/database/PositionDao.java
@@ -649,6 +649,5 @@ public class PositionDao extends AnetSubscribableObjectDao<Position, PositionSea
             + "WHERE uuid = :positionUuid")
         .bind("personUuid", personUuid).bind("updatedAt", DaoUtils.asLocalDateTime(Instant.now()))
         .bind("positionUuid", positionUuid).execute();
-
   }
 }

--- a/src/main/java/mil/dds/anet/resources/PersonResource.java
+++ b/src/main/java/mil/dds/anet/resources/PersonResource.java
@@ -202,7 +202,7 @@ public class PersonResource {
 
     final String existingPositionUuid = DaoUtils.getUuid(p.getPosition());
     ResourceUtils.validateHistoryInput(p.getUuid(), p.getPreviousPositions(), true,
-        existingPositionUuid != null, existingPositionUuid);
+        existingPositionUuid);
 
     if (AnetObjectEngine.getInstance().getPersonDao().hasHistoryConflict(p.getUuid(), null,
         p.getPreviousPositions(), true)) {
@@ -268,7 +268,7 @@ public class PersonResource {
 
     final String winnerPositionUuid = DaoUtils.getUuid(winner.getPosition());
     ResourceUtils.validateHistoryInput(winnerUuid, winner.getPreviousPositions(), true,
-        winnerPositionUuid != null, winnerPositionUuid);
+        winnerPositionUuid);
 
     int numRows = dao.mergePeople(winner, loser);
     if (numRows == 0) {

--- a/src/main/java/mil/dds/anet/resources/PersonResource.java
+++ b/src/main/java/mil/dds/anet/resources/PersonResource.java
@@ -270,6 +270,13 @@ public class PersonResource {
     ResourceUtils.validateHistoryInput(winnerUuid, winner.getPreviousPositions(), true,
         winnerPositionUuid);
 
+    if (AnetObjectEngine.getInstance().getPersonDao().hasHistoryConflict(winnerUuid, loserUuid,
+        winner.getPreviousPositions(), true)) {
+      throw new WebApplicationException(
+          "At least one of the positions in the history is occupied for the specified period.",
+          Status.CONFLICT);
+    }
+
     int numRows = dao.mergePeople(winner, loser);
     if (numRows == 0) {
       throw new WebApplicationException(

--- a/src/main/java/mil/dds/anet/resources/PositionResource.java
+++ b/src/main/java/mil/dds/anet/resources/PositionResource.java
@@ -174,7 +174,7 @@ public class PositionResource {
 
     final String existingPersonUuid = DaoUtils.getUuid(existing.getPerson());
     ResourceUtils.validateHistoryInput(pos.getUuid(), pos.getPreviousPeople(), false,
-        existingPersonUuid != null, existingPersonUuid);
+        existingPersonUuid);
 
     if (AnetObjectEngine.getInstance().getPersonDao().hasHistoryConflict(pos.getUuid(), null,
         pos.getPreviousPeople(), false)) {
@@ -270,7 +270,7 @@ public class PositionResource {
 
     final String winnerPersonUuid = DaoUtils.getUuid(winnerPosition.getPerson());
     ResourceUtils.validateHistoryInput(winnerPosition.getUuid(), winnerPosition.getPreviousPeople(),
-        false, winnerPersonUuid != null, winnerPersonUuid);
+        false, winnerPersonUuid);
 
     // Check that given two position can be merged
     arePositionsMergeable(winnerPosition, loserPosition);

--- a/src/main/java/mil/dds/anet/resources/PositionResource.java
+++ b/src/main/java/mil/dds/anet/resources/PositionResource.java
@@ -277,7 +277,7 @@ public class PositionResource {
     if (AnetObjectEngine.getInstance().getPersonDao().hasHistoryConflict(winnerPosition.getUuid(),
         loserUuid, winnerPosition.getPreviousPeople(), false)) {
       throw new WebApplicationException(
-          "At least one of the positions in the history is occupied for the specified period.",
+          "At least one of the people in the history is occupied for the specified period.",
           Status.CONFLICT);
     }
     validatePosition(user, winnerPosition);

--- a/src/main/java/mil/dds/anet/resources/PositionResource.java
+++ b/src/main/java/mil/dds/anet/resources/PositionResource.java
@@ -170,7 +170,10 @@ public class PositionResource {
       @GraphQLArgument(name = "position") Position pos) {
     final Person user = DaoUtils.getUserFromContext(context);
     final Position existing = dao.getByUuid(pos.getUuid());
-    ResourceUtils.validateHistoryInput(pos.getUuid(), pos.getPreviousPeople());
+    Person person = existing.getPerson();
+    final boolean hasPerson = !(person == null);
+    ResourceUtils.validateHistoryInput(pos.getUuid(), pos.getPreviousPeople(), hasPerson, false,
+        hasPerson ? person.getUuid() : null);
     assertCanUpdatePosition(user, existing);
     if (AnetObjectEngine.getInstance().getPersonDao().hasHistoryConflict(pos.getUuid(), null,
         pos.getPreviousPeople(), false)) {
@@ -262,9 +265,10 @@ public class PositionResource {
       @GraphQLArgument(name = "loserUuid") String loserUuid) {
     final Person user = DaoUtils.getUserFromContext(context);
     final Position loserPosition = dao.getByUuid(loserUuid);
-
-    ResourceUtils.validateHistoryInput(winnerPosition.getUuid(),
-        winnerPosition.getPreviousPeople());
+    final Person person = winnerPosition.getPerson();
+    final boolean hasPerson = !(person == null);
+    ResourceUtils.validateHistoryInput(winnerPosition.getUuid(), winnerPosition.getPreviousPeople(),
+        hasPerson, false, hasPerson ? person.getUuid() : null);
     assertCanUpdatePosition(user, winnerPosition);
     // Check that given two position can be merged
     arePositionsMergeable(winnerPosition, loserPosition);

--- a/src/main/java/mil/dds/anet/utils/ResourceUtils.java
+++ b/src/main/java/mil/dds/anet/utils/ResourceUtils.java
@@ -7,9 +7,6 @@ import mil.dds.anet.beans.PersonPositionHistory;
 
 public class ResourceUtils {
 
-  private static final String TIME_CONFLICT_ERROR_TEXT =
-      "At least one of the positions in the history is occupied for the specified period.";
-
   public static void validateHistoryInput(final String uuid,
       final List<PersonPositionHistory> previousPositions, final boolean checkPerson,
       final String relationUuid) {
@@ -67,7 +64,7 @@ public class ResourceUtils {
       final PersonPositionHistory pph = previousPositions.get(i);
       for (int j = i + 1; j < historySize; j++) {
         if (overlap(pph, previousPositions.get(j))) {
-          throw new WebApplicationException(TIME_CONFLICT_ERROR_TEXT, Status.CONFLICT);
+          throw new WebApplicationException("History entries should not overlap.", Status.CONFLICT);
         }
       }
     }

--- a/src/main/java/mil/dds/anet/utils/ResourceUtils.java
+++ b/src/main/java/mil/dds/anet/utils/ResourceUtils.java
@@ -15,6 +15,13 @@ public class ResourceUtils {
       throw new WebApplicationException("Uuid cannot be null.", Status.BAD_REQUEST);
     }
 
+    if (Utils.isEmptyOrNull(previousPositions)) {
+      if (relationUuid != null) {
+        throw new WebApplicationException("History should not be empty.", Status.BAD_REQUEST);
+      }
+      return;
+    }
+
     boolean seenNullEndTime = false;
     for (final PersonPositionHistory pph : previousPositions) {
       // Check if start time is null
@@ -73,18 +80,12 @@ public class ResourceUtils {
   private static boolean overlap(final PersonPositionHistory pph1,
       final PersonPositionHistory pph2) {
     if (pph1.getEndTime() == null) {
-      return overlapNullEndTime(pph1, pph2);
+      return pph2.getEndTime().isAfter(pph1.getStartTime());
     }
     if (pph2.getEndTime() == null) {
-      return overlapNullEndTime(pph2, pph1);
+      return pph1.getEndTime().isAfter(pph2.getStartTime());
     }
     return pph2.getStartTime().isBefore(pph1.getEndTime())
         && pph2.getEndTime().isAfter(pph1.getStartTime());
-  }
-
-  private static boolean overlapNullEndTime(final PersonPositionHistory pph1,
-      final PersonPositionHistory pph2) {
-    return pph1.getEndTime() == null
-        && (pph2.getEndTime() == null || pph2.getEndTime().isAfter(pph1.getStartTime()));
   }
 }

--- a/src/main/java/mil/dds/anet/utils/ResourceUtils.java
+++ b/src/main/java/mil/dds/anet/utils/ResourceUtils.java
@@ -11,8 +11,8 @@ public class ResourceUtils {
       "At least one of the positions in the history is occupied for the specified period.";
 
   public static void validateHistoryInput(final String uuid,
-      final List<PersonPositionHistory> previousPositions, final boolean hasRelation,
-      final boolean checkPerson, final String relationUuid) {
+      final List<PersonPositionHistory> previousPositions, final boolean checkPerson,
+      final boolean hasRelation, final String relationUuid) {
     // Check if uuid is null
     if (uuid == null) {
       throw new WebApplicationException("Uuid cannot be null.", Status.BAD_REQUEST);

--- a/src/test/java/mil/dds/anet/test/resources/AbstractResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/AbstractResourceTest.java
@@ -35,6 +35,8 @@ import mil.dds.anet.test.client.Organization;
 import mil.dds.anet.test.client.OrganizationInput;
 import mil.dds.anet.test.client.Person;
 import mil.dds.anet.test.client.PersonInput;
+import mil.dds.anet.test.client.PersonPositionHistory;
+import mil.dds.anet.test.client.PersonPositionHistoryInput;
 import mil.dds.anet.test.client.PersonSearchQueryInput;
 import mil.dds.anet.test.client.Position;
 import mil.dds.anet.test.client.PositionInput;
@@ -331,6 +333,17 @@ public abstract class AbstractResourceTest {
 
   protected static List<PositionInput> getPositionsInput(final List<Position> positions) {
     return positions.stream().map(p -> getPositionInput(p)).collect(Collectors.toList());
+  }
+
+  protected static PersonPositionHistoryInput getPersonPositionHistoryInput(
+      final PersonPositionHistory pph) {
+    return getInput(pph, PersonPositionHistoryInput.class);
+  }
+
+  protected static List<PersonPositionHistoryInput> getPersonPositionHistoryInput(
+      final List<PersonPositionHistory> history) {
+    return history.stream().map(pph -> getPersonPositionHistoryInput(pph))
+        .collect(Collectors.toList());
   }
 
   protected static TaskInput getTaskInput(final Task task) {

--- a/src/test/java/mil/dds/anet/test/resources/GraphQlResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/GraphQlResourceTest.java
@@ -12,6 +12,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.HashMap;
 import java.util.Map;
@@ -85,7 +86,7 @@ public class GraphQlResourceTest extends AbstractResourceTest {
     for (final File f : fileList) {
       if (f.isFile()) {
         try (final FileInputStream input = new FileInputStream(f)) {
-          String raw = IOUtils.toString(input);
+          String raw = IOUtils.toString(input, StandardCharsets.UTF_8);
           final Map<String, Object> query = new HashMap<String, Object>();
           for (final Map.Entry<String, Object> entry : variables.entrySet()) {
             raw = raw.replace("${" + entry.getKey() + "}", entry.getValue().toString());

--- a/src/test/java/mil/dds/anet/test/resources/LocationResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/LocationResourceTest.java
@@ -6,24 +6,21 @@ import static org.assertj.core.api.Assertions.fail;
 import com.graphql_java_generator.exception.GraphQLRequestExecutionException;
 import com.graphql_java_generator.exception.GraphQLRequestPreparationException;
 import javax.ws.rs.ForbiddenException;
-import javax.ws.rs.NotFoundException;
 import mil.dds.anet.test.TestData;
 import mil.dds.anet.test.client.AnetBeanList_Location;
 import mil.dds.anet.test.client.Location;
 import mil.dds.anet.test.client.LocationInput;
 import mil.dds.anet.test.client.LocationSearchQueryInput;
-import mil.dds.anet.test.client.LocationType;
 import mil.dds.anet.test.client.Person;
 import mil.dds.anet.test.client.Position;
 import mil.dds.anet.test.client.PositionType;
-import mil.dds.anet.test.client.Status;
 import mil.dds.anet.test.client.util.MutationExecutor;
 import mil.dds.anet.test.client.util.QueryExecutor;
 import org.junit.jupiter.api.Test;
 
 public class LocationResourceTest extends AbstractResourceTest {
 
-  protected static final String FIELDS = "{ uuid name type status lat lng customFields }";
+  public static final String FIELDS = "{ uuid name type status lat lng customFields }";
 
   @Test
   public void locationTestGraphQL()
@@ -124,44 +121,6 @@ public class LocationResourceTest extends AbstractResourceTest {
       if (isSuperUser) {
         fail("Unexpected ForbiddenException");
       }
-    }
-  }
-
-  @Test
-  public void mergeLocationTest()
-      throws GraphQLRequestExecutionException, GraphQLRequestPreparationException {
-    // Create Loser Location
-    final LocationInput firstLocationInput = LocationInput.builder()
-        .withName("MergeLocationsTest First Location").withType(LocationType.POINT_LOCATION)
-        .withLat(47.613442).withLng(-52.740936).withStatus(Status.ACTIVE).build();
-
-    final Location firstLocation = adminMutationExecutor.createLocation(FIELDS, firstLocationInput);
-    assertThat(firstLocation).isNotNull();
-    assertThat(firstLocation.getUuid()).isNotNull();
-
-    // Create Winner Location
-    final LocationInput secondLocationInput = LocationInput.builder()
-        .withName("MergeLocationsTest Second Location").withType(LocationType.POINT_LOCATION)
-        .withLat(47.561517).withLng(-52.70876).withStatus(Status.ACTIVE).build();
-
-    final Location secondLocation =
-        adminMutationExecutor.createLocation(FIELDS, secondLocationInput);
-    assertThat(secondLocation).isNotNull();
-    assertThat(secondLocation.getUuid()).isNotNull();
-
-    final LocationInput mergedLocationInput = getLocationInput(firstLocation);
-    mergedLocationInput.setStatus(secondLocation.getStatus());
-
-    final Location mergedLocation =
-        adminMutationExecutor.mergeLocations(FIELDS, secondLocation.getUuid(), mergedLocationInput);
-    assertThat(mergedLocation).isNotNull();
-    assertThat(mergedLocation.getUuid()).isNotNull();
-
-    // Assert that loser is gone.
-    try {
-      adminQueryExecutor.location(FIELDS, secondLocation.getUuid());
-      fail("Expected NotFoundException");
-    } catch (NotFoundException expectedException) {
     }
   }
 

--- a/src/test/java/mil/dds/anet/test/resources/PersonResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/PersonResourceTest.java
@@ -62,7 +62,7 @@ public class PersonResourceTest extends AbstractResourceTest {
       "uuid name status role emailAddress phoneNumber rank biography country avatar code"
           + " gender endOfTourDate domainUsername pendingVerification createdAt updatedAt"
           + " customFields";
-  private static final String PERSON_FIELDS_ONLY_HISTORY =
+  public static final String PERSON_FIELDS_ONLY_HISTORY =
       "{ uuid previousPositions { startTime endTime position { uuid } } }";
   public static final String POSITION_FIELDS = String.format("{ %s person { %s } %s }",
       _POSITION_FIELDS, _PERSON_FIELDS, _CUSTOM_SENSITIVE_INFORMATION_FIELDS);

--- a/src/test/java/mil/dds/anet/test/resources/PositionResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/PositionResourceTest.java
@@ -721,7 +721,17 @@ public class PositionResourceTest extends AbstractResourceTest {
     assertThat(secondPosition).isNotNull();
     assertThat(secondPosition.getUuid()).isNotNull();
 
+    final PersonPositionHistoryInput hist =
+        PersonPositionHistoryInput.builder().withCreatedAt(Instant.now().minus(49, ChronoUnit.DAYS))
+            .withStartTime(Instant.now().minus(49, ChronoUnit.DAYS)).withEndTime(null)
+            .withPerson(getPersonInput(testPerson)).withPosition(getPositionInput(secondPosition))
+            .build();
+
+    final List<PersonPositionHistoryInput> historyList = new ArrayList<>();
+    historyList.add(hist);
     final PositionInput mergedPositionInput = getPositionInput(firstPosition);
+    mergedPositionInput.setPreviousPeople(historyList);
+    mergedPositionInput.setPerson(getPersonInput(testPerson));
     mergedPositionInput.setStatus(secondPosition.getStatus());
     mergedPositionInput.setType(secondPosition.getType());
 

--- a/src/test/java/mil/dds/anet/test/resources/merge/LocationMergeTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/merge/LocationMergeTest.java
@@ -1,0 +1,57 @@
+package mil.dds.anet.test.resources.merge;
+
+import static mil.dds.anet.test.resources.LocationResourceTest.FIELDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+import com.graphql_java_generator.exception.GraphQLRequestExecutionException;
+import com.graphql_java_generator.exception.GraphQLRequestPreparationException;
+import javax.ws.rs.NotFoundException;
+import mil.dds.anet.test.client.Location;
+import mil.dds.anet.test.client.LocationInput;
+import mil.dds.anet.test.client.LocationType;
+import mil.dds.anet.test.client.Status;
+import mil.dds.anet.test.resources.AbstractResourceTest;
+import org.junit.jupiter.api.Test;
+
+public class LocationMergeTest extends AbstractResourceTest {
+
+  @Test
+  public void testMerge()
+      throws GraphQLRequestExecutionException, GraphQLRequestPreparationException {
+    // Create Loser Location
+    final LocationInput firstLocationInput = LocationInput.builder()
+        .withName("MergeLocationsTest First Location").withType(LocationType.POINT_LOCATION)
+        .withLat(47.613442).withLng(-52.740936).withStatus(Status.ACTIVE).build();
+
+    final Location firstLocation = adminMutationExecutor.createLocation(FIELDS, firstLocationInput);
+    assertThat(firstLocation).isNotNull();
+    assertThat(firstLocation.getUuid()).isNotNull();
+
+    // Create Winner Location
+    final LocationInput secondLocationInput = LocationInput.builder()
+        .withName("MergeLocationsTest Second Location").withType(LocationType.POINT_LOCATION)
+        .withLat(47.561517).withLng(-52.70876).withStatus(Status.ACTIVE).build();
+
+    final Location secondLocation =
+        adminMutationExecutor.createLocation(FIELDS, secondLocationInput);
+    assertThat(secondLocation).isNotNull();
+    assertThat(secondLocation.getUuid()).isNotNull();
+
+    final LocationInput mergedLocationInput = getLocationInput(firstLocation);
+    mergedLocationInput.setStatus(secondLocation.getStatus());
+
+    final Location mergedLocation =
+        adminMutationExecutor.mergeLocations(FIELDS, secondLocation.getUuid(), mergedLocationInput);
+    assertThat(mergedLocation).isNotNull();
+    assertThat(mergedLocation.getUuid()).isNotNull();
+
+    // Assert that loser is gone.
+    try {
+      adminQueryExecutor.location(FIELDS, secondLocation.getUuid());
+      fail("Expected NotFoundException");
+    } catch (NotFoundException expectedException) {
+    }
+  }
+
+}

--- a/src/test/java/mil/dds/anet/test/resources/merge/PersonMergeTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/merge/PersonMergeTest.java
@@ -1,0 +1,159 @@
+package mil.dds.anet.test.resources.merge;
+
+import static mil.dds.anet.test.resources.PersonResourceTest.FIELDS;
+import static mil.dds.anet.test.resources.PersonResourceTest.POSITION_FIELDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+import com.graphql_java_generator.exception.GraphQLRequestExecutionException;
+import com.graphql_java_generator.exception.GraphQLRequestPreparationException;
+import java.time.Instant;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.List;
+import javax.ws.rs.NotFoundException;
+import mil.dds.anet.test.TestData;
+import mil.dds.anet.test.client.Organization;
+import mil.dds.anet.test.client.Person;
+import mil.dds.anet.test.client.PersonInput;
+import mil.dds.anet.test.client.PersonPositionHistoryInput;
+import mil.dds.anet.test.client.Position;
+import mil.dds.anet.test.client.PositionInput;
+import mil.dds.anet.test.client.PositionType;
+import mil.dds.anet.test.client.Role;
+import mil.dds.anet.test.client.Status;
+import mil.dds.anet.test.resources.AbstractResourceTest;
+import mil.dds.anet.test.utils.UtilsTest;
+import mil.dds.anet.utils.DaoUtils;
+import org.junit.jupiter.api.Test;
+
+public class PersonMergeTest extends AbstractResourceTest {
+
+  @Test
+  public void testMerge()
+      throws GraphQLRequestExecutionException, GraphQLRequestPreparationException {
+    // Create a person
+    PersonInput loserInput =
+        PersonInput.builder().withRole(Role.ADVISOR).withName("Loser for Merging").build();
+    Person loser = adminMutationExecutor.createPerson(FIELDS, loserInput);
+    assertThat(loser).isNotNull();
+    assertThat(loser.getUuid()).isNotNull();
+
+    // Create a Position
+    final PositionInput testInput =
+        PositionInput.builder().withName("A Test Position created by mergePeopleTest")
+            .withType(PositionType.ADVISOR).withStatus(Status.ACTIVE).build();
+
+    // Assign to an AO
+    final Organization ao = adminMutationExecutor.createOrganization("{ uuid }",
+        TestData.createAdvisorOrganizationInput(true));
+    testInput.setOrganization(getOrganizationInput(ao));
+    testInput.setLocation(getLocationInput(getGeneralHospital()));
+
+    final Position created = adminMutationExecutor.createPosition(POSITION_FIELDS, testInput);
+    assertThat(created).isNotNull();
+    assertThat(created.getUuid()).isNotNull();
+    assertThat(created.getName()).isEqualTo(testInput.getName());
+
+    // Assign the loser into the position
+    Integer nrUpdated =
+        adminMutationExecutor.putPersonInPosition("", getPersonInput(loser), created.getUuid());
+    assertThat(nrUpdated).isEqualTo(1);
+
+    final PositionInput testInput1 = PositionInput.builder().withType(PositionType.ADVISOR)
+        .withName("Test Position for person history edit  1")
+        .withOrganization(getOrganizationInput(ao))
+        .withLocation(getLocationInput(getGeneralHospital())).withStatus(Status.ACTIVE).build();
+
+    final Position createdPos1 = adminMutationExecutor.createPosition(POSITION_FIELDS, testInput1);
+    assertThat(createdPos1).isNotNull();
+    assertThat(createdPos1.getUuid()).isNotNull();
+    assertThat(createdPos1.getName()).isEqualTo(testInput1.getName());
+    final PositionInput posInput1 = PositionInput.builder().withUuid(createdPos1.getUuid()).build();
+    final PositionInput testInput2 = PositionInput.builder().withType(PositionType.ADVISOR)
+        .withName("Test Position for person history edit 2")
+        .withOrganization(getOrganizationInput(ao))
+        .withLocation(getLocationInput(getGeneralHospital())).withStatus(Status.ACTIVE).build();
+
+    final Position createdPos2 = adminMutationExecutor.createPosition(POSITION_FIELDS, testInput2);
+    assertThat(createdPos2).isNotNull();
+    assertThat(createdPos2.getUuid()).isNotNull();
+    assertThat(createdPos2.getName()).isEqualTo(testInput2.getName());
+    final PositionInput posInput2 = PositionInput.builder().withUuid(createdPos2.getUuid()).build();
+    final PersonPositionHistoryInput hist1 = PersonPositionHistoryInput.builder()
+        .withCreatedAt(Instant.now().minus(100, ChronoUnit.DAYS))
+        .withStartTime(Instant.now().minus(100, ChronoUnit.DAYS))
+        .withEndTime(Instant.now().minus(50, ChronoUnit.DAYS)).withPosition(posInput1).build();
+    final PersonPositionHistoryInput hist2 =
+        PersonPositionHistoryInput.builder().withCreatedAt(Instant.now().minus(49, ChronoUnit.DAYS))
+            .withStartTime(Instant.now().minus(49, ChronoUnit.DAYS)).withEndTime(null)
+            .withPosition(posInput2).build();
+
+    final List<PersonPositionHistoryInput> historyList = new ArrayList<>();
+    historyList.add(hist1);
+    historyList.add(hist2);
+
+    final PersonInput winnerInput = PersonInput.builder().withName("Winner for merging")
+        .withRole(Role.ADVISOR).withStatus(Status.ACTIVE).withPreviousPositions(historyList)
+        .withPosition(posInput2)
+        // set HTML of biography
+        .withBiography(UtilsTest.getCombinedHtmlTestCase().getInput())
+        // set JSON of customFields
+        .withCustomFields(UtilsTest.getCombinedJsonTestCase().getInput()).withGender("Female")
+        .withCountry("Canada").withCode("1234568")
+        .withEndOfTourDate(
+            ZonedDateTime.of(2020, 4, 1, 0, 0, 0, 0, DaoUtils.getServerNativeZoneId()).toInstant())
+        .build();
+
+    final Person winner = adminMutationExecutor.createPerson(FIELDS, winnerInput);
+    assertThat(winner).isNotNull();
+    assertThat(winner.getUuid()).isNotNull();
+    winnerInput.setUuid(winner.getUuid());
+    nrUpdated = adminMutationExecutor.mergePeople("", loser.getUuid(), winnerInput);
+    assertThat(nrUpdated).isEqualTo(1);
+
+    // Assert that loser is gone.
+    try {
+      adminQueryExecutor.person(FIELDS, loser.getUuid());
+      fail("Expected NotFoundException");
+    } catch (NotFoundException expectedException) {
+    }
+
+    // Assert that the position is empty.
+    Position winnerPos = adminQueryExecutor.position(POSITION_FIELDS, created.getUuid());
+    assertThat(winnerPos.getPerson()).isNull();
+
+    // Re-create loser and put into the position.
+    loserInput = PersonInput.builder().withRole(Role.ADVISOR).withName("Loser for Merging").build();
+    loser = adminMutationExecutor.createPerson(FIELDS, loserInput);
+    assertThat(loser).isNotNull();
+    assertThat(loser.getUuid()).isNotNull();
+
+    nrUpdated =
+        adminMutationExecutor.putPersonInPosition("", getPersonInput(loser), created.getUuid());
+    assertThat(nrUpdated).isEqualTo(1);
+
+    nrUpdated = adminMutationExecutor.mergePeople("", loser.getUuid(), winnerInput);
+    assertThat(nrUpdated).isEqualTo(1);
+
+    // Assert that loser is gone.
+    try {
+      adminQueryExecutor.person(FIELDS, loser.getUuid());
+      fail("Expected NotFoundException");
+    } catch (NotFoundException expectedException) {
+    }
+
+    // Assert that the winner is in the position.
+    winnerPos = adminQueryExecutor.position(POSITION_FIELDS, createdPos2.getUuid());
+    assertThat(winnerPos.getPerson().getUuid()).isEqualTo(winner.getUuid());
+  }
+
+  // TODO: Test the following conditions:
+  // - You selected the same person twice
+  // - Winner not found
+  // - Loser not found
+  // - You can only merge people of the same role
+  // - At least one of the positions in the history is occupied for the specified period.
+
+}

--- a/src/test/java/mil/dds/anet/test/resources/merge/PositionMergeTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/merge/PositionMergeTest.java
@@ -1,0 +1,95 @@
+package mil.dds.anet.test.resources.merge;
+
+import static mil.dds.anet.test.resources.PositionResourceTest.FIELDS;
+import static mil.dds.anet.test.resources.PositionResourceTest.ORGANIZATION_FIELDS;
+import static mil.dds.anet.test.resources.PositionResourceTest.PERSON_FIELDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+import com.graphql_java_generator.exception.GraphQLRequestExecutionException;
+import com.graphql_java_generator.exception.GraphQLRequestPreparationException;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.List;
+import javax.ws.rs.NotFoundException;
+import mil.dds.anet.test.client.AnetBeanList_Organization;
+import mil.dds.anet.test.client.OrganizationSearchQueryInput;
+import mil.dds.anet.test.client.OrganizationType;
+import mil.dds.anet.test.client.Person;
+import mil.dds.anet.test.client.PersonInput;
+import mil.dds.anet.test.client.PersonPositionHistoryInput;
+import mil.dds.anet.test.client.Position;
+import mil.dds.anet.test.client.PositionInput;
+import mil.dds.anet.test.client.PositionType;
+import mil.dds.anet.test.client.Role;
+import mil.dds.anet.test.client.Status;
+import mil.dds.anet.test.resources.AbstractResourceTest;
+import org.junit.jupiter.api.Test;
+
+public class PositionMergeTest extends AbstractResourceTest {
+
+  @Test
+  public void testMerge()
+      throws GraphQLRequestExecutionException, GraphQLRequestPreparationException {
+    // Create a new position and designate the person upfront
+    final PersonInput testPersonInput = PersonInput.builder().withName("MergePositionsTest Person")
+        .withRole(Role.PRINCIPAL).withStatus(Status.ACTIVE).build();
+
+    final Person testPerson = adminMutationExecutor.createPerson(PERSON_FIELDS, testPersonInput);
+    assertThat(testPerson).isNotNull();
+    assertThat(testPerson.getUuid()).isNotNull();
+
+    final OrganizationSearchQueryInput queryOrgs = OrganizationSearchQueryInput.builder()
+        .withText("Ministry").withType(OrganizationType.PRINCIPAL_ORG).build();
+    final AnetBeanList_Organization orgs =
+        adminQueryExecutor.organizationList(getListFields(ORGANIZATION_FIELDS), queryOrgs);
+    assertThat(orgs.getList().size()).isGreaterThan(0);
+
+    final PositionInput firstPositionInput = PositionInput.builder()
+        .withName("MergePositionsTest First Position").withType(PositionType.PRINCIPAL)
+        .withOrganization(getOrganizationInput(orgs.getList().get(0))).withStatus(Status.ACTIVE)
+        .withPerson(getPersonInput(testPerson)).build();
+
+    final Position firstPosition = adminMutationExecutor.createPosition(FIELDS, firstPositionInput);
+    assertThat(firstPosition).isNotNull();
+    assertThat(firstPosition.getUuid()).isNotNull();
+
+    final PositionInput secondPositionInput = PositionInput.builder()
+        .withName("MergePositionsTest Second Position").withType(PositionType.PRINCIPAL)
+        .withOrganization(getOrganizationInput(orgs.getList().get(0))).withStatus(Status.ACTIVE)
+        .build();
+
+    final Position secondPosition =
+        adminMutationExecutor.createPosition(FIELDS, secondPositionInput);
+    assertThat(secondPosition).isNotNull();
+    assertThat(secondPosition.getUuid()).isNotNull();
+
+    final PersonPositionHistoryInput hist =
+        PersonPositionHistoryInput.builder().withCreatedAt(Instant.now().minus(49, ChronoUnit.DAYS))
+            .withStartTime(Instant.now().minus(49, ChronoUnit.DAYS)).withEndTime(null)
+            .withPerson(getPersonInput(testPerson)).withPosition(getPositionInput(secondPosition))
+            .build();
+
+    final List<PersonPositionHistoryInput> historyList = new ArrayList<>();
+    historyList.add(hist);
+    final PositionInput mergedPositionInput = getPositionInput(firstPosition);
+    mergedPositionInput.setPreviousPeople(historyList);
+    mergedPositionInput.setPerson(getPersonInput(testPerson));
+    mergedPositionInput.setStatus(secondPosition.getStatus());
+    mergedPositionInput.setType(secondPosition.getType());
+
+    final Position mergedPosition =
+        adminMutationExecutor.mergePositions(FIELDS, secondPosition.getUuid(), mergedPositionInput);
+    assertThat(mergedPosition).isNotNull();
+    assertThat(mergedPosition.getUuid()).isNotNull();
+
+    // Assert that loser is gone.
+    try {
+      adminQueryExecutor.position(FIELDS, secondPosition.getUuid());
+      fail("Expected NotFoundException");
+    } catch (NotFoundException expectedException) {
+    }
+  }
+
+}

--- a/src/test/java/mil/dds/anet/test/utils/ResourceUtilsTest.java
+++ b/src/test/java/mil/dds/anet/test/utils/ResourceUtilsTest.java
@@ -24,8 +24,8 @@ public class ResourceUtilsTest {
   @Test
   public void testValidateHistoryInput() {
     final Object[][] testData = new Object[][] {
-        // Each item has: { isValid,checkPerson,hasRelation,relationUuid, uuid, start time, end
-        // time, … }
+        // Each item has:
+        // { isValid, checkPerson, hasRelation, relationUuid, uuid, start time, end time, … }
         // - null uuid
         {false, true, false, null, null, "personel", "posUuid", "2004-02-27T00:00:00.000Z",
             "2004-02-28T00:00:00.000Z"},
@@ -111,7 +111,7 @@ public class ResourceUtilsTest {
       }
       logger.debug("checking {}", Arrays.toString(testItem));
       try {
-        ResourceUtils.validateHistoryInput(uuid, hist, hasRelation, checkPerson, relationUuid);
+        ResourceUtils.validateHistoryInput(uuid, hist, checkPerson, hasRelation, relationUuid);
         if (!isValid) {
           fail("Expected a WebApplicationException");
         }

--- a/src/test/java/mil/dds/anet/test/utils/ResourceUtilsTest.java
+++ b/src/test/java/mil/dds/anet/test/utils/ResourceUtilsTest.java
@@ -25,27 +25,26 @@ public class ResourceUtilsTest {
   public void testValidateHistoryInput() {
     final Object[][] testData = new Object[][] {
         // Each item has:
-        // { isValid, checkPerson, hasRelation, relationUuid, uuid, start time, end time, … }
+        // { isValid, checkPerson, relationUuid, uuid, start time, end time, … }
         // - null uuid
-        {false, true, false, null, null, "personel", "posUuid", "2004-02-27T00:00:00.000Z",
+        {false, true, null, null, "personel", "posUuid", "2004-02-27T00:00:00.000Z",
             "2004-02-28T00:00:00.000Z"},
         // - null startTime
-        {false, true, true, "relPosUuid", "uuid", "uuid", "relPosUuid", null,
-            "2004-02-28T00:00:00.000Z"},
+        {false, true, "relPosUuid", "uuid", "uuid", "relPosUuid", null, "2004-02-28T00:00:00.000Z"},
         // - two null endTime's
-        {false, true, true, "relPosUuid", "uuid", "uuid", "posUuid", "2004-02-27T00:00:00.000Z",
-            null, "uuid", "relPosUuid", "2004-02-27T00:00:00.000Z", null},
+        {false, true, "relPosUuid", "uuid", "uuid", "posUuid", "2004-02-27T00:00:00.000Z", null,
+            "uuid", "relPosUuid", "2004-02-27T00:00:00.000Z", null},
         // - endTime before startTime
-        {false, true, true, "relPosUuid", "uuid", "uuid", "posUuid", "2004-02-27T00:00:00.000Z",
+        {false, true, "relPosUuid", "uuid", "uuid", "posUuid", "2004-02-27T00:00:00.000Z",
             "2004-02-26T23:59:59.999Z"},
         // - overlap
-        {false, true, false, null, "uuid", "uuid", "posUuid", "2004-02-27T00:00:00.000Z",
+        {false, true, null, "uuid", "uuid", "posUuid", "2004-02-27T00:00:00.000Z",
             "2004-02-27T02:00:00.000Z", "uuid", "posUuid", "2004-02-27T01:00:00.000Z",
             "2004-02-27T03:00:00.000Z"},
-        {false, true, true, "relPosUuid", "uuid", "uuid", "relPosUuid", "2004-02-27T00:00:00.000Z",
-            null, "persUuid", "posUuid", "2004-02-27T01:00:00.000Z", "2004-02-27T03:00:00.000Z"},
+        {false, true, "relPosUuid", "uuid", "uuid", "relPosUuid", "2004-02-27T00:00:00.000Z", null,
+            "persUuid", "posUuid", "2004-02-27T01:00:00.000Z", "2004-02-27T03:00:00.000Z"},
         // - very long history with overlap
-        {false, true, true, "relPosUuid", "uuid", "persUuid", "posUuid", "2004-02-27T00:00:00.000Z",
+        {false, true, "relPosUuid", "uuid", "persUuid", "posUuid", "2004-02-27T00:00:00.000Z",
             "2004-02-27T00:00:00.000Z", "uuid", "posUuid", "2004-02-27T00:00:00.000Z",
             "2004-02-27T00:00:00.000Z", "uuid", "posUuid", "2004-02-27T00:00:00.000Z",
             "2004-02-27T00:00:00.000Z", "uuid", "posUuid", "2004-02-27T00:00:00.000Z",
@@ -58,22 +57,21 @@ public class ResourceUtilsTest {
             "2004-02-27T00:00:00.000Z", "uuid", "posUuid", "2004-02-27T00:00:00.000Z",
             "2004-02-27T00:00:00.001Z", "uuid", "relPosUuid", "2004-02-27T00:00:00.000Z", null},
         // - no history at all
-        {true, true, false, null, "uuid"},
+        {true, true, null, "uuid"},
         // - valid history
-        {true, true, true, "relPosUuid", "uuid", "uuid", "relPosUuid", "2004-02-27T00:00:00.000Z",
-            null},
-        {true, true, false, null, "uuid", "uuid", "posUuid", "2004-02-27T00:00:00.000Z",
+        {true, true, "relPosUuid", "uuid", "uuid", "relPosUuid", "2004-02-27T00:00:00.000Z", null},
+        {true, true, null, "uuid", "uuid", "posUuid", "2004-02-27T00:00:00.000Z",
             "2004-02-27T00:00:00.000Z"},
-        {true, true, false, null, "uuid", "uuid", "posUuid", "2004-02-27T00:00:00.000Z",
+        {true, true, null, "uuid", "uuid", "posUuid", "2004-02-27T00:00:00.000Z",
             "2004-02-27T01:00:00.000Z"},
-        {true, true, false, null, "uuid", "uuid", "posUuid", "2004-02-27T00:00:00.000Z",
+        {true, true, null, "uuid", "uuid", "posUuid", "2004-02-27T00:00:00.000Z",
             "2004-02-27T00:00:00.000Z", "uuid", "posUuid", "2004-02-27T00:00:00.000Z",
             "2004-02-27T00:00:00.000Z"},
-        {true, true, false, null, "uuid", "uuid", "posUuid", "2004-02-27T00:00:00.000Z",
+        {true, true, null, "uuid", "uuid", "posUuid", "2004-02-27T00:00:00.000Z",
             "2004-02-27T01:00:00.000Z", "uuid", "posUuid", "2004-02-27T01:00:00.000Z",
             "2004-02-27T02:00:00.000Z"},
         // - very long history
-        {true, true, true, "relPosUuid", "uuid", "uuid", "posUuid", "2004-02-27T00:00:00.000Z",
+        {true, true, "relPosUuid", "uuid", "uuid", "posUuid", "2004-02-27T00:00:00.000Z",
             "2004-02-27T00:00:00.000Z", "uuid", "posUuid", "2004-02-27T00:00:00.000Z",
             "2004-02-27T00:00:00.000Z", "uuid", "posUuid", "2004-02-27T00:00:00.000Z",
             "2004-02-27T00:00:00.000Z", "uuid", "posUuid", "2004-02-27T00:00:00.000Z",
@@ -92,7 +90,6 @@ public class ResourceUtilsTest {
       int i = 0;
       final boolean isValid = (boolean) testItem[i++];
       final boolean checkPerson = (boolean) testItem[i++];
-      final boolean hasRelation = (boolean) testItem[i++];
       final String relationUuid = (String) testItem[i++];
       final String uuid = (String) testItem[i++];
       final List<PersonPositionHistory> hist = new ArrayList<>();
@@ -111,7 +108,7 @@ public class ResourceUtilsTest {
       }
       logger.debug("checking {}", Arrays.toString(testItem));
       try {
-        ResourceUtils.validateHistoryInput(uuid, hist, checkPerson, hasRelation, relationUuid);
+        ResourceUtils.validateHistoryInput(uuid, hist, checkPerson, relationUuid);
         if (!isValid) {
           fail("Expected a WebApplicationException");
         }

--- a/src/test/java/mil/dds/anet/test/utils/ResourceUtilsTest.java
+++ b/src/test/java/mil/dds/anet/test/utils/ResourceUtilsTest.java
@@ -23,90 +23,142 @@ public class ResourceUtilsTest {
 
   @Test
   public void testValidateHistoryInput() {
+    // We test the following conditions:
+    // - Uuid cannot be null.
+    // - Start time cannot be empty.
+    // - There cannot be more than one history entry without an end time.
+    // - History entry must have an end time. (if there is no current relation)
+    // - Last history entry must be identical to person's current position. (checkPerson)
+    // - Last history entry must be identical to position's current person. (not checkPerson)
+    // - End time cannot before start time.
+    // - There should be a history entry without an end time. (if there is a current relation)
+    // - History entries should not overlap.
     final Object[][] testData = new Object[][] {
         // Each item has:
-        // { isValid, checkPerson, relationUuid, uuid, start time, end time, … }
+        // { isValid, uuid, relationUuid, (pphUuid, start time, end time,)… }
         // - null uuid
-        {false, true, null, null, "personel", "posUuid", "2004-02-27T00:00:00.000Z",
-            "2004-02-28T00:00:00.000Z"},
+        {false, null, null, "pphUuid", "2004-02-27T00:00:00.000Z", "2004-02-28T00:00:00.000Z"},
+        {false, null, "relUuid", "pphUuid", "2004-02-27T00:00:00.000Z", "2004-02-28T00:00:00.000Z"},
         // - null startTime
-        {false, true, "relPosUuid", "uuid", "uuid", "relPosUuid", null, "2004-02-28T00:00:00.000Z"},
+        {false, "uuid", null, "pphUuid", null, "2004-02-28T00:00:00.000Z"},
+        {false, "uuid", "relUuid", "pphUuid", null, "2004-02-28T00:00:00.000Z"},
         // - two null endTime's
-        {false, true, "relPosUuid", "uuid", "uuid", "posUuid", "2004-02-27T00:00:00.000Z", null,
-            "uuid", "relPosUuid", "2004-02-27T00:00:00.000Z", null},
-        // - endTime before startTime
-        {false, true, "relPosUuid", "uuid", "uuid", "posUuid", "2004-02-27T00:00:00.000Z",
-            "2004-02-26T23:59:59.999Z"},
-        // - overlap
-        {false, true, null, "uuid", "uuid", "posUuid", "2004-02-27T00:00:00.000Z",
-            "2004-02-27T02:00:00.000Z", "uuid", "posUuid", "2004-02-27T01:00:00.000Z",
+        {false, "uuid", null, "pphUuid", "2004-02-27T00:00:00.000Z", null, "pphUuid",
+            "2004-02-27T00:00:00.000Z", null},
+        {false, "uuid", "relUuid", "relUuid", "2004-02-27T00:00:00.000Z", null, "relUuid",
+            "2004-02-27T00:00:00.000Z", null},
+        // - null endTime without current relation
+        {false, "uuid", null, "pphUuid", "2004-02-27T00:00:00.000Z", null},
+        // - null endTime with wrong relation
+        {false, "uuid", "relUuid", "pphUuid", "2004-02-27T00:00:00.000Z", null},
+        // - no null endTime with current relation
+        {false, "uuid", "relUuid", "relUuid", "2004-02-27T01:00:00.000Z",
             "2004-02-27T03:00:00.000Z"},
-        {false, true, "relPosUuid", "uuid", "uuid", "relPosUuid", "2004-02-27T00:00:00.000Z", null,
-            "persUuid", "posUuid", "2004-02-27T01:00:00.000Z", "2004-02-27T03:00:00.000Z"},
+        // - endTime before startTime
+        {false, "uuid", null, "pphUuid", "2004-02-27T00:00:00.000Z", "2004-02-26T23:59:59.999Z"},
+        {false, "uuid", "relUuid", "pphUuid", "2004-02-27T00:00:00.000Z",
+            "2004-02-26T23:59:59.999Z"},
+        // - no history but with relation
+        {false, "uuid", "relUuid"},
+        // - overlap
+        {false, "uuid", null, "pphUuid", "2004-02-27T00:00:00.000Z", "2004-02-27T02:00:00.000Z",
+            "pphUuid", "2004-02-27T01:00:00.000Z", "2004-02-27T03:00:00.000Z"},
+        {false, "uuid", null, "pphUuid", "2004-02-27T00:00:00.000Z", "2004-02-27T02:00:00.000Z",
+            "pphUuid", "2004-02-27T01:00:00.000Z", "2004-02-27T01:30:00.000Z"},
+        {false, "uuid", null, "pphUuid", "2004-02-27T01:00:00.000Z", "2004-02-27T03:00:00.000Z",
+            "pphUuid", "2004-02-27T00:00:00.000Z", "2004-02-27T02:00:00.000Z"},
+        {false, "uuid", null, "pphUuid", "2004-02-27T01:00:00.000Z", "2004-02-27T03:00:00.000Z",
+            "pphUuid", "2004-02-27T00:00:00.000Z", "2004-02-27T04:00:00.000Z"},
+        {false, "uuid", "relUuid", "pphUuid", "2004-02-27T01:00:00.000Z",
+            "2004-02-27T03:00:00.000Z", "relUuid", "2004-02-27T00:00:00.000Z", null},
+        {false, "uuid", "relUuid", "relUuid", "2004-02-27T00:00:00.000Z", null, "pphUuid",
+            "2004-02-27T01:00:00.000Z", "2004-02-27T03:00:00.000Z"},
         // - very long history with overlap
-        {false, true, "relPosUuid", "uuid", "persUuid", "posUuid", "2004-02-27T00:00:00.000Z",
-            "2004-02-27T00:00:00.000Z", "uuid", "posUuid", "2004-02-27T00:00:00.000Z",
-            "2004-02-27T00:00:00.000Z", "uuid", "posUuid", "2004-02-27T00:00:00.000Z",
-            "2004-02-27T00:00:00.000Z", "uuid", "posUuid", "2004-02-27T00:00:00.000Z",
-            "2004-02-27T00:00:00.000Z", "uuid", "posUuid", "2004-02-27T00:00:00.000Z",
-            "2004-02-27T00:00:00.000Z", "uuid", "posUuid", "2004-02-27T00:00:00.000Z",
-            "2004-02-27T00:00:00.000Z", "uuid", "posUuid", "2004-02-27T00:00:00.000Z",
-            "2004-02-27T00:00:00.000Z", "uuid", "posUuid", "2004-02-27T00:00:00.000Z",
-            "2004-02-27T00:00:00.000Z", "uuid", "posUuid", "2004-02-27T00:00:00.000Z",
-            "2004-02-27T00:00:00.000Z", "uuid", "posUuid", "2004-02-27T00:00:00.000Z",
-            "2004-02-27T00:00:00.000Z", "uuid", "posUuid", "2004-02-27T00:00:00.000Z",
-            "2004-02-27T00:00:00.001Z", "uuid", "relPosUuid", "2004-02-27T00:00:00.000Z", null},
-        // - no history at all
-        {true, true, null, "uuid"},
+        {false, "uuid", "relUuid", "pphUuid", "2004-02-27T00:00:00.000Z",
+            "2004-02-27T00:00:00.000Z", "pphUuid", "2004-02-27T00:00:00.000Z",
+            "2004-02-27T00:00:00.000Z", "pphUuid", "2004-02-27T00:00:00.000Z",
+            "2004-02-27T00:00:00.000Z", "pphUuid", "2004-02-27T00:00:00.000Z",
+            "2004-02-27T00:00:00.000Z", "pphUuid", "2004-02-27T00:00:00.000Z",
+            "2004-02-27T00:00:00.000Z", "pphUuid", "2004-02-27T00:00:00.000Z",
+            "2004-02-27T00:00:00.000Z", "pphUuid", "2004-02-27T00:00:00.000Z",
+            "2004-02-27T00:00:00.000Z", "pphUuid", "2004-02-27T00:00:00.000Z",
+            "2004-02-27T00:00:00.000Z", "pphUuid", "2004-02-27T00:00:00.000Z",
+            "2004-02-27T00:00:00.000Z", "pphUuid", "2004-02-27T00:00:00.000Z",
+            "2004-02-27T00:00:00.000Z", "pphUuid", "2004-02-27T00:00:00.000Z",
+            "2004-02-27T00:00:00.001Z", "relUuid", "2004-02-27T00:00:00.000Z", null},
+        // - no history and without relation
+        {true, "uuid", null},
         // - valid history
-        {true, true, "relPosUuid", "uuid", "uuid", "relPosUuid", "2004-02-27T00:00:00.000Z", null},
-        {true, true, null, "uuid", "uuid", "posUuid", "2004-02-27T00:00:00.000Z",
-            "2004-02-27T00:00:00.000Z"},
-        {true, true, null, "uuid", "uuid", "posUuid", "2004-02-27T00:00:00.000Z",
-            "2004-02-27T01:00:00.000Z"},
-        {true, true, null, "uuid", "uuid", "posUuid", "2004-02-27T00:00:00.000Z",
-            "2004-02-27T00:00:00.000Z", "uuid", "posUuid", "2004-02-27T00:00:00.000Z",
-            "2004-02-27T00:00:00.000Z"},
-        {true, true, null, "uuid", "uuid", "posUuid", "2004-02-27T00:00:00.000Z",
-            "2004-02-27T01:00:00.000Z", "uuid", "posUuid", "2004-02-27T01:00:00.000Z",
-            "2004-02-27T02:00:00.000Z"},
+        {true, "uuid", null, "pphUuid", "2004-02-27T00:00:00.000Z", "2004-02-27T00:00:00.000Z"},
+        {true, "uuid", "relUuid", "relUuid", "2004-02-27T00:00:00.000Z", null},
+        {true, "uuid", null, "pphUuid", "2004-02-27T00:00:00.000Z", "2004-02-27T00:00:00.000Z",
+            "pphUuid", "2004-02-27T00:00:00.000Z", "2004-02-27T00:00:00.000Z"},
+        {true, "uuid", "relUuid", "pphUuid", "2004-02-27T00:00:00.000Z", "2004-02-27T00:00:00.000Z",
+            "relUuid", "2004-02-27T00:00:00.000Z", null},
+        {true, "uuid", null, "pphUuid", "2004-02-27T00:00:00.000Z", "2004-02-27T01:00:00.000Z",
+            "pphUuid", "2004-02-27T01:00:00.000Z", "2004-02-27T02:00:00.000Z"},
+        {true, "uuid", "relUuid", "pphUuid", "2004-02-27T00:00:00.000Z", "2004-02-27T01:00:00.000Z",
+            "relUuid", "2004-02-27T01:00:00.000Z", null},
         // - very long history
-        {true, true, "relPosUuid", "uuid", "uuid", "posUuid", "2004-02-27T00:00:00.000Z",
-            "2004-02-27T00:00:00.000Z", "uuid", "posUuid", "2004-02-27T00:00:00.000Z",
-            "2004-02-27T00:00:00.000Z", "uuid", "posUuid", "2004-02-27T00:00:00.000Z",
-            "2004-02-27T00:00:00.000Z", "uuid", "posUuid", "2004-02-27T00:00:00.000Z",
-            "2004-02-27T00:00:00.000Z", "uuid", "posUuid", "2004-02-27T00:00:00.000Z",
-            "2004-02-27T00:00:00.000Z", "uuid", "posUuid", "2004-02-27T00:00:00.000Z",
-            "2004-02-27T00:00:00.000Z", "uuid", "posUuid", "2004-02-27T00:00:00.000Z",
-            "2004-02-27T00:00:00.000Z", "uuid", "posUuid", "2004-02-27T00:00:00.000Z",
-            "2004-02-27T00:00:00.000Z", "uuid", "posUuid", "2004-02-27T00:00:00.000Z",
-            "2004-02-27T00:00:00.000Z", "uuid", "posUuid", "2004-02-27T00:00:00.000Z",
-            "2004-02-27T00:00:00.000Z", "uuid", "posUuid", "2004-02-27T00:00:00.000Z",
-            "2004-02-27T00:00:00.000Z", "uuid", "relPosUuid", "2004-02-27T00:00:00.000Z", null},
+        {true, "uuid", null, "pphUuid", "2004-02-27T00:00:00.000Z", "2004-02-27T00:00:00.000Z",
+            "pphUuid", "2004-02-27T00:00:00.000Z", "2004-02-27T00:00:00.000Z", "pphUuid",
+            "2004-02-27T00:00:00.000Z", "2004-02-27T00:00:00.000Z", "pphUuid",
+            "2004-02-27T00:00:00.000Z", "2004-02-27T00:00:00.000Z", "pphUuid",
+            "2004-02-27T00:00:00.000Z", "2004-02-27T00:00:00.000Z", "pphUuid",
+            "2004-02-27T00:00:00.000Z", "2004-02-27T00:00:00.000Z", "pphUuid",
+            "2004-02-27T00:00:00.000Z", "2004-02-27T00:00:00.000Z", "pphUuid",
+            "2004-02-27T00:00:00.000Z", "2004-02-27T00:00:00.000Z", "pphUuid",
+            "2004-02-27T00:00:00.000Z", "2004-02-27T01:00:00.000Z", "pphUuid",
+            "2004-02-27T01:00:00.000Z", "2004-02-27T02:00:00.000Z", "pphUuid",
+            "2004-02-27T03:00:00.000Z", "2004-02-27T04:00:00.000Z", "pphUuid",
+            "2004-02-27T02:00:00.000Z", "2004-02-27T03:00:00.000Z"},
+        {true, "uuid", "relUuid", "pphUuid", "2004-02-27T00:00:00.000Z", "2004-02-27T00:00:00.000Z",
+            "pphUuid", "2004-02-27T00:00:00.000Z", "2004-02-27T00:00:00.000Z", "pphUuid",
+            "2004-02-27T00:00:00.000Z", "2004-02-27T00:00:00.000Z", "pphUuid",
+            "2004-02-27T00:00:00.000Z", "2004-02-27T00:00:00.000Z", "pphUuid",
+            "2004-02-27T00:00:00.000Z", "2004-02-27T00:00:00.000Z", "pphUuid",
+            "2004-02-27T00:00:00.000Z", "2004-02-27T00:00:00.000Z", "pphUuid",
+            "2004-02-27T00:00:00.000Z", "2004-02-27T00:00:00.000Z", "pphUuid",
+            "2004-02-27T00:00:00.000Z", "2004-02-27T00:00:00.000Z", "pphUuid",
+            "2004-02-27T00:00:00.000Z", "2004-02-27T01:00:00.000Z", "pphUuid",
+            "2004-02-27T01:00:00.000Z", "2004-02-27T02:00:00.000Z", "pphUuid",
+            "2004-02-27T03:00:00.000Z", "2004-02-27T04:00:00.000Z", "pphUuid",
+            "2004-02-27T02:00:00.000Z", "2004-02-27T03:00:00.000Z", "relUuid",
+            "2004-02-27T04:00:00.000Z", null},
         // end
     };
 
+    validateHistory(testData, true);
+    validateHistory(testData, false);
+  }
+
+  private void validateHistory(final Object[][] testData, final boolean checkPerson) {
     for (final Object[] testItem : testData) {
       int i = 0;
       final boolean isValid = (boolean) testItem[i++];
-      final boolean checkPerson = (boolean) testItem[i++];
-      final String relationUuid = (String) testItem[i++];
       final String uuid = (String) testItem[i++];
+      final String relationUuid = (String) testItem[i++];
       final List<PersonPositionHistory> hist = new ArrayList<>();
       while (i < testItem.length) {
         final PersonPositionHistory pph = new PersonPositionHistory();
         final Person person = new Person();
-        person.setUuid((String) testItem[i++]);
         pph.setPerson(person);
 
         final Position position = new Position();
-        position.setUuid((String) testItem[i++]);
         pph.setPosition(position);
+
+        final String pphUuid = (String) testItem[i++];
+        if (checkPerson) {
+          position.setUuid(pphUuid);
+        } else {
+          person.setUuid(pphUuid);
+        }
+
         pph.setStartTime(toInstant(testItem[i++]));
         pph.setEndTime(toInstant(testItem[i++]));
         hist.add(pph);
       }
-      logger.debug("checking {}", Arrays.toString(testItem));
+      logger.debug("checking {} with checkPerson={}", Arrays.toString(testItem), checkPerson);
       try {
         ResourceUtils.validateHistoryInput(uuid, hist, checkPerson, relationUuid);
         if (!isValid) {
@@ -114,7 +166,7 @@ public class ResourceUtilsTest {
         }
       } catch (WebApplicationException e) {
         if (isValid) {
-          fail("Unexpected WebApplicationException");
+          fail("Unexpected WebApplicationException: " + e);
         }
       }
     }

--- a/src/test/resources/anet.graphql
+++ b/src/test/resources/anet.graphql
@@ -310,7 +310,7 @@ type Mutation {
   emailReport(email: AnetEmailInput, uuid: String): Int
   emailRollup(advisorOrganizationUuid: String, email: AnetEmailInput, endDate: Instant, orgType: OrganizationType, principalOrganizationUuid: String, startDate: Instant): Int
   mergeLocations(loserUuid: String, winnerLocation: LocationInput): Location
-  mergePeople(copyPosition: Boolean = false, loserUuid: String, winnerUuid: String): Int
+  mergePeople(loserUuid: String, winnerPerson: PersonInput): Int
   mergePositions(loserUuid: String, winnerPosition: PositionInput): Position
   publishReport(uuid: String): Int!
   putPersonInPosition(person: PersonInput, uuid: String): Int!


### PR DESCRIPTION
Merge people tool is enhanced to give advisors the ability to choose different fields from each side separately. The position history of the merged person can also be written manually. 

Closes #3497

#### User changes
- none

#### Super User changes
- none

#### Admin changes
- Admins have more options when merging people.

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [x] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [x] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [x] Opened debt issues for anything not resolved here
