### PR TITLE
Lift calendar up from the other DOM elements

### DIFF
--- a/client/src/components/BlueprintOverrides.css
+++ b/client/src/components/BlueprintOverrides.css
@@ -14,6 +14,9 @@
 	/* Make sure it is on top of the advanced search popup */
 	z-index: 1070 !important;
 }
+.bp3-transition-container {
+	z-index: 30000 !important;
+}
 
 /* Make bp3 timepicker in-line
 .bp3-timepicker {

--- a/client/src/components/CustomDateInput.js
+++ b/client/src/components/CustomDateInput.js
@@ -74,7 +74,7 @@ const CustomDateInput = ({
       showActionsBar
       closeOnSelection={!withTime}
       timePickerProps={timePickerProps}
-      popoverProps={{ usePortal: false }}
+      popoverProps={{ usePortal: true }}
       disabled={disabled}
     />
   )

--- a/client/src/components/CustomDateInput.js
+++ b/client/src/components/CustomDateInput.js
@@ -27,6 +27,7 @@ const CustomDateInput = ({
   id,
   disabled,
   showIcon,
+  placement,
   withTime,
   value,
   onChange,
@@ -74,7 +75,7 @@ const CustomDateInput = ({
       showActionsBar
       closeOnSelection={!withTime}
       timePickerProps={timePickerProps}
-      popoverProps={{ usePortal: true }}
+      popoverProps={{ usePortal: true, placement }}
       disabled={disabled}
     />
   )
@@ -83,6 +84,7 @@ CustomDateInput.propTypes = {
   id: PropTypes.string,
   disabled: PropTypes.bool,
   showIcon: PropTypes.bool,
+  placement: PropTypes.string,
   withTime: PropTypes.bool,
   value: PropTypes.oneOfType([
     PropTypes.string,
@@ -95,6 +97,7 @@ CustomDateInput.propTypes = {
 CustomDateInput.defaultProps = {
   disabled: false,
   showIcon: true,
+  placement: "auto",
   withTime: false
 }
 

--- a/client/src/components/advancedSearch/DateRangeFilter.js
+++ b/client/src/components/advancedSearch/DateRangeFilter.js
@@ -137,6 +137,7 @@ const DateRangeFilter = ({
           value.relative === ON) && (
           <CustomDateInput
             showIcon={false}
+            placement="right"
             value={dateStart}
             onChange={handleChangeStart}
           />
@@ -147,6 +148,7 @@ const DateRangeFilter = ({
         {(value.relative === BETWEEN || value.relative === BEFORE) && (
           <CustomDateInput
             showIcon={false}
+            placement="left"
             value={dateEnd}
             onChange={handleChangeEnd}
           />


### PR DESCRIPTION
Fixes #3565 

#### User changes
- Calendar popup is visible and usable in the filtered search container.

#### Super User changes
- None

#### Admin changes
- None

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
