### PR TITLE
Print or export people profiles

### DIFF
--- a/anet-dictionary.yml
+++ b/anet-dictionary.yml
@@ -26,7 +26,6 @@ dateFormats:
 printOptions:
   sensitiveInformationText: Sensitive Information
 
-
 reportWorkflow:
   nbOfHoursQuarantineApproved: 24
   nbOfHoursApprovalTimeout: 48

--- a/anet-dictionary.yml
+++ b/anet-dictionary.yml
@@ -23,6 +23,10 @@ dateFormats:
       date: dddd, D MMMM YYYY
       withTime: dddd, D MMMM YYYY @ HH:mm
 
+printOptions:
+  sensitiveInformationText: Sensitive Information
+
+
 reportWorkflow:
   nbOfHoursQuarantineApproved: 24
   nbOfHoursApprovalTimeout: 48

--- a/anet-dictionary.yml
+++ b/anet-dictionary.yml
@@ -25,6 +25,7 @@ dateFormats:
 
 printOptions:
   sensitiveInformationText: Sensitive Information
+  sensitiveInformationTooltipText: Releasability Information
 
 reportWorkflow:
   nbOfHoursQuarantineApproved: 24

--- a/client/src/components/Compact.js
+++ b/client/src/components/Compact.js
@@ -1,7 +1,127 @@
 // Print friendly table layout for pages
 import styled from "@emotion/styled"
+import AppContext from "components/AppContext"
+import LinkTo from "components/LinkTo"
+import {
+  CompactSecurityBanner,
+  SETTING_KEY_COLOR
+} from "components/SecurityBanner"
+import moment from "moment"
 import PropTypes from "prop-types"
-import React from "react"
+import React, { useContext } from "react"
+import { Link, useLocation } from "react-router-dom"
+import anetLogo from "resources/logo.svg"
+import Settings from "settings"
+
+export const CompactHeaderContent = ({ object }) => {
+  const location = useLocation()
+  const { appSettings } = useContext(AppContext)
+  return (
+    <HeaderContentS bgc={appSettings[SETTING_KEY_COLOR]}>
+      <img src={anetLogo} alt="logo" width="50" height="12" />
+      <ClassificationBanner />
+      <span style={{ fontSize: "12px" }}>
+        <Link to={location.pathname}>{object.uuid}</Link>
+      </span>
+    </HeaderContentS>
+  )
+}
+
+CompactHeaderContent.propTypes = {
+  object: PropTypes.object
+}
+
+export const CompactFooterContent = () => {
+  const { currentUser, appSettings } = useContext(AppContext)
+  return (
+    <FooterContentS bgc={appSettings[SETTING_KEY_COLOR]}>
+      <img src={anetLogo} alt="logo" width="50" height="12" />
+      <ClassificationBanner />
+      <PrintedByBoxS>
+        <div>
+          printed by <LinkTo modelType="Person" model={currentUser} />
+        </div>
+        <div>
+          {moment().format(Settings.dateFormats.forms.displayLong.withTime)}
+        </div>
+      </PrintedByBoxS>
+    </FooterContentS>
+  )
+}
+
+const PrintedByBoxS = styled.span`
+  align-self: flex-start;
+  width: auto;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  align-items: flex-end;
+  flex-wrap: wrap;
+  font-size: 10px;
+  & > span {
+    display: inline-block;
+    text-align: right;
+  }
+`
+
+// background color of banner makes reading blue links hard. Force white color
+const HF_COMMON_STYLE = `
+  position: absolute;
+  left: 0mm;
+  display: flex;
+  width: 100%;
+  max-height: 50px;
+  margin: 10px auto;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem;
+  -webkit-print-color-adjust: exact !important;
+  color-adjust: exact !important;
+  img {
+    max-width: 50px !important;
+    max-height: 24px !important;
+  }
+  & * {
+    color: white !important;
+  }
+  @media print {
+    position: fixed;
+    max-height: 70px;
+  }
+`
+
+const HeaderContentS = styled.div`
+  ${HF_COMMON_STYLE};
+  top: 0mm;
+  border-bottom: 1px solid black;
+  background-color: ${props => props.bgc} !important;
+`
+
+const FooterContentS = styled.div`
+  ${HF_COMMON_STYLE};
+  bottom: 0mm;
+  border-top: 1px solid black;
+  background-color: ${props => props.bgc} !important;
+`
+
+const ClassificationBanner = () => {
+  return (
+    <ClassificationBannerS>
+      <CompactSecurityBanner />
+    </ClassificationBannerS>
+  )
+}
+
+const ClassificationBannerS = styled.div`
+  width: auto;
+  max-width: 67%;
+  text-align: center;
+  display: inline-block;
+  & > .banner {
+    padding: 2px 4px;
+  }
+`
 
 const CompactTable = ({ children }) => {
   return (

--- a/client/src/components/Compact.js
+++ b/client/src/components/Compact.js
@@ -13,8 +13,7 @@ import { Link, useLocation } from "react-router-dom"
 import anetLogo from "resources/logo.svg"
 import Settings from "settings"
 
-export const CompactHeaderContent = ({ object, sensitiveInformation }) => {
-  const location = useLocation()
+export const CompactHeaderContent = ({ sensitiveInformation }) => {
   const { appSettings } = useContext(AppContext)
   return (
     <HeaderContentS bgc={appSettings[SETTING_KEY_COLOR]}>
@@ -25,23 +24,22 @@ export const CompactHeaderContent = ({ object, sensitiveInformation }) => {
           <span>{Settings.printOptions.sensitiveInformationText}</span>
         )}
       </ClassificationBoxS>
-      <span style={{ fontSize: "12px" }}>
-        ANET Uuid: <Link to={location.pathname}>{object.uuid}</Link>
-      </span>
     </HeaderContentS>
   )
 }
 
 CompactHeaderContent.propTypes = {
-  object: PropTypes.object,
   sensitiveInformation: PropTypes.bool
 }
 
-export const CompactFooterContent = () => {
+export const CompactFooterContent = ({ object }) => {
+  const location = useLocation()
   const { currentUser, appSettings } = useContext(AppContext)
   return (
     <FooterContentS bgc={appSettings[SETTING_KEY_COLOR]}>
-      <img src={anetLogo} alt="logo" width="50" height="12" />
+      <span style={{ fontSize: "12px" }}>
+        uuid: <Link to={location.pathname}>{object.uuid}</Link>
+      </span>
       <ClassificationBanner />
       <PrintedByBoxS>
         <div>
@@ -55,12 +53,18 @@ export const CompactFooterContent = () => {
   )
 }
 
+CompactFooterContent.propTypes = {
+  object: PropTypes.object
+}
+
 const ClassificationBoxS = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
   font-size: 12px;
   min-width: 235px;
+  text-align: center;
+  margin: auto;
 `
 
 const PrintedByBoxS = styled.span`
@@ -84,7 +88,7 @@ const HF_COMMON_STYLE = `
   left: 0mm;
   display: flex;
   width: 100%;
-  max-height: 50px;
+  max-height: 80px;
   margin: 10px auto;
   flex-direction: row;
   justify-content: space-between;
@@ -101,7 +105,7 @@ const HF_COMMON_STYLE = `
   }
   @media print {
     position: fixed;
-    max-height: 70px;
+    max-height: 80px;
   }
 `
 
@@ -186,16 +190,13 @@ export const CompactRow = ({ label, content, ...otherProps }) => {
   const CustomStyled = styled(CompactRowS)`
     ${style};
   `
-  // lower case if string
-  const lowerLabel =
-    typeof label === "string" ? label.toLocaleLowerCase() : label
 
   // top level th have different width
   const isTopLevelTh = className === "reportField"
 
   return (
     <CustomStyled className={className || null}>
-      <RowLabelS isTopLevelTh={isTopLevelTh}>{lowerLabel}</RowLabelS>
+      <RowLabelS isTopLevelTh={isTopLevelTh}>{label}</RowLabelS>
       <CompactRowContentS>{content}</CompactRowContentS>
     </CustomStyled>
   )

--- a/client/src/components/Compact.js
+++ b/client/src/components/Compact.js
@@ -1,4 +1,7 @@
 // Print friendly table layout for pages
+import { Icon, Intent } from "@blueprintjs/core"
+import { IconNames } from "@blueprintjs/icons"
+import { Tooltip2 } from "@blueprintjs/popover2"
 import styled from "@emotion/styled"
 import AppContext from "components/AppContext"
 import LinkTo from "components/LinkTo"
@@ -20,9 +23,7 @@ export const CompactHeaderContent = ({ sensitiveInformation }) => {
       <img src={anetLogo} alt="logo" width="50" height="12" />
       <ClassificationBoxS>
         <ClassificationBanner />
-        {sensitiveInformation && (
-          <span>{Settings.printOptions.sensitiveInformationText}</span>
-        )}
+        {sensitiveInformation && <ReleasabilityInformation />}
       </ClassificationBoxS>
     </HeaderContentS>
   )
@@ -37,7 +38,7 @@ export const CompactFooterContent = ({ object }) => {
   const { currentUser, appSettings } = useContext(AppContext)
   return (
     <FooterContentS bgc={appSettings[SETTING_KEY_COLOR]}>
-      <span style={{ fontSize: "12px" }}>
+      <span style={{ fontSize: "10px" }}>
         uuid: <Link to={location.pathname}>{object.uuid}</Link>
       </span>
       <ClassificationBanner />
@@ -57,11 +58,39 @@ CompactFooterContent.propTypes = {
   object: PropTypes.object
 }
 
+const ReleasabilityInformation = () => {
+  return (
+    <ReleasabilityInformationS>
+      <span className="releasability-information">
+        {" "}
+        - {Settings.printOptions.sensitiveInformationText}
+      </span>
+      <span className="releasability-tooltip">
+        <Tooltip2
+          content={Settings.printOptions.sensitiveInformationTooltipText}
+          intent={Intent.WARNING}
+        >
+          <Icon icon={IconNames.INFO_SIGN} intent={Intent.PRIMARY} />
+        </Tooltip2>
+      </span>
+    </ReleasabilityInformationS>
+  )
+}
+
+const ReleasabilityInformationS = styled.div`
+  .releasability-tooltip {
+    padding: 0 1rem;
+    @media print {
+      display: none;
+    }
+  }
+`
+
 const ClassificationBoxS = styled.div`
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
   align-items: center;
-  font-size: 12px;
+  font-size: 18px;
   min-width: 235px;
   text-align: center;
   margin: auto;
@@ -149,7 +178,13 @@ const CompactTable = ({ className, children }) => {
           <EmptySpaceTdS colSpan="2" />
         </tr>
       </thead>
-      <tbody>{children}</tbody>
+      {
+        <tbody>
+          <tr>
+            <td>{children}</td>
+          </tr>
+        </tbody>
+      }
       <tfoot>
         <tr>
           <EmptySpaceTdS colSpan="2" />
@@ -223,10 +258,18 @@ const RowLabelS = styled.th`
 `
 
 export const CompactRowContentS = styled.td`
+  display: flex;
+  justify-content: space-between;
   padding: 4px 1rem;
   & .form-control-static {
     margin-bottom: 0;
     padding-top: 0;
+  }
+  & .bp3-popover2-target {
+    padding: 0 1rem;
+    @media print {
+      display: none;
+    }
   }
 `
 

--- a/client/src/components/Compact.js
+++ b/client/src/components/Compact.js
@@ -80,6 +80,9 @@ const ReleasabilityInformation = () => {
 const ReleasabilityInformationS = styled.div`
   .releasability-tooltip {
     padding: 0 1rem;
+    svg {
+      height: 20px;
+    }
     @media print {
       display: none;
     }
@@ -267,6 +270,9 @@ export const CompactRowContentS = styled.td`
   }
   & .bp3-popover2-target {
     padding: 0 1rem;
+    svg {
+      height: 16px;
+    }
     @media print {
       display: none;
     }

--- a/client/src/components/Compact.js
+++ b/client/src/components/Compact.js
@@ -13,22 +13,28 @@ import { Link, useLocation } from "react-router-dom"
 import anetLogo from "resources/logo.svg"
 import Settings from "settings"
 
-export const CompactHeaderContent = ({ object }) => {
+export const CompactHeaderContent = ({ object, sensitiveInformation }) => {
   const location = useLocation()
   const { appSettings } = useContext(AppContext)
   return (
     <HeaderContentS bgc={appSettings[SETTING_KEY_COLOR]}>
       <img src={anetLogo} alt="logo" width="50" height="12" />
-      <ClassificationBanner />
+      <ClassificationBoxS>
+        <ClassificationBanner />
+        {sensitiveInformation && (
+          <span>{Settings.printOptions.sensitiveInformationText}</span>
+        )}
+      </ClassificationBoxS>
       <span style={{ fontSize: "12px" }}>
-        <Link to={location.pathname}>{object.uuid}</Link>
+        ANET Uuid: <Link to={location.pathname}>{object.uuid}</Link>
       </span>
     </HeaderContentS>
   )
 }
 
 CompactHeaderContent.propTypes = {
-  object: PropTypes.object
+  object: PropTypes.object,
+  sensitiveInformation: PropTypes.bool
 }
 
 export const CompactFooterContent = () => {
@@ -48,6 +54,14 @@ export const CompactFooterContent = () => {
     </FooterContentS>
   )
 }
+
+const ClassificationBoxS = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  font-size: 12px;
+  min-width: 235px;
+`
 
 const PrintedByBoxS = styled.span`
   align-self: flex-start;

--- a/client/src/components/Compact.js
+++ b/client/src/components/Compact.js
@@ -137,9 +137,9 @@ const ClassificationBannerS = styled.div`
   }
 `
 
-const CompactTable = ({ children }) => {
+const CompactTable = ({ className, children }) => {
   return (
-    <CompactTableS>
+    <CompactTableS className={className}>
       <thead>
         <tr>
           <EmptySpaceTdS colSpan="2" />
@@ -156,6 +156,7 @@ const CompactTable = ({ children }) => {
 }
 
 CompactTable.propTypes = {
+  className: PropTypes.string,
   children: PropTypes.node
 }
 

--- a/client/src/components/CustomFields.js
+++ b/client/src/components/CustomFields.js
@@ -1084,7 +1084,8 @@ export const mapReadonlyCustomFieldsToComps = ({
   parentFieldName = DEFAULT_CUSTOM_FIELDS_PARENT, // key path in the values object to get to the level of fields given by the fieldsConfig
   values,
   vertical,
-  labelColumnWidth
+  labelColumnWidth,
+  isCompact
 }) => {
   return Object.entries(fieldsConfig).reduce((accum, [key, fieldConfig]) => {
     let extraColElem = null
@@ -1122,6 +1123,7 @@ export const mapReadonlyCustomFieldsToComps = ({
         vertical={vertical}
         extraColElem={extraColElem}
         labelColumnWidth={labelColumnWidth}
+        isCompact={isCompact}
         {...fieldProps}
         {...extraProps}
       />
@@ -1133,6 +1135,7 @@ export const mapReadonlyCustomFieldsToComps = ({
         humanValue={<i>Missing ReadonlyFieldComponent for {type}</i>}
         extraColElem={extraColElem}
         labelColumnWidth={labelColumnWidth}
+        isCompact={isCompact}
         {...fieldProps}
       />
     )

--- a/client/src/components/FieldHelper.js
+++ b/client/src/components/FieldHelper.js
@@ -108,6 +108,7 @@ const Field = ({
           <>
             {widget}
             {getHelpBlock(field, form)}
+            {extraColElem}
             {children}
           </>
         }

--- a/client/src/components/SimpleMultiCheckboxDropdown.js
+++ b/client/src/components/SimpleMultiCheckboxDropdown.js
@@ -45,6 +45,32 @@ const SimpleMultiCheckboxDropdown = ({ label, options, setOptions }) => {
               />
             </label>
           ))}
+          <div>
+            <button
+              className="btn btn-primary"
+              onClick={() =>
+                setOptions(prev => {
+                  const newer = { ...prev }
+                  Object.keys(newer).forEach(key => (newer[key].active = true))
+                  return newer
+                })
+              }
+            >
+              Select All
+            </button>
+            <button
+              className="btn btn-primary"
+              onClick={() =>
+                setOptions(prev => {
+                  const newer = { ...prev }
+                  Object.keys(newer).forEach(key => (newer[key].active = false))
+                  return newer
+                })
+              }
+            >
+              Clear All
+            </button>
+          </div>
         </div>
       </div>
     </DropdownButton>
@@ -88,6 +114,14 @@ const DropdownButton = styled.span`
       margin-left: auto;
       min-width: 16px;
       height: 16px;
+    }
+
+    div {
+      width: 100%;
+
+      button {
+        width: 50%;
+      }
     }
   }
   & > div {

--- a/client/src/components/SimpleMultiCheckboxDropdown.js
+++ b/client/src/components/SimpleMultiCheckboxDropdown.js
@@ -59,12 +59,12 @@ const DropdownButton = styled.span`
   z-index: 102;
   & > div {
     position: relative;
-    width: 100%;
+    width: 200%;
   }
   & > div > div {
     display: flex;
-    flex-direction: column;
-    justify-content: center;
+    flex-flow: row wrap;
+    justify-content: space-between;
     align-items: center;
     width: 100%;
 
@@ -76,7 +76,8 @@ const DropdownButton = styled.span`
     left: 0;
 
     label {
-      width: 100%;
+      flex: 1 1 1;
+      width: 48%;
       display: flex;
       flex-direction: row;
       justify-content: space-around;
@@ -85,7 +86,7 @@ const DropdownButton = styled.span`
 
     input {
       margin-left: auto;
-      width: 16px;
+      min-width: 16px;
       height: 16px;
     }
   }

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1136,6 +1136,9 @@ header.searchPagination {
   .content-container {
     display: block !important;
     height: 100% !important;
+    margin: 0 !important;
+    padding: 0 !important;
+    overflow: visible !important;
   }
   /* adds random characters at the end of document which causes printed pdf to have empty pages*/
   svg > text#__react_svg_text_measurement_id {

--- a/client/src/pages/Routing.js
+++ b/client/src/pages/Routing.js
@@ -23,6 +23,7 @@ import OrganizationEdit from "pages/organizations/Edit"
 import OrganizationNew from "pages/organizations/New"
 import OrganizationShow from "pages/organizations/Show"
 import PageMissing from "pages/PageMissing"
+import PersonCompact from "pages/people/Compact"
 import PersonEdit from "pages/people/Edit"
 import PersonNew from "pages/people/New"
 import PersonShow from "pages/people/Show"
@@ -71,6 +72,7 @@ const Routing = () => {
         render={({ match: { url } }) => (
           <Switch>
             <Route path={`${url}/new`} component={PersonNew} />
+            <Route path={`${url}/:uuid/compact`} component={PersonCompact} />
             <Route path={`${url}/:uuid/edit`} component={PersonEdit} />
             <Route path={`${url}/:uuid`} component={PersonShow} />
           </Switch>

--- a/client/src/pages/people/Compact.js
+++ b/client/src/pages/people/Compact.js
@@ -234,8 +234,8 @@ const CompactPersonView = ({ pageDispatchers }) => {
         <td colSpan="4">
           <AvatarDisplayComponent
             avatar={person.avatar}
-            height={256}
-            width={256}
+            height={pageSize.name === "A4" ? 256 : 200}
+            width={pageSize.name === "A4" ? 256 : 200}
             style={{
               maxWidth: "100%",
               display: "block",

--- a/client/src/pages/people/Compact.js
+++ b/client/src/pages/people/Compact.js
@@ -94,6 +94,11 @@ const GQL_GET_PERSON = gql`
     }
   }
 `
+const PAGE_SIZES = {
+  A4: { name: "A4", width: "210mm", height: "297mm" },
+  A5: { name: "A5", width: "148mm", height: "210mm" }
+}
+
 // Redundant fields to print
 const DEFAULT_FIELD_GROUP_EXCEPTIONS = [
   "gender",
@@ -177,6 +182,7 @@ const CompactPersonView = ({ pageDispatchers }) => {
   const { currentUser } = useContext(AppContext)
   const history = useHistory()
   const { uuid } = useParams()
+  const [pageSize, setPageSize] = useState(PAGE_SIZES.A4)
   const [optionalFields, setOptionalFields] = useState(ALL_FIELD_OPTIONS)
   const { loading, error, data } = API.useApiQuery(GQL_GET_PERSON, {
     uuid
@@ -256,9 +262,10 @@ const CompactPersonView = ({ pageDispatchers }) => {
             returnToDefaultPage={returnToDefaultPage}
             optionalFields={optionalFields}
             setOptionalFields={setOptionalFields}
+            setPageSize={setPageSize}
           />
 
-          <CompactPersonViewS className="compact-view">
+          <CompactPersonViewS className="compact-view" pageSize={pageSize}>
             <CompactHeaderContent object={person} />
             <CompactTable>{leftColum}</CompactTable>
             <CompactTable>{rightColum}</CompactTable>
@@ -450,11 +457,17 @@ const CompactPersonViewS = styled.div`
   position: relative;
   outline: 2px solid grey;
   padding: 0 1rem;
-  width: 21cm;
+  width: ${props => {
+    return props.pageSize.width
+  }};
+  height: ${props => {
+    return props.pageSize.height
+  }};
   display: flex;
   @media print {
     position: fixed;
     left: 0mm;
+    top: 0mm;
     outline: none;
     &[data-draft="draft"]:before {
       top: 40%;
@@ -476,11 +489,27 @@ const CompactPersonViewHeader = ({
   returnToDefaultPage,
   noPerson,
   optionalFields,
-  setOptionalFields
+  setOptionalFields,
+  setPageSize
 }) => {
   return (
     <Header>
       <HeaderTitle value="title">Summary / Print</HeaderTitle>
+      <DropdownButton
+        title="Page Size"
+        bsStyle="primary"
+        id="pageSizeButton"
+        onSelect={setPageSize}
+      >
+        {Object.keys(PAGE_SIZES).map(pageSize => (
+          <MenuItem
+            key={PAGE_SIZES[pageSize].name}
+            eventKey={PAGE_SIZES[pageSize]}
+          >
+            {PAGE_SIZES[pageSize].name}
+          </MenuItem>
+        ))}
+      </DropdownButton>
       <DropdownButton
         title="Presets"
         bsStyle="primary"
@@ -534,7 +563,8 @@ CompactPersonViewHeader.propTypes = {
       active: PropTypes.bool.isRequired
     })
   ).isRequired,
-  setOptionalFields: PropTypes.func
+  setOptionalFields: PropTypes.func,
+  setPageSize: PropTypes.func
 }
 
 CompactPersonViewHeader.defaultProps = {

--- a/client/src/pages/people/Compact.js
+++ b/client/src/pages/people/Compact.js
@@ -305,8 +305,8 @@ const CompactPersonView = ({ pageDispatchers }) => {
               sensitiveInformation={containsSensitiveInformation}
             />
             <TwoColumnLayout>
-              <CompactTable>{leftColum}</CompactTable>
-              <CompactTable>{rightColum}</CompactTable>
+              <CompactTable className="left-table">{leftColum}</CompactTable>
+              <CompactTable className="right-table">{rightColum}</CompactTable>
             </TwoColumnLayout>
             <CompactFooterContent />
           </CompactPersonViewS>

--- a/client/src/pages/people/Compact.js
+++ b/client/src/pages/people/Compact.js
@@ -247,6 +247,9 @@ const CompactPersonView = ({ pageDispatchers }) => {
     <a href={`mailto:${person.emailAddress}`}>{person.emailAddress}</a>
   )
   const orderedFields = orderPersonFields()
+  const containsSensitiveInformation = !!orderedFields.find(field =>
+    Object.keys(Person.customSensitiveInformation).includes(field.key)
+  )
   const numberOfFieldsUnderAvatar = leftColumnFields || 6
   const leftColumUnderAvatar = orderedFields.slice(0, numberOfFieldsUnderAvatar)
   const rightColum = orderedFields.slice(numberOfFieldsUnderAvatar)
@@ -297,7 +300,10 @@ const CompactPersonView = ({ pageDispatchers }) => {
             setLeftColumnFields={setLeftColumnFields}
           />
           <CompactPersonViewS className="compact-view" pageSize={pageSize}>
-            <CompactHeaderContent object={person} />
+            <CompactHeaderContent
+              object={person}
+              sensitiveInformation={containsSensitiveInformation}
+            />
             <TwoColumnLayout>
               <CompactTable>{leftColum}</CompactTable>
               <CompactTable>{rightColum}</CompactTable>

--- a/client/src/pages/people/Compact.js
+++ b/client/src/pages/people/Compact.js
@@ -301,14 +301,13 @@ const CompactPersonView = ({ pageDispatchers }) => {
           />
           <CompactPersonViewS className="compact-view" pageSize={pageSize}>
             <CompactHeaderContent
-              object={person}
               sensitiveInformation={containsSensitiveInformation}
             />
             <TwoColumnLayout>
               <CompactTable className="left-table">{leftColum}</CompactTable>
               <CompactTable className="right-table">{rightColum}</CompactTable>
             </TwoColumnLayout>
-            <CompactFooterContent />
+            <CompactFooterContent object={person} />
           </CompactPersonViewS>
         </>
       )}
@@ -564,6 +563,7 @@ const CompactPersonViewHeader = ({
           <MenuItem
             key={PAGE_SIZES[pageSize].name}
             eventKey={PAGE_SIZES[pageSize]}
+            style={{ minWidth: "205px" }}
           >
             {PAGE_SIZES[pageSize].name}
           </MenuItem>
@@ -578,7 +578,11 @@ const CompactPersonViewHeader = ({
         }
       >
         {PRESETS.map(preset => (
-          <MenuItem key={preset.name} eventKey={preset.fields}>
+          <MenuItem
+            key={preset.name}
+            eventKey={preset.fields}
+            style={{ minWidth: "185px" }}
+          >
             {preset.label}
           </MenuItem>
         ))}

--- a/client/src/pages/people/Compact.js
+++ b/client/src/pages/people/Compact.js
@@ -322,8 +322,12 @@ const CompactPersonView = ({ pageDispatchers }) => {
                       </FullColumn>
                     )) || (
                       <>
-                        <HalfColumn>{leftColumn}</HalfColumn>
-                        <HalfColumn>{rightColumn}</HalfColumn>
+                        <HalfColumn className="left-table">
+                          {leftColumn}
+                        </HalfColumn>
+                        <HalfColumn className="right-table">
+                          {rightColumn}
+                        </HalfColumn>
                       </>
                     )}
                   </PersonContainer>

--- a/client/src/pages/people/Show.js
+++ b/client/src/pages/people/Show.js
@@ -179,7 +179,12 @@ const PersonShow = ({ pageDispatchers }) => {
 
   const action = (
     <div>
-      <Button bsStyle="primary" onClick={onCompactClick}>
+      <Button
+        value="compactView"
+        type="button"
+        bsStyle="primary"
+        onClick={onCompactClick}
+      >
         Summary / Print
       </Button>
       {canEdit && (

--- a/client/src/pages/people/Show.js
+++ b/client/src/pages/people/Show.js
@@ -45,7 +45,7 @@ import {
   Table
 } from "react-bootstrap"
 import { connect } from "react-redux"
-import { useLocation, useParams } from "react-router-dom"
+import { useHistory, useLocation, useParams } from "react-router-dom"
 import Settings from "settings"
 import utils from "utils"
 
@@ -110,6 +110,7 @@ const GQL_GET_PERSON = gql`
 
 const PersonShow = ({ pageDispatchers }) => {
   const { currentUser, loadAppData } = useContext(AppContext)
+  const history = useHistory()
   const routerLocation = useLocation()
   const [showAssignPositionModal, setShowAssignPositionModal] = useState(false)
   const [
@@ -178,6 +179,9 @@ const PersonShow = ({ pageDispatchers }) => {
 
   const action = (
     <div>
+      <Button bsStyle="primary" onClick={onCompactClick}>
+        Summary / Print
+      </Button>
       {canEdit && (
         <LinkTo
           modelType="Person"
@@ -595,6 +599,12 @@ const PersonShow = ({ pageDispatchers }) => {
     setShowAssociatedPositionsModal(false)
     if (success) {
       refetch()
+    }
+  }
+
+  function onCompactClick() {
+    if (!_isEmpty(person)) {
+      history.push(`${person.uuid}/compact`)
     }
   }
 }

--- a/client/src/pages/reports/Compact.js
+++ b/client/src/pages/reports/Compact.js
@@ -2,8 +2,9 @@ import styled from "@emotion/styled"
 import { DEFAULT_PAGE_PROPS, DEFAULT_SEARCH_PROPS } from "actions"
 import API from "api"
 import { gql } from "apollo-boost"
-import AppContext from "components/AppContext"
 import CompactTable, {
+  CompactFooterContent,
+  CompactHeaderContent,
   CompactRow,
   CompactRowContentS,
   CompactRowS,
@@ -22,10 +23,6 @@ import {
 } from "components/Page"
 import { GRAPHQL_NOTES_FIELDS } from "components/RelatedObjectNotes"
 import { ActionButton, ActionStatus } from "components/ReportWorkflow"
-import {
-  CompactSecurityBanner,
-  SETTING_KEY_COLOR
-} from "components/SecurityBanner"
 import SimpleMultiCheckboxDropdown from "components/SimpleMultiCheckboxDropdown"
 import { Formik } from "formik"
 import _groupBy from "lodash/groupBy"
@@ -33,11 +30,10 @@ import _isEmpty from "lodash/isEmpty"
 import { Person, Report, Task } from "models"
 import moment from "moment"
 import PropTypes from "prop-types"
-import React, { useContext, useState } from "react"
+import React, { useState } from "react"
 import { Button } from "react-bootstrap"
 import { connect } from "react-redux"
-import { Link, useHistory, useLocation, useParams } from "react-router-dom"
-import anetLogo from "resources/logo.svg"
+import { useHistory, useParams } from "react-router-dom"
 import Settings from "settings"
 import utils from "utils"
 
@@ -276,7 +272,7 @@ const CompactReportView = ({ pageDispatchers }) => {
             setOptionalFields={setOptionalFields}
           />
           <CompactReportViewS className="compact-view" data-draft={draftAttr}>
-            <CompactReportHeaderContent report={report} />
+            <CompactHeaderContent object={report} />
             <CompactTable>
               <CompactTitle label={getReportTitle()} className="reportField" />
               <CompactSubTitle
@@ -356,7 +352,7 @@ const CompactReportView = ({ pageDispatchers }) => {
                 />
               ) : null}
             </CompactTable>
-            <CompactReportFooterContent report={report} />
+            <CompactFooterContent />
           </CompactReportViewS>
         </>
       )}
@@ -622,8 +618,8 @@ const CompactReportViewS = styled.div`
     transform: rotateZ(-45deg);
   }
   @media print {
-    position: static;
-    padding: 0;
+    position: fixed;
+    left: 0mm;
     outline: none;
     &[data-draft="draft"]:before {
       top: 40%;
@@ -719,114 +715,6 @@ const Buttons = styled.div`
   button {
     margin-left: 5px;
     margin-right: 5px;
-  }
-`
-
-const CompactReportHeaderContent = ({ report }) => {
-  const location = useLocation()
-  const { appSettings } = useContext(AppContext)
-  return (
-    <HeaderContentS bgc={appSettings[SETTING_KEY_COLOR]}>
-      <img src={anetLogo} alt="logo" width="50" height="12" />
-      <ClassificationBanner />
-      <span style={{ fontSize: "12px" }}>
-        <Link to={location.pathname}>{report.uuid}</Link>
-      </span>
-    </HeaderContentS>
-  )
-}
-
-CompactReportHeaderContent.propTypes = {
-  report: PropTypes.object
-}
-
-const CompactReportFooterContent = () => {
-  const { currentUser, appSettings } = useContext(AppContext)
-  return (
-    <FooterContentS bgc={appSettings[SETTING_KEY_COLOR]}>
-      <img src={anetLogo} alt="logo" width="50" height="12" />
-      <ClassificationBanner />
-      <PrintedByBoxS>
-        <div>
-          printed by <LinkTo modelType="Person" model={currentUser} />
-        </div>
-        <div>{moment().format(Report.getEngagementDateFormat())}</div>
-      </PrintedByBoxS>
-    </FooterContentS>
-  )
-}
-
-// background color of banner makes reading blue links hard. Force white color
-const HF_COMMON_STYLE = `
-  position: absolute;
-  left: 0mm;
-  display: flex;
-  width: 100%;
-  max-height: 50px;
-  margin: 10px auto;
-  flex-direction: row;
-  justify-content: space-between;
-  align-items: center;
-  padding: 1rem;
-  -webkit-print-color-adjust: exact !important;
-  color-adjust: exact !important;
-  img {
-    max-width: 50px !important;
-    max-height: 24px !important;
-  }
-  & * {
-    color: white !important;
-  }
-  @media print {
-    position: fixed;
-    max-height: 70px;
-  }
-`
-
-const HeaderContentS = styled.div`
-  ${HF_COMMON_STYLE};
-  top: 0mm;
-  border-bottom: 1px solid black;
-  background-color: ${props => props.bgc} !important;
-`
-
-const FooterContentS = styled.div`
-  ${HF_COMMON_STYLE};
-  bottom: 0mm;
-  border-top: 1px solid black;
-  background-color: ${props => props.bgc} !important;
-`
-
-const PrintedByBoxS = styled.span`
-  align-self: flex-start;
-  width: auto;
-  display: flex;
-  flex-direction: column;
-  justify-content: flex-end;
-  align-items: flex-end;
-  flex-wrap: wrap;
-  font-size: 10px;
-  & > span {
-    display: inline-block;
-    text-align: right;
-  }
-`
-
-const ClassificationBanner = () => {
-  return (
-    <ClassificationBannerS>
-      <CompactSecurityBanner />
-    </ClassificationBannerS>
-  )
-}
-
-const ClassificationBannerS = styled.div`
-  width: auto;
-  max-width: 67%;
-  text-align: center;
-  display: inline-block;
-  & > .banner {
-    padding: 2px 4px;
   }
 `
 

--- a/client/src/pages/reports/Compact.js
+++ b/client/src/pages/reports/Compact.js
@@ -272,7 +272,7 @@ const CompactReportView = ({ pageDispatchers }) => {
             setOptionalFields={setOptionalFields}
           />
           <CompactReportViewS className="compact-view" data-draft={draftAttr}>
-            <CompactHeaderContent object={report} />
+            <CompactHeaderContent />
             <CompactTable>
               <CompactTitle label={getReportTitle()} className="reportField" />
               <CompactSubTitle
@@ -352,7 +352,7 @@ const CompactReportView = ({ pageDispatchers }) => {
                 />
               ) : null}
             </CompactTable>
-            <CompactFooterContent />
+            <CompactFooterContent object={report} />
           </CompactReportViewS>
         </>
       )}

--- a/client/tests/webdriver/baseSpecs/printPerson.spec.js
+++ b/client/tests/webdriver/baseSpecs/printPerson.spec.js
@@ -6,50 +6,50 @@ import ShowPerson from "../pages/showPerson.page"
 const SOME_FIELDS = {
   currentPosition: {
     id: "position",
-    fieldLabel: "current position"
+    fieldLabel: "Current Position"
   },
   previousPositions: {
     id: "prevPositions",
-    fieldLabel: "previous positions"
+    fieldLabel: "Previous Positions"
   },
   phone: {
     id: "phoneNumber",
-    fieldLabel: "phone"
+    fieldLabel: "Phone"
   },
   domainUsername: {
     id: "domainUsername",
-    fieldLabel: "domain username"
+    fieldLabel: "Domain username"
   },
   gender: {
     id: "gender",
-    fieldLabel: "gender"
+    fieldLabel: "Gender"
   },
   birthday: {
     id: "birthday",
-    fieldLabel: "date of birth"
+    fieldLabel: "Date of birth"
   }
 }
 
 const PRESET_DEFAULT_LABELS = [
-  "current position",
-  "previous positions",
-  "phone",
-  "nationality",
-  "date of birth",
-  "domain username",
-  "position on the political spectrum",
-  "rank",
-  "biography"
+  "Current Position",
+  "Previous Positions",
+  "Phone",
+  "Nationality",
+  "Date of birth",
+  "Domain username",
+  "Position on the political spectrum",
+  "Rank",
+  "Biography"
 ]
 
 const PRESET_WITHOUT_SENSITIVE_LABELS = [
-  "current position",
-  "previous positions",
-  "phone",
-  "nationality",
-  "domain username",
-  "rank",
-  "biography"
+  "Current Position",
+  "Previous Positions",
+  "Phone",
+  "Nationality",
+  "Domain username",
+  "Rank",
+  "Biography"
 ]
 
 describe("Show person page", () => {

--- a/client/tests/webdriver/baseSpecs/printPerson.spec.js
+++ b/client/tests/webdriver/baseSpecs/printPerson.spec.js
@@ -1,0 +1,128 @@
+import { expect } from "chai"
+import Home from "../pages/home.page"
+import Search from "../pages/search.page"
+import ShowPerson from "../pages/showPerson.page"
+
+const SOME_FIELDS = {
+  currentPosition: {
+    id: "position",
+    fieldLabel: "current position"
+  },
+  previousPositions: {
+    id: "prevPositions",
+    fieldLabel: "previous positions"
+  },
+  phone: {
+    id: "phoneNumber",
+    fieldLabel: "phone"
+  },
+  domainUsername: {
+    id: "domainUsername",
+    fieldLabel: "domain username"
+  },
+  gender: {
+    id: "gender",
+    fieldLabel: "gender"
+  },
+  birthday: {
+    id: "birthday",
+    fieldLabel: "date of birth"
+  }
+}
+
+const PRESET_DEFAULT_LABELS = [
+  "current position",
+  "previous positions",
+  "phone",
+  "nationality",
+  "date of birth",
+  "domain username",
+  "position on the political spectrum",
+  "rank",
+  "biography"
+]
+
+const PRESET_WITHOUT_SENSITIVE_LABELS = [
+  "current position",
+  "previous positions",
+  "phone",
+  "nationality",
+  "domain username",
+  "rank",
+  "biography"
+]
+
+describe("Show person page", () => {
+  beforeEach("Should have print button", () => {
+    Home.openAsAdminUser()
+    Home.searchBar.setValue("Roger")
+    Home.submitSearch.click()
+    Search.foundPeopleTable.waitForExist({ timeout: 20000 })
+    Search.foundPeopleTable.waitForDisplayed()
+    Search.linkOfPersonFound("Roger").click()
+    ShowPerson.compactViewButton.waitForExist()
+    ShowPerson.compactViewButton.waitForDisplayed()
+    ShowPerson.compactViewButton.click()
+    ShowPerson.compactView.waitForExist()
+    ShowPerson.compactView.waitForDisplayed()
+  })
+  describe("When on the print person page", () => {
+    it("All fields can be selected using the optional fields dropdown", () => {
+      ShowPerson.optionalFieldsButton.click()
+      ShowPerson.selectAllButton.waitForDisplayed()
+      ShowPerson.selectAllButton.click()
+      ShowPerson.waitForCompactField(
+        false,
+        ...Object.values(SOME_FIELDS).map(field => field.fieldLabel)
+      )
+    })
+    it("All fields can be cleared using the optional fields dropdown", () => {
+      ShowPerson.optionalFieldsButton.click()
+      ShowPerson.clearAllButton.waitForDisplayed()
+      ShowPerson.clearAllButton.click()
+      ShowPerson.waitForCompactField(
+        true,
+        ...Object.values(SOME_FIELDS).map(field => field.fieldLabel)
+      )
+    })
+    it("Individual fields can be selected using optional fields dropdown", () => {
+      ShowPerson.optionalFieldsButton.click()
+      ShowPerson.clearAllButton.waitForDisplayed()
+      ShowPerson.clearAllButton.click()
+      ShowPerson.pickACompactField(SOME_FIELDS.currentPosition.id)
+      ShowPerson.waitForCompactField(
+        false,
+        SOME_FIELDS.currentPosition.fieldLabel
+      )
+      ShowPerson.pickACompactField(SOME_FIELDS.birthday.id)
+      ShowPerson.waitForCompactField(false, SOME_FIELDS.birthday.fieldLabel)
+    })
+    it("Default preset should select correct fields and display sensitive information warning", () => {
+      ShowPerson.presetsButton.click()
+      ShowPerson.defaultPreset.waitForDisplayed()
+      ShowPerson.defaultPreset.click()
+      ShowPerson.waitForCompactField(false, ...PRESET_DEFAULT_LABELS)
+      ShowPerson.sensitiveInformationWarning.waitForDisplayed()
+    })
+    it("Exclude sensitive fields preset should select correct fields", () => {
+      ShowPerson.presetsButton.click()
+      ShowPerson.withoutSensitivePreset.waitForDisplayed()
+      ShowPerson.withoutSensitivePreset.click()
+      ShowPerson.waitForCompactField(false, ...PRESET_WITHOUT_SENSITIVE_LABELS)
+      ShowPerson.sensitiveInformationWarning.waitForDisplayed({ reverse: true })
+    })
+    it("Should select the number of fields on the left", () => {
+      ShowPerson.optionalFieldsButton.click()
+      ShowPerson.selectAllButton.waitForDisplayed()
+      ShowPerson.selectAllButton.click()
+      ShowPerson.leftColumnNumber.setValue(4)
+      // Left column contains 2 additional fields name and avatar
+      expect(ShowPerson.leftTableFields.length).to.equal(6)
+    })
+    it("Should return to the show person page when detailed view button clicked", () => {
+      ShowPerson.detailedViewButton.click()
+      ShowPerson.compactViewButton.waitForExist()
+      ShowPerson.compactViewButton.waitForDisplayed()
+    })
+  })
+})

--- a/client/tests/webdriver/baseSpecs/printReport.spec.js
+++ b/client/tests/webdriver/baseSpecs/printReport.spec.js
@@ -25,12 +25,12 @@ describe("Show print report page", () => {
     it("We should see the correct report fields", () => {
       const mustHaveFieldTexts = [
         "purpose",
-        "key outcomes",
-        "next steps",
+        "Key outcomes",
+        "Next steps",
         "principals",
         "advisors",
-        "atmospherics",
-        "efforts"
+        "Atmospherics",
+        "Efforts"
       ]
       const fields = ShowReport.compactReportFields
       const fieldTexts = Array.from(fields).map(field => field.getText())

--- a/client/tests/webdriver/pages/showPerson.page.js
+++ b/client/tests/webdriver/pages/showPerson.page.js
@@ -5,6 +5,58 @@ class ShowPerson extends Page {
     return browser.$("div a.edit-person")
   }
 
+  get compactView() {
+    return browser.$(".compact-view")
+  }
+
+  get compactViewButton() {
+    return browser.$("button[value='compactView']")
+  }
+
+  get printButton() {
+    return browser.$("button[value='print']")
+  }
+
+  get detailedViewButton() {
+    return browser.$("button[value='detailedView']")
+  }
+
+  get optionalFieldsButton() {
+    return browser.$('//button[text()="Optional Fields ⇓"]')
+  }
+
+  get clearAllButton() {
+    return browser.$('//button[text()="Clear All"]')
+  }
+
+  get selectAllButton() {
+    return browser.$('//button[text()="Select All"]')
+  }
+
+  get presetsButton() {
+    return browser.$("#presetsButton")
+  }
+
+  get defaultPreset() {
+    return browser.$('//a[text()="Default"]')
+  }
+
+  get withoutSensitivePreset() {
+    return browser.$('//a[text()="Exclude sensitive fields"]')
+  }
+
+  get sensitiveInformationWarning() {
+    return this.compactView.$('//span[text()="Sensitive Information"]')
+  }
+
+  get leftColumnNumber() {
+    return browser.$("#leftColumnNumber")
+  }
+
+  get leftTableFields() {
+    return this.compactView.$$(".left-table > tbody > tr")
+  }
+
   get assessmentsTable() {
     return this.quarterlyAssessmentContainer.$("table.assessments-table")
   }
@@ -54,6 +106,18 @@ class ShowPerson extends Page {
 
   get birthday() {
     return browser.$('div[name="formSensitiveFields.birthday"]')
+  }
+
+  pickACompactField(field) {
+    browser.$(`#${field}`).click()
+  }
+
+  waitForCompactField(reverse, ...fields) {
+    fields.forEach(field => {
+      this.compactView
+        .$(`//th[text()="${field}"]`)
+        .waitForDisplayed({ reverse: reverse })
+    })
   }
 
   waitForAssessmentModalForm(reverse = false) {

--- a/client/tests/webdriver/pages/showPerson.page.js
+++ b/client/tests/webdriver/pages/showPerson.page.js
@@ -54,7 +54,7 @@ class ShowPerson extends Page {
   }
 
   get leftTableFields() {
-    return this.compactView.$$(".left-table > tbody > tr")
+    return this.compactView.$$(".left-table > tr")
   }
 
   get assessmentsTable() {

--- a/src/main/resources/anet-schema.yml
+++ b/src/main/resources/anet-schema.yml
@@ -363,6 +363,16 @@ properties:
                 title: The long date/time format if `engagementsIncludeTimeAndDuration` is `true`
                 description: Used to show the report engagement date/time in the user interface; should be easy to read, e.g. "Sunday, 6 December 1998 @ 15:30"; see https://momentjs.com/docs/#/displaying/format/ for format specifiers.
 
+  printOptions:
+    type: object
+    additionalProperties: false
+    required: [sensitiveInformationText]
+    properties:
+      sensitiveInformationText:
+        type: string
+        title: Classification text for printed documents
+        description: Used to indicate the printed document contains sensitive information
+
   reportWorkflow:
     type: object
     additionalProperties: false

--- a/src/main/resources/anet-schema.yml
+++ b/src/main/resources/anet-schema.yml
@@ -372,6 +372,10 @@ properties:
         type: string
         title: Classification text for printed documents
         description: Used to indicate the printed document contains sensitive information
+      sensitiveInformationTooltipText:
+        type: string
+        title: Tooltip text for extra information about releasability
+        description: Used to inform the user about the releasability of the document
 
   reportWorkflow:
     type: object

--- a/testDictionaries/no-custom-fields.yml
+++ b/testDictionaries/no-custom-fields.yml
@@ -24,6 +24,7 @@ dateFormats:
 
 printOptions:
   sensitiveInformationText: Sensitive Information
+  sensitiveInformationTooltipText: Releasability Information
 
 reportWorkflow:
   nbOfHoursQuarantineApproved: 24

--- a/testDictionaries/no-custom-fields.yml
+++ b/testDictionaries/no-custom-fields.yml
@@ -22,6 +22,9 @@ dateFormats:
       date: dddd, D MMMM YYYY
       withTime: dddd, D MMMM YYYY @ HH:mm
 
+printOptions:
+  sensitiveInformationText: Sensitive Information
+
 reportWorkflow:
   nbOfHoursQuarantineApproved: 24
   nbOfHoursApprovalTimeout: 48

--- a/testDictionaries/no-custom-fields.yml
+++ b/testDictionaries/no-custom-fields.yml
@@ -290,11 +290,9 @@ fields:
         - inputFieldName
         - phoneNumber
         - country
-        - birthday
         - colourOptions
         - textareaFieldName
         - code
-        - politicalPosition
         - rank
         - numberFieldName
         - nlt
@@ -426,6 +424,7 @@ fields:
         - prevPositions
         - phoneNumber
         - country
+        - birthday
         - colourOptions
         - textareaFieldName
         - domainUsername
@@ -433,6 +432,7 @@ fields:
         - multipleButtons
         - inputFieldName
         - code
+        - politicalPosition
         - rank
         - numberFieldName
         - nlt


### PR DESCRIPTION
Print option for people profiles is added. Users can edit the layout by using _Left Column Fields_ and _Page Size_ options. In addition to that, they can select different field groups by using _Presets_  or individual fields by using _Optional Fields_.

Closes #3621 
Related to #1325 

#### User changes
- Users can print or export people's profile information.

#### Super User changes
- None

#### Admin changes
- None

#### System admin changes
- [x] anet.yml or anet-dictionary.yml needs change
`sensitiveInformationText` under `printOptions` must be added in the dictionary. This will be displayed on the header of the printed document if it contains sensitive information.
```
printOptions:
  sensitiveInformationText: "Example Text"
```
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [x] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
