### PR TITLE
Fix ANET init command

### DIFF
--- a/src/main/java/mil/dds/anet/InitializationCommand.java
+++ b/src/main/java/mil/dds/anet/InitializationCommand.java
@@ -38,9 +38,16 @@ public class InitializationCommand extends EnvironmentCommand<AnetConfiguration>
 
     final PersonSearchQuery psq = new PersonSearchQuery();
     final List<Person> currPeople = engine.getPersonDao().search(psq).getList();
-    if (!currPeople.isEmpty()) {
-      System.out.println("ERROR: Data detected in database");
-      System.out.println("\tThis task can only be run on an empty database");
+    if (currPeople.isEmpty()) {
+      System.out.println("ERROR: ANET Importer missing from database");
+      System.out.println("\tYou should run all migrations first");
+      System.exit(1);
+      return;
+    }
+    // Only person should be "ANET Importer"
+    if (currPeople.size() != 1 || !"ANET Importer".equals(currPeople.get(0).getName())) {
+      System.out.println("ERROR: Other people besides ANET Importer detected in database");
+      System.out.println("\tThis task can only be run on an otherwise empty database");
       System.exit(1);
       return;
     }


### PR DESCRIPTION
Migrations add one user: "ANET Importer", so account for this when checking the preconditions of the ANET init command.

#### User changes
- none

#### Super User changes
- none

#### Admin changes
- none

#### System admin changes
The command `bin/anet init anet.yml` when initially setting up ANET works again.
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [ ] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here