### PR TITLE
Change the way report is selected from MyReports

### DIFF
--- a/client/tests/webdriver/baseSpecs/printReport.spec.js
+++ b/client/tests/webdriver/baseSpecs/printReport.spec.js
@@ -6,9 +6,7 @@ import ShowReport from "../pages/showReport.page"
 describe("Show print report page", () => {
   beforeEach("Open the show report page", () => {
     MyReports.open()
-    ShowReport.openAsAdminUser(
-      MyReports.getReportUrl("A test report from Arthur")
-    )
+    MyReports.selectReport("A test report from Arthur")
     ShowReport.compactViewButton.click()
     ShowReport.compactView.waitForExist()
     ShowReport.compactView.waitForDisplayed()

--- a/client/tests/webdriver/baseSpecs/showReport.spec.js
+++ b/client/tests/webdriver/baseSpecs/showReport.spec.js
@@ -5,9 +5,7 @@ import ShowReport from "../pages/showReport.page"
 describe("Show report page", () => {
   beforeEach("Open the show report page", () => {
     MyReports.open()
-    ShowReport.openAsAdminUser(
-      MyReports.getReportUrl("A test report from Arthur")
-    )
+    MyReports.selectReport("A test report from Arthur")
   })
   describe("When on the show page of a report with assessments", () => {
     it("We should see a table of tasks instant assessments related to the current report", () => {

--- a/client/tests/webdriver/baseSpecs/unpublishReport.spec.js
+++ b/client/tests/webdriver/baseSpecs/unpublishReport.spec.js
@@ -6,9 +6,7 @@ import ShowReport from "../pages/report/showReport.page"
 describe("When unpublishing a report", () => {
   beforeEach("Open the show report page", () => {
     MyReports.open()
-    MyReports.openAsAdminUser(
-      MyReports.getReportUrl("A test report to be unpublished from Arthur")
-    )
+    MyReports.selectReport("A test report to be unpublished from Arthur")
   })
   it("Should unpublish the report successfully", () => {
     const unpublishedReportUuid = ShowReport.uuid

--- a/client/tests/webdriver/customFieldsSpecs/showTask.spec.js
+++ b/client/tests/webdriver/customFieldsSpecs/showTask.spec.js
@@ -6,9 +6,7 @@ import ShowTask from "../pages/showTask.page"
 describe("Show task page", () => {
   beforeEach("Open the show task page", () => {
     MyReports.open()
-    ShowReport.openAsAdminUser(
-      MyReports.getReportUrl("A test report from Arthur")
-    )
+    MyReports.selectReport("A test report from Arthur")
     ShowTask.openAsAdminUser(ShowReport.task12BUrl)
   })
 

--- a/client/tests/webdriver/pages/myReports.page.js
+++ b/client/tests/webdriver/pages/myReports.page.js
@@ -7,12 +7,18 @@ class MyReports extends Page {
     super.openAsAdminUser(PAGE_URL)
   }
 
-  getReportUrl(urlText) {
+  selectReport(linkText) {
     const tableTab = browser.$(
       "#published-reports .report-collection div header div button[value='table']"
     )
+    tableTab.waitForExist()
+    tableTab.waitForDisplayed()
     tableTab.click()
-    return $(`*=${urlText}`).getAttribute("href")
+    const reportLink = browser.$(`*=${linkText}`)
+    reportLink.waitForExist()
+    reportLink.waitForDisplayed()
+    reportLink.click()
+    super.waitUntilLoaded()
   }
 }
 

--- a/client/tests/webdriver/pages/page.js
+++ b/client/tests/webdriver/pages/page.js
@@ -16,13 +16,17 @@ class Page {
     return `${url}${credSep}user=${credentials}&pass=${credentials}`
   }
 
-  _open(pathName, credentials) {
-    browser.url(this._buildUrl(pathName, credentials))
+  waitUntilLoaded() {
     browser.$("div.loader").waitForExist({
       timeout: 30000,
       reverse: true,
       timeoutMsg: "Expected everything to be loaded by now"
     })
+  }
+
+  _open(pathName, credentials) {
+    browser.url(this._buildUrl(pathName, credentials))
+    this.waitUntilLoaded()
   }
 
   open(pathName = "/", credentials = Page.DEFAULT_CREDENTIALS.user) {


### PR DESCRIPTION
Should prevent wdio test errors like:

1) When on the print report page "before each" hook for Show print report page
Can't call getAttribute on element with selector "*=A test report from Arthur" because element wasn't found