### PR TITLE
Fix advanced selects inside advanced search

### DIFF
--- a/client/src/components/advancedSelectWidget/AdvancedSelect.js
+++ b/client/src/components/advancedSelectWidget/AdvancedSelect.js
@@ -355,7 +355,9 @@ const AdvancedSelect = ({
                 placement="bottom"
                 modifiers={{
                   preventOverflow: {
-                    enabled: false
+                    options: {
+                      rootBoundary: "viewport"
+                    }
                   },
                   hide: {
                     enabled: false

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -896,11 +896,6 @@ header.searchPagination {
   padding: 15px;
 }
 
-.advanced-search-content {
-  max-height: 40vh;
-  overflow: auto;
-}
-
 .advanced-search-content .form-group {
   margin: 0 0 15px !important;
 }


### PR DESCRIPTION
Fix the advanced selects inside advanced search: they would be 'enclosed' inside the advanced search dialog; now they 'pop out'.

Fixes NCI-Agency/anet#3588

#### User changes
- Matching options in an advanced select in the advanced search filters are now fully visible.

#### Super User changes
- none

#### Admin changes
- none

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here