### PR TITLE
Sanitize JSON before storing it

### DIFF
--- a/src/test/java/mil/dds/anet/test/resources/PersonResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/PersonResourceTest.java
@@ -608,12 +608,13 @@ public class PersonResourceTest extends AbstractResourceTest {
     if (doInsert) {
       final List<CustomSensitiveInformationInput> csiInput = customSensitiveFields.stream()
           .map(csf -> CustomSensitiveInformationInput.builder().withCustomFieldName(csf)
-              .withCustomFieldValue(UUID.randomUUID().toString()).build())
+              .withCustomFieldValue(getCustomFieldValue(csf, UUID.randomUUID().toString())).build())
           .collect(Collectors.toList());
       personInput.setCustomSensitiveInformation(csiInput);
     } else {
       personInput.getCustomSensitiveInformation().stream()
-          .forEach(csiInput -> csiInput.setCustomFieldValue(UUID.randomUUID().toString()));
+          .forEach(csiInput -> csiInput.setCustomFieldValue(
+              getCustomFieldValue(csiInput.getCustomFieldName(), UUID.randomUUID().toString())));
     }
     final Integer nrUpdated = mutationExecutor.updatePerson("", personInput);
     assertThat(nrUpdated).isEqualTo(1);
@@ -642,10 +643,15 @@ public class PersonResourceTest extends AbstractResourceTest {
       // Restore previous values
       final PersonInput personInputRestore = getInput(person, PersonInput.class);
       personInput.getCustomSensitiveInformation().stream()
-          .forEach(csiInput -> csiInput.setCustomFieldValue(UUID.randomUUID().toString()));
+          .forEach(csiInput -> csiInput.setCustomFieldValue(
+              getCustomFieldValue(csiInput.getCustomFieldName(), UUID.randomUUID().toString())));
       final Integer nrUpdatedRestore = mutationExecutor.updatePerson("", personInputRestore);
       assertThat(nrUpdatedRestore).isEqualTo(1);
     }
+  }
+
+  private String getCustomFieldValue(String fieldName, String value) {
+    return String.format("{\"%1$s\":\"%2$s\"}", fieldName, value);
   }
 
   @Test
@@ -676,7 +682,7 @@ public class PersonResourceTest extends AbstractResourceTest {
     final PersonInput personInput = getInput(person, PersonInput.class);
     final List<CustomSensitiveInformationInput> csiInput = customSensitiveFields.stream()
         .map(csf -> CustomSensitiveInformationInput.builder().withCustomFieldName(csf)
-            .withCustomFieldValue(customFieldValue).build())
+            .withCustomFieldValue(getCustomFieldValue(csf, customFieldValue)).build())
         .collect(Collectors.toList());
     personInput.setCustomSensitiveInformation(csiInput);
     final Instant beforeUpdate = Instant.now();


### PR DESCRIPTION
Sanitize the JSON inside a customSensitiveInformation field's value before storing it in the database.

Minor update of #3342 

#### User changes
- none

#### Super User changes
- none

#### Admin changes
- none

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [x] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here