### PR TITLE
When merging positions, be able to pick and choose which "Associated Positions" are merged

### DIFF
--- a/client/src/components/EditAssociatedPositions.js
+++ b/client/src/components/EditAssociatedPositions.js
@@ -1,0 +1,142 @@
+import React, { useState } from "react"
+import { Button } from "@blueprintjs/core"
+import { Modal, Row, Col, Grid } from "react-bootstrap"
+import PropTypes from "prop-types"
+import AssociatedPositions from "../pages/positions/AssociatedPositions"
+
+function EditAssociatedPositions({
+  associatedPositions1,
+  associatedPositions2,
+  title,
+  setAssociatedPositions,
+  initialMergedAssociatedPositions
+}) {
+  const [showModal, setShowModal] = useState(false)
+  const [finalAssociatedPositions, setFinalAssociatedPositions] = useState(
+    initialMergedAssociatedPositions
+  )
+  return (
+    <div
+      className="edit-associated-positions"
+      style={{ display: "flex", flexDirection: "column" }}
+    >
+      <Button
+        intent="primary"
+        onClick={() => {
+          setShowModal(true)
+          setFinalAssociatedPositions(initialMergedAssociatedPositions)
+        }}
+      >
+        Edit Associated Positions
+      </Button>
+      <Modal
+        show={showModal}
+        onHide={onHide}
+        dialogClassName="edit-history-dialog"
+      >
+        <Modal.Header closeButton>
+          <Modal.Title>{title}</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          <Grid fluid>
+            <Row>
+              <Col md={4}>
+                <AssociatedPositions
+                  associatedPositions={associatedPositions1}
+                  action={(item, index) => (
+                    <Button
+                      onClick={() => editItem(item)}
+                      intent={isInMerged(item) ? "danger" : "primary"}
+                    >
+                      {isInMerged(item) ? "Remove" : "Add"}
+                    </Button>
+                  )}
+                />
+              </Col>
+              <Col md={4}>
+                <AssociatedPositions
+                  associatedPositions={finalAssociatedPositions}
+                  action={(item, index) => (
+                    <Button onClick={() => editItem(item)} intent="danger">
+                      Remove
+                    </Button>
+                  )}
+                />
+              </Col>
+              <Col md={4}>
+                <AssociatedPositions
+                  associatedPositions={associatedPositions2}
+                  action={(item, index) => (
+                    <Button
+                      onClick={() => editItem(item)}
+                      intent={isInMerged(item) ? "danger" : "primary"}
+                    >
+                      {isInMerged(item) ? "Remove" : "Add"}
+                    </Button>
+                  )}
+                />
+              </Col>
+            </Row>
+            <Row>
+              <div className="submit-buttons">
+                <div>
+                  <Button onClick={() => setShowModal(false)}>Cancel</Button>
+                </div>
+                <div>
+                  <Button onClick={onSave}>Save</Button>
+                </div>
+              </div>
+            </Row>
+          </Grid>
+        </Modal.Body>
+      </Modal>
+    </div>
+  )
+
+  function onHide() {
+    setShowModal(false)
+  }
+
+  function editItem(item) {
+    isInMerged(item) ? removeItem(item) : addItem(item)
+  }
+
+  function isInMerged(item) {
+    if (
+      finalAssociatedPositions.filter(ap => ap.uuid === item.uuid).length > 0
+    ) {
+      return true
+    } else {
+      return false
+    }
+  }
+
+  function removeItem(item) {
+    setFinalAssociatedPositions(
+      finalAssociatedPositions.filter(ap => ap.uuid !== item.uuid)
+    )
+  }
+
+  function addItem(item) {
+    setFinalAssociatedPositions([...finalAssociatedPositions, item])
+  }
+
+  function onSave() {
+    setAssociatedPositions(finalAssociatedPositions)
+    setShowModal(false)
+  }
+}
+
+EditAssociatedPositions.propTypes = {
+  associatedPositions1: PropTypes.array,
+  associatedPositions2: PropTypes.array,
+  title: PropTypes.string,
+  setAssociatedPositions: PropTypes.func,
+  initialMergedAssociatedPositions: PropTypes.array
+}
+
+EditAssociatedPositions.defaultProps = {
+  title: "Edit Associated Positions"
+}
+
+export default EditAssociatedPositions

--- a/client/src/pages/admin/MergePositions.js
+++ b/client/src/pages/admin/MergePositions.js
@@ -43,6 +43,7 @@ import { useHistory } from "react-router-dom"
 import POSITIONS_ICON from "resources/positions.png"
 import Settings from "settings"
 import utils from "utils"
+import EditAssociatedPositions from "../../components/EditAssociatedPositions"
 import AssociatedPositions from "../positions/AssociatedPositions"
 import PreviousPeople from "../positions/PreviousPeople"
 
@@ -195,11 +196,29 @@ const MergePositions = ({ pageDispatchers }) => {
               <PositionField
                 label="Associated Positions"
                 value={
-                  <AssociatedPositions
-                    associatedPositions={mergedPosition.associatedPositions}
-                  />
+                  <>
+                    <AssociatedPositions
+                      associatedPositions={mergedPosition.associatedPositions}
+                    />
+                    <EditAssociatedPositions
+                      associatedPositions1={position1.associatedPositions}
+                      associatedPositions2={position2.associatedPositions}
+                      setAssociatedPositions={mergedAssociatedPositions =>
+                        dispatchMergeActions(
+                          setAMergedField(
+                            "associatedPositions",
+                            mergedAssociatedPositions,
+                            null
+                          )
+                        )
+                      }
+                      initialMergedAssociatedPositions={
+                        mergedPosition.associatedPositions
+                      }
+                    />
+                  </>
                 }
-                align="center"
+                align="column"
                 action={getClearButton(() =>
                   dispatchMergeActions(
                     setAMergedField("associatedPositions", [], null)

--- a/client/src/pages/positions/AssociatedPositions.js
+++ b/client/src/pages/positions/AssociatedPositions.js
@@ -3,13 +3,14 @@ import PropTypes from "prop-types"
 import React from "react"
 import { Table } from "react-bootstrap"
 
-function AssociatedPositions({ associatedPositions }) {
+function AssociatedPositions({ associatedPositions, action }) {
   return (
     <Table>
       <thead>
         <tr>
           <th>Name</th>
           <th>Position</th>
+          {action && <th>Action</th>}
         </tr>
       </thead>
       <tbody>
@@ -33,13 +34,15 @@ function AssociatedPositions({ associatedPositions }) {
         <td>
           <LinkTo modelType="Position" model={pos} />
         </td>
+        {action && <td>{action(pos, idx)}</td>}
       </tr>
     )
   }
 }
 
 AssociatedPositions.propTypes = {
-  associatedPositions: PropTypes.array
+  associatedPositions: PropTypes.array,
+  action: PropTypes.func
 }
 
 AssociatedPositions.defaultProps = {


### PR DESCRIPTION
When merging positions admins can form the associated positions of the merged position by selecting the positions on both sides one by one.

Closes #3531

#### User changes
- none

#### Super User changes
- none

#### Admin changes
- Admins have more control over the associated positions of the merged position.

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [ ] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
