### PR TITLE
Update react-tooltip to v4.2.21

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -23,7 +23,6 @@
         "autoprefixer",
         "com.networknt:json-schema-validator",
         "draft-js",
-        "react-tooltip",
         "yup"
       ],
       "enabled": false

--- a/client/package.json
+++ b/client/package.json
@@ -170,7 +170,7 @@
     "react-scroll": "1.8.2",
     "react-svg-text": "0.1.2",
     "react-toastify": "7.0.4",
-    "react-tooltip": "4.2.10",
+    "react-tooltip": "4.2.21",
     "react-ultimate-pagination": "1.2.0",
     "react-use-dimensions": "1.2.1",
     "redux": "4.1.0",

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -15662,10 +15662,10 @@ react-toastify@7.0.4:
   dependencies:
     clsx "^1.1.1"
 
-react-tooltip@4.2.10:
-  version "4.2.10"
-  resolved "https://registry.yarnpkg.com/react-tooltip/-/react-tooltip-4.2.10.tgz#ed1a1acd388940c96f4b6309f4fd4dcce5e01bdc"
-  integrity sha512-D7ZLx6/QwpUl0SZRek3IZy/HWpsEEp0v3562tcT8IwZgu8IgV7hY5ZzniTkHyRcuL+IQnljpjj7A7zCgl2+T3w==
+react-tooltip@4.2.21:
+  version "4.2.21"
+  resolved "https://registry.yarnpkg.com/react-tooltip/-/react-tooltip-4.2.21.tgz#840123ed86cf33d50ddde8ec8813b2960bfded7f"
+  integrity sha512-zSLprMymBDowknr0KVDiJ05IjZn9mQhhg4PRsqln0OZtURAJ1snt1xi5daZfagsh6vfsziZrc9pErPTDY1ACig==
   dependencies:
     prop-types "^15.7.2"
     uuid "^7.0.3"


### PR DESCRIPTION
Allow Renovate to update react-tooltip dependency again.