### PR TITLE
Fix reports insights

### DIFF
--- a/client/src/pages/insights/Show.js
+++ b/client/src/pages/insights/Show.js
@@ -237,9 +237,10 @@ const InsightsShow = ({ pageDispatchers, searchQuery, setSearchQuery }) => {
   }
 
   function setInsightDefaultSearchQuery() {
+    const insightConfig = INSIGHT_DETAILS[insight]
     const queryParams = insightDefaultQueryParams[insight]
     deserializeQueryParams(
-      SEARCH_OBJECT_TYPES.POSITIONS,
+      insightConfig.searchProps.searchObjectTypes[0],
       queryParams,
       deserializeCallback
     )

--- a/client/tests/webdriver/baseSpecs/insights.spec.js
+++ b/client/tests/webdriver/baseSpecs/insights.spec.js
@@ -1,0 +1,17 @@
+import { expect } from "chai"
+import Insights, { INSIGHTS } from "../pages/insights.page"
+
+describe("Insights pages", () => {
+  it("Should open each insights page", () => {
+    Insights.openAsAdminUser()
+    INSIGHTS.forEach(insight => {
+      Insights.insightsMenu.waitForExist()
+      Insights.insightsMenu.waitForDisplayed()
+      Insights.insightsMenu.click()
+      Insights.getInsightLink(insight).click()
+      Insights.alert.waitForDisplayed({ timeout: 1000, reverse: true })
+      // eslint-disable-next-line no-unused-expressions
+      expect(Insights.getInsightDiv(insight).isExisting()).to.be.true
+    })
+  })
+})

--- a/client/tests/webdriver/pages/insights.page.js
+++ b/client/tests/webdriver/pages/insights.page.js
@@ -1,0 +1,39 @@
+import Page from "./page"
+
+// Copied from src/pages/insights/Show.js
+const NOT_APPROVED_REPORTS = "not-approved-reports"
+const CANCELLED_REPORTS = "cancelled-reports"
+const REPORTS_BY_TASK = "reports-by-task"
+const REPORTS_BY_DAY_OF_WEEK = "reports-by-day-of-week"
+const FUTURE_ENGAGEMENTS_BY_LOCATION = "future-engagements-by-location"
+const PENDING_ASSESSMENTS_BY_POSITION = "pending-assessments-by-position"
+const ADVISOR_REPORTS = "advisor-reports"
+export const INSIGHTS = [
+  NOT_APPROVED_REPORTS,
+  CANCELLED_REPORTS,
+  REPORTS_BY_TASK,
+  FUTURE_ENGAGEMENTS_BY_LOCATION,
+  REPORTS_BY_DAY_OF_WEEK,
+  PENDING_ASSESSMENTS_BY_POSITION,
+  ADVISOR_REPORTS
+]
+
+class Insights extends Page {
+  get insightsMenu() {
+    return browser.$("#insights")
+  }
+
+  getInsightLink(insight) {
+    return browser.$(`a[href="/insights/${insight}"]`)
+  }
+
+  get alert() {
+    return browser.$(".alert")
+  }
+
+  getInsightDiv(insight) {
+    return browser.$(`div[id="${insight}"]`)
+  }
+}
+
+export default new Insights()


### PR DESCRIPTION
Fix reports-related Insights (basically: all but the **Pending Assessments by Position** insight).

Fixes NCI-Agency/anet#3567

#### User changes
- None.

#### Super User changes
- All Insights are working again.

#### Admin changes
- All Insights are working again.

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
- [x] Described the user behavior in PR body
- [x] Referenced/updated all related issues
- [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
- [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
- [ ] Added and/or updated unit tests
- [x] Added and/or updated e2e tests
- [ ] Added and/or updated data migrations
- [ ] Updated documentation
- [x] Resolved all build errors and warnings
- [ ] Opened debt issues for anything not resolved here