### PR TITLE
Add client-side tests for custom sensitive information

### DIFF
--- a/client/tests/webdriver/customFieldsSpecs/customSensitiveFields.spec.js
+++ b/client/tests/webdriver/customFieldsSpecs/customSensitiveFields.spec.js
@@ -1,0 +1,188 @@
+import { expect } from "chai"
+import CreatePerson from "../pages/createNewPerson.page"
+import Home from "../pages/home.page"
+import Search from "../pages/search.page"
+import ShowPerson from "../pages/showPerson.page"
+
+const DEFAULT_USERNAME = "jack"
+
+const NON_COUNTERPART_PRINCIPLE = {
+  name: "Steve",
+  birthday: "9 September 1999",
+  politicalPosition: "Left"
+}
+const COUNTERPART_PRINCIPLE = {
+  name: "Roger",
+  birthday: "1 January 2001",
+  politicalPosition: "Right"
+}
+
+const NEW_PERSON_FIELDS_1 = {
+  lastname: "sensitivePerson1",
+  rank: "CIV",
+  gender: "FEMALE"
+}
+
+const NEW_PERSON_FIELDS_2 = {
+  lastname: "sensitivePerson2",
+  rank: "CIV",
+  gender: "MALE"
+}
+
+describe("Visibility of custom sensitive information", () => {
+  describe("Users", () => {
+    it("Should be able to find the non counterpart principal with sensitive information", () => {
+      Home.open("/", DEFAULT_USERNAME)
+      Home.searchBar.setValue(NON_COUNTERPART_PRINCIPLE.name)
+      Home.submitSearch.click()
+      Search.foundPeopleTable.waitForExist({ timeout: 20000 })
+      Search.foundPeopleTable.waitForDisplayed()
+      Search.linkOfPersonFound(NON_COUNTERPART_PRINCIPLE.name).click()
+    })
+    it("Should not be able to see political position field if not authorized", () => {
+      ShowPerson.politicalPosition.waitForDisplayed({
+        timeout: 1000,
+        reverse: true
+      })
+    })
+    it("Should be able to see birthday field with the correct value if authorized", () => {
+      ShowPerson.birthday.waitForDisplayed()
+      expect(ShowPerson.birthday.getText()).to.equal(
+        NON_COUNTERPART_PRINCIPLE.birthday
+      )
+    })
+    it("Should be able to find the counterpart principal with sensitive information", () => {
+      Home.open("/", DEFAULT_USERNAME)
+      Home.searchBar.setValue(COUNTERPART_PRINCIPLE.name)
+      Home.submitSearch.click()
+      Search.foundPeopleTable.waitForExist({ timeout: 20000 })
+      Search.foundPeopleTable.waitForDisplayed()
+      Search.linkOfPersonFound(COUNTERPART_PRINCIPLE.name).click()
+    })
+    it("Should be able to see political position field with the correct value if counterpart", () => {
+      ShowPerson.politicalPosition.waitForDisplayed()
+      expect(ShowPerson.politicalPosition.getText()).to.equal(
+        COUNTERPART_PRINCIPLE.politicalPosition
+      )
+    })
+    it("Should be able to see birthday field with the correct value if counterpart", () => {
+      ShowPerson.birthday.waitForDisplayed()
+      expect(ShowPerson.birthday.getText()).to.equal(
+        COUNTERPART_PRINCIPLE.birthday
+      )
+    })
+  })
+  describe("Superusers", () => {
+    it("Should be able to find the principal with sensitive information", () => {
+      Home.openAsSuperUser()
+      Home.searchBar.setValue(NON_COUNTERPART_PRINCIPLE.name)
+      Home.submitSearch.click()
+      Search.foundPeopleTable.waitForExist({ timeout: 20000 })
+      Search.foundPeopleTable.waitForDisplayed()
+      Search.linkOfPersonFound(NON_COUNTERPART_PRINCIPLE.name).click()
+    })
+    it("Should not be able to see political position field if not authorized", () => {
+      ShowPerson.politicalPosition.waitForDisplayed({
+        timeout: 1000,
+        reverse: true
+      })
+    })
+    it("Should be able to see birthday field with the correct value if authorized", () => {
+      ShowPerson.birthday.waitForDisplayed()
+      expect(ShowPerson.birthday.getText()).to.equal(
+        NON_COUNTERPART_PRINCIPLE.birthday
+      )
+    })
+  })
+  describe("Admins", () => {
+    it("Should be able to find the principal with sensitive information", () => {
+      Home.openAsAdminUser()
+      Home.searchBar.setValue(NON_COUNTERPART_PRINCIPLE.name)
+      Home.submitSearch.click()
+      Search.foundPeopleTable.waitForExist({ timeout: 20000 })
+      Search.foundPeopleTable.waitForDisplayed()
+      Search.linkOfPersonFound(NON_COUNTERPART_PRINCIPLE.name).click()
+    })
+    it("Should be able to see political position field with the correct value", () => {
+      ShowPerson.politicalPosition.waitForDisplayed()
+      expect(ShowPerson.politicalPosition.getText()).to.equal(
+        NON_COUNTERPART_PRINCIPLE.politicalPosition
+      )
+    })
+    it("Should be able to see birthday field with the correct value", () => {
+      ShowPerson.birthday.waitForDisplayed()
+      expect(ShowPerson.birthday.getText()).to.equal(
+        NON_COUNTERPART_PRINCIPLE.birthday
+      )
+    })
+  })
+})
+
+describe("Creating and editing custom sensitive information", () => {
+  describe("Superusers", () => {
+    it("Should be able load a new person form and fill normal required fields", () => {
+      CreatePerson.openAsSuperUser()
+      CreatePerson.form.waitForExist()
+      CreatePerson.form.waitForDisplayed()
+      // fill other required fields at the beginning
+      CreatePerson.lastName.setValue(NEW_PERSON_FIELDS_1.lastname)
+      CreatePerson.rank.selectByAttribute("value", NEW_PERSON_FIELDS_1.rank)
+      CreatePerson.gender.selectByAttribute("value", NEW_PERSON_FIELDS_1.gender)
+    })
+    it("Should not be able to edit sensitive fields if not authorized", () => {
+      CreatePerson.politicalPositionSensitiveFieldContainer.waitForDisplayed({
+        timeout: 1000,
+        reverse: true
+      })
+    })
+    it("Should be able to create a new person with sensitive information", () => {
+      CreatePerson.birthday.setValue("08-06-1963")
+      CreatePerson.submitForm()
+      CreatePerson.waitForAlertSuccessToLoad()
+      expect(ShowPerson.birthday.getText()).to.equal("8 June 1963")
+    })
+    it("Should be able to edit sensitive information if authorized", () => {
+      ShowPerson.editButton.click()
+      CreatePerson.form.waitForExist()
+      CreatePerson.form.waitForDisplayed()
+      CreatePerson.birthday.setValue(
+        "\uE003".repeat(CreatePerson.birthday.getValue().length) + "01-01-1956"
+      )
+      CreatePerson.submitForm()
+      CreatePerson.waitForAlertSuccessToLoad()
+      expect(ShowPerson.birthday.getText()).to.equal("1 January 1956")
+    })
+  })
+  describe("Admins", () => {
+    it("Should be able load a new person form and fill normal required fields", () => {
+      CreatePerson.openAsAdmin()
+      CreatePerson.form.waitForExist()
+      CreatePerson.form.waitForDisplayed()
+      // fill other required fields at the beginning
+      CreatePerson.lastName.setValue(NEW_PERSON_FIELDS_2.lastname)
+      CreatePerson.rank.selectByAttribute("value", NEW_PERSON_FIELDS_1.rank)
+      CreatePerson.gender.selectByAttribute("value", NEW_PERSON_FIELDS_2.gender)
+    })
+    it("Should be able to create a new person with sensitive information", () => {
+      CreatePerson.birthday.setValue("01-01-1956")
+      CreatePerson.middleButton.click()
+      CreatePerson.submitForm()
+      CreatePerson.waitForAlertSuccessToLoad()
+      expect(ShowPerson.birthday.getText()).to.equal("1 January 1956")
+      expect(ShowPerson.politicalPosition.getText()).to.equal("Middle")
+    })
+    it("Should be able to edit sensitive information", () => {
+      ShowPerson.editButton.click()
+      CreatePerson.form.waitForExist()
+      CreatePerson.form.waitForDisplayed()
+      CreatePerson.birthday.setValue(
+        "\uE003".repeat(CreatePerson.birthday.getValue().length) + "08-06-1963"
+      )
+      CreatePerson.leftButton.click()
+      CreatePerson.submitForm()
+      CreatePerson.waitForAlertSuccessToLoad()
+      expect(ShowPerson.birthday.getText()).to.equal("8 June 1963")
+      expect(ShowPerson.politicalPosition.getText()).to.equal("Left")
+    })
+  })
+})

--- a/client/tests/webdriver/pages/createNewPerson.page.js
+++ b/client/tests/webdriver/pages/createNewPerson.page.js
@@ -7,6 +7,11 @@ const INVISIBLE_CUSTOM_FIELDS = {
   number: "formCustomFields.numberFieldName"
 }
 
+const SENSITIVE_CUSTOM_FIELDS = {
+  birthday: "formSensitiveFields.birthday",
+  politicalPosition: "formSensitiveFields.politicalPosition"
+}
+
 class CreatePerson extends Page {
   get form() {
     return browser.$("form.form-horizontal")
@@ -128,8 +133,42 @@ class CreatePerson extends Page {
     )
   }
 
+  get sensitiveFieldsContainer() {
+    return browser.$("#sensitive-fields")
+  }
+
+  get birthdaySensitiveFieldContainer() {
+    return this.getSensitiveFieldContainerByName(
+      SENSITIVE_CUSTOM_FIELDS.birthday
+    )
+  }
+
+  get politicalPositionSensitiveFieldContainer() {
+    return this.getSensitiveFieldContainerByName(
+      SENSITIVE_CUSTOM_FIELDS.politicalPosition
+    )
+  }
+
+  get birthday() {
+    return this.sensitiveFieldsContainer.$(
+      'input[id="formSensitiveFields.birthday'
+    )
+  }
+
+  get leftButton() {
+    return this.sensitiveFieldsContainer.$('label[id="LEFT"]')
+  }
+
+  get middleButton() {
+    return this.sensitiveFieldsContainer.$('label[id="MIDDLE"]')
+  }
+
   getCustomFieldContainerByName(name) {
     return this.customFieldsContainer.$(`div[id="fg-${name}"]`)
+  }
+
+  getSensitiveFieldContainerByName(name) {
+    return this.sensitiveFieldsContainer.$(`div[id="fg-${name}"]`)
   }
 
   openAsSuperUser() {

--- a/client/tests/webdriver/pages/showPerson.page.js
+++ b/client/tests/webdriver/pages/showPerson.page.js
@@ -1,6 +1,10 @@
 import Page from "./page"
 
 class ShowPerson extends Page {
+  get editButton() {
+    return browser.$("div a.edit-person")
+  }
+
   get assessmentsTable() {
     return this.quarterlyAssessmentContainer.$("table.assessments-table")
   }
@@ -42,6 +46,14 @@ class ShowPerson extends Page {
 
   get quarterlyAssessmentContainer() {
     return browser.$("#entity-assessments-results-quarterly")
+  }
+
+  get politicalPosition() {
+    return browser.$('div[name="formSensitiveFields.politicalPosition"]')
+  }
+
+  get birthday() {
+    return browser.$('div[name="formSensitiveFields.birthday"]')
   }
 
   waitForAssessmentModalForm(reverse = false) {


### PR DESCRIPTION
Added client-side tests that check if only the authorized users can see or edit custom sensitive information.

Closes #3587 

#### User changes
- none

#### Super User changes
- none

#### Admin changes
- none

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [x] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
