### PR TITLE
Add sensitive custom fields

### DIFF
--- a/anet-dictionary.yml
+++ b/anet-dictionary.yml
@@ -485,10 +485,12 @@ fields:
         type: date
         label: Date of birth
         authorizationGroupUuids: ['39a78d51-c351-452c-9206-4305ec8dd76d', 'c21e7321-7ec5-4837-8805-a302f9575754']
+        tooltipText: This field contains sensitive information!
       idCard:
         type: text
         label: ID card
         authorizationGroupUuids: ['1050c9e3-e679-4c60-8bdc-5139fbc1c10b']
+        tooltipText: This field contains sensitive information!
 
   location:
     format: LAT_LON

--- a/anet-dictionary.yml
+++ b/anet-dictionary.yml
@@ -480,6 +480,15 @@ fields:
             label: Object date
             helpText: Help text for object date field
             visibleWhen: $[?(@ && @.colourOptions === 'GREEN')]
+    customSensitiveInformation:
+      birthday:
+        type: date
+        label: Date of birth
+        authorizationGroupUuids: ['39a78d51-c351-452c-9206-4305ec8dd76d', 'c21e7321-7ec5-4837-8805-a302f9575754']
+      idCard:
+        type: text
+        label: ID card
+        authorizationGroupUuids: ['1050c9e3-e679-4c60-8bdc-5139fbc1c10b']
 
   location:
     format: LAT_LON

--- a/anet-dictionary.yml
+++ b/anet-dictionary.yml
@@ -486,11 +486,21 @@ fields:
         label: Date of birth
         authorizationGroupUuids: ['39a78d51-c351-452c-9206-4305ec8dd76d', 'c21e7321-7ec5-4837-8805-a302f9575754']
         tooltipText: This field contains sensitive information!
-      idCard:
-        type: text
-        label: ID card
+      politicalPosition:
+        type: enum
+        label: Position on the political spectrum
         authorizationGroupUuids: ['1050c9e3-e679-4c60-8bdc-5139fbc1c10b']
         tooltipText: This field contains sensitive information!
+        choices:
+          LEFT:
+            label: Left
+            color: 'salmon'
+          MIDDLE:
+            label: Middle
+            color: 'gold'
+          RIGHT:
+            label: Right
+            color: 'skyblue'
 
   location:
     format: LAT_LON
@@ -889,7 +899,7 @@ fields:
         - prevPositions
         - phoneNumber
         - country
-        - idCard
+        - birthday
         - colourOptions
         - textareaFieldName
         - domainUsername
@@ -897,7 +907,7 @@ fields:
         - multipleButtons
         - inputFieldName
         - code
-        - birthday
+        - politicalPosition
         - rank
         - numberFieldName
         - nlt

--- a/anet-dictionary.yml
+++ b/anet-dictionary.yml
@@ -880,13 +880,14 @@ fields:
                   color: '#0000ff'
       # number of fields after Avatar in the left column for principals
       # adjust this number if two columns are not balanced on the Person Page
-      numberOfFieldsInLeftColumn: 6
+      numberOfFieldsInLeftColumn: 7
       # select and order person fields (including custom fields)
       showPageOrderedFields:
         - position
         - prevPositions
         - phoneNumber
         - country
+        - idCard
         - colourOptions
         - textareaFieldName
         - domainUsername
@@ -894,6 +895,7 @@ fields:
         - multipleButtons
         - inputFieldName
         - code
+        - birthday
         - rank
         - numberFieldName
         - nlt

--- a/client/src/components/AvatarEditModal.js
+++ b/client/src/components/AvatarEditModal.js
@@ -3,13 +3,15 @@ import PropTypes from "prop-types"
 import React, { useState } from "react"
 import { Button, Modal } from "react-bootstrap"
 
-const AvatarEditModal = ({ title, onAvatarUpdate }) => {
+const AvatarEditModal = ({ title, onAvatarUpdate, disabled }) => {
   const [showModal, setShowModal] = useState(false)
   const [currentPreview, setCurrentPreview] = useState(null)
 
   return (
     <div>
-      <button onClick={open}>{title}</button>
+      <button disabled={disabled} onClick={open}>
+        {title}
+      </button>
 
       <Modal show={showModal} onHide={close}>
         <Modal.Header closeButton>
@@ -41,7 +43,8 @@ const AvatarEditModal = ({ title, onAvatarUpdate }) => {
 }
 AvatarEditModal.propTypes = {
   title: PropTypes.string.isRequired,
-  onAvatarUpdate: PropTypes.func.isRequired
+  onAvatarUpdate: PropTypes.func.isRequired,
+  disabled: PropTypes.bool
 }
 
 export default AvatarEditModal

--- a/client/src/components/AvatarEditModal.js
+++ b/client/src/components/AvatarEditModal.js
@@ -3,15 +3,13 @@ import PropTypes from "prop-types"
 import React, { useState } from "react"
 import { Button, Modal } from "react-bootstrap"
 
-const AvatarEditModal = ({ title, onAvatarUpdate, disabled }) => {
+const AvatarEditModal = ({ title, onAvatarUpdate }) => {
   const [showModal, setShowModal] = useState(false)
   const [currentPreview, setCurrentPreview] = useState(null)
 
   return (
     <div>
-      <button disabled={disabled} onClick={open}>
-        {title}
-      </button>
+      <button onClick={open}>{title}</button>
 
       <Modal show={showModal} onHide={close}>
         <Modal.Header closeButton>
@@ -43,8 +41,7 @@ const AvatarEditModal = ({ title, onAvatarUpdate, disabled }) => {
 }
 AvatarEditModal.propTypes = {
   title: PropTypes.string.isRequired,
-  onAvatarUpdate: PropTypes.func.isRequired,
-  disabled: PropTypes.bool
+  onAvatarUpdate: PropTypes.func.isRequired
 }
 
 export default AvatarEditModal

--- a/client/src/components/CustomDateInput.js
+++ b/client/src/components/CustomDateInput.js
@@ -71,6 +71,7 @@ const CustomDateInput = ({
       }}
       placeholder={inputFormat}
       maxDate={moment().add(20, "years").endOf("year").toDate()}
+      minDate={moment().subtract(100, "years").startOf("year").toDate()}
       canClearSelection={false}
       showActionsBar
       closeOnSelection={!withTime}

--- a/client/src/components/CustomFields.js
+++ b/client/src/components/CustomFields.js
@@ -873,18 +873,16 @@ const CustomField = ({
   fieldName,
   formikProps,
   invisibleFields,
-  vertical,
-  disabled
+  vertical
 }) => {
   const { type, helpText, authorizationGroupUuids } = fieldConfig
   let extraColElem
   if (authorizationGroupUuids) {
     if (fieldConfig.authorizationGroupUuids) {
-      disabled = false
       extraColElem = (
         <div>
           <Tooltip2 content={fieldConfig.tooltipText} intent={Intent.WARNING}>
-            <Icon icon={IconNames.ERROR} intent={Intent.WARNING} />
+            <Icon icon={IconNames.INFO_SIGN} intent={Intent.PRIMARY} />
           </Tooltip2>
         </div>
       )
@@ -908,10 +906,7 @@ const CustomField = ({
     },
     [fieldName, setFieldTouched, setFieldValue, validateFormDebounced, type]
   )
-  // Show readonly components for disabled fields
-  const FieldComponent = disabled
-    ? READONLY_FIELD_COMPONENTS[type]
-    : FIELD_COMPONENTS[type]
+  const FieldComponent = FIELD_COMPONENTS[type]
   const extraProps = useMemo(() => {
     switch (type) {
       case CUSTOM_FIELD_TYPE.SPECIAL_FIELD:
@@ -964,8 +959,7 @@ CustomField.propTypes = {
   fieldName: PropTypes.string.isRequired,
   formikProps: PropTypes.object,
   invisibleFields: PropTypes.array,
-  vertical: PropTypes.bool,
-  disabled: PropTypes.bool
+  vertical: PropTypes.bool
 }
 
 const CustomFields = ({
@@ -973,8 +967,7 @@ const CustomFields = ({
   formikProps,
   parentFieldName,
   invisibleFields,
-  vertical,
-  disabled
+  vertical
 }) => {
   return (
     <>
@@ -988,7 +981,6 @@ const CustomFields = ({
             formikProps={formikProps}
             invisibleFields={invisibleFields}
             vertical={vertical}
-            disabled={disabled}
           />
         )
       })}
@@ -1000,13 +992,11 @@ CustomFields.propTypes = {
   formikProps: PropTypes.object,
   parentFieldName: PropTypes.string.isRequired,
   invisibleFields: PropTypes.array,
-  vertical: PropTypes.bool,
-  disabled: PropTypes.bool
+  vertical: PropTypes.bool
 }
 CustomFields.defaultProps = {
   parentFieldName: DEFAULT_CUSTOM_FIELDS_PARENT,
-  vertical: false,
-  disabled: false
+  vertical: false
 }
 
 const READONLY_FIELD_COMPONENTS = {

--- a/client/src/components/CustomFields.js
+++ b/client/src/components/CustomFields.js
@@ -858,6 +858,7 @@ export const getFieldPropsFromFieldConfig = fieldConfig => {
     placeholder,
     helpText,
     authorizationGroupUuids,
+    tooltipText,
     validations,
     visibleWhen,
     test,
@@ -882,10 +883,7 @@ const CustomField = ({
       disabled = false
       extraColElem = (
         <div>
-          <Tooltip2
-            content="You are authorized to edit this field"
-            intent={Intent.WARNING}
-          >
+          <Tooltip2 content={fieldConfig.tooltipText} intent={Intent.WARNING}>
             <Icon icon={IconNames.ERROR} intent={Intent.WARNING} />
           </Tooltip2>
         </div>
@@ -1102,10 +1100,7 @@ export const mapReadonlyCustomFieldsToComps = ({
     if (fieldConfig.authorizationGroupUuids) {
       extraColElem = (
         <div>
-          <Tooltip2
-            content="This field contains sensitive information!"
-            intent={Intent.WARNING}
-          >
+          <Tooltip2 content={fieldConfig.tooltipText} intent={Intent.WARNING}>
             <Icon
               icon={IconNames.INFO_SIGN}
               intent={Intent.PRIMARY}

--- a/client/src/components/CustomFields.js
+++ b/client/src/components/CustomFields.js
@@ -955,10 +955,9 @@ const CustomField = ({
   ) : (
     <FastField
       name={fieldName}
-      label={fieldProps.label}
-      vertical={fieldProps.vertical}
       component={FieldHelper.ReadonlyField}
       humanValue={<i>Missing FieldComponent for {type}</i>}
+      {...fieldProps}
     />
   )
 }
@@ -1064,13 +1063,12 @@ export const ReadonlyCustomFields = ({
           <FastField
             key={key}
             name={fieldName}
-            label={fieldProps.label}
-            vertical={fieldProps.vertical}
             isCompact={isCompact}
             component={FieldHelper.ReadonlyField}
             humanValue={<i>Missing ReadonlyFieldComponent for {type}</i>}
             extraColElem={extraColElem}
             labelColumnWidth={labelColumnWidth}
+            {...fieldProps}
           />
         )
       })}
@@ -1138,12 +1136,11 @@ export const mapReadonlyCustomFieldsToComps = ({
       <FastField
         key={key}
         name={fieldName}
-        label={fieldProps.label}
-        vertical={fieldProps.vertical}
         component={FieldHelper.ReadonlyField}
         humanValue={<i>Missing ReadonlyFieldComponent for {type}</i>}
         extraColElem={extraColElem}
         labelColumnWidth={labelColumnWidth}
+        {...fieldProps}
       />
     )
 

--- a/client/src/components/CustomFields.js
+++ b/client/src/components/CustomFields.js
@@ -1103,16 +1103,23 @@ export const mapReadonlyCustomFieldsToComps = ({
       extraColElem = (
         <div>
           <Tooltip2
-            content="You are authorized to see this field"
+            content="This field contains sensitive information!"
             intent={Intent.WARNING}
           >
-            <Icon icon={IconNames.ERROR} intent={Intent.WARNING} />
+            <Icon
+              icon={IconNames.INFO_SIGN}
+              intent={Intent.PRIMARY}
+              className="sensitive-information-icon"
+            />
           </Tooltip2>
         </div>
       )
     }
     const fieldName = `${parentFieldName}.${key}`
     const fieldProps = getFieldPropsFromFieldConfig(fieldConfig)
+    if (fieldConfig.authorizationGroupUuids) {
+      fieldProps.className = "sensitive-information"
+    }
     const { type } = fieldConfig
     let extraProps = {}
     if (type === CUSTOM_FIELD_TYPE.ARRAY_OF_OBJECTS) {

--- a/client/src/components/CustomFields.js
+++ b/client/src/components/CustomFields.js
@@ -145,7 +145,8 @@ const ReadonlyTextField = fieldProps => {
     vertical,
     isCompact,
     extraColElem,
-    labelColumnWidth
+    labelColumnWidth,
+    className
   } = fieldProps
   return (
     <FastField
@@ -156,6 +157,7 @@ const ReadonlyTextField = fieldProps => {
       extraColElem={extraColElem}
       labelColumnWidth={labelColumnWidth}
       component={FieldHelper.ReadonlyField}
+      className={className}
     />
   )
 }
@@ -180,7 +182,8 @@ const ReadonlyDateField = fieldProps => {
     isCompact,
     withTime,
     extraColElem,
-    labelColumnWidth
+    labelColumnWidth,
+    className
   } = fieldProps
   return (
     <FastField
@@ -199,6 +202,7 @@ const ReadonlyDateField = fieldProps => {
             : Settings.dateFormats.forms.displayShort.date
         )
       }
+      className={className}
     />
   )
 }
@@ -242,7 +246,8 @@ const ReadonlyJsonField = ({
   label,
   values,
   extraColElem,
-  labelColumnWidth
+  labelColumnWidth,
+  className
 }) => {
   const value = Object.get(values, name) || {}
   return (
@@ -253,6 +258,7 @@ const ReadonlyJsonField = ({
       humanValue={JSON.stringify(value)}
       extraColElem={extraColElem}
       labelColumnWidth={labelColumnWidth}
+      className={className}
     />
   )
 }
@@ -261,7 +267,8 @@ ReadonlyJsonField.propTypes = {
   label: PropTypes.string.isRequired,
   values: PropTypes.object.isRequired,
   extraColElem: PropTypes.object,
-  labelColumnWidth: PropTypes.number
+  labelColumnWidth: PropTypes.number,
+  className: PropTypes.string
 }
 
 const EnumField = fieldProps => {
@@ -292,7 +299,8 @@ const ReadonlyEnumField = fieldProps => {
     isCompact,
     choices,
     extraColElem,
-    labelColumnWidth
+    labelColumnWidth,
+    className
   } = fieldProps
   return (
     <FastField
@@ -305,6 +313,7 @@ const ReadonlyEnumField = fieldProps => {
       humanValue={fieldVal => enumHumanValue(choices, fieldVal)}
       extraColElem={extraColElem}
       labelColumnWidth={labelColumnWidth}
+      className={className}
     />
   )
 }
@@ -564,7 +573,8 @@ const ReadonlyAnetObjectField = ({
   values,
   isCompact,
   extraColElem,
-  labelColumnWidth
+  labelColumnWidth,
+  className
 }) => {
   const { type, uuid } = Object.get(values, name) || {}
   return (
@@ -589,6 +599,7 @@ const ReadonlyAnetObjectField = ({
       }
       extraColElem={extraColElem}
       labelColumnWidth={labelColumnWidth}
+      className={className}
     />
   )
 }
@@ -598,7 +609,8 @@ ReadonlyAnetObjectField.propTypes = {
   values: PropTypes.object.isRequired,
   isCompact: PropTypes.bool,
   extraColElem: PropTypes.object,
-  labelColumnWidth: PropTypes.number
+  labelColumnWidth: PropTypes.number,
+  className: PropTypes.string
 }
 
 const ArrayOfAnetObjectsField = ({
@@ -684,7 +696,8 @@ const ReadonlyArrayOfAnetObjectsField = ({
   values,
   isCompact,
   extraColElem,
-  labelColumnWidth
+  labelColumnWidth,
+  className
 }) => {
   const fieldValue = Object.get(values, name) || []
   return (
@@ -710,6 +723,7 @@ const ReadonlyArrayOfAnetObjectsField = ({
       }
       extraColElem={extraColElem}
       labelColumnWidth={labelColumnWidth}
+      className={className}
     />
   )
 }
@@ -719,7 +733,8 @@ ReadonlyArrayOfAnetObjectsField.propTypes = {
   values: PropTypes.object.isRequired,
   isCompact: PropTypes.bool,
   extraColElem: PropTypes.object,
-  labelColumnWidth: PropTypes.number
+  labelColumnWidth: PropTypes.number,
+  className: PropTypes.string
 }
 
 const FIELD_COMPONENTS = {

--- a/client/src/components/CustomFields.js
+++ b/client/src/components/CustomFields.js
@@ -12,7 +12,8 @@ import Model, {
   createYupObjectShape,
   CUSTOM_FIELD_TYPE,
   DEFAULT_CUSTOM_FIELDS_PARENT,
-  INVISIBLE_CUSTOM_FIELDS_FIELD
+  INVISIBLE_CUSTOM_FIELDS_FIELD,
+  SENSITIVE_CUSTOM_FIELDS_PARENT
 } from "components/Model"
 import RemoveButton from "components/RemoveButton"
 import RichTextEditor from "components/RichTextEditor"
@@ -1166,27 +1167,22 @@ export const customFieldsJSONString = (
 // customSensitiveInformation should be changed according to formSensitiveField values
 // When field is not initialized new field object should be pushed to customSensitiveInformation
 export const updateCustomSensitiveInformation = (
-  allSensitiveFields,
-  customSensitiveInformation,
-  formSensitiveFields
+  values,
+  parentFieldName = SENSITIVE_CUSTOM_FIELDS_PARENT
 ) => {
-  const allSensitiveInformationNames = Object.keys(allSensitiveFields)
-  allSensitiveInformationNames.forEach(sensitiveFieldName => {
-    const newFormFieldValue = formSensitiveFields?.[sensitiveFieldName]
-    const newSensitiveFieldValue = JSON.stringify({
-      [sensitiveFieldName]: newFormFieldValue
-    })
-    const correspondingSensitiveField = customSensitiveInformation.find(
-      field => field.customFieldName === sensitiveFieldName
+  const customSensitiveInformation = []
+  const sensitiveFieldValues = Object.get(values, parentFieldName) || []
+  Object.keys(sensitiveFieldValues).forEach(sensitiveFieldName => {
+    const existingField = values.customSensitiveInformation?.find(
+      sf => sf.customFieldName === sensitiveFieldName
     )
-    if (!correspondingSensitiveField) {
-      const newSensitiveField = {
-        customFieldName: sensitiveFieldName,
-        customFieldValue: newSensitiveFieldValue
-      }
-      customSensitiveInformation.push(newSensitiveField)
-    } else {
-      correspondingSensitiveField.customFieldValue = newSensitiveFieldValue
-    }
+    customSensitiveInformation.push({
+      customFieldName: sensitiveFieldName,
+      customFieldValue: JSON.stringify({
+        [sensitiveFieldName]: sensitiveFieldValues[sensitiveFieldName]
+      }),
+      uuid: existingField?.uuid
+    })
   })
+  return customSensitiveInformation
 }

--- a/client/src/components/CustomFields.js
+++ b/client/src/components/CustomFields.js
@@ -1172,3 +1172,31 @@ export const customFieldsJSONString = (
     return JSON.stringify(filteredCustomFieldsValues)
   }
 }
+
+// customSensitiveInformation should be changed according to formSensitiveField values
+// When field is not initialized new field object should be pushed to customSensitiveInformation
+export const updateCustomSensitiveInformation = (
+  allSensitiveFields,
+  customSensitiveInformation,
+  formSensitiveFields
+) => {
+  const allSensitiveInformationNames = Object.keys(allSensitiveFields)
+  allSensitiveInformationNames.forEach(sensitiveFieldName => {
+    const newFormFieldValue = formSensitiveFields?.[sensitiveFieldName]
+    const newSensitiveFieldValue = JSON.stringify({
+      [sensitiveFieldName]: newFormFieldValue
+    })
+    const correspondingSensitiveField = customSensitiveInformation.find(
+      field => field.customFieldName === sensitiveFieldName
+    )
+    if (!correspondingSensitiveField) {
+      const newSensitiveField = {
+        customFieldName: sensitiveFieldName,
+        customFieldValue: newSensitiveFieldValue
+      }
+      customSensitiveInformation.push(newSensitiveField)
+    } else {
+      correspondingSensitiveField.customFieldValue = newSensitiveFieldValue
+    }
+  })
+}

--- a/client/src/components/CustomFields.js
+++ b/client/src/components/CustomFields.js
@@ -1082,10 +1082,22 @@ export const mapReadonlyCustomFieldsToComps = ({
   parentFieldName = DEFAULT_CUSTOM_FIELDS_PARENT, // key path in the values object to get to the level of fields given by the fieldsConfig
   values,
   vertical,
-  extraColElem,
   labelColumnWidth
 }) => {
   return Object.entries(fieldsConfig).reduce((accum, [key, fieldConfig]) => {
+    let extraColElem = null
+    if (fieldConfig.authorizationGroupUuids) {
+      extraColElem = (
+        <div>
+          <Tooltip2
+            content="You are authorized to see this field"
+            intent={Intent.WARNING}
+          >
+            <Icon icon={IconNames.ERROR} intent={Intent.WARNING} />
+          </Tooltip2>
+        </div>
+      )
+    }
     const fieldName = `${parentFieldName}.${key}`
     const fieldProps = getFieldPropsFromFieldConfig(fieldConfig)
     const { type } = fieldConfig

--- a/client/src/components/FieldHelper.js
+++ b/client/src/components/FieldHelper.js
@@ -71,7 +71,8 @@ const Field = ({
   vertical,
   isCompact,
   extraAddon,
-  labelColumnWidth
+  labelColumnWidth,
+  className
 }) => {
   const id = getFieldId(field)
   const widget = useMemo(
@@ -102,6 +103,7 @@ const Field = ({
     return (
       <CompactRow
         label={label}
+        className={className}
         content={
           <>
             {widget}
@@ -114,7 +116,12 @@ const Field = ({
   }
 
   return (
-    <FormGroup id={`fg-${id}`} controlId={id} validationState={validationState}>
+    <FormGroup
+      id={`fg-${id}`}
+      controlId={id}
+      validationState={validationState}
+      className={className}
+    >
       {vertical ? (
         <>
           <div>{label !== null && <ControlLabel>{label}</ControlLabel>}</div>
@@ -153,7 +160,8 @@ Field.propTypes = {
   vertical: PropTypes.bool,
   extraAddon: PropTypes.object,
   isCompact: PropTypes.bool,
-  labelColumnWidth: PropTypes.number
+  labelColumnWidth: PropTypes.number,
+  className: PropTypes.string
 }
 Field.defaultProps = {
   vertical: false, // default direction of label and input = horizontal
@@ -253,6 +261,7 @@ export const ReadonlyField = ({
   isCompact,
   ...otherProps
 }) => {
+  const { className } = otherProps
   const widgetElem = useMemo(
     () => (
       <FormControl.Static componentClass="div" {...field} {...otherProps}>
@@ -273,6 +282,7 @@ export const ReadonlyField = ({
       addon={addon}
       vertical={vertical}
       isCompact={isCompact}
+      className={className}
     />
   )
 }

--- a/client/src/components/Model.js
+++ b/client/src/components/Model.js
@@ -730,4 +730,18 @@ export default class Model {
       customSensitiveInformationField?.authorizationGroupUuids || []
     return fieldAuthGroupUuids.some(uuid => userAuthGroupUuids.includes(uuid))
   }
+
+  static getAuthorizedSensitiveFields(
+    isAuthorizedCallback,
+    user,
+    customSensitiveInformation,
+    ...args
+  ) {
+    const authorizedFieldsConfig = {}
+    Object.entries(customSensitiveInformation).forEach(([k, v]) => {
+      isAuthorizedCallback(user, customSensitiveInformation[k], ...args) &&
+        (authorizedFieldsConfig[k] = v)
+    })
+    return authorizedFieldsConfig
+  }
 }

--- a/client/src/components/Model.js
+++ b/client/src/components/Model.js
@@ -717,4 +717,17 @@ export default class Model {
   filterClientSideFields(...additionalFields) {
     return Model.filterClientSideFields(this, ...additionalFields)
   }
+
+  static isAuthorized(user, customSensitiveInformationField) {
+    // Admins are always allowed
+    if (user?.isAdmin()) {
+      return true
+    }
+    // Else user has to be in the authorizationGroups
+    const userAuthGroupUuids =
+      user?.position?.authorizationGroups.map(ag => ag.uuid) || []
+    const fieldAuthGroupUuids =
+      customSensitiveInformationField?.authorizationGroupUuids || []
+    return fieldAuthGroupUuids.some(uuid => userAuthGroupUuids.includes(uuid))
+  }
 }

--- a/client/src/components/Model.js
+++ b/client/src/components/Model.js
@@ -128,6 +128,7 @@ export const NOTE_TYPE = {
 }
 
 export const DEFAULT_CUSTOM_FIELDS_PARENT = "formCustomFields"
+export const SENSITIVE_CUSTOM_FIELDS_PARENT = "formSensitiveFields"
 export const INVISIBLE_CUSTOM_FIELDS_FIELD = "invisibleCustomFields"
 export const NOTES_FIELD = "notes"
 
@@ -701,7 +702,8 @@ export default class Model {
 
   static FILTERED_CLIENT_SIDE_FIELDS = [
     NOTES_FIELD,
-    DEFAULT_CUSTOM_FIELDS_PARENT
+    DEFAULT_CUSTOM_FIELDS_PARENT,
+    SENSITIVE_CUSTOM_FIELDS_PARENT
   ]
 
   static filterClientSideFields(obj, ...additionalFields) {

--- a/client/src/components/Model.js
+++ b/client/src/components/Model.js
@@ -314,10 +314,14 @@ export const createAssessmentSchema = (
   })
 }
 
-export const createCustomFieldsSchema = customFieldsConfig =>
+export const createCustomFieldsSchema = (
+  customFieldsConfig,
+  customFieldsParent = DEFAULT_CUSTOM_FIELDS_PARENT
+) =>
   yup.object().shape({
-    [DEFAULT_CUSTOM_FIELDS_PARENT]: createYupObjectShape(
-      customFieldsConfig
+    [customFieldsParent]: createYupObjectShape(
+      customFieldsConfig,
+      customFieldsParent
     ).nullable()
   })
 

--- a/client/src/components/Model.js
+++ b/client/src/components/Model.js
@@ -19,6 +19,14 @@ import * as yup from "yup"
 export const REPORT_RELATED_OBJECT_TYPE = "reports"
 export const REPORT_STATE_PUBLISHED = "PUBLISHED"
 
+export const GRAPHQL_CUSTOM_SENSITIVE_INFORMATION_FIELDS = /* GraphQL */ `
+  customSensitiveInformation {
+    uuid
+    customFieldName
+    customFieldValue
+  }
+`
+
 export const GRAPHQL_NOTE_FIELDS = /* GraphQL */ `
   uuid
   createdAt

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -152,6 +152,16 @@ fieldset.danger {
   width: 10em;
 }
 
+.sensitive-information {
+  background-color: cornsilk;
+}
+.sensitive-information.form-group {
+  min-height: 34px;
+}
+.sensitive-information-icon svg {
+  height: 34px;
+}
+
 .shortcut-list {
   margin-top: -4px;
 }

--- a/client/src/models/AuthorizationGroup.js
+++ b/client/src/models/AuthorizationGroup.js
@@ -13,18 +13,17 @@ export default class AuthorizationGroup extends Model {
     return "Authorization Group"
   }
 
-  static yupSchema = yup
-    .object()
-    .shape({
-      name: yup.string().required().default(""),
-      description: yup.string().required().default(""),
-      status: yup
-        .string()
-        .required()
-        .default(() => Model.STATUS.ACTIVE),
-      positions: yup.array().nullable().default([])
-    })
-    .concat(Model.yupSchema)
+  static schema = {}
+
+  static yupSchema = yup.object().shape({
+    name: yup.string().required().default(""),
+    description: yup.string().required().default(""),
+    status: yup
+      .string()
+      .required()
+      .default(() => Model.STATUS.ACTIVE),
+    positions: yup.array().nullable().default([])
+  })
 
   static autocompleteQuery = "uuid, name, description"
 

--- a/client/src/models/Comment.js
+++ b/client/src/models/Comment.js
@@ -6,8 +6,7 @@ export default class Comment extends Model {
   static schema = {
     reportUuid: null,
     author: {},
-    text: "",
-    ...Model.schema
+    text: ""
   }
 
   toString() {

--- a/client/src/models/Organization.js
+++ b/client/src/models/Organization.js
@@ -155,4 +155,18 @@ export default class Organization extends Model {
         organization.identificationCode || ""
       }`
   }
+
+  static FILTERED_CLIENT_SIDE_FIELDS = ["childrenOrgs", "positions", "tasks"]
+
+  static filterClientSideFields(obj, ...additionalFields) {
+    return Model.filterClientSideFields(
+      obj,
+      ...Organization.FILTERED_CLIENT_SIDE_FIELDS,
+      ...additionalFields
+    )
+  }
+
+  filterClientSideFields(...additionalFields) {
+    return Organization.filterClientSideFields(this, ...additionalFields)
+  }
 }

--- a/client/src/models/Person.js
+++ b/client/src/models/Person.js
@@ -35,7 +35,11 @@ export default class Person extends Model {
   static principalAssessmentConfig =
     Settings.fields.principal.person.assessments
 
-  static customFields = Settings.fields.person.customFields
+  static customFields = {
+    ...Settings.fields.person.customFields,
+    ...Settings.fields.person.customSensitiveInformation
+  }
+
   // create yup schema for the customFields, based on the customFields config
   static customFieldsSchema = createCustomFieldsSchema(Person.customFields)
 
@@ -223,6 +227,12 @@ export default class Person extends Model {
       this.position &&
       (this.position.type === Position.TYPE.SUPER_USER ||
         this.position.type === Position.TYPE.ADMINISTRATOR)
+    )
+  }
+
+  isCounterpart(position) {
+    return position.associatedPositions.find(
+      pos => pos.uuid === this.position.uuid
     )
   }
 

--- a/client/src/models/Person.js
+++ b/client/src/models/Person.js
@@ -230,21 +230,6 @@ export default class Person extends Model {
     )
   }
 
-  isCounterpart(position) {
-    return position.associatedPositions.find(
-      pos => pos.uuid === this.position.uuid
-    )
-  }
-
-  isAuthorized(key) {
-    const currentUserAuthGroups = this.position.authorizationGroups.map(
-      ag => ag.uuid
-    )
-    const fieldAuthGroups =
-      Person.customSensitiveInformation[key].authorizationGroupUuids
-    return fieldAuthGroups.some(k => currentUserAuthGroups.includes(k))
-  }
-
   hasAssignedPosition() {
     // has a non-empty position with a non-zero uuid
     return !_isEmpty(this.position) && !!this.position.uuid
@@ -467,5 +452,15 @@ export default class Person extends Model {
 
   filterClientSideFields(...additionalFields) {
     return Person.filterClientSideFields(this, ...additionalFields)
+  }
+
+  static isAuthorized(user, customSensitiveInformationField, position) {
+    if (Model.isAuthorized(user, customSensitiveInformationField)) {
+      return true
+    }
+    // Else user has to be counterpart
+    return user?.position?.associatedPositions?.find(
+      pos => pos.uuid === position.uuid
+    )
   }
 }

--- a/client/src/models/Person.js
+++ b/client/src/models/Person.js
@@ -271,6 +271,21 @@ export default class Person extends Model {
     return orgUuids.includes(org.uuid)
   }
 
+  getAuthorizedSensitiveFields(customSensitiveInformation) {
+    if (this.isAdmin()) {
+      return customSensitiveInformation
+    }
+    const currentUserAuthGroups = this.position.authorizationGroups.map(
+      ag => ag.uuid
+    )
+    const authorizedFieldsConfig = {}
+    Object.entries(customSensitiveInformation).forEach(([k, v]) => {
+      v.authorizationGroupUuids.some(r => currentUserAuthGroups.includes(r)) &&
+        (authorizedFieldsConfig[k] = v)
+    })
+    return authorizedFieldsConfig
+  }
+
   iconUrl() {
     if (this.isAdvisor()) {
       return RS_ICON

--- a/client/src/models/Person.js
+++ b/client/src/models/Person.js
@@ -230,6 +230,21 @@ export default class Person extends Model {
     )
   }
 
+  isCounterpart(position) {
+    return position.associatedPositions.find(
+      pos => pos.uuid === this.position.uuid
+    )
+  }
+
+  isAuthorized(key) {
+    const currentUserAuthGroups = this.position.authorizationGroups.map(
+      ag => ag.uuid
+    )
+    const fieldAuthGroups =
+      Person.customSensitiveInformation[key].authorizationGroupUuids
+    return fieldAuthGroups.some(k => currentUserAuthGroups.includes(k))
+  }
+
   hasAssignedPosition() {
     // has a non-empty position with a non-zero uuid
     return !_isEmpty(this.position) && !!this.position.uuid

--- a/client/src/models/Person.js
+++ b/client/src/models/Person.js
@@ -271,21 +271,6 @@ export default class Person extends Model {
     return orgUuids.includes(org.uuid)
   }
 
-  getAuthorizedSensitiveFields(customSensitiveInformation) {
-    if (this.isAdmin()) {
-      return customSensitiveInformation
-    }
-    const currentUserAuthGroups = this.position.authorizationGroups.map(
-      ag => ag.uuid
-    )
-    const authorizedFieldsConfig = {}
-    Object.entries(customSensitiveInformation).forEach(([k, v]) => {
-      v.authorizationGroupUuids.some(r => currentUserAuthGroups.includes(r)) &&
-        (authorizedFieldsConfig[k] = v)
-    })
-    return authorizedFieldsConfig
-  }
-
   iconUrl() {
     if (this.isAdvisor()) {
       return RS_ICON
@@ -461,6 +446,19 @@ export default class Person extends Model {
     // Else user has to be counterpart
     return user?.position?.associatedPositions?.find(
       pos => pos.uuid === position.uuid
+    )
+  }
+
+  static getAuthorizedSensitiveFields(
+    user,
+    customSensitiveInformation,
+    position
+  ) {
+    return Model.getAuthorizedSensitiveFields(
+      Person.isAuthorized,
+      user,
+      customSensitiveInformation,
+      position
     )
   }
 }

--- a/client/src/models/Person.js
+++ b/client/src/models/Person.js
@@ -230,12 +230,6 @@ export default class Person extends Model {
     )
   }
 
-  isCounterpart(position) {
-    return position.associatedPositions.find(
-      pos => pos.uuid === this.position.uuid
-    )
-  }
-
   hasAssignedPosition() {
     // has a non-empty position with a non-zero uuid
     return !_isEmpty(this.position) && !!this.position.uuid

--- a/client/src/models/Person.js
+++ b/client/src/models/Person.js
@@ -402,4 +402,18 @@ export default class Person extends Model {
     }
     return config || []
   }
+
+  static FILTERED_CLIENT_SIDE_FIELDS = ["firstName", "lastName"]
+
+  static filterClientSideFields(obj, ...additionalFields) {
+    return Model.filterClientSideFields(
+      obj,
+      ...Person.FILTERED_CLIENT_SIDE_FIELDS,
+      ...additionalFields
+    )
+  }
+
+  filterClientSideFields(...additionalFields) {
+    return Person.filterClientSideFields(this, ...additionalFields)
+  }
 }

--- a/client/src/models/Person.js
+++ b/client/src/models/Person.js
@@ -366,7 +366,8 @@ export default class Person extends Model {
     return fieldsArrayFromConfig.filter(field => {
       if (
         Settings.fields.person[field] ||
-        Settings.fields.person?.customFields?.[field]
+        Settings.fields.person?.customFields?.[field] ||
+        Settings.fields.person?.customSensitiveInformation?.[field]
       ) {
         return true
       }

--- a/client/src/models/Person.js
+++ b/client/src/models/Person.js
@@ -2,6 +2,7 @@ import API from "api"
 import Model, {
   createCustomFieldsSchema,
   GRAPHQL_NOTES_FIELDS,
+  SENSITIVE_CUSTOM_FIELDS_PARENT,
   yupDate
 } from "components/Model"
 import _isEmpty from "lodash/isEmpty"
@@ -42,6 +43,10 @@ export default class Person extends Model {
 
   // create yup schema for the customFields, based on the customFields config
   static customFieldsSchema = createCustomFieldsSchema(Person.customFields)
+  static sensitiveFieldsSchema = createCustomFieldsSchema(
+    Person.customSensitiveInformation,
+    SENSITIVE_CUSTOM_FIELDS_PARENT
+  )
 
   static principalShowPageOrderedFields = Person.initShowPageFieldsOrdered(true)
   static advisorShowPageOrderedFields = Person.initShowPageFieldsOrdered(false)
@@ -161,6 +166,7 @@ export default class Person extends Model {
     })
     // not actually in the database, the database contains the JSON customFields
     .concat(Person.customFieldsSchema)
+    .concat(Person.sensitiveFieldsSchema)
     .concat(Model.yupSchema)
 
   static autocompleteQuery =

--- a/client/src/models/Person.js
+++ b/client/src/models/Person.js
@@ -35,10 +35,10 @@ export default class Person extends Model {
   static principalAssessmentConfig =
     Settings.fields.principal.person.assessments
 
-  static customFields = {
-    ...Settings.fields.person.customFields,
-    ...Settings.fields.person.customSensitiveInformation
-  }
+  static customFields = Settings.fields.person.customFields
+
+  static customSensitiveInformation =
+    Settings.fields.person.customSensitiveInformation
 
   // create yup schema for the customFields, based on the customFields config
   static customFieldsSchema = createCustomFieldsSchema(Person.customFields)
@@ -387,7 +387,11 @@ export default class Person extends Model {
     return (
       this.getShowPageFieldsOrdered()
         // filter out custom fields
-        .filter(key => !Person?.customFields?.[key])
+        .filter(
+          key =>
+            !Person?.customFields?.[key] &&
+            !Person?.customSensitiveInformation?.[key]
+        )
     )
   }
 
@@ -399,6 +403,19 @@ export default class Person extends Model {
         .filter(key => Person?.customFields?.[key])
         .reduce((accum, key) => {
           accum[key] = Person.customFields[key]
+          return accum
+        }, {})
+    )
+  }
+
+  // we want custom fields as an object not array so we can parse it using existing code
+  getSensitiveFieldsOrderedAsObject() {
+    return (
+      this.getShowPageFieldsOrdered()
+        // filter out non-custom fields
+        .filter(key => Person?.customSensitiveInformation?.[key])
+        .reduce((accum, key) => {
+          accum[key] = Person.customSensitiveInformation[key]
           return accum
         }, {})
     )

--- a/client/src/models/Report.js
+++ b/client/src/models/Report.js
@@ -1,6 +1,5 @@
 import Model, {
   createCustomFieldsSchema,
-  DEFAULT_CUSTOM_FIELDS_PARENT,
   NOTE_TYPE,
   REPORT_RELATED_OBJECT_TYPE,
   REPORT_STATE_PUBLISHED,
@@ -590,18 +589,25 @@ export default class Report extends Model {
     )
   }
 
-  static getCleanReport(values) {
-    // Strip notes and any synthetic fields from a report
-    return Object.without(
-      new Report(values),
-      "notes",
-      "showSensitiveInfo",
-      "authors",
-      DEFAULT_CUSTOM_FIELDS_PARENT,
-      Report.TASKS_ASSESSMENTS_PARENT_FIELD,
-      Report.ATTENDEES_ASSESSMENTS_PARENT_FIELD,
-      Report.TASKS_ASSESSMENTS_UUIDS_FIELD,
-      Report.ATTENDEES_ASSESSMENTS_UUIDS_FIELD
+  static FILTERED_CLIENT_SIDE_FIELDS = [
+    "authors",
+    "cancelled",
+    "showSensitiveInfo",
+    Report.TASKS_ASSESSMENTS_PARENT_FIELD,
+    Report.ATTENDEES_ASSESSMENTS_PARENT_FIELD,
+    Report.TASKS_ASSESSMENTS_UUIDS_FIELD,
+    Report.ATTENDEES_ASSESSMENTS_UUIDS_FIELD
+  ]
+
+  static filterClientSideFields(obj, ...additionalFields) {
+    return Model.filterClientSideFields(
+      obj,
+      ...Report.FILTERED_CLIENT_SIDE_FIELDS,
+      ...additionalFields
     )
+  }
+
+  filterClientSideFields(...additionalFields) {
+    return Report.filterClientSideFields(this, ...additionalFields)
   }
 }

--- a/client/src/models/Task.js
+++ b/client/src/models/Task.js
@@ -186,4 +186,18 @@ export default class Task extends Model {
     // The given task instance might have a specific assessments config
     return utils.parseJsonSafe(this.customFields).assessments || []
   }
+
+  static FILTERED_CLIENT_SIDE_FIELDS = ["assessment_customFieldEnum1"]
+
+  static filterClientSideFields(obj, ...additionalFields) {
+    return Model.filterClientSideFields(
+      obj,
+      ...Task.FILTERED_CLIENT_SIDE_FIELDS,
+      ...additionalFields
+    )
+  }
+
+  filterClientSideFields(...additionalFields) {
+    return Task.filterClientSideFields(this, ...additionalFields)
+  }
 }

--- a/client/src/pages/App.js
+++ b/client/src/pages/App.js
@@ -106,6 +106,12 @@ const GQL_GET_APP_DATA = gql`
           }
           ${GRAPHQL_NOTIFICATIONS_NOTE_FIELDS}
         }
+        authorizationGroups {
+          uuid
+          name
+          description
+          status
+        }
       }
     }
 

--- a/client/src/pages/admin/MergeLocations.js
+++ b/client/src/pages/admin/MergeLocations.js
@@ -261,12 +261,7 @@ const MergeLocations = ({ pageDispatchers }) => {
     const loser = mergedLocation.uuid === location1.uuid ? location2 : location1
     mergedLocation.customFields = customFieldsJSONString(mergedLocation)
 
-    const winnerLocation = Object.without(
-      mergedLocation,
-      "notes",
-      "displayedCoordinate",
-      DEFAULT_CUSTOM_FIELDS_PARENT
-    )
+    const winnerLocation = Location.filterClientSideFields(mergedLocation)
 
     API.mutation(GQL_MERGE_LOCATION, {
       loserUuid: loser.uuid,

--- a/client/src/pages/admin/authorizationgroup/Edit.js
+++ b/client/src/pages/admin/authorizationgroup/Edit.js
@@ -6,9 +6,6 @@ import {
   mapPageDispatchersToProps,
   useBoilerplate
 } from "components/Page"
-import RelatedObjectNotes, {
-  GRAPHQL_NOTES_FIELDS
-} from "components/RelatedObjectNotes"
 import { AuthorizationGroup } from "models"
 import React from "react"
 import { connect } from "react-redux"
@@ -40,7 +37,6 @@ const GQL_GET_AUTHORIZATION_GROUP = gql`
         }
       }
       status
-      ${GRAPHQL_NOTES_FIELDS}
     }
   }
 `
@@ -70,16 +66,6 @@ const AuthorizationGroupEdit = ({ pageDispatchers }) => {
 
   return (
     <div>
-      <RelatedObjectNotes
-        notes={authorizationGroup.notes}
-        relatedObject={
-          authorizationGroup.uuid && {
-            relatedObjectType: AuthorizationGroup.relatedObjectType,
-            relatedObjectUuid: authorizationGroup.uuid,
-            relatedObject: authorizationGroup
-          }
-        }
-      />
       <AuthorizationGroupForm
         edit
         initialValues={authorizationGroup}

--- a/client/src/pages/admin/authorizationgroup/Form.js
+++ b/client/src/pages/admin/authorizationgroup/Form.js
@@ -229,10 +229,7 @@ const AuthorizationGroupForm = ({ edit, title, initialValues }) => {
   }
 
   function save(values, form) {
-    const authorizationGroup = Object.without(
-      new AuthorizationGroup(values),
-      "notes"
-    )
+    const authorizationGroup = AuthorizationGroup.filterClientSideFields(values)
     authorizationGroup.positions = values.positions.map(pos =>
       Position.filterClientSideFields(pos, "previousPeople", "customFields")
     )

--- a/client/src/pages/admin/authorizationgroup/Show.js
+++ b/client/src/pages/admin/authorizationgroup/Show.js
@@ -12,9 +12,6 @@ import {
   useBoilerplate
 } from "components/Page"
 import PositionTable from "components/PositionTable"
-import RelatedObjectNotes, {
-  GRAPHQL_NOTES_FIELDS
-} from "components/RelatedObjectNotes"
 import ReportCollection, {
   FORMAT_CALENDAR,
   FORMAT_MAP,
@@ -53,7 +50,6 @@ const GQL_GET_AUTHORIZATION_GROUP = gql`
         }
       }
       status
-      ${GRAPHQL_NOTES_FIELDS}
     }
   }
 `
@@ -101,16 +97,6 @@ const AuthorizationGroupShow = ({ pageDispatchers }) => {
         )
         return (
           <div>
-            <RelatedObjectNotes
-              notes={authorizationGroup.notes}
-              relatedObject={
-                authorizationGroup.uuid && {
-                  relatedObjectType: AuthorizationGroup.relatedObjectType,
-                  relatedObjectUuid: authorizationGroup.uuid,
-                  relatedObject: authorizationGroup
-                }
-              }
-            />
             <Messages success={stateSuccess} error={stateError} />
             <Form className="form-horizontal" method="post">
               <Fieldset

--- a/client/src/pages/organizations/Form.js
+++ b/client/src/pages/organizations/Form.js
@@ -16,7 +16,7 @@ import * as FieldHelper from "components/FieldHelper"
 import Fieldset from "components/Fieldset"
 import LinkTo from "components/LinkTo"
 import Messages from "components/Messages"
-import Model, { DEFAULT_CUSTOM_FIELDS_PARENT } from "components/Model"
+import Model from "components/Model"
 import NavigationWarning from "components/NavigationWarning"
 import NoPaginationTaskTable from "components/NoPaginationTaskTable"
 import { jumpToTop } from "components/Page"
@@ -426,14 +426,8 @@ const OrganizationForm = ({ edit, title, initialValues }) => {
   }
 
   function save(values, form) {
-    const organization = Object.without(
-      new Organization(values),
-      "notes",
-      "childrenOrgs",
-      "positions",
-      "tasks",
-      "customFields", // initial JSON from the db
-      DEFAULT_CUSTOM_FIELDS_PARENT
+    const organization = Organization.filterClientSideFields(
+      new Organization(values)
     )
     // strip tasks fields not in data model
     organization.tasks = values.tasks.map(t => utils.getReference(t))

--- a/client/src/pages/people/Edit.js
+++ b/client/src/pages/people/Edit.js
@@ -86,6 +86,15 @@ const PersonEdit = ({ pageDispatchers }) => {
     data.person[DEFAULT_CUSTOM_FIELDS_PARENT] = utils.parseJsonSafe(
       data.person.customFields
     )
+    if (data.person.customSensitiveInformation) {
+      // Add sensitive information fields to formCustomFields
+      data.person[
+        DEFAULT_CUSTOM_FIELDS_PARENT
+      ] = utils.addCustomSensitiveInformation(
+        data.person[DEFAULT_CUSTOM_FIELDS_PARENT],
+        data.person.customSensitiveInformation
+      )
+    }
   }
   const person = new Person(data ? data.person : {})
   const legendText = person.isPendingVerification()

--- a/client/src/pages/people/Edit.js
+++ b/client/src/pages/people/Edit.js
@@ -4,7 +4,8 @@ import { gql } from "apollo-boost"
 import { initInvisibleFields } from "components/CustomFields"
 import {
   DEFAULT_CUSTOM_FIELDS_PARENT,
-  GRAPHQL_CUSTOM_SENSITIVE_INFORMATION_FIELDS
+  GRAPHQL_CUSTOM_SENSITIVE_INFORMATION_FIELDS,
+  SENSITIVE_CUSTOM_FIELDS_PARENT
 } from "components/Model"
 import {
   mapPageDispatchersToProps,
@@ -88,10 +89,7 @@ const PersonEdit = ({ pageDispatchers }) => {
     )
     if (data.person.customSensitiveInformation) {
       // Add sensitive information fields to formCustomFields
-      data.person[
-        DEFAULT_CUSTOM_FIELDS_PARENT
-      ] = utils.addCustomSensitiveInformation(
-        data.person[DEFAULT_CUSTOM_FIELDS_PARENT],
+      data.person[SENSITIVE_CUSTOM_FIELDS_PARENT] = utils.parseSensitiveFields(
         data.person.customSensitiveInformation
       )
     }
@@ -106,6 +104,7 @@ const PersonEdit = ({ pageDispatchers }) => {
 
   // mutates the object
   initInvisibleFields(person, Settings.fields.person.customFields)
+  initInvisibleFields(person, Settings.fields.person.customSensitiveInformation)
 
   return (
     <div>

--- a/client/src/pages/people/Edit.js
+++ b/client/src/pages/people/Edit.js
@@ -2,7 +2,10 @@ import { DEFAULT_SEARCH_PROPS, PAGE_PROPS_NO_NAV } from "actions"
 import API from "api"
 import { gql } from "apollo-boost"
 import { initInvisibleFields } from "components/CustomFields"
-import { DEFAULT_CUSTOM_FIELDS_PARENT } from "components/Model"
+import {
+  DEFAULT_CUSTOM_FIELDS_PARENT,
+  GRAPHQL_CUSTOM_SENSITIVE_INFORMATION_FIELDS
+} from "components/Model"
 import {
   mapPageDispatchersToProps,
   PageDispatchersPropType,
@@ -49,6 +52,7 @@ const GQL_GET_PERSON = gql`
         }
       }
       customFields
+      ${GRAPHQL_CUSTOM_SENSITIVE_INFORMATION_FIELDS}
       ${GRAPHQL_NOTES_FIELDS}
     }
   }

--- a/client/src/pages/people/Form.js
+++ b/client/src/pages/people/Form.js
@@ -141,6 +141,11 @@ const PersonForm = ({ edit, title, saveText, initialValues }) => {
         const warnDomainUsername =
           values.status === Model.STATUS.INACTIVE &&
           !_isEmpty(values.domainUsername)
+        const authorizedSensitiveFields =
+          currentUser &&
+          currentUser.getAuthorizedSensitiveFields(
+            Person.customSensitiveInformation
+          )
         const ranks = Settings.fields.person.ranks || []
         const roleButtons = isAdmin ? adminRoleButtons : userRoleButtons
         const countries = getCountries(values.role)
@@ -525,10 +530,10 @@ const PersonForm = ({ edit, title, saveText, initialValues }) => {
                 </Fieldset>
               )}
 
-              {!_isEmpty(Person.customSensitiveInformation) && (
+              {!_isEmpty(authorizedSensitiveFields) && (
                 <Fieldset title="Sensitive information" id="sensitive-fields">
                   <CustomFieldsContainer
-                    fieldsConfig={Person.customSensitiveInformation}
+                    fieldsConfig={authorizedSensitiveFields}
                     parentFieldName={SENSITIVE_CUSTOM_FIELDS_PARENT}
                     formikProps={{
                       setFieldTouched,

--- a/client/src/pages/people/Form.js
+++ b/client/src/pages/people/Form.js
@@ -143,8 +143,10 @@ const PersonForm = ({ edit, title, saveText, initialValues }) => {
           !_isEmpty(values.domainUsername)
         const authorizedSensitiveFields =
           currentUser &&
-          currentUser.getAuthorizedSensitiveFields(
-            Person.customSensitiveInformation
+          Person.getAuthorizedSensitiveFields(
+            currentUser,
+            Person.customSensitiveInformation,
+            values.position
           )
         const ranks = Settings.fields.person.ranks || []
         const roleButtons = isAdmin ? adminRoleButtons : userRoleButtons

--- a/client/src/pages/people/Form.js
+++ b/client/src/pages/people/Form.js
@@ -14,7 +14,7 @@ import { parseHtmlWithLinkTo } from "components/editor/LinkAnet"
 import * as FieldHelper from "components/FieldHelper"
 import Fieldset from "components/Fieldset"
 import Messages from "components/Messages"
-import Model, { DEFAULT_CUSTOM_FIELDS_PARENT } from "components/Model"
+import Model, { SENSITIVE_CUSTOM_FIELDS_PARENT } from "components/Model"
 import "components/NameInput.css"
 import NavigationWarning from "components/NavigationWarning"
 import OptionListModal from "components/OptionListModal"
@@ -546,6 +546,22 @@ const PersonForm = ({ edit, title, saveText, initialValues }) => {
                   />
                 </Fieldset>
               )}
+
+              {!_isEmpty(Person.customSensitiveInformation) && (
+                <Fieldset title="Sensitive information" id="sensitive-fields">
+                  <CustomFieldsContainer
+                    fieldsConfig={Person.customSensitiveInformation}
+                    parentFieldName={SENSITIVE_CUSTOM_FIELDS_PARENT}
+                    disabled={!canEditNonSensitiveFields}
+                    formikProps={{
+                      setFieldTouched,
+                      setFieldValue,
+                      values,
+                      validateForm
+                    }}
+                  />
+                </Fieldset>
+              )}
               {showSimilarPeople && (
                 <SimilarObjectsModal
                   objectType="Person"
@@ -655,11 +671,6 @@ const PersonForm = ({ edit, title, saveText, initialValues }) => {
       { firstName: values.firstName, lastName: values.lastName },
       true
     )
-    person.customSensitiveInformation.forEach(sensitiveField => {
-      sensitiveField.customFieldValue = customFieldsJSONString(
-        values[DEFAULT_CUSTOM_FIELDS_PARENT][sensitiveField.customFieldName]
-      )
-    })
     person.customFields = customFieldsJSONString(values)
     return API.mutation(edit ? GQL_UPDATE_PERSON : GQL_CREATE_PERSON, {
       person

--- a/client/src/pages/people/Form.js
+++ b/client/src/pages/people/Form.js
@@ -655,11 +655,7 @@ const PersonForm = ({ edit, title, saveText, initialValues }) => {
       { firstName: values.firstName, lastName: values.lastName },
       true
     )
-    updateCustomSensitiveInformation(
-      Person.customSensitiveInformation,
-      person.customSensitiveInformation,
-      values.formSensitiveFields
-    )
+    person.customSensitiveInformation = updateCustomSensitiveInformation(values)
     person.customFields = customFieldsJSONString(values)
     return API.mutation(edit ? GQL_UPDATE_PERSON : GQL_CREATE_PERSON, {
       person

--- a/client/src/pages/people/Form.js
+++ b/client/src/pages/people/Form.js
@@ -11,7 +11,6 @@ import {
   customFieldsJSONString,
   updateCustomSensitiveInformation
 } from "components/CustomFields"
-import { parseHtmlWithLinkTo } from "components/editor/LinkAnet"
 import * as FieldHelper from "components/FieldHelper"
 import Fieldset from "components/Fieldset"
 import Messages from "components/Messages"
@@ -130,7 +129,6 @@ const PersonForm = ({ edit, title, saveText, initialValues }) => {
       }) => {
         const isSelf = Person.isEqual(currentUser, values)
         const isAdmin = currentUser && currentUser.isAdmin()
-        const isSuperUser = currentUser && currentUser.isSuperUser()
         const isAdvisor = Person.isAdvisor(values)
         const isPendingVerification = Person.isPendingVerification(values)
         const endOfTourDateInPast = values.endOfTourDate
@@ -156,12 +154,9 @@ const PersonForm = ({ edit, title, saveText, initialValues }) => {
           ((isPendingVerification || !edit) &&
             currentUser &&
             (currentUser.isSuperUser() || isSelf))
-        const canEditNonSensitiveFields = isAdmin || isSuperUser
         // admins and super users with edit permissions can change status to INACTIVE, only admins can change back to ACTIVE (but nobody can change status of self!)
         const disableStatusChange =
-          (initialValues.status === Model.STATUS.INACTIVE && !isAdmin) ||
-          isSelf ||
-          !canEditNonSensitiveFields
+          (initialValues.status === Model.STATUS.INACTIVE && !isAdmin) || isSelf
         const fullName = Person.fullName(Person.parseFullName(values.name))
         const nameMessage = "This is not " + (isSelf ? "me" : fullName)
         const modalTitle = `It is possible that the information of ${fullName} is out of date. Please help us identify if any of the following is the case:`
@@ -198,7 +193,6 @@ const PersonForm = ({ edit, title, saveText, initialValues }) => {
                 <AvatarEditModal
                   title="Edit avatar"
                   onAvatarUpdate={onAvatarUpdate}
-                  disabled={!canEditNonSensitiveFields}
                 />
                 <FormGroup>
                   <Col sm={2} componentClass={ControlLabel} htmlFor="lastName">
@@ -390,7 +384,6 @@ const PersonForm = ({ edit, title, saveText, initialValues }) => {
                     component={FieldHelper.RadioButtonToggleGroupField}
                     buttons={statusButtons}
                     onChange={value => setFieldValue("status", value)}
-                    disabled={!canEditNonSensitiveFields}
                   >
                     {willAutoKickPosition && (
                       <HelpBlock>
@@ -427,19 +420,16 @@ const PersonForm = ({ edit, title, saveText, initialValues }) => {
                       : ""
                   }
                   component={FieldHelper.InputField}
-                  disabled={!canEditNonSensitiveFields}
                 />
                 <FastField
                   name="phoneNumber"
                   label={Settings.fields.person.phoneNumber}
                   component={FieldHelper.InputField}
-                  disabled={!canEditNonSensitiveFields}
                 />
                 <FastField
                   name="rank"
                   label={Settings.fields.person.rank}
                   component={FieldHelper.SpecialField}
-                  disabled={!canEditNonSensitiveFields}
                   widget={
                     <FastField component="select" className="form-control">
                       <option />
@@ -456,7 +446,6 @@ const PersonForm = ({ edit, title, saveText, initialValues }) => {
                   name="gender"
                   label={Settings.fields.person.gender}
                   component={FieldHelper.SpecialField}
-                  disabled={!canEditNonSensitiveFields}
                   widget={
                     <FastField component="select" className="form-control">
                       <option />
@@ -469,7 +458,6 @@ const PersonForm = ({ edit, title, saveText, initialValues }) => {
                   name="country"
                   label={Settings.fields.person.country}
                   component={FieldHelper.SpecialField}
-                  disabled={!canEditNonSensitiveFields}
                   widget={
                     <FastField component="select" className="form-control">
                       <option />
@@ -495,7 +483,6 @@ const PersonForm = ({ edit, title, saveText, initialValues }) => {
                   onChange={value => setFieldValue("endOfTourDate", value)}
                   onBlur={() => setFieldTouched("endOfTourDate")}
                   widget={<CustomDateInput id="endOfTourDate" />}
-                  disabled={!canEditNonSensitiveFields}
                 >
                   {isAdvisor && endOfTourDateInPast && (
                     <Alert bsStyle="warning">
@@ -503,41 +490,31 @@ const PersonForm = ({ edit, title, saveText, initialValues }) => {
                     </Alert>
                   )}
                 </FastField>
-                {canEditNonSensitiveFields ? (
-                  <FastField
-                    name="biography"
-                    component={FieldHelper.SpecialField}
-                    disabled={!canEditNonSensitiveFields}
-                    onChange={value => {
-                      // prevent initial unnecessary render of RichTextEditor
-                      if (!_isEqual(value, values.biography)) {
-                        setFieldValue("biography", value)
-                      }
-                    }}
-                    widget={
-                      <RichTextEditor
-                        className="biography"
-                        onHandleBlur={() => {
-                          // validation will be done by setFieldValue
-                          setFieldTouched("biography", true, false)
-                        }}
-                      />
+                <FastField
+                  name="biography"
+                  component={FieldHelper.SpecialField}
+                  onChange={value => {
+                    // prevent initial unnecessary render of RichTextEditor
+                    if (!_isEqual(value, values.biography)) {
+                      setFieldValue("biography", value)
                     }
-                  />
-                ) : (
-                  <FastField
-                    name="biography"
-                    component={FieldHelper.ReadonlyField}
-                    humanValue={parseHtmlWithLinkTo(values.biography)}
-                  />
-                )}
+                  }}
+                  widget={
+                    <RichTextEditor
+                      className="biography"
+                      onHandleBlur={() => {
+                        // validation will be done by setFieldValue
+                        setFieldTouched("biography", true, false)
+                      }}
+                    />
+                  }
+                />
               </Fieldset>
 
               {!_isEmpty(Person.customFields) && (
                 <Fieldset title="Person information" id="custom-fields">
                   <CustomFieldsContainer
                     fieldsConfig={Person.customFields}
-                    disabled={!canEditNonSensitiveFields}
                     formikProps={{
                       setFieldTouched,
                       setFieldValue,
@@ -553,7 +530,6 @@ const PersonForm = ({ edit, title, saveText, initialValues }) => {
                   <CustomFieldsContainer
                     fieldsConfig={Person.customSensitiveInformation}
                     parentFieldName={SENSITIVE_CUSTOM_FIELDS_PARENT}
-                    disabled={!canEditNonSensitiveFields}
                     formikProps={{
                       setFieldTouched,
                       setFieldValue,

--- a/client/src/pages/people/Form.js
+++ b/client/src/pages/people/Form.js
@@ -13,7 +13,7 @@ import {
 import * as FieldHelper from "components/FieldHelper"
 import Fieldset from "components/Fieldset"
 import Messages from "components/Messages"
-import Model, { DEFAULT_CUSTOM_FIELDS_PARENT } from "components/Model"
+import Model from "components/Model"
 import "components/NameInput.css"
 import NavigationWarning from "components/NavigationWarning"
 import OptionListModal from "components/OptionListModal"
@@ -624,14 +624,7 @@ const PersonForm = ({ edit, title, saveText, initialValues }) => {
 
   function save(values, form) {
     values.avatar = currentAvatar
-    const person = Object.without(
-      new Person(values),
-      "notes",
-      "firstName",
-      "lastName",
-      "customFields", // initial JSON from the db
-      DEFAULT_CUSTOM_FIELDS_PARENT
-    )
+    const person = Person.filterClientSideFields(new Person(values))
     if (values.pendingVerification) {
       person.pendingVerification = false
     }

--- a/client/src/pages/people/Form.js
+++ b/client/src/pages/people/Form.js
@@ -8,7 +8,8 @@ import AvatarEditModal from "components/AvatarEditModal"
 import CustomDateInput from "components/CustomDateInput"
 import {
   CustomFieldsContainer,
-  customFieldsJSONString
+  customFieldsJSONString,
+  updateCustomSensitiveInformation
 } from "components/CustomFields"
 import { parseHtmlWithLinkTo } from "components/editor/LinkAnet"
 import * as FieldHelper from "components/FieldHelper"
@@ -670,6 +671,11 @@ const PersonForm = ({ edit, title, saveText, initialValues }) => {
     person.name = Person.fullName(
       { firstName: values.firstName, lastName: values.lastName },
       true
+    )
+    updateCustomSensitiveInformation(
+      Person.customSensitiveInformation,
+      person.customSensitiveInformation,
+      values.formSensitiveFields
     )
     person.customFields = customFieldsJSONString(values)
     return API.mutation(edit ? GQL_UPDATE_PERSON : GQL_CREATE_PERSON, {

--- a/client/src/pages/people/Show.js
+++ b/client/src/pages/people/Show.js
@@ -15,7 +15,10 @@ import Fieldset from "components/Fieldset"
 import GuidedTour from "components/GuidedTour"
 import LinkTo from "components/LinkTo"
 import Messages from "components/Messages"
-import { DEFAULT_CUSTOM_FIELDS_PARENT } from "components/Model"
+import {
+  DEFAULT_CUSTOM_FIELDS_PARENT,
+  GRAPHQL_CUSTOM_SENSITIVE_INFORMATION_FIELDS
+} from "components/Model"
 import {
   mapPageDispatchersToProps,
   PageDispatchersPropType,
@@ -98,6 +101,7 @@ const GQL_GET_PERSON = gql`
         }
       }
       customFields
+      ${GRAPHQL_CUSTOM_SENSITIVE_INFORMATION_FIELDS}
       ${GRAPHQL_NOTES_FIELDS}
     }
   }

--- a/client/src/pages/people/Show.js
+++ b/client/src/pages/people/Show.js
@@ -152,6 +152,7 @@ const PersonShow = ({ pageDispatchers }) => {
   const isAdmin = currentUser && currentUser.isAdmin()
   const hasPosition = position && position.uuid
   const canEdit =
+    (currentUser && currentUser.isCounterpart(position)) ||
     Person.isEqual(currentUser, person) ||
     isAdmin ||
     (hasPosition && currentUser.isSuperUserForOrg(position.organization)) ||

--- a/client/src/pages/people/Show.js
+++ b/client/src/pages/people/Show.js
@@ -17,7 +17,8 @@ import LinkTo from "components/LinkTo"
 import Messages from "components/Messages"
 import {
   DEFAULT_CUSTOM_FIELDS_PARENT,
-  GRAPHQL_CUSTOM_SENSITIVE_INFORMATION_FIELDS
+  GRAPHQL_CUSTOM_SENSITIVE_INFORMATION_FIELDS,
+  SENSITIVE_CUSTOM_FIELDS_PARENT
 } from "components/Model"
 import {
   mapPageDispatchersToProps,
@@ -137,10 +138,7 @@ const PersonShow = ({ pageDispatchers }) => {
     )
     if (data.person.customSensitiveInformation) {
       // Add sensitive information fields to formCustomFields
-      data.person[
-        DEFAULT_CUSTOM_FIELDS_PARENT
-      ] = utils.addCustomSensitiveInformation(
-        data.person[DEFAULT_CUSTOM_FIELDS_PARENT],
+      data.person[SENSITIVE_CUSTOM_FIELDS_PARENT] = utils.parseSensitiveFields(
         data.person.customSensitiveInformation
       )
     }
@@ -332,6 +330,11 @@ const PersonShow = ({ pageDispatchers }) => {
       fieldsConfig: person.getCustomFieldsOrderedAsObject(),
       values: person
     })
+    const mappedSensitiveFields = mapReadonlyCustomFieldsToComps({
+      fieldsConfig: person.getSensitiveFieldsOrderedAsObject(),
+      parentFieldName: SENSITIVE_CUSTOM_FIELDS_PARENT,
+      values: person
+    })
     const mappedNonCustomFields = mapNonCustomFields()
     // map fields that have privileged access check to the condition
     const privilegedAccessedFields = {
@@ -364,10 +367,17 @@ const PersonShow = ({ pageDispatchers }) => {
             )
         )
         // Also filter if somehow there is no field in both maps
-        .filter(key => mappedNonCustomFields[key] || mappedCustomFields[key])
+        .filter(
+          key =>
+            mappedNonCustomFields[key] ||
+            mappedCustomFields[key] ||
+            mappedSensitiveFields[key]
+        )
         // then map it to components and keys, keys used for React list rendering
         .map(key => [
-          mappedNonCustomFields[key] || mappedCustomFields[key],
+          mappedNonCustomFields[key] ||
+            mappedCustomFields[key] ||
+            mappedSensitiveFields[key],
           key
         ])
         .map(([el, key]) =>

--- a/client/src/pages/people/Show.js
+++ b/client/src/pages/people/Show.js
@@ -354,24 +354,15 @@ const PersonShow = ({ pageDispatchers }) => {
             : true
         )
         // filter out unauthorized sensitive fields
-        .filter(key => {
-          if (
-            Object.keys(
+        .filter(
+          key =>
+            !Object.keys(
               Settings.fields.person.customSensitiveInformation
-            ).includes(key)
-          ) {
-            if (
-              person.customSensitiveInformation.find(
-                sensitiveInfo => sensitiveInfo.customFieldName === key
-              )
-            ) {
-              return true
-            } else {
-              return false
-            }
-          }
-          return true
-        })
+            ).includes(key) ||
+            person.customSensitiveInformation.find(
+              sensitiveInfo => sensitiveInfo.customFieldName === key
+            )
+        )
         // Also filter if somehow there is no field in both maps
         .filter(key => mappedNonCustomFields[key] || mappedCustomFields[key])
         // then map it to components and keys, keys used for React list rendering

--- a/client/src/pages/people/Show.js
+++ b/client/src/pages/people/Show.js
@@ -358,12 +358,10 @@ const PersonShow = ({ pageDispatchers }) => {
         // filter out unauthorized sensitive fields
         .filter(
           key =>
-            !Object.keys(
-              Settings.fields.person.customSensitiveInformation
-            ).includes(key) ||
-            person.customSensitiveInformation.find(
-              sensitiveInfo => sensitiveInfo.customFieldName === key
-            )
+            !Object.keys(Person.customSensitiveInformation).includes(key) ||
+            currentUser.isAdmin() ||
+            currentUser.isCounterpart(position) ||
+            currentUser.isAuthorized(key)
         )
         // Also filter if somehow there is no field in both maps
         .filter(

--- a/client/src/pages/people/Show.js
+++ b/client/src/pages/people/Show.js
@@ -359,9 +359,11 @@ const PersonShow = ({ pageDispatchers }) => {
         .filter(
           key =>
             !Object.keys(Person.customSensitiveInformation).includes(key) ||
-            currentUser.isAdmin() ||
-            currentUser.isCounterpart(position) ||
-            currentUser.isAuthorized(key)
+            Person.isAuthorized(
+              currentUser,
+              Person.customSensitiveInformation?.[key],
+              position
+            )
         )
         // Also filter if somehow there is no field in both maps
         .filter(

--- a/client/src/pages/people/Show.js
+++ b/client/src/pages/people/Show.js
@@ -159,7 +159,6 @@ const PersonShow = ({ pageDispatchers }) => {
   const isAdmin = currentUser && currentUser.isAdmin()
   const hasPosition = position && position.uuid
   const canEdit =
-    (currentUser && currentUser.isCounterpart(position)) ||
     Person.isEqual(currentUser, person) ||
     isAdmin ||
     (hasPosition && currentUser.isSuperUserForOrg(position.organization)) ||

--- a/client/src/pages/reports/Form.js
+++ b/client/src/pages/reports/Form.js
@@ -23,7 +23,6 @@ import Fieldset from "components/Fieldset"
 import Messages from "components/Messages"
 import Model, {
   ASSESSMENTS_RELATED_OBJECT_TYPE,
-  DEFAULT_CUSTOM_FIELDS_PARENT,
   NOTE_TYPE
 } from "components/Model"
 import NavigationWarning from "components/NavigationWarning"
@@ -421,7 +420,7 @@ const ReportForm = ({
         const hasAssessments = values.engagementDate && !isFutureEngagement
         let relatedObject
         if (hasAssessments) {
-          relatedObject = Report.getCleanReport(values)
+          relatedObject = Report.filterClientSideFields(new Report(values))
         }
 
         return (
@@ -1330,13 +1329,7 @@ const ReportForm = ({
   }
 
   function save(values, sendEmail) {
-    const report = Object.without(
-      Report.getCleanReport(values),
-      "cancelled",
-      "reportPeople",
-      "tasks",
-      "customFields" // initial JSON from the db
-    )
+    const report = Report.filterClientSideFields(new Report(values))
     if (Report.isFuture(values.engagementDate)) {
       // Empty fields which should not be set for future reports.
       // They might have been set before the report has been marked as future.
@@ -1357,13 +1350,10 @@ const ReportForm = ({
     }
     // strip reportPeople fields not in data model
     report.reportPeople = values.reportPeople.map(reportPerson => {
-      const rp = Object.without(
+      const rp = Person.filterClientSideFields(
         reportPerson,
-        "firstName",
-        "lastName",
         "position",
-        "customFields",
-        DEFAULT_CUSTOM_FIELDS_PARENT
+        "customFields"
       )
       rp.author = !!reportPerson.author
       rp.attendee = !!reportPerson.attendee

--- a/client/src/pages/reports/Show.js
+++ b/client/src/pages/reports/Show.js
@@ -362,7 +362,7 @@ const ReportShow = ({ setSearchQuery, pageDispatchers }) => {
   if (hasAssessments) {
     report = Object.assign(report, report.getTasksEngagementAssessments())
     report = Object.assign(report, report.getAttendeesEngagementAssessments())
-    relatedObject = Report.getCleanReport(report)
+    relatedObject = Report.filterClientSideFields(report)
   }
 
   return (

--- a/client/src/pages/tasks/Form.js
+++ b/client/src/pages/tasks/Form.js
@@ -17,11 +17,7 @@ import {
 import * as FieldHelper from "components/FieldHelper"
 import Fieldset from "components/Fieldset"
 import Messages from "components/Messages"
-import Model, {
-  DEFAULT_CUSTOM_FIELDS_PARENT,
-  GRAPHQL_NOTE_FIELDS,
-  NOTE_TYPE
-} from "components/Model"
+import Model, { GRAPHQL_NOTE_FIELDS, NOTE_TYPE } from "components/Model"
 import NavigationWarning from "components/NavigationWarning"
 import OrganizationTable from "components/OrganizationTable"
 import { jumpToTop } from "components/Page"
@@ -503,13 +499,7 @@ const TaskForm = ({ edit, title, initialValues }) => {
   }
 
   function save(values, form) {
-    const task = Object.without(
-      new Task(values),
-      "notes",
-      "assessment_customFieldEnum1",
-      "customFields", // initial JSON from the db
-      DEFAULT_CUSTOM_FIELDS_PARENT
-    )
+    const task = Task.filterClientSideFields(new Task(values))
     task.customFieldRef1 = utils.getReference(task.customFieldRef1)
     task.customFields = customFieldsJSONString(values)
     const variables = { task: task }

--- a/client/src/utils.js
+++ b/client/src/utils.js
@@ -192,7 +192,7 @@ export default {
     return typeof result === "object" ? result || {} : {}
   },
 
-  addCustomSensitiveInformation(formCustomFields, customSensitiveInformation) {
+  parseSensitiveFields: function(customSensitiveInformation) {
     const sensitiveInformationObjects = customSensitiveInformation.map(
       sensitiveInfo => this.parseJsonSafe(sensitiveInfo.customFieldValue)
     )
@@ -203,7 +203,7 @@ export default {
       },
       {}
     )
-    return { ...formCustomFields, ...allSensitiveFields }
+    return allSensitiveFields
   },
 
   arrayOfNumbers: function(arr) {

--- a/client/src/utils.js
+++ b/client/src/utils.js
@@ -192,6 +192,20 @@ export default {
     return typeof result === "object" ? result || {} : {}
   },
 
+  addCustomSensitiveInformation(formCustomFields, customSensitiveInformation) {
+    const sensitiveInformationObjects = customSensitiveInformation.map(
+      sensitiveInfo => this.parseJsonSafe(sensitiveInfo.customFieldValue)
+    )
+    const allSensitiveFields = sensitiveInformationObjects.reduce(
+      (accum, key) => {
+        accum = { ...accum, ...key }
+        return accum
+      },
+      {}
+    )
+    return { ...formCustomFields, ...allSensitiveFields }
+  },
+
   arrayOfNumbers: function(arr) {
     return (
       arr &&

--- a/client/tests/webdriver/baseSpecs/createNewLocation.spec.js
+++ b/client/tests/webdriver/baseSpecs/createNewLocation.spec.js
@@ -32,7 +32,7 @@ describe("When creating a new Location", () => {
     CreateNewLocation.latField.setValue(BAD_LAT_LNG_VAL)
     CreateNewLocation.lngField.setValue(BAD_LAT_LNG_VAL)
     // trigger onblur effect
-    browser.keys(["Tab"])
+    CreateNewLocation.nameField.click()
 
     CreateNewLocation.latLngErrorsDisplayed()
   })

--- a/insertBaseData-mssql.sql
+++ b/insertBaseData-mssql.sql
@@ -945,10 +945,10 @@ INSERT INTO customSensitiveInformation (uuid, customFieldName, customFieldValue,
 	VALUES
 		-- Steve
 		(N'4263793a-18bc-4cef-a535-0116615301e1', 'birthday', '{"birthday":"1999-09-09T00:00:00.000Z"}', 'people', '90fa5784-9e63-4353-8119-357bcd88e287', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
-		(N'c9ca5fd9-699e-4643-8025-91a2f2e0cd77', 'idCard', '{"idCard":"A123456"}', 'people', '90fa5784-9e63-4353-8119-357bcd88e287', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+		(N'c9ca5fd9-699e-4643-8025-91a2f2e0cd77', 'politicalPosition', '{"politicalPosition":"LEFT"}', 'people', '90fa5784-9e63-4353-8119-357bcd88e287', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
 		-- Roger
 		(N'84b46418-4350-4b52-8789-2b292fc0ab60', 'birthday', '{"birthday":"2001-01-01T00:00:00.000Z"}', 'people', '6866ce4d-1f8c-4f78-bdc2-4767e9a859b0', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
-		(N'810cf44b-91f6-474a-b522-5ba822ccfc1c', 'idCard', '{"idCard":"B987654"}', 'people', '6866ce4d-1f8c-4f78-bdc2-4767e9a859b0', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+		(N'810cf44b-91f6-474a-b522-5ba822ccfc1c', 'politicalPosition', '{"politicalPosition":"RIGHT"}', 'people', '6866ce4d-1f8c-4f78-bdc2-4767e9a859b0', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
 
 -- Add some notes and link them to the objects they relate to
 SET @authorUuid = (SELECT uuid FROM people WHERE name = 'BECCABON, Rebecca');

--- a/insertBaseData-mssql.sql
+++ b/insertBaseData-mssql.sql
@@ -22,6 +22,7 @@ SET QUOTED_IDENTIFIER ON
 --DROP TABLE authorizationGroupPositions;
 --DROP TABLE authorizationGroups;
 --DROP TABLE reportAuthorizationGroups;
+--DROP TABLE customSensitiveInformation;
 --DROP TABLE notes;
 --DROP TABLE noteRelatedObjects;
 --DROP TABLE DATABASECHANGELOG;
@@ -52,6 +53,7 @@ DELETE FROM locations;
 DELETE FROM organizations;
 DELETE FROM adminSettings;
 DELETE FROM authorizationGroups;
+DELETE FROM customSensitiveInformation;
 
 --Advisors
 INSERT INTO people (uuid, name, status, role, emailAddress, phoneNumber, rank, biography, domainUsername, country, gender, endOfTourDate, createdAt, updatedAt)
@@ -79,11 +81,11 @@ INSERT INTO people (uuid, name, status, role, emailAddress, phoneNumber, rank, b
 	VALUES (lower(newid()), 'REPORTGIRL, Ima', 0, 0, 'ima+reportgirl@example.com', '+444-44-4545', 'CIV', 'I need a career change', 'nopos', 'Mexico', 'FEMALE', DATEADD(year, 1, CURRENT_TIMESTAMP), CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
 -- Principals
 INSERT INTO people (uuid, name, status, role, emailAddress, phoneNumber, rank, biography, country, gender, createdAt, updatedAt)
-	VALUES (lower(newid()), 'STEVESON, Steve', 0, 1, 'hunter+steve@example.com', '+011-232-12324', 'LtCol', 'this is a sample person who could be a Principal!', 'Afghanistan', 'MALE', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+	VALUES ('90fa5784-9e63-4353-8119-357bcd88e287', 'STEVESON, Steve', 0, 1, 'hunter+steve@example.com', '+011-232-12324', 'LtCol', 'this is a sample person who could be a Principal!', 'Afghanistan', 'MALE', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
 INSERT INTO people (uuid, name, status, role, emailAddress, phoneNumber, rank, biography, country, gender, createdAt, updatedAt)
-	VALUES (lower(newid()), 'ROGWELL, Roger', 0, 1, 'hunter+roger@example.com', '+1-412-7324', 'Maj', 'Roger is another test person we have in the database', 'Afghanistan', 'MALE', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+	VALUES ('6866ce4d-1f8c-4f78-bdc2-4767e9a859b0', 'ROGWELL, Roger', 0, 1, 'hunter+roger@example.com', '+1-412-7324', 'Maj', 'Roger is another test person we have in the database', 'Afghanistan', 'MALE', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
 INSERT INTO people (uuid, name, status, role, emailAddress, phoneNumber, rank, biography, country, gender, createdAt, updatedAt)
-	VALUES (lower(newid()), 'TOPFERNESS, Christopf', 0, 1, 'hunter+christopf@example.com', '+1-422222222', 'CIV', 'Christopf works in the MoD Office', 'Afghanistan', 'MALE', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+	VALUES ('237e8bf7-2ae4-4d49-b7c8-eca6a92d4767', 'TOPFERNESS, Christopf', 0, 1, 'hunter+christopf@example.com', '+1-422222222', 'CIV', 'Christopf works in the MoD Office', 'Afghanistan', 'MALE', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
 INSERT INTO people (uuid, name, status, role, emailAddress, phoneNumber, rank, biography, country, gender, createdAt, updatedAt)
 	VALUES (lower(newid()), 'CHRISVILLE, Chris', 0, 1, 'chrisville+chris@example.com', '+1-412-7324', 'Maj', 'Chris is another test person we have in the database', 'Afghanistan', 'MALE', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
 INSERT INTO people (uuid, name, status, role, emailAddress, phoneNumber, rank, biography, country, gender, createdAt, updatedAt)
@@ -901,30 +903,27 @@ INSERT INTO reportPeople (personUuid, reportUuid, isPrimary, isAuthor)
 
 -- Authorization groups
 INSERT INTO authorizationGroups (uuid, name, description, status, createdAt, updatedAt)
-	VALUES (lower(newid()), 'EF 1.1 positions', 'All positions related to EF 1.1', 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+	VALUES ('1050c9e3-e679-4c60-8bdc-5139fbc1c10b', 'EF 1.1 positions', 'All positions related to EF 1.1', 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
 INSERT INTO authorizationGroups (uuid, name, description, status, createdAt, updatedAt)
-	VALUES (lower(newid()), 'EF 2.1 positions', 'All positions related to EF 2.1', 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+	VALUES ('39a78d51-c351-452c-9206-4305ec8dd76d', 'EF 2.1 positions', 'All positions related to EF 2.1', 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
 INSERT INTO authorizationGroups (uuid, name, description, status, createdAt, updatedAt)
-	VALUES (lower(newid()), 'EF 2.2 positions', 'All positions related to EF 2.2', 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+	VALUES ('c21e7321-7ec5-4837-8805-a302f9575754', 'EF 2.2 positions', 'All positions related to EF 2.2', 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
 INSERT INTO authorizationGroups (uuid, name, description, status, createdAt, updatedAt)
-	VALUES (lower(newid()), 'Inactive positions', 'Inactive positions', 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+	VALUES ('90a5196d-acf3-4a81-8ff9-3a8c7acabdf3', 'Inactive positions', 'Inactive positions', 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
 
 -- Authorization group positions
 INSERT INTO authorizationGroupPositions (authorizationGroupUuid, positionUuid)
-  SELECT a.uuid, p.uuid
-  FROM authorizationGroups a, positions p
-  WHERE a.name LIKE 'EF 1.1%'
-  AND p.name LIKE 'EF 1.1%';
+  SELECT '1050c9e3-e679-4c60-8bdc-5139fbc1c10b', p.uuid
+  FROM positions p
+  WHERE p.name LIKE 'EF 1.1%';
 INSERT INTO authorizationGroupPositions (authorizationGroupUuid, positionUuid)
-  SELECT a.uuid, p.uuid
-  FROM authorizationGroups a, positions p
-  WHERE a.name LIKE 'EF 2.1%'
-  AND p.name LIKE 'EF 2.1%';
+  SELECT '39a78d51-c351-452c-9206-4305ec8dd76d', p.uuid
+  FROM positions p
+  WHERE p.name LIKE 'EF 2.1%';
 INSERT INTO authorizationGroupPositions (authorizationGroupUuid, positionUuid)
-  SELECT a.uuid, p.uuid
-  FROM authorizationGroups a, positions p
-  WHERE a.name LIKE 'EF 2.2%'
-  AND p.name LIKE 'EF 2.2%';
+  SELECT 'c21e7321-7ec5-4837-8805-a302f9575754', p.uuid
+  FROM positions p
+  WHERE p.name LIKE 'EF 2.2%';
 
 -- Report authorization groups
 INSERT INTO reportAuthorizationGroups (reportUuid, authorizationGroupUuid)
@@ -940,6 +939,16 @@ INSERT INTO reportAuthorizationGroups (reportUuid, authorizationGroupUuid)
     WHERE rap.reportUuid = rp.reportUuid
     AND rap.authorizationGroupUuid = agp.authorizationGroupUuid
   );
+
+-- Create customSensitiveInformation for some principals
+INSERT INTO customSensitiveInformation (uuid, customFieldName, customFieldValue, relatedObjectType, relatedObjectUuid, createdAt, updatedAt)
+	VALUES
+		-- Steve
+		(N'4263793a-18bc-4cef-a535-0116615301e1', 'birthday', '{"birthday":"1999-09-09T00:00:00.000Z"}', 'people', '90fa5784-9e63-4353-8119-357bcd88e287', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+		(N'c9ca5fd9-699e-4643-8025-91a2f2e0cd77', 'idCard', '{"idCard":"A123456"}', 'people', '90fa5784-9e63-4353-8119-357bcd88e287', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+		-- Roger
+		(N'84b46418-4350-4b52-8789-2b292fc0ab60', 'birthday', '{"birthday":"2001-01-01T00:00:00.000Z"}', 'people', '6866ce4d-1f8c-4f78-bdc2-4767e9a859b0', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+		(N'810cf44b-91f6-474a-b522-5ba822ccfc1c', 'idCard', '{"idCard":"B987654"}', 'people', '6866ce4d-1f8c-4f78-bdc2-4767e9a859b0', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
 
 -- Add some notes and link them to the objects they relate to
 SET @authorUuid = (SELECT uuid FROM people WHERE name = 'BECCABON, Rebecca');

--- a/mssql2pg.pl
+++ b/mssql2pg.pl
@@ -20,7 +20,7 @@ s/^(?=(SET|DECLARE))/-- /;
 # Eliminate the weird "[key]" column naming
 s/\[key\]/key/g;
 # Quote mixed-case column and table names
-s/(?<![":-])\b([a-z]\w+[A-Z]\w+)/"$1"/g;
+s/(?<!['":-])\b([a-z]\w+[A-Z]\w+)/"$1"/g;
 # Turn a couple very specific 1/0 booleans into true/false booleans
 # This one is for "isAuthor" in "reportPeople"
 s/(?<=\Q:reportuuid, \E[10]\Q, \E)([10])/$1 ? 'TRUE' : 'FALSE'/ie;

--- a/src/main/java/mil/dds/anet/AnetObjectEngine.java
+++ b/src/main/java/mil/dds/anet/AnetObjectEngine.java
@@ -28,6 +28,7 @@ import mil.dds.anet.database.AdminDao.AdminSettingKeys;
 import mil.dds.anet.database.ApprovalStepDao;
 import mil.dds.anet.database.AuthorizationGroupDao;
 import mil.dds.anet.database.CommentDao;
+import mil.dds.anet.database.CustomSensitiveInformationDao;
 import mil.dds.anet.database.EmailDao;
 import mil.dds.anet.database.JobHistoryDao;
 import mil.dds.anet.database.LocationDao;
@@ -65,6 +66,7 @@ public class AnetObjectEngine {
   private final SavedSearchDao savedSearchDao;
   private final EmailDao emailDao;
   private final ReportSensitiveInformationDao reportSensitiveInformationDao;
+  private final CustomSensitiveInformationDao customSensitiveInformationDao;
   private final AuthorizationGroupDao authorizationGroupDao;
   private final NoteDao noteDao;
   private final JobHistoryDao jobHistoryDao;
@@ -95,6 +97,7 @@ public class AnetObjectEngine {
     adminDao = injector.getInstance(AdminDao.class);
     savedSearchDao = injector.getInstance(SavedSearchDao.class);
     reportSensitiveInformationDao = injector.getInstance(ReportSensitiveInformationDao.class);
+    customSensitiveInformationDao = injector.getInstance(CustomSensitiveInformationDao.class);
     emailDao = injector.getInstance(EmailDao.class);
     authorizationGroupDao = injector.getInstance(AuthorizationGroupDao.class);
     noteDao = injector.getInstance(NoteDao.class);
@@ -159,6 +162,10 @@ public class AnetObjectEngine {
 
   public ReportSensitiveInformationDao getReportSensitiveInformationDao() {
     return reportSensitiveInformationDao;
+  }
+
+  public CustomSensitiveInformationDao getCustomSensitiveInformationDao() {
+    return customSensitiveInformationDao;
   }
 
   public AuthorizationGroupDao getAuthorizationGroupDao() {

--- a/src/main/java/mil/dds/anet/beans/CustomSensitiveInformation.java
+++ b/src/main/java/mil/dds/anet/beans/CustomSensitiveInformation.java
@@ -72,4 +72,10 @@ public class CustomSensitiveInformation extends AbstractAnetBean {
         });
   }
 
+  @Override
+  public String toString() {
+    return String.format("[uuid:%s customFieldName:%s relatedObjectType:%s relatedObjectUuid:%s]",
+        uuid, customFieldName, relatedObjectType, relatedObjectUuid);
+  }
+
 }

--- a/src/main/java/mil/dds/anet/beans/CustomSensitiveInformation.java
+++ b/src/main/java/mil/dds/anet/beans/CustomSensitiveInformation.java
@@ -1,0 +1,75 @@
+package mil.dds.anet.beans;
+
+import io.leangen.graphql.annotations.GraphQLInputField;
+import io.leangen.graphql.annotations.GraphQLQuery;
+import io.leangen.graphql.annotations.GraphQLRootContext;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import mil.dds.anet.utils.IdDataLoaderKey;
+import mil.dds.anet.views.AbstractAnetBean;
+import mil.dds.anet.views.UuidFetcher;
+
+public class CustomSensitiveInformation extends AbstractAnetBean {
+
+  @GraphQLQuery
+  @GraphQLInputField
+  private String customFieldName;
+  @GraphQLQuery
+  @GraphQLInputField
+  private String customFieldValue;
+  @GraphQLQuery
+  @GraphQLInputField
+  private String relatedObjectType;
+  @GraphQLQuery
+  @GraphQLInputField
+  private String relatedObjectUuid;
+  // annotated below
+  private RelatableObject relatedObject;
+
+  public String getCustomFieldName() {
+    return customFieldName;
+  }
+
+  public void setCustomFieldName(String customFieldName) {
+    this.customFieldName = customFieldName;
+  }
+
+  public String getCustomFieldValue() {
+    return customFieldValue;
+  }
+
+  public void setCustomFieldValue(String customFieldValue) {
+    this.customFieldValue = customFieldValue;
+  }
+
+  public String getRelatedObjectType() {
+    return relatedObjectType;
+  }
+
+  public void setRelatedObjectType(String relatedObjectType) {
+    this.relatedObjectType = relatedObjectType;
+  }
+
+  public String getRelatedObjectUuid() {
+    return relatedObjectUuid;
+  }
+
+  public void setRelatedObjectUuid(String relatedObjectUuid) {
+    this.relatedObjectUuid = relatedObjectUuid;
+  }
+
+  @GraphQLQuery(name = "relatedObject")
+  public CompletableFuture<RelatableObject> loadRelatedObject(
+      @GraphQLRootContext Map<String, Object> context) {
+    if (relatedObject != null) {
+      return CompletableFuture.completedFuture(relatedObject);
+    }
+    return new UuidFetcher<AbstractAnetBean>()
+        .load(context, IdDataLoaderKey.valueOfTableName(relatedObjectType), relatedObjectUuid)
+        .thenApply(o -> {
+          relatedObject = (RelatableObject) o;
+          return relatedObject;
+        });
+  }
+
+}

--- a/src/main/java/mil/dds/anet/beans/NoteRelatedObject.java
+++ b/src/main/java/mil/dds/anet/beans/NoteRelatedObject.java
@@ -6,7 +6,6 @@ import io.leangen.graphql.annotations.GraphQLInputField;
 import io.leangen.graphql.annotations.GraphQLQuery;
 import io.leangen.graphql.annotations.GraphQLRootContext;
 import java.time.Instant;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import javax.ws.rs.WebApplicationException;
@@ -61,25 +60,6 @@ public class NoteRelatedObject extends AbstractAnetBean {
 
   @Override
   public void setUpdatedAt(Instant updatedAt) {
-    // just ignore
-  }
-
-  @Override
-  public CompletableFuture<List<Note>> loadNotes(@GraphQLRootContext Map<String, Object> context) {
-    throw new WebApplicationException("no notes field on NoteRelatedObject");
-  }
-
-  @Override
-  @JsonIgnore
-  @GraphQLIgnore
-  public List<Note> getNotes() {
-    throw new WebApplicationException("no notes field on NoteRelatedObject");
-  }
-
-  @Override
-  @JsonIgnore
-  @GraphQLIgnore
-  public void setNotes(List<Note> notes) {
     // just ignore
   }
 

--- a/src/main/java/mil/dds/anet/beans/Position.java
+++ b/src/main/java/mil/dds/anet/beans/Position.java
@@ -41,15 +41,17 @@ public class Position extends AbstractCustomizableAnetBean implements RelatableO
   // annotated below
   private ForeignObjectHolder<Person> person = new ForeignObjectHolder<>(); // The Current person.
   // annotated below
-  List<Position> associatedPositions;
+  private List<Position> associatedPositions;
   // annotated below
   private ForeignObjectHolder<Location> location = new ForeignObjectHolder<>();
   // annotated below
-  List<PersonPositionHistory> previousPeople;
+  private List<PersonPositionHistory> previousPeople;
   // annotated below
-  Boolean isApprover;
+  private Boolean isApprover;
   // annotated below
-  List<Task> responsibleTasks;
+  private List<Task> responsibleTasks;
+  // annotated below
+  private List<AuthorizationGroup> authorizationGroups;
 
   public String getName() {
     return name;
@@ -259,6 +261,19 @@ public class Position extends AbstractCustomizableAnetBean implements RelatableO
     return AnetObjectEngine.getInstance().getTaskDao().getTasksBySearch(context, uuid, query)
         .thenApply(o -> {
           responsibleTasks = o;
+          return o;
+        });
+  }
+
+  @GraphQLQuery(name = "authorizationGroups")
+  public CompletableFuture<List<AuthorizationGroup>> loadAuthorizationGroups(
+      @GraphQLRootContext Map<String, Object> context) {
+    if (authorizationGroups != null) {
+      return CompletableFuture.completedFuture(authorizationGroups);
+    }
+    return AnetObjectEngine.getInstance().getAuthorizationGroupDao()
+        .getAuthorizationGroupsForPosition(context, uuid).thenApply(o -> {
+          authorizationGroups = o;
           return o;
         });
   }

--- a/src/main/java/mil/dds/anet/database/CustomSensitiveInformationDao.java
+++ b/src/main/java/mil/dds/anet/database/CustomSensitiveInformationDao.java
@@ -74,6 +74,13 @@ public class CustomSensitiveInformationDao
         .bindBean(csi).bind("updatedAt", DaoUtils.asLocalDateTime(csi.getUpdatedAt())).execute();
   }
 
+  @InTransaction
+  public int deleteFor(String relatedObjectUuid) {
+    return getDbHandle().execute(
+        "DELETE FROM \"customSensitiveInformation\" WHERE \"relatedObjectUuid\" = ?",
+        relatedObjectUuid);
+  }
+
   public CompletableFuture<List<CustomSensitiveInformation>> getCustomSensitiveInformationForRelatedObject(
       @GraphQLRootContext Map<String, Object> context, String relatedObjectUuid) {
     final Person user = DaoUtils.getUserFromContext(context);

--- a/src/main/java/mil/dds/anet/database/CustomSensitiveInformationDao.java
+++ b/src/main/java/mil/dds/anet/database/CustomSensitiveInformationDao.java
@@ -128,6 +128,7 @@ public class CustomSensitiveInformationDao
     }
   }
 
+  @SuppressWarnings("lgtm[java/unused-parameter]") // match the signature of checkAndUpdate
   private void checkAndInsert(final Person user, final String relatedObjectType,
       final String relatedObjectUuid, final CustomSensitiveInformation csi) {
     if (!hasCustomSensitiveInformationAuthorization(user, csi)) {

--- a/src/main/java/mil/dds/anet/database/CustomSensitiveInformationDao.java
+++ b/src/main/java/mil/dds/anet/database/CustomSensitiveInformationDao.java
@@ -114,6 +114,7 @@ public class CustomSensitiveInformationDao
   private boolean canUpdateCustomSensitiveInformation(final Person user,
       final CustomSensitiveInformation csi) {
     // FIXME: check against dictionary whether user has access to csi
+    // Note that a `null` user means this is called through a merge function, by an admin
     return true;
   }
 

--- a/src/main/java/mil/dds/anet/database/CustomSensitiveInformationDao.java
+++ b/src/main/java/mil/dds/anet/database/CustomSensitiveInformationDao.java
@@ -77,7 +77,8 @@ public class CustomSensitiveInformationDao
   @InTransaction
   public int deleteFor(String relatedObjectUuid) {
     return getDbHandle().execute(
-        "DELETE FROM \"customSensitiveInformation\" WHERE \"relatedObjectUuid\" = ?",
+        "/* deleteCustomSensitiveInformation */ "
+            + "DELETE FROM \"customSensitiveInformation\" WHERE \"relatedObjectUuid\" = ?",
         relatedObjectUuid);
   }
 

--- a/src/main/java/mil/dds/anet/database/CustomSensitiveInformationDao.java
+++ b/src/main/java/mil/dds/anet/database/CustomSensitiveInformationDao.java
@@ -1,0 +1,91 @@
+package mil.dds.anet.database;
+
+import io.leangen.graphql.annotations.GraphQLRootContext;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import mil.dds.anet.AnetObjectEngine;
+import mil.dds.anet.beans.CustomSensitiveInformation;
+import mil.dds.anet.beans.search.AbstractSearchQuery;
+import mil.dds.anet.database.mappers.CustomSensitiveInformationMapper;
+import mil.dds.anet.utils.DaoUtils;
+import mil.dds.anet.utils.FkDataLoaderKey;
+import mil.dds.anet.views.ForeignKeyFetcher;
+
+public class CustomSensitiveInformationDao
+    extends AnetBaseDao<CustomSensitiveInformation, AbstractSearchQuery<?>> {
+
+  @Override
+  public CustomSensitiveInformation getByUuid(String uuid) {
+    return getByIds(Arrays.asList(uuid)).get(0);
+  }
+
+  static class SelfIdBatcher extends IdBatcher<CustomSensitiveInformation> {
+    private static final String sql = "/* batch.getCustomSensitiveInformationByUuids */ "
+        + "SELECT * FROM \"customSensitiveInformation\" WHERE uuid IN ( <uuids> )";
+
+    public SelfIdBatcher() {
+      super(sql, "uuids", new CustomSensitiveInformationMapper());
+    }
+  }
+
+  @Override
+  public List<CustomSensitiveInformation> getByIds(List<String> uuids) {
+    final IdBatcher<CustomSensitiveInformation> idBatcher =
+        AnetObjectEngine.getInstance().getInjector().getInstance(SelfIdBatcher.class);
+    return idBatcher.getByIds(uuids);
+  }
+
+  @Override
+  public CustomSensitiveInformation insertInternal(CustomSensitiveInformation csi) {
+    getDbHandle()
+        .createUpdate("/* insertCustomSensitiveInformation */ "
+            + "INSERT INTO \"customSensitiveInformation\" (uuid, \"customFieldName\", "
+            + "\"customFieldValue\", \"relatedObjectType\", \"relatedObjectUuid\", \"createdAt\", "
+            + "\"updatedAt\") VALUES (:uuid, :customFieldName, :customFieldValue, "
+            + ":relatedObjectType, :relatedObjectUuid, :createdAt, :updatedAt)")
+        .bindBean(csi).bind("createdAt", DaoUtils.asLocalDateTime(csi.getCreatedAt()))
+        .bind("updatedAt", DaoUtils.asLocalDateTime(csi.getUpdatedAt())).execute();
+    return csi;
+  }
+
+  @Override
+  public int updateInternal(CustomSensitiveInformation csi) {
+    return getDbHandle()
+        .createUpdate("/* updateCustomSensitiveInformation */ "
+            + "UPDATE \"customSensitiveInformation\" SET \"customFieldName\" = :customFieldName, "
+            + "\"customFieldValue\" = :customFieldValue, "
+            + "\"relatedObjectType\" = :relatedObjectType, "
+            + "\"relatedObjectUuid\" = :relatedObjectUuid, \"updatedAt\" = :updatedAt "
+            + "WHERE uuid = :uuid")
+        .bindBean(csi).bind("updatedAt", DaoUtils.asLocalDateTime(csi.getUpdatedAt())).execute();
+  }
+
+  public CompletableFuture<List<CustomSensitiveInformation>> getCustomSensitiveInformationForRelatedObject(
+      @GraphQLRootContext Map<String, Object> context, String relatedObjectUuid) {
+    // FIXME: check whether DaoUtils.getUserFromContext(context) has access to elements in the
+    // resulting list
+    return new ForeignKeyFetcher<CustomSensitiveInformation>().load(context,
+        FkDataLoaderKey.RELATED_OBJECT_CUSTOM_SENSITIVE_INFORMATION, relatedObjectUuid);
+  }
+
+  static class SensitiveInformationBatcher extends ForeignKeyBatcher<CustomSensitiveInformation> {
+    private static final String sql = "/* batch.getCustomSensitiveInformationForRelatedObject */ "
+        + "SELECT * FROM \"customSensitiveInformation\" "
+        + "WHERE \"customSensitiveInformation\".\"relatedObjectUuid\" IN ( <foreignKeys> ) "
+        + "ORDER BY \"customSensitiveInformation\".\"customFieldName\"";
+
+    public SensitiveInformationBatcher() {
+      super(sql, "foreignKeys", new CustomSensitiveInformationMapper(), "relatedObjectUuid");
+    }
+  }
+
+  public List<List<CustomSensitiveInformation>> getCustomSensitiveInformation(
+      List<String> foreignKeys) {
+    final ForeignKeyBatcher<CustomSensitiveInformation> notesBatcher =
+        AnetObjectEngine.getInstance().getInjector().getInstance(SensitiveInformationBatcher.class);
+    return notesBatcher.getByForeignKeys(foreignKeys);
+  }
+
+}

--- a/src/main/java/mil/dds/anet/database/LocationDao.java
+++ b/src/main/java/mil/dds/anet/database/LocationDao.java
@@ -83,6 +83,12 @@ public class LocationDao extends AnetBaseDao<Location, LocationSearchQuery> {
     updateM2mForMerge("noteRelatedObjects", "noteUuid", "relatedObjectUuid", winnerLocationUuid,
         loserLocationUuid);
 
+    // Update customSensitiveInformation for winner
+    DaoUtils.saveCustomSensitiveInformation(null, LocationDao.TABLE_NAME, winnerLocationUuid,
+        winnerLocation.getCustomSensitiveInformation());
+    // Delete customSensitiveInformation for loser
+    deleteForMerge("customSensitiveInformation", "relatedObjectUuid", loserLocationUuid);
+
     // Finally, delete the location
     return deleteForMerge("locations", "uuid", loserLocationUuid);
   }

--- a/src/main/java/mil/dds/anet/database/OrganizationDao.java
+++ b/src/main/java/mil/dds/anet/database/OrganizationDao.java
@@ -24,10 +24,11 @@ import ru.vyarus.guicey.jdbi3.tx.InTransaction;
 
 public class OrganizationDao extends AnetBaseDao<Organization, OrganizationSearchQuery> {
 
-  private static String[] fields = {"uuid", "shortName", "longName", "status", "identificationCode",
-      "type", "createdAt", "updatedAt", "parentOrgUuid", "customFields"};
-  public static String TABLE_NAME = "organizations";
-  public static String ORGANIZATION_FIELDS = DaoUtils.buildFieldAliases(TABLE_NAME, fields, true);
+  private static final String[] fields = {"uuid", "shortName", "longName", "status",
+      "identificationCode", "type", "createdAt", "updatedAt", "parentOrgUuid", "customFields"};
+  public static final String TABLE_NAME = "organizations";
+  public static final String ORGANIZATION_FIELDS =
+      DaoUtils.buildFieldAliases(TABLE_NAME, fields, true);
 
   @Override
   public Organization getByUuid(String uuid) {

--- a/src/main/java/mil/dds/anet/database/PersonDao.java
+++ b/src/main/java/mil/dds/anet/database/PersonDao.java
@@ -44,19 +44,20 @@ public class PersonDao extends AnetBaseDao<Person, PersonSearchQuery> {
       LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
   // Must always retrieve these e.g. for ORDER BY
-  public static String[] minimalFields = {"uuid", "name", "rank", "createdAt"};
-  public static String[] additionalFields = {"status", "role", "emailAddress", "phoneNumber",
+  public static final String[] minimalFields = {"uuid", "name", "rank", "createdAt"};
+  public static final String[] additionalFields = {"status", "role", "emailAddress", "phoneNumber",
       "biography", "country", "gender", "endOfTourDate", "domainUsername", "pendingVerification",
       "code", "updatedAt", "customFields"};
   // "avatar" has its own batcher
-  public static String[] avatarFields = {"uuid", "avatar"};
+  public static final String[] avatarFields = {"uuid", "avatar"};
   public static final String[] allFields =
       ObjectArrays.concat(minimalFields, additionalFields, String.class);
-  public static String TABLE_NAME = "people";
-  public static String PERSON_FIELDS = DaoUtils.buildFieldAliases(TABLE_NAME, allFields, true);
-  public static String PERSON_AVATAR_FIELDS =
+  public static final String TABLE_NAME = "people";
+  public static final String PERSON_FIELDS =
+      DaoUtils.buildFieldAliases(TABLE_NAME, allFields, true);
+  public static final String PERSON_AVATAR_FIELDS =
       DaoUtils.buildFieldAliases(TABLE_NAME, avatarFields, true);
-  public static String PERSON_FIELDS_NOAS =
+  public static final String PERSON_FIELDS_NOAS =
       DaoUtils.buildFieldAliases(TABLE_NAME, allFields, false);
 
   private static final String EHCACHE_CONFIG = "/ehcache-config.xml";

--- a/src/main/java/mil/dds/anet/database/PersonDao.java
+++ b/src/main/java/mil/dds/anet/database/PersonDao.java
@@ -398,6 +398,12 @@ public class PersonDao extends AnetBaseDao<Person, PersonSearchQuery> {
     // update notes
     updateM2mForMerge("noteRelatedObjects", "noteUuid", "relatedObjectUuid", winnerUuid, loserUuid);
 
+    // Update customSensitiveInformation for winner
+    DaoUtils.saveCustomSensitiveInformation(null, PersonDao.TABLE_NAME, winnerUuid,
+        winner.getCustomSensitiveInformation());
+    // Delete customSensitiveInformation for loser
+    deleteForMerge("customSensitiveInformation", "relatedObjectUuid", loserUuid);
+
     // finally, delete the person!
     final int nr = deleteForMerge("people", "uuid", loserUuid);
     // E.g. positions may have been updated, so evict from the cache

--- a/src/main/java/mil/dds/anet/database/PositionDao.java
+++ b/src/main/java/mil/dds/anet/database/PositionDao.java
@@ -484,6 +484,9 @@ public class PositionDao extends AnetBaseDao<Position, PositionSearchQuery> {
         "DELETE FROM \"positionRelationships\" WHERE \"positionUuid_a\" = ? OR \"positionUuid_b\"= ?",
         positionUuid, positionUuid);
 
+    // delete customSensitiveInformation for this position
+    AnetObjectEngine.getInstance().getCustomSensitiveInformationDao().deleteFor(positionUuid);
+
     final int nr = getDbHandle().createUpdate("DELETE FROM positions WHERE uuid = :positionUuid")
         .bind("positionUuid", positionUuid).execute();
     // Evict the person (previously) holding this position from the domain users cache

--- a/src/main/java/mil/dds/anet/database/PositionDao.java
+++ b/src/main/java/mil/dds/anet/database/PositionDao.java
@@ -579,6 +579,12 @@ public class PositionDao extends AnetBaseDao<Position, PositionSearchQuery> {
     updateM2mForMerge("authorizationGroupPositions", "authorizationGroupUuid", "positionUuid",
         winnerUuid, loserUuid);
 
+    // Update customSensitiveInformation for winner
+    DaoUtils.saveCustomSensitiveInformation(null, PositionDao.TABLE_NAME, winnerUuid,
+        winner.getCustomSensitiveInformation());
+    // Delete customSensitiveInformation for loser
+    deleteForMerge("customSensitiveInformation", "relatedObjectUuid", loserUuid);
+
     // Finally, delete loser
     final int nr = deleteForMerge("positions", "uuid", loserUuid);
 

--- a/src/main/java/mil/dds/anet/database/PositionDao.java
+++ b/src/main/java/mil/dds/anet/database/PositionDao.java
@@ -33,10 +33,11 @@ import ru.vyarus.guicey.jdbi3.tx.InTransaction;
 
 public class PositionDao extends AnetBaseDao<Position, PositionSearchQuery> {
 
-  public static String[] fields = {"uuid", "name", "code", "createdAt", "updatedAt",
+  public static final String[] fields = {"uuid", "name", "code", "createdAt", "updatedAt",
       "organizationUuid", "currentPersonUuid", "type", "status", "locationUuid", "customFields"};
-  public static String TABLE_NAME = "positions";
-  public static String POSITIONS_FIELDS = DaoUtils.buildFieldAliases(TABLE_NAME, fields, true);
+  public static final String TABLE_NAME = "positions";
+  public static final String POSITIONS_FIELDS =
+      DaoUtils.buildFieldAliases(TABLE_NAME, fields, true);
 
   @Override
   public Position insertInternal(Position p) {

--- a/src/main/java/mil/dds/anet/database/ReportDao.java
+++ b/src/main/java/mil/dds/anet/database/ReportDao.java
@@ -375,7 +375,7 @@ public class ReportDao extends AnetBaseDao<Report, ReportSearchQuery> {
     getDbHandle().execute(
         "/* deleteReport.comments */ DELETE FROM comments where \"reportUuid\" = ?", reportUuid);
 
-    // Delete \"reportActions\"
+    // Delete reportActions
     getDbHandle().execute(
         "/* deleteReport.actions */ DELETE FROM \"reportActions\" where \"reportUuid\" = ?",
         reportUuid);
@@ -384,6 +384,9 @@ public class ReportDao extends AnetBaseDao<Report, ReportSearchQuery> {
     getDbHandle().execute(
         "/* deleteReport.\"authorizationGroups\" */ DELETE FROM \"reportAuthorizationGroups\" where \"reportUuid\" = ?",
         reportUuid);
+
+    // Delete customSensitiveInformation
+    AnetObjectEngine.getInstance().getCustomSensitiveInformationDao().deleteFor(reportUuid);
 
     // Delete report
     // GraphQL mutations *have* to return something, so we return the number of deleted report rows

--- a/src/main/java/mil/dds/anet/database/mappers/CustomSensitiveInformationMapper.java
+++ b/src/main/java/mil/dds/anet/database/mappers/CustomSensitiveInformationMapper.java
@@ -1,0 +1,22 @@
+package mil.dds.anet.database.mappers;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import mil.dds.anet.beans.CustomSensitiveInformation;
+import org.jdbi.v3.core.mapper.RowMapper;
+import org.jdbi.v3.core.statement.StatementContext;
+
+public class CustomSensitiveInformationMapper implements RowMapper<CustomSensitiveInformation> {
+
+  @Override
+  public CustomSensitiveInformation map(ResultSet rs, StatementContext ctx) throws SQLException {
+    final CustomSensitiveInformation csi = new CustomSensitiveInformation();
+    MapperUtils.setCommonBeanFields(csi, rs, null);
+    csi.setCustomFieldName(rs.getString("customFieldName"));
+    csi.setCustomFieldValue(rs.getString("customFieldValue"));
+    csi.setRelatedObjectType(rs.getString("relatedObjectType"));
+    csi.setRelatedObjectUuid(rs.getString("relatedObjectUuid"));
+    return csi;
+  }
+
+}

--- a/src/main/java/mil/dds/anet/resources/LocationResource.java
+++ b/src/main/java/mil/dds/anet/resources/LocationResource.java
@@ -73,8 +73,11 @@ public class LocationResource {
       }
     }
 
-    AnetAuditLogger.log("Location {} created by {}", l, user);
-    return l;
+    DaoUtils.saveCustomSensitiveInformation(user, LocationDao.TABLE_NAME, created.getUuid(),
+        l.getCustomSensitiveInformation());
+
+    AnetAuditLogger.log("Location {} created by {}", created, user);
+    return created;
   }
 
   @GraphQLMutation(name = "updateLocation")
@@ -96,6 +99,10 @@ public class LocationResource {
         existing.loadApprovalSteps(engine.getContext()).join();
     Utils.updateApprovalSteps(l, l.getPlanningApprovalSteps(), existingPlanningApprovalSteps,
         l.getApprovalSteps(), existingApprovalSteps);
+
+    DaoUtils.saveCustomSensitiveInformation(user, LocationDao.TABLE_NAME, l.getUuid(),
+        l.getCustomSensitiveInformation());
+
     AnetAuditLogger.log("Location {} updated by {}", l, user);
     // GraphQL mutations *have* to return something, so we return the number of updated rows
     return numRows;

--- a/src/main/java/mil/dds/anet/resources/OrganizationResource.java
+++ b/src/main/java/mil/dds/anet/resources/OrganizationResource.java
@@ -83,6 +83,10 @@ public class OrganizationResource {
         engine.getApprovalStepDao().insertAtEnd(step);
       }
     }
+
+    DaoUtils.saveCustomSensitiveInformation(user, OrganizationDao.TABLE_NAME, created.getUuid(),
+        org.getCustomSensitiveInformation());
+
     AnetAuditLogger.log("Organization {} created by {}", created, user);
     return created;
   }
@@ -108,6 +112,10 @@ public class OrganizationResource {
     final Organization existing = dao.getByUuid(org.getUuid());
     final int numRows = AuthUtils.isAdmin(user) ? doAdminUpdates(org, existing) : 1;
     doSuperUserUpdates(org, existing);
+
+    DaoUtils.saveCustomSensitiveInformation(user, OrganizationDao.TABLE_NAME, org.getUuid(),
+        org.getCustomSensitiveInformation());
+
     AnetAuditLogger.log("Organization {} updated by {}", org, user);
 
     // GraphQL mutations *have* to return something, so we return the number of updated rows

--- a/src/main/java/mil/dds/anet/resources/PersonResource.java
+++ b/src/main/java/mil/dds/anet/resources/PersonResource.java
@@ -77,6 +77,9 @@ public class PersonResource {
           DaoUtils.getUuid(created.getPosition()));
     }
 
+    DaoUtils.saveCustomSensitiveInformation(user, PersonDao.TABLE_NAME, created.getUuid(),
+        p.getCustomSensitiveInformation());
+
     AnetAuditLogger.log("Person {} created by {}", created, user);
     return created;
   }
@@ -184,6 +187,10 @@ public class PersonResource {
     if (numRows == 0) {
       throw new WebApplicationException("Couldn't process person update", Status.NOT_FOUND);
     }
+
+    DaoUtils.saveCustomSensitiveInformation(user, PersonDao.TABLE_NAME, p.getUuid(),
+        p.getCustomSensitiveInformation());
+
     AnetAuditLogger.log("Person {} updated by {}", p, user);
     // GraphQL mutations *have* to return something, so we return the number of updated rows
     return numRows;

--- a/src/main/java/mil/dds/anet/resources/TaskResource.java
+++ b/src/main/java/mil/dds/anet/resources/TaskResource.java
@@ -76,7 +76,11 @@ public class TaskResource {
         engine.getApprovalStepDao().insertAtEnd(step);
       }
     }
-    AnetAuditLogger.log("Task {} created by {}", t, user);
+
+    DaoUtils.saveCustomSensitiveInformation(user, TaskDao.TABLE_NAME, created.getUuid(),
+        t.getCustomSensitiveInformation());
+
+    AnetAuditLogger.log("Task {} created by {}", created, user);
     return created;
   }
 
@@ -150,6 +154,10 @@ public class TaskResource {
           existing.loadApprovalSteps(engine.getContext()).join();
       Utils.updateApprovalSteps(t, t.getPlanningApprovalSteps(), existingPlanningApprovalSteps,
           t.getApprovalSteps(), existingApprovalSteps);
+
+      DaoUtils.saveCustomSensitiveInformation(user, TaskDao.TABLE_NAME, t.getUuid(),
+          t.getCustomSensitiveInformation());
+
       AnetAuditLogger.log("Task {} updatedby {}", t, user);
 
       // GraphQL mutations *have* to return something, so we return the number of updated rows

--- a/src/main/java/mil/dds/anet/utils/BatchingUtils.java
+++ b/src/main/java/mil/dds/anet/utils/BatchingUtils.java
@@ -10,6 +10,7 @@ import mil.dds.anet.AnetObjectEngine;
 import mil.dds.anet.beans.ApprovalStep;
 import mil.dds.anet.beans.AuthorizationGroup;
 import mil.dds.anet.beans.Comment;
+import mil.dds.anet.beans.CustomSensitiveInformation;
 import mil.dds.anet.beans.Location;
 import mil.dds.anet.beans.Note;
 import mil.dds.anet.beans.NoteRelatedObject;
@@ -156,6 +157,14 @@ public final class BatchingUtils {
                 dispatcherService);
           }
         }, dataLoaderOptions));
+    dataLoaderRegistry.register(FkDataLoaderKey.RELATED_OBJECT_APPROVAL_STEPS.toString(),
+        new DataLoader<>(new BatchLoader<String, List<ApprovalStep>>() {
+          @Override
+          public CompletionStage<List<List<ApprovalStep>>> load(List<String> foreignKeys) {
+            return CompletableFuture.supplyAsync(
+                () -> engine.getApprovalStepDao().getApprovalSteps(foreignKeys), dispatcherService);
+          }
+        }, dataLoaderOptions));
     dataLoaderRegistry.register(FkDataLoaderKey.RELATED_OBJECT_PLANNING_APPROVAL_STEPS.toString(),
         new DataLoader<>(new BatchLoader<String, List<ApprovalStep>>() {
           @Override
@@ -165,12 +174,14 @@ public final class BatchingUtils {
                 dispatcherService);
           }
         }, dataLoaderOptions));
-    dataLoaderRegistry.register(FkDataLoaderKey.RELATED_OBJECT_APPROVAL_STEPS.toString(),
-        new DataLoader<>(new BatchLoader<String, List<ApprovalStep>>() {
+    dataLoaderRegistry.register(
+        FkDataLoaderKey.RELATED_OBJECT_CUSTOM_SENSITIVE_INFORMATION.toString(),
+        new DataLoader<>(new BatchLoader<String, List<CustomSensitiveInformation>>() {
           @Override
-          public CompletionStage<List<List<ApprovalStep>>> load(List<String> foreignKeys) {
-            return CompletableFuture.supplyAsync(
-                () -> engine.getApprovalStepDao().getApprovalSteps(foreignKeys), dispatcherService);
+          public CompletionStage<List<List<CustomSensitiveInformation>>> load(
+              List<String> foreignKeys) {
+            return CompletableFuture.supplyAsync(() -> engine.getCustomSensitiveInformationDao()
+                .getCustomSensitiveInformation(foreignKeys), dispatcherService);
           }
         }, dataLoaderOptions));
     dataLoaderRegistry.register(IdDataLoaderKey.PEOPLE.toString(),

--- a/src/main/java/mil/dds/anet/utils/BatchingUtils.java
+++ b/src/main/java/mil/dds/anet/utils/BatchingUtils.java
@@ -243,6 +243,15 @@ public final class BatchingUtils {
                 dispatcherService);
           }
         }, dataLoaderOptions));
+    dataLoaderRegistry.register(FkDataLoaderKey.POSITION_AUTHORIZATION_GROUPS.toString(),
+        new DataLoader<>(new BatchLoader<String, List<AuthorizationGroup>>() {
+          @Override
+          public CompletionStage<List<List<AuthorizationGroup>>> load(List<String> foreignKeys) {
+            return CompletableFuture.supplyAsync(
+                () -> engine.getAuthorizationGroupDao().getAuthorizationGroups(foreignKeys),
+                dispatcherService);
+          }
+        }, dataLoaderOptions));
     dataLoaderRegistry.register(FkDataLoaderKey.POSITION_CURRENT_POSITION_FOR_PERSON.toString(),
         new DataLoader<>(new BatchLoader<String, List<Position>>() {
           @Override

--- a/src/main/java/mil/dds/anet/utils/DaoUtils.java
+++ b/src/main/java/mil/dds/anet/utils/DaoUtils.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import mil.dds.anet.AnetObjectEngine;
+import mil.dds.anet.beans.CustomSensitiveInformation;
 import mil.dds.anet.beans.Person;
 import mil.dds.anet.views.AbstractAnetBean;
 import org.slf4j.Logger;
@@ -112,6 +113,13 @@ public class DaoUtils {
 
   public static Person getUserFromContext(Map<String, Object> context) {
     return (Person) context.get("user");
+  }
+
+  public static void saveCustomSensitiveInformation(final Person user, final String tableName,
+      final String uuid, final List<CustomSensitiveInformation> customSensitiveInformation) {
+    AnetObjectEngine.getInstance().getCustomSensitiveInformationDao()
+        .insertOrUpdateCustomSensitiveInformation(user, tableName, uuid,
+            customSensitiveInformation);
   }
 
   public static ZoneId getServerNativeZoneId() {

--- a/src/main/java/mil/dds/anet/utils/FkDataLoaderKey.java
+++ b/src/main/java/mil/dds/anet/utils/FkDataLoaderKey.java
@@ -13,6 +13,8 @@ public enum FkDataLoaderKey {
   POSITION_PERSON_POSITION_HISTORY, // position.personPositionHistory
   RELATED_OBJECT_APPROVAL_STEPS, // <relatedObject, e.g. organization or task>.approvalSteps
   RELATED_OBJECT_PLANNING_APPROVAL_STEPS, // <relatedObject>.planningApprovalSteps
+  RELATED_OBJECT_CUSTOM_SENSITIVE_INFORMATION, // <relatedObject, e.g.
+                                               // person>.customSensitiveInformation
   REPORT_PEOPLE, // report.reportPeople
   REPORT_REPORT_ACTIONS, // report.reportActions
   REPORT_REPORT_SENSITIVE_INFORMATION, // report.reportSensitiveInformation

--- a/src/main/java/mil/dds/anet/utils/FkDataLoaderKey.java
+++ b/src/main/java/mil/dds/anet/utils/FkDataLoaderKey.java
@@ -9,6 +9,7 @@ public enum FkDataLoaderKey {
   PERSON_ORGANIZATIONS, // person.organizations
   PERSON_PERSON_POSITION_HISTORY, // person.personPositionHistory
   POSITION_ASSOCIATED_POSITIONS, // position.associatedPositions
+  POSITION_AUTHORIZATION_GROUPS, // position.authorizatonGroups
   POSITION_CURRENT_POSITION_FOR_PERSON, // position.currentPositionForPerson
   POSITION_PERSON_POSITION_HISTORY, // position.personPositionHistory
   RELATED_OBJECT_APPROVAL_STEPS, // <relatedObject, e.g. organization or task>.approvalSteps

--- a/src/main/java/mil/dds/anet/utils/PendingAssessmentsHelper.java
+++ b/src/main/java/mil/dds/anet/utils/PendingAssessmentsHelper.java
@@ -39,7 +39,7 @@ import mil.dds.anet.database.PositionDao;
 import mil.dds.anet.database.TaskDao;
 import mil.dds.anet.emails.PendingAssessmentsNotificationEmail;
 import mil.dds.anet.threads.AnetEmailWorker;
-import mil.dds.anet.views.AbstractAnetBean;
+import mil.dds.anet.views.AbstractCustomizableAnetBean;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -504,12 +504,12 @@ public class PendingAssessmentsHelper {
 
   private CompletableFuture<Boolean> processExistingAssessments(final Map<String, Object> context,
       final Instant now, final Set<Recurrence> recurrenceSet,
-      final Map<? extends AbstractAnetBean, Set<Recurrence>> objectsToAssess) {
+      final Map<? extends AbstractCustomizableAnetBean, Set<Recurrence>> objectsToAssess) {
     final CompletableFuture<?>[] allFutures = objectsToAssess.entrySet().stream().map(e -> {
-      final AbstractAnetBean entryKey = e.getKey();
+      final AbstractCustomizableAnetBean entryKey = e.getKey();
       final Set<Recurrence> periods = e.getValue();
       // For positions, the current person holding it gets assessed (otherwise the object itself)
-      final AbstractAnetBean ota =
+      final AbstractCustomizableAnetBean ota =
           entryKey instanceof Position ? ((Position) entryKey).getPerson() : entryKey;
       return ota.loadNotes(context).thenApply(notes -> {
         final Map<Recurrence, Instant> assessmentsByRecurrence = new HashMap<>();

--- a/src/main/java/mil/dds/anet/views/AbstractAnetBean.java
+++ b/src/main/java/mil/dds/anet/views/AbstractAnetBean.java
@@ -3,13 +3,7 @@ package mil.dds.anet.views;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.leangen.graphql.annotations.GraphQLInputField;
 import io.leangen.graphql.annotations.GraphQLQuery;
-import io.leangen.graphql.annotations.GraphQLRootContext;
 import java.time.Instant;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.CompletableFuture;
-import mil.dds.anet.AnetObjectEngine;
-import mil.dds.anet.beans.Note;
 
 public abstract class AbstractAnetBean {
 
@@ -22,7 +16,7 @@ public abstract class AbstractAnetBean {
   @GraphQLQuery
   @GraphQLInputField
   protected Instant updatedAt;
-  private List<Note> notes;
+  // annotated below
   private String batchUuid;
 
   public AbstractAnetBean() {
@@ -51,27 +45,6 @@ public abstract class AbstractAnetBean {
 
   public void setUpdatedAt(Instant updatedAt) {
     this.updatedAt = updatedAt;
-  }
-
-  @GraphQLQuery(name = "notes")
-  public CompletableFuture<List<Note>> loadNotes(@GraphQLRootContext Map<String, Object> context) {
-    if (notes != null) {
-      return CompletableFuture.completedFuture(notes);
-    }
-    return AnetObjectEngine.getInstance().getNoteDao().getNotesForRelatedObject(context, uuid)
-        .thenApply(o -> {
-          notes = o;
-          return o;
-        });
-  }
-
-  public List<Note> getNotes() {
-    return notes;
-  }
-
-  @GraphQLInputField(name = "notes")
-  public void setNotes(List<Note> notes) {
-    this.notes = notes;
   }
 
   @JsonIgnore

--- a/src/main/java/mil/dds/anet/views/AbstractCustomizableAnetBean.java
+++ b/src/main/java/mil/dds/anet/views/AbstractCustomizableAnetBean.java
@@ -10,6 +10,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import mil.dds.anet.AnetObjectEngine;
+import mil.dds.anet.beans.CustomSensitiveInformation;
 import mil.dds.anet.beans.Note;
 import mil.dds.anet.utils.Utils;
 import org.slf4j.Logger;
@@ -25,6 +26,8 @@ public abstract class AbstractCustomizableAnetBean extends AbstractAnetBean {
   private String customFields;
   // annotated below
   private List<Note> notes;
+  // annotated below
+  private List<CustomSensitiveInformation> customSensitiveInformation;
 
   public String getCustomFields() {
     return customFields;
@@ -44,6 +47,29 @@ public abstract class AbstractCustomizableAnetBean extends AbstractAnetBean {
           notes = o;
           return o;
         });
+  }
+
+  @GraphQLQuery(name = "customSensitiveInformation")
+  public CompletableFuture<List<CustomSensitiveInformation>> loadCustomSensitiveInformation(
+      @GraphQLRootContext Map<String, Object> context) {
+    if (customSensitiveInformation != null) {
+      return CompletableFuture.completedFuture(customSensitiveInformation);
+    }
+    return AnetObjectEngine.getInstance().getCustomSensitiveInformationDao()
+        .getCustomSensitiveInformationForRelatedObject(context, uuid).thenApply(o -> {
+          customSensitiveInformation = o;
+          return o;
+        });
+  }
+
+  public List<CustomSensitiveInformation> getCustomSensitiveInformation() {
+    return customSensitiveInformation;
+  }
+
+  @GraphQLInputField(name = "customSensitiveInformation")
+  public void setCustomSensitiveInformation(
+      List<CustomSensitiveInformation> customSensitiveInformation) {
+    this.customSensitiveInformation = customSensitiveInformation;
   }
 
   public void checkAndFixCustomFields() {

--- a/src/main/java/mil/dds/anet/views/AbstractCustomizableAnetBean.java
+++ b/src/main/java/mil/dds/anet/views/AbstractCustomizableAnetBean.java
@@ -46,15 +46,6 @@ public abstract class AbstractCustomizableAnetBean extends AbstractAnetBean {
         });
   }
 
-  public List<Note> getNotes() {
-    return notes;
-  }
-
-  @GraphQLInputField(name = "notes")
-  public void setNotes(List<Note> notes) {
-    this.notes = notes;
-  }
-
   public void checkAndFixCustomFields() {
     try {
       setCustomFields(Utils.sanitizeJson(getCustomFields()));

--- a/src/main/resources/anet-schema.yml
+++ b/src/main/resources/anet-schema.yml
@@ -156,6 +156,8 @@ $defs:
               type: number
             label:
               type: string
+      authorizationGroupUuids:
+        type: array
 
     dependencies: # should be dependentSchemas but the validator does not recognize it (yet)
       type:
@@ -246,6 +248,19 @@ $defs:
         type: object
         additionalProperties:
           "$ref": "#/$defs/customField"
+
+# definition for custom sensitive information
+  customSensitiveInformation:
+    allOf:
+    - "$ref": "#/$defs/customField"
+    - properties:
+        authorizationGroupUuids:
+          type: array
+          uniqueItems: true
+          minItems: 1
+          items:
+            type: string
+            description: The list of authorizationGroup uuid's that have access to this custom sensitive information
 
 #########################################################
 ### schema root
@@ -535,6 +550,10 @@ properties:
             type: object
             additionalProperties:
               "$ref": "#/$defs/customField"
+          customSensitiveInformation:
+            type: object
+            additionalProperties:
+              "$ref": "#/$defs/customSensitiveInformation"
 
       location:
         type: object

--- a/src/main/resources/anet-schema.yml
+++ b/src/main/resources/anet-schema.yml
@@ -158,6 +158,8 @@ $defs:
               type: string
       authorizationGroupUuids:
         type: array
+      tooltipText:
+        type: string
 
     dependencies: # should be dependentSchemas but the validator does not recognize it (yet)
       type:
@@ -254,6 +256,8 @@ $defs:
     allOf:
     - "$ref": "#/$defs/customField"
     - properties:
+        tooltipText:
+          type: string
         authorizationGroupUuids:
           type: array
           uniqueItems: true

--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -3973,4 +3973,25 @@
 		</sql>
 	</changeSet>
 
+	<changeSet id="add-customSensitiveInformation-table" author="gjvoosten">
+		<createTable tableName="customSensitiveInformation">
+			<column name="uuid" type="${uuid_type}">
+				<constraints nullable="false" />
+			</column>
+			<column name="customFieldName" type="${long_text_type}">
+				<constraints nullable="false" />
+			</column>
+			<column name="customFieldValue" type="${long_text_type}" />
+			<!-- The next two columns combined act as a generic foreign key reference to a (table name, uuid)-tuple -->
+			<column name="relatedObjectType" type="varchar(255)">
+				<constraints nullable="false" />
+			</column>
+			<column name="relatedObjectUuid" type="${uuid_type}">
+				<constraints nullable="false" />
+			</column>
+			<column name="createdAt" type="datetime" />
+			<column name="updatedAt" type="datetime" />
+		</createTable>
+	</changeSet>
+
 </databaseChangeLog>

--- a/src/test/java/mil/dds/anet/test/resources/PersonResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/PersonResourceTest.java
@@ -52,7 +52,7 @@ import org.junit.jupiter.api.Test;
 public class PersonResourceTest extends AbstractResourceTest {
 
   private static final String BIRTHDAY_FIELD = "birthday";
-  private static final String ID_CARD_FIELD = "idCard";
+  private static final String POLITICAL_POSITION_FIELD = "politicalPosition";
   private static final String _CUSTOM_SENSITIVE_INFORMATION_FIELDS =
       "customSensitiveInformation { uuid customFieldName customFieldValue"
           + " relatedObjectType relatedObjectUuid createdAt updatedAt }";
@@ -542,7 +542,7 @@ public class PersonResourceTest extends AbstractResourceTest {
     final String steveUuid = getSteveSteveson().getUuid();
     // Elizabeth can read all sensitive data of her counterpart Steve
     checkSensitiveInformation(steveUuid, "elizabeth",
-        ImmutableList.of(BIRTHDAY_FIELD, ID_CARD_FIELD));
+        ImmutableList.of(BIRTHDAY_FIELD, POLITICAL_POSITION_FIELD));
     // Jim has no access to Steve's sensitive data
     checkSensitiveInformation(steveUuid, "jim", ImmutableList.of());
   }
@@ -554,11 +554,12 @@ public class PersonResourceTest extends AbstractResourceTest {
     final String christopfUuid = getChristopfTopferness().getUuid();
     // Admin has access to everything
     checkSensitiveInformationEdit(christopfUuid, adminUser,
-        ImmutableList.of(BIRTHDAY_FIELD, ID_CARD_FIELD), true);
+        ImmutableList.of(BIRTHDAY_FIELD, POLITICAL_POSITION_FIELD), true);
     // Henry has access to Christopf's birthday
     checkSensitiveInformationEdit(christopfUuid, "henry", ImmutableList.of(BIRTHDAY_FIELD), true);
-    // Bob has access to Christopf's idCard
-    checkSensitiveInformationEdit(christopfUuid, "bob", ImmutableList.of(ID_CARD_FIELD), true);
+    // Bob has access to Christopf's politicalPosition
+    checkSensitiveInformationEdit(christopfUuid, "bob", ImmutableList.of(POLITICAL_POSITION_FIELD),
+        true);
   }
 
   @Test
@@ -568,11 +569,12 @@ public class PersonResourceTest extends AbstractResourceTest {
     final String steveUuid = getSteveSteveson().getUuid();
     // Admin has access to everything
     checkSensitiveInformationEdit(steveUuid, adminUser,
-        ImmutableList.of(BIRTHDAY_FIELD, ID_CARD_FIELD), false);
+        ImmutableList.of(BIRTHDAY_FIELD, POLITICAL_POSITION_FIELD), false);
     // Henry has access to Steve's birthday
     checkSensitiveInformationEdit(steveUuid, "henry", ImmutableList.of(BIRTHDAY_FIELD), false);
-    // Bob has access to Steve's idCard
-    checkSensitiveInformationEdit(steveUuid, "bob", ImmutableList.of(ID_CARD_FIELD), false);
+    // Bob has access to Steve's politicalPosition
+    checkSensitiveInformationEdit(steveUuid, "bob", ImmutableList.of(POLITICAL_POSITION_FIELD),
+        false);
   }
 
   private Person checkSensitiveInformation(final String personUuid, final String user,
@@ -652,8 +654,9 @@ public class PersonResourceTest extends AbstractResourceTest {
     // Try to do some updates that are not allowed
     final String steveUuid = getSteveSteveson().getUuid();
     // Henry only has access to Steve's birthday
-    checkUnauthorizedSensitiveInformation(steveUuid, "henry", ImmutableList.of(ID_CARD_FIELD));
-    // Bob only has access to Steve's idCard
+    checkUnauthorizedSensitiveInformation(steveUuid, "henry",
+        ImmutableList.of(POLITICAL_POSITION_FIELD));
+    // Bob only has access to Steve's politicalPosition
     checkUnauthorizedSensitiveInformation(steveUuid, "bob", ImmutableList.of(BIRTHDAY_FIELD));
   }
 
@@ -704,7 +707,8 @@ public class PersonResourceTest extends AbstractResourceTest {
     personInput = getInput(person, PersonInput.class);
     personInput.getCustomSensitiveInformation().stream()
         .forEach(csiInput -> csiInput.setCustomFieldName(
-            BIRTHDAY_FIELD.equals(csiInput.getCustomFieldName()) ? ID_CARD_FIELD : BIRTHDAY_FIELD));
+            BIRTHDAY_FIELD.equals(csiInput.getCustomFieldName()) ? POLITICAL_POSITION_FIELD
+                : BIRTHDAY_FIELD));
     checkIllegalSensitiveInformation(person, personInput, personInput);
 
     // Test with wrong relatedObjectUuid

--- a/src/test/java/mil/dds/anet/test/resources/PersonResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/PersonResourceTest.java
@@ -3,6 +3,7 @@ package mil.dds.anet.test.resources;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
+import com.google.common.collect.ImmutableList;
 import com.graphql_java_generator.exception.GraphQLRequestExecutionException;
 import com.graphql_java_generator.exception.GraphQLRequestPreparationException;
 import java.io.File;
@@ -16,13 +17,17 @@ import java.util.Base64;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import javax.ws.rs.ForbiddenException;
 import javax.ws.rs.NotFoundException;
+import mil.dds.anet.AnetObjectEngine;
 import mil.dds.anet.test.TestData;
 import mil.dds.anet.test.client.AnetBeanList_Organization;
 import mil.dds.anet.test.client.AnetBeanList_Person;
 import mil.dds.anet.test.client.AnetBeanList_Position;
+import mil.dds.anet.test.client.CustomSensitiveInformation;
+import mil.dds.anet.test.client.CustomSensitiveInformationInput;
 import mil.dds.anet.test.client.Organization;
 import mil.dds.anet.test.client.OrganizationSearchQueryInput;
 import mil.dds.anet.test.client.OrganizationType;
@@ -46,15 +51,20 @@ import org.junit.jupiter.api.Test;
 
 public class PersonResourceTest extends AbstractResourceTest {
 
+  private static final String BIRTHDAY_FIELD = "birthday";
+  private static final String ID_CARD_FIELD = "idCard";
+  private static final String _CUSTOM_SENSITIVE_INFORMATION_FIELDS =
+      "customSensitiveInformation { uuid customFieldName customFieldValue"
+          + " relatedObjectType relatedObjectUuid createdAt updatedAt }";
   private static final String _POSITION_FIELDS = "uuid name code type status organization { uuid }";
   private static final String _PERSON_FIELDS =
       "uuid name status role emailAddress phoneNumber rank biography country avatar code"
           + " gender endOfTourDate domainUsername pendingVerification createdAt updatedAt"
           + " customFields";
-  private static final String POSITION_FIELDS =
-      "{ " + _POSITION_FIELDS + " person { " + _PERSON_FIELDS + " } }";
-  private static final String FIELDS =
-      "{ " + _PERSON_FIELDS + " position { " + _POSITION_FIELDS + " } }";
+  private static final String POSITION_FIELDS = String.format("{ %s person { %s } %s }",
+      _POSITION_FIELDS, _PERSON_FIELDS, _CUSTOM_SENSITIVE_INFORMATION_FIELDS);
+  private static final String FIELDS = String.format("{ %s position { %s } %s }", _PERSON_FIELDS,
+      _POSITION_FIELDS, _CUSTOM_SENSITIVE_INFORMATION_FIELDS);
 
   // 200 x 200 avatar
   final File DEFAULT_AVATAR =
@@ -522,6 +532,230 @@ public class PersonResourceTest extends AbstractResourceTest {
       userMutationExecutor.createPerson(FIELDS, advisorPosition2Input);
       fail("Expected ForbiddenException");
     } catch (ForbiddenException expectedException) {
+    }
+  }
+
+  @Test
+  public void testReadCustomSensitiveInformation()
+      throws GraphQLRequestExecutionException, GraphQLRequestPreparationException {
+    // Steve already has sensitive data
+    final String steveUuid = getSteveSteveson().getUuid();
+    // Elizabeth can read all sensitive data of her counterpart Steve
+    checkSensitiveInformation(steveUuid, "elizabeth",
+        ImmutableList.of(BIRTHDAY_FIELD, ID_CARD_FIELD));
+    // Jim has no access to Steve's sensitive data
+    checkSensitiveInformation(steveUuid, "jim", ImmutableList.of());
+  }
+
+  @Test
+  public void testInsertCustomSensitiveInformation()
+      throws GraphQLRequestExecutionException, GraphQLRequestPreparationException {
+    // Christopf has no sensitive data yet
+    final String christopfUuid = getChristopfTopferness().getUuid();
+    // Admin has access to everything
+    checkSensitiveInformationEdit(christopfUuid, adminUser,
+        ImmutableList.of(BIRTHDAY_FIELD, ID_CARD_FIELD), true);
+    // Henry has access to Christopf's birthday
+    checkSensitiveInformationEdit(christopfUuid, "henry", ImmutableList.of(BIRTHDAY_FIELD), true);
+    // Bob has access to Christopf's idCard
+    checkSensitiveInformationEdit(christopfUuid, "bob", ImmutableList.of(ID_CARD_FIELD), true);
+  }
+
+  @Test
+  public void testUpdateCustomSensitiveInformation()
+      throws GraphQLRequestExecutionException, GraphQLRequestPreparationException {
+    // Steve already has sensitive data
+    final String steveUuid = getSteveSteveson().getUuid();
+    // Admin has access to everything
+    checkSensitiveInformationEdit(steveUuid, adminUser,
+        ImmutableList.of(BIRTHDAY_FIELD, ID_CARD_FIELD), false);
+    // Henry has access to Steve's birthday
+    checkSensitiveInformationEdit(steveUuid, "henry", ImmutableList.of(BIRTHDAY_FIELD), false);
+    // Bob has access to Steve's idCard
+    checkSensitiveInformationEdit(steveUuid, "bob", ImmutableList.of(ID_CARD_FIELD), false);
+  }
+
+  private Person checkSensitiveInformation(final String personUuid, final String user,
+      // List should be in alphabetical order
+      final ImmutableList<String> customSensitiveFields)
+      throws GraphQLRequestExecutionException, GraphQLRequestPreparationException {
+    final QueryExecutor queryExecutor = getQueryExecutor(user);
+    final int size = customSensitiveFields.size();
+
+    final Person person = queryExecutor.person(FIELDS, personUuid);
+    assertThat(person).isNotNull();
+    assertThat(person.getCustomSensitiveInformation()).hasSize(size);
+    assertThat(person.getCustomSensitiveInformation())
+        .allMatch(csi -> customSensitiveFields.contains(csi.getCustomFieldName()));
+
+    return person;
+  }
+
+  private void checkSensitiveInformationEdit(final String personUuid, final String user,
+      // List should be in alphabetical order
+      final ImmutableList<String> customSensitiveFields, final boolean doInsert)
+      throws GraphQLRequestExecutionException, GraphQLRequestPreparationException {
+    final Person person = checkSensitiveInformation(personUuid, user,
+        doInsert ? ImmutableList.of() : customSensitiveFields);
+
+    final QueryExecutor queryExecutor = getQueryExecutor(user);
+    final MutationExecutor mutationExecutor = getMutationExecutor(user);
+    final int size = customSensitiveFields.size();
+
+    final PersonInput personInput = getInput(person, PersonInput.class);
+    if (doInsert) {
+      final List<CustomSensitiveInformationInput> csiInput = customSensitiveFields.stream()
+          .map(csf -> CustomSensitiveInformationInput.builder().withCustomFieldName(csf)
+              .withCustomFieldValue(UUID.randomUUID().toString()).build())
+          .collect(Collectors.toList());
+      personInput.setCustomSensitiveInformation(csiInput);
+    } else {
+      personInput.getCustomSensitiveInformation().stream()
+          .forEach(csiInput -> csiInput.setCustomFieldValue(UUID.randomUUID().toString()));
+    }
+    final Integer nrUpdated = mutationExecutor.updatePerson("", personInput);
+    assertThat(nrUpdated).isEqualTo(1);
+    final Person personUpdated = queryExecutor.person(FIELDS, personInput.getUuid());
+    assertThat(personUpdated).isNotNull();
+    assertThat(personUpdated.getCustomSensitiveInformation()).hasSize(size);
+    for (int i = 0; i < size; i++) {
+      final CustomSensitiveInformationInput csiInput =
+          personInput.getCustomSensitiveInformation().get(i);
+      final CustomSensitiveInformation csiUpdated =
+          personUpdated.getCustomSensitiveInformation().get(i);
+      if (doInsert) {
+        assertThat(csiUpdated.getUpdatedAt()).isNotNull();
+      } else {
+        assertThat(csiUpdated.getUpdatedAt()).isAfter(csiInput.getUpdatedAt());
+      }
+      assertThat(csiUpdated.getCustomFieldValue()).isEqualTo(csiInput.getCustomFieldValue());
+    }
+
+    if (doInsert) {
+      // Delete customSensitiveInformation again
+      final int nrDeleted =
+          AnetObjectEngine.getInstance().getCustomSensitiveInformationDao().deleteFor(personUuid);
+      assertThat(nrDeleted).isEqualTo(size);
+    } else {
+      // Restore previous values
+      final PersonInput personInputRestore = getInput(person, PersonInput.class);
+      personInput.getCustomSensitiveInformation().stream()
+          .forEach(csiInput -> csiInput.setCustomFieldValue(UUID.randomUUID().toString()));
+      final Integer nrUpdatedRestore = mutationExecutor.updatePerson("", personInputRestore);
+      assertThat(nrUpdatedRestore).isEqualTo(1);
+    }
+  }
+
+  @Test
+  public void testUnauthorizedCustomSensitiveInformation()
+      throws GraphQLRequestExecutionException, GraphQLRequestPreparationException {
+    // Try to do some updates that are not allowed
+    final String steveUuid = getSteveSteveson().getUuid();
+    // Henry only has access to Steve's birthday
+    checkUnauthorizedSensitiveInformation(steveUuid, "henry", ImmutableList.of(ID_CARD_FIELD));
+    // Bob only has access to Steve's idCard
+    checkUnauthorizedSensitiveInformation(steveUuid, "bob", ImmutableList.of(BIRTHDAY_FIELD));
+  }
+
+  private void checkUnauthorizedSensitiveInformation(final String personUuid, final String user,
+      // List should be in alphabetical order
+      final ImmutableList<String> customSensitiveFields)
+      throws GraphQLRequestExecutionException, GraphQLRequestPreparationException {
+    final QueryExecutor queryExecutor = getQueryExecutor(user);
+    final MutationExecutor mutationExecutor = getMutationExecutor(user);
+
+    final Person person = queryExecutor.person(FIELDS, personUuid);
+    assertThat(person).isNotNull();
+    assertThat(person.getCustomSensitiveInformation())
+        .noneMatch(csi -> customSensitiveFields.contains(csi.getCustomFieldName()));
+
+    final String customFieldValue = "__UPDATE_NOT_ALLOWED__";
+    final PersonInput personInput = getInput(person, PersonInput.class);
+    final List<CustomSensitiveInformationInput> csiInput = customSensitiveFields.stream()
+        .map(csf -> CustomSensitiveInformationInput.builder().withCustomFieldName(csf)
+            .withCustomFieldValue(customFieldValue).build())
+        .collect(Collectors.toList());
+    personInput.setCustomSensitiveInformation(csiInput);
+    final Instant beforeUpdate = Instant.now();
+    final Integer nrUpdated = mutationExecutor.updatePerson("", personInput);
+    assertThat(nrUpdated).isEqualTo(1);
+    final Person personUpdated = adminQueryExecutor.person(FIELDS, personInput.getUuid());
+    assertThat(personUpdated).isNotNull();
+    assertThat(personUpdated.getCustomSensitiveInformation())
+        .allMatch(csi -> !customFieldValue.equals(csi.getCustomFieldValue())
+            && beforeUpdate.isAfter(csi.getUpdatedAt()));
+  }
+
+  @Test
+  public void testIllegalCustomSensitiveInformation()
+      throws GraphQLRequestExecutionException, GraphQLRequestPreparationException {
+    // Try to do some updates that are illegal
+    final Person person = adminQueryExecutor.person(FIELDS, getSteveSteveson().getUuid());
+    assertThat(person).isNotNull();
+    assertThat(person.getCustomSensitiveInformation()).isNotEmpty();
+
+    // Test with non-existing UUID
+    PersonInput personInput = getInput(person, PersonInput.class);
+    personInput.getCustomSensitiveInformation().stream()
+        .forEach(csiInput -> csiInput.setUuid(UUID.randomUUID().toString()));
+    checkIllegalSensitiveInformation(person, personInput, personInput);
+
+    // Test with wrong customFieldName
+    personInput = getInput(person, PersonInput.class);
+    personInput.getCustomSensitiveInformation().stream()
+        .forEach(csiInput -> csiInput.setCustomFieldName(
+            BIRTHDAY_FIELD.equals(csiInput.getCustomFieldName()) ? ID_CARD_FIELD : BIRTHDAY_FIELD));
+    checkIllegalSensitiveInformation(person, personInput, personInput);
+
+    // Test with wrong relatedObjectUuid
+    personInput = getInput(person, PersonInput.class);
+    final PersonInput otherPersonInput = getInput(getNickNicholson(), PersonInput.class);
+    otherPersonInput.setCustomSensitiveInformation(personInput.getCustomSensitiveInformation());
+    checkIllegalSensitiveInformation(person, otherPersonInput, personInput);
+    final Person otherPersonUpdated = adminQueryExecutor.person(FIELDS, otherPersonInput.getUuid());
+    assertThat(otherPersonUpdated).isNotNull();
+    assertThat(otherPersonUpdated.getCustomSensitiveInformation()).isEmpty();
+
+    // Test with wrong relatedObjectType
+    personInput = getInput(person, PersonInput.class);
+    final PositionInput positionInput = personInput.getPosition();
+    positionInput.setCustomSensitiveInformation(personInput.getCustomSensitiveInformation());
+    final Integer nrUpdated = adminMutationExecutor.updatePosition("", positionInput);
+    assertThat(nrUpdated).isEqualTo(1);
+    final Position positionUpdated =
+        adminQueryExecutor.position(POSITION_FIELDS, positionInput.getUuid());
+    assertThat(positionUpdated).isNotNull();
+    assertThat(positionUpdated.getCustomSensitiveInformation()).isEmpty();
+    final Person personUpdated = adminQueryExecutor.person(FIELDS, personInput.getUuid());
+    assertThat(personUpdated).isNotNull();
+    assertCsi(personUpdated.getCustomSensitiveInformation(),
+        person.getCustomSensitiveInformation());
+  }
+
+  private void checkIllegalSensitiveInformation(final Person person,
+      final PersonInput personToUpdate, final PersonInput personToCheck)
+      throws GraphQLRequestExecutionException, GraphQLRequestPreparationException {
+    final Integer nrUpdated = adminMutationExecutor.updatePerson("", personToUpdate);
+    assertThat(nrUpdated).isEqualTo(1);
+    final Person personUpdated = adminQueryExecutor.person(FIELDS, personToCheck.getUuid());
+    assertThat(personUpdated).isNotNull();
+    assertCsi(personUpdated.getCustomSensitiveInformation(),
+        person.getCustomSensitiveInformation());
+  }
+
+  private void assertCsi(final List<CustomSensitiveInformation> csiList1,
+      List<CustomSensitiveInformation> csiList2) {
+    assertThat(csiList1).hasSameSizeAs(csiList2);
+    for (int i = 0; i < csiList1.size(); i++) {
+      final CustomSensitiveInformation csi1 = csiList1.get(i);
+      final CustomSensitiveInformation csi2 = csiList2.get(i);
+      assertThat(csi1.getUuid()).isEqualTo(csi2.getUuid());
+      assertThat(csi1.getCustomFieldName()).isEqualTo(csi2.getCustomFieldName());
+      assertThat(csi1.getCustomFieldValue()).isEqualTo(csi2.getCustomFieldValue());
+      assertThat(csi1.getRelatedObjectType()).isEqualTo(csi2.getRelatedObjectType());
+      assertThat(csi1.getRelatedObjectUuid()).isEqualTo(csi2.getRelatedObjectUuid());
+      assertThat(csi1.getCreatedAt()).isEqualTo(csi2.getCreatedAt());
+      assertThat(csi1.getUpdatedAt()).isEqualTo(csi2.getUpdatedAt());
     }
   }
 

--- a/src/test/resources/anet.graphql
+++ b/src/test/resources/anet.graphql
@@ -15,7 +15,6 @@ type Activity {
 type AdminSetting {
   createdAt: Instant
   key: String
-  notes: [Note]
   updatedAt: Instant
   value: String
 }
@@ -23,7 +22,6 @@ type AdminSetting {
 input AdminSettingInput {
   createdAt: Instant
   key: String
-  notes: [NoteInput]
   updatedAt: Instant
   value: String
 }
@@ -100,7 +98,6 @@ type ApprovalStep {
   createdAt: Instant
   name: String
   nextStepUuid: String
-  notes: [Note]
   relatedObjectUuid: String
   restrictedApproval: Boolean!
   type: ApprovalStepType
@@ -113,7 +110,6 @@ input ApprovalStepInput {
   createdAt: Instant
   name: String
   nextStepUuid: String
-  notes: [NoteInput]
   relatedObjectUuid: String
   restrictedApproval: Boolean
   type: ApprovalStepType
@@ -136,7 +132,6 @@ type AuthorizationGroup {
   createdAt: Instant
   description: String
   name: String
-  notes: [Note]
   positions: [Position]
   status: Status
   updatedAt: Instant
@@ -147,7 +142,6 @@ input AuthorizationGroupInput {
   createdAt: Instant
   description: String
   name: String
-  notes: [NoteInput]
   positions: [PositionInput]
   status: Status
   updatedAt: Instant
@@ -174,7 +168,6 @@ enum AuthorizationGroupSearchSortBy {
 type Comment {
   author: Person
   createdAt: Instant
-  notes: [Note]
   reportUuid: String
   text: String
   updatedAt: Instant
@@ -184,9 +177,29 @@ type Comment {
 input CommentInput {
   author: PersonInput
   createdAt: Instant
-  notes: [NoteInput]
   reportUuid: String
   text: String
+  updatedAt: Instant
+  uuid: String
+}
+
+type CustomSensitiveInformation {
+  createdAt: Instant
+  customFieldName: String
+  customFieldValue: String
+  relatedObject: RelatableObject
+  relatedObjectType: String
+  relatedObjectUuid: String
+  updatedAt: Instant
+  uuid: String
+}
+
+input CustomSensitiveInformationInput {
+  createdAt: Instant
+  customFieldName: String
+  customFieldValue: String
+  relatedObjectType: String
+  relatedObjectUuid: String
   updatedAt: Instant
   uuid: String
 }
@@ -203,6 +216,7 @@ type Location {
   approvalSteps: [ApprovalStep]
   createdAt: Instant
   customFields: String
+  customSensitiveInformation: [CustomSensitiveInformation]
   lat: Float
   lng: Float
   name: String
@@ -217,10 +231,10 @@ input LocationInput {
   approvalSteps: [ApprovalStepInput]
   createdAt: Instant
   customFields: String
+  customSensitiveInformation: [CustomSensitiveInformationInput]
   lat: Float
   lng: Float
   name: String
-  notes: [NoteInput]
   planningApprovalSteps: [ApprovalStepInput]
   status: Status
   updatedAt: Instant
@@ -290,7 +304,6 @@ type Note {
   author: Person
   createdAt: Instant
   noteRelatedObjects: [NoteRelatedObject]
-  notes: [Note]
   text: String
   type: NoteType
   updatedAt: Instant
@@ -301,7 +314,6 @@ input NoteInput {
   author: PersonInput
   createdAt: Instant
   noteRelatedObjects: [NoteRelatedObjectInput]
-  notes: [NoteInput]
   text: String
   type: NoteType
   updatedAt: Instant
@@ -334,6 +346,7 @@ type Organization {
   childrenOrgs(query: OrganizationSearchQueryInput): [Organization]
   createdAt: Instant
   customFields: String
+  customSensitiveInformation: [CustomSensitiveInformation]
   descendantOrgs(query: OrganizationSearchQueryInput): [Organization]
   identificationCode: String
   longName: String
@@ -353,9 +366,9 @@ input OrganizationInput {
   approvalSteps: [ApprovalStepInput]
   createdAt: Instant
   customFields: String
+  customSensitiveInformation: [CustomSensitiveInformationInput]
   identificationCode: String
   longName: String
-  notes: [NoteInput]
   parentOrg: OrganizationInput
   planningApprovalSteps: [ApprovalStepInput]
   shortName: String
@@ -400,6 +413,7 @@ type Person {
   country: String
   createdAt: Instant
   customFields: String
+  customSensitiveInformation: [CustomSensitiveInformation]
   domainUsername: String
   emailAddress: String
   endOfTourDate: Instant
@@ -424,12 +438,12 @@ input PersonInput {
   country: String
   createdAt: Instant
   customFields: String
+  customSensitiveInformation: [CustomSensitiveInformationInput]
   domainUsername: String
   emailAddress: String
   endOfTourDate: Instant
   gender: String
   name: String
-  notes: [NoteInput]
   pendingVerification: Boolean
   phoneNumber: String
   position: PositionInput
@@ -444,7 +458,6 @@ input PersonInput {
 type PersonPositionHistory {
   createdAt: Instant
   endTime: Instant
-  notes: [Note]
   person: Person
   position: Position
   startTime: Instant
@@ -454,7 +467,6 @@ type PersonPositionHistory {
 input PersonPositionHistoryInput {
   createdAt: Instant
   endTime: Instant
-  notes: [NoteInput]
   person: PersonInput
   position: PositionInput
   startTime: Instant
@@ -494,6 +506,7 @@ type Position {
   code: String
   createdAt: Instant
   customFields: String
+  customSensitiveInformation: [CustomSensitiveInformation]
   isApprover: Boolean
   location: Location
   name: String
@@ -513,9 +526,9 @@ input PositionInput {
   code: String
   createdAt: Instant
   customFields: String
+  customSensitiveInformation: [CustomSensitiveInformationInput]
   location: LocationInput
   name: String
-  notes: [NoteInput]
   organization: OrganizationInput
   person: PersonInput
   previousPeople: [PersonPositionHistoryInput]
@@ -609,6 +622,7 @@ type Report {
   comments: [Comment]
   createdAt: Instant
   customFields: String
+  customSensitiveInformation: [CustomSensitiveInformation]
   duration: Int
   engagementDate: Instant
   engagementDayOfWeek: Int
@@ -635,7 +649,6 @@ type Report {
 
 type ReportAction {
   createdAt: Instant
-  notes: [Note]
   person: Person
   planned: Boolean!
   report: Report
@@ -666,6 +679,7 @@ input ReportInput {
   comments: [CommentInput]
   createdAt: Instant
   customFields: String
+  customSensitiveInformation: [CustomSensitiveInformationInput]
   duration: Int
   engagementDate: Instant
   engagementDayOfWeek: Int
@@ -674,7 +688,6 @@ input ReportInput {
   keyOutcomes: String
   location: LocationInput
   nextSteps: String
-  notes: [NoteInput]
   principalOrg: OrganizationInput
   releasedAt: Instant
   reportPeople: [ReportPersonInput]
@@ -697,6 +710,7 @@ type ReportPerson {
   country: String
   createdAt: Instant
   customFields: String
+  customSensitiveInformation: [CustomSensitiveInformation]
   domainUsername: String
   emailAddress: String
   endOfTourDate: Instant
@@ -724,12 +738,12 @@ input ReportPersonInput {
   country: String
   createdAt: Instant
   customFields: String
+  customSensitiveInformation: [CustomSensitiveInformationInput]
   domainUsername: String
   emailAddress: String
   endOfTourDate: Instant
   gender: String
   name: String
-  notes: [NoteInput]
   pendingVerification: Boolean
   phoneNumber: String
   position: PositionInput
@@ -790,7 +804,6 @@ enum ReportSearchSortBy {
 
 type ReportSensitiveInformation {
   createdAt: Instant
-  notes: [Note]
   text: String
   updatedAt: Instant
   uuid: String
@@ -798,7 +811,6 @@ type ReportSensitiveInformation {
 
 input ReportSensitiveInformationInput {
   createdAt: Instant
-  notes: [NoteInput]
   text: String
   updatedAt: Instant
   uuid: String
@@ -828,7 +840,6 @@ type RollupGraph {
 type SavedSearch {
   createdAt: Instant
   name: String
-  notes: [Note]
   objectType: SearchObjectType
   owner: Person
   query: String
@@ -839,7 +850,6 @@ type SavedSearch {
 input SavedSearchInput {
   createdAt: Instant
   name: String
-  notes: [NoteInput]
   objectType: SearchObjectType
   owner: PersonInput
   query: String
@@ -875,6 +885,7 @@ type Task {
   customFieldEnum2: String
   customFieldRef1: Task
   customFields: String
+  customSensitiveInformation: [CustomSensitiveInformation]
   longName: String
   notes: [Note]
   plannedCompletion: Instant
@@ -898,8 +909,8 @@ input TaskInput {
   customFieldEnum2: String
   customFieldRef1: TaskInput
   customFields: String
+  customSensitiveInformation: [CustomSensitiveInformationInput]
   longName: String
-  notes: [NoteInput]
   plannedCompletion: Instant
   planningApprovalSteps: [ApprovalStepInput]
   projectedCompletion: Instant

--- a/src/test/resources/anet.graphql
+++ b/src/test/resources/anet.graphql
@@ -503,6 +503,7 @@ enum PersonSearchSortBy {
 
 type Position {
   associatedPositions: [Position]
+  authorizationGroups: [AuthorizationGroup]
   code: String
   createdAt: Instant
   customFields: String

--- a/src/test/resources/graphQLTests/appQuery.gql
+++ b/src/test/resources/graphQLTests/appQuery.gql
@@ -29,6 +29,17 @@ me {
     associatedPositions {
       uuid
       name
+      code
+      type
+      status
+      organization {
+        uuid
+        shortName
+      }
+      location {
+        uuid
+        name
+      }
       person {
         uuid
         name
@@ -37,22 +48,56 @@ me {
         position {
           uuid
           name
-          code
           type
+          code
+          status
           organization {
             uuid
             shortName
+            identificationCode
           }
           location {
             uuid
             name
           }
         }
+        customFields
+        notes {
+          noteRelatedObjects {
+            noteUuid
+          }
+          createdAt
+          type
+          text
+        }
       }
-      organization {
+    }
+    responsibleTasks(
+      query: {
+        status: ACTIVE
+      }
+    ) {
+      uuid
+      shortName
+      longName
+      customFieldRef1 {
         uuid
-        shortName
       }
+      customFields
+      notes {
+        noteRelatedObjects {
+          noteUuid
+        }
+        createdAt
+        type
+        text
+      }
+    }
+    authorizationGroups {
+      uuid
+      name
+      description
+      status
     }
   }
 }
@@ -62,12 +107,26 @@ adminSettings {
   value
 }
 
-organizationTopLevelOrgs: organizationList(
+topLevelAdvisorOrgs: organizationList(
   query: {
     pageSize: 0
     hasParentOrg: false
     status: ACTIVE
     type: ADVISOR_ORG
+  }
+) {
+  list {
+    uuid
+    shortName
+  }
+}
+
+topLevelPrincipalOrgs: organizationList(
+  query: {
+    pageSize: 0
+    hasParentOrg: false
+    status: ACTIVE
+    type: PRINCIPAL_ORG
   }
 ) {
   list {

--- a/testDictionaries/no-custom-fields.yml
+++ b/testDictionaries/no-custom-fields.yml
@@ -240,10 +240,22 @@ fields:
         type: date
         label: Date of birth
         authorizationGroupUuids: ['39a78d51-c351-452c-9206-4305ec8dd76d', 'c21e7321-7ec5-4837-8805-a302f9575754']
-      idCard:
-        type: text
-        label: ID card
+        tooltipText: This field contains sensitive information!
+      politicalPosition:
+        type: enum
+        label: Position on the political spectrum
         authorizationGroupUuids: ['1050c9e3-e679-4c60-8bdc-5139fbc1c10b']
+        tooltipText: This field contains sensitive information!
+        choices:
+          LEFT:
+            label: Left
+            color: 'salmon'
+          MIDDLE:
+            label: Middle
+            color: 'gold'
+          RIGHT:
+            label: Right
+            color: 'skyblue'
 
   location:
     format: LAT_LON
@@ -264,7 +276,7 @@ fields:
                   Norway, Poland, Portugal, Romania, Slovakia, Slovenia, Spain, Sweden, Turkey, Ukraine, United Kingdom, United States of America]
       # number of fields after Avatar in the left column for advisors
       # adjust this number if two columns are not balanced on the Person Page
-      numberOfFieldsInLeftColumn: 6
+      numberOfFieldsInLeftColumn: 7
       # select and order person fields (including custom fields)
       showPageOrderedFields:
         - position
@@ -275,9 +287,11 @@ fields:
         - inputFieldName
         - phoneNumber
         - country
+        - birthday
         - colourOptions
         - textareaFieldName
         - code
+        - politicalPosition
         - rank
         - numberFieldName
         - nlt

--- a/testDictionaries/no-custom-fields.yml
+++ b/testDictionaries/no-custom-fields.yml
@@ -235,6 +235,15 @@ fields:
     gender: Gender
     biography: Biography
     endOfTourDate: End of tour
+    customSensitiveInformation:
+      birthday:
+        type: date
+        label: Date of birth
+        authorizationGroupUuids: ['39a78d51-c351-452c-9206-4305ec8dd76d', 'c21e7321-7ec5-4837-8805-a302f9575754']
+      idCard:
+        type: text
+        label: ID card
+        authorizationGroupUuids: ['1050c9e3-e679-4c60-8bdc-5139fbc1c10b']
 
   location:
     format: LAT_LON


### PR DESCRIPTION
Person objects have `customSensitiveInformation` which are only visible to admins, counterparts, and users whose position is in the `authorizationGroup`. Admins can edit all sensitive fields while superusers can edit only the ones they are authorized for. 

Closes #3342 

#### User changes
- Authorized users can see sensitive information of people.

#### Super User changes
- Superusers can see and edit sensitive information of people if they are authorized.

#### Admin changes
- Admins can see and edit any sensitive information of people.

#### System admin changes
- [x] anet.yml or anet-dictionary.yml needs change
  Sensitive fields should be added to the `person` and  `showPageOrderedFields` in the dictionary:
  ```
  fields:
    person:
      customSensitiveInformation:
        birthday:
          type: date
          label: Date of birth
          authorizationGroupUuids: [...]
          tooltipText: "This field contains sensitive information!"

    …

    principal:
      person:
        showPageOrderedFields:
          …
          - birthday
          …
  ```
- [x] db needs migration
- [ ] documentation has changed
- [x] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [x] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [x] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [x] Opened debt issues for anything not resolved here
