### PR TITLE
Add location type to simulator

### DIFF
--- a/client/tests/sim/stories/LocationStories.js
+++ b/client/tests/sim/stories/LocationStories.js
@@ -1,17 +1,24 @@
 import Model from "components/Model"
 import faker from "faker"
 import { Location } from "models"
-import { populate, runGQL } from "../simutils"
+import { fuzzy, populate, runGQL } from "../simutils"
 
 async function populateLocation(location, user) {
   const template = {
     status: () => Model.STATUS.ACTIVE,
+    type: () =>
+      fuzzy.withProbability(0.6)
+        ? Location.LOCATION_TYPES.GEOGRAPHICAL_AREA
+        : fuzzy.withProbability(0.75)
+          ? Location.LOCATION_TYPES.PRINCIPAL_LOCATION
+          : Location.LOCATION_TYPES.ADVISOR_LOCATION,
     name: () => faker.address.city(),
     lat: () => faker.address.latitude(38.4862816432, 29.318572496, 10),
     lng: () => faker.address.longitude(75.1580277851, 60.5284298033, 10)
   }
   populate(location, template)
     .status.always()
+    .type.always()
     .name.always()
     .lat.always()
     .lng.always()

--- a/client/tests/sim/stories/PositionStories.js
+++ b/client/tests/sim/stories/PositionStories.js
@@ -1,7 +1,7 @@
 import Model from "components/Model"
 import faker from "faker"
 import _isEmpty from "lodash/isEmpty"
-import { Organization, Person, Position } from "models"
+import { Location, Organization, Person, Position } from "models"
 import { fuzzy, identity, populate, runGQL, specialUser } from "../simutils"
 import { getRandomObject } from "./NoteStories"
 
@@ -200,7 +200,12 @@ const _createPosition = async function(user) {
       randomObject?.uuid === user.uuid ||
       randomObject?.domainUsername === specialUser.name
   )
-  const location = await getRandomObject(user, "locations")
+  const location = await getRandomObject(user, "locations", {
+    type:
+      organization.type === Organization.TYPE.ADVISOR_ORG
+        ? Location.LOCATION_TYPES.ADVISOR_LOCATION
+        : Location.LOCATION_TYPES.PRINCIPAL_LOCATION
+  })
   const template = {
     name: () => faker.name.jobTitle(),
     code: () => faker.lorem.slug(),

--- a/client/tests/sim/stories/ReportStories.js
+++ b/client/tests/sim/stories/ReportStories.js
@@ -3,8 +3,8 @@ import faker from "faker"
 import _isEmpty from "lodash/isEmpty"
 import _isEqual from "lodash/isEqual"
 import _uniqWith from "lodash/uniqWith"
-import { Report, Person, Position } from "models"
-import { fuzzy, runGQL, populate } from "../simutils"
+import { Location, Person, Position, Report } from "models"
+import { fuzzy, populate, runGQL } from "../simutils"
 import { getRandomObject } from "./NoteStories"
 
 const getRandomPerson = async function(user, hasPosition, type, role) {
@@ -35,7 +35,12 @@ const getRandomPerson = async function(user, hasPosition, type, role) {
 
 async function populateReport(report, user, args) {
   const location = await getRandomObject(user, "locations", {
-    status: Model.STATUS.ACTIVE
+    status: Model.STATUS.ACTIVE,
+    type: fuzzy.withProbability(0.75)
+      ? Location.LOCATION_TYPES.PRINCIPAL_LOCATION
+      : fuzzy.withProbability(0.95)
+        ? Location.LOCATION_TYPES.ADVISOR_LOCATION
+        : Location.LOCATION_TYPES.VIRTUAL_LOCATION
   })
   async function getAttendees() {
     const reportPeople = []


### PR DESCRIPTION
Set location type for locations.
Pick a location of the appropriate type for positions.
Pick an appropriate location for reports.

Adds missing part of NCI-Agency/anet#3547.