### PR TITLE
Fix invalid dom warnings in compact view of reports

### DIFF
--- a/client/src/components/Compact.js
+++ b/client/src/components/Compact.js
@@ -184,7 +184,9 @@ const CompactTable = ({ className, children }) => {
       {
         <tbody>
           <tr>
-            <td>{children}</td>
+            <td>
+              <InnerTable>{children}</InnerTable>
+            </td>
           </tr>
         </tbody>
       }
@@ -203,6 +205,21 @@ CompactTable.propTypes = {
 }
 
 export default CompactTable
+
+const InnerTable = styled.table`
+  display: flex;
+  flex-flow: row wrap;
+  width: 100%;
+  margin-bottom: 10px;
+`
+
+export const HalfColumn = styled.tbody`
+  flex: 1 1 50%;
+`
+
+export const FullColumn = styled.tbody`
+  flex: 1 1 100%;
+`
 
 const CompactTableS = styled.table`
   width: 100% !important;

--- a/client/src/components/Compact.js
+++ b/client/src/components/Compact.js
@@ -16,6 +16,39 @@ import { Link, useLocation } from "react-router-dom"
 import anetLogo from "resources/logo.svg"
 import Settings from "settings"
 
+export const PAGE_SIZES = {
+  A4: {
+    name: "A4 (210 x 297 mm)",
+    width: "210mm",
+    height: "297mm",
+    avatarSize: 256
+  },
+  A5: {
+    name: "A5 (148 x 210 mm)",
+    width: "148mm",
+    height: "210mm",
+    avatarSize: 128
+  },
+  letter: {
+    name: "Letter (8.5 x 11 inches)",
+    width: "216mm",
+    height: "279mm",
+    avatarSize: 256
+  },
+  juniorLegal: {
+    name: "Junior Legal (5 x 8 inches)",
+    width: "127mm",
+    height: "203mm",
+    avatarSize: 128
+  },
+  legal: {
+    name: "Legal (8.5 x 14 inches)",
+    width: "216mm",
+    height: "356mm",
+    avatarSize: 256
+  }
+}
+
 export const CompactHeaderContent = ({ sensitiveInformation }) => {
   const { appSettings } = useContext(AppContext)
   return (

--- a/client/src/components/Compact.js
+++ b/client/src/components/Compact.js
@@ -49,6 +49,76 @@ export const PAGE_SIZES = {
   }
 }
 
+export const CompactView = ({
+  className,
+  pageSize,
+  backgroundText,
+  children
+}) => {
+  return (
+    <CompactViewS
+      className={className}
+      pageSize={pageSize}
+      backgroundText={backgroundText}
+    >
+      {children}
+    </CompactViewS>
+  )
+}
+
+CompactView.propTypes = {
+  className: PropTypes.string,
+  pageSize: PropTypes.object,
+  backgroundText: PropTypes.string,
+  children: PropTypes.node
+}
+
+// color-adjust forces browsers to keep color values of the node
+// supported in most major browsers' new versions, but not in IE or some older versions
+// TODO: Find a way to calculate background text width after 45deg rotation currently it is hardcoded as 130
+const CompactViewS = styled.div`
+  position: relative;
+  outline: 2px solid grey;
+  padding: 0 1rem;
+  width: ${props => props.pageSize.width};
+  &:before {
+    content: "${props => props.backgroundText}";
+    z-index: -1000;
+    position: absolute;
+    font-weight: 100;
+    top: 40%;
+    left: ${props => getBackgroundIndent(props.pageSize.width, 130)};
+    font-size: 150px;
+    color: rgba(161, 158, 158, 0.3) !important;
+    -webkit-print-color-adjust: exact;
+    color-adjust: exact !important;
+    transform: rotateZ(-45deg);
+  }
+  @media print {
+    outline: none;
+    .banner {
+      display: inline-block !important;
+      -webkit-print-color-adjust: exact;
+      color-adjust: exact !important;
+    }
+    table {
+      page-break-inside: auto;
+    }
+    tr {
+      page-break-inside: auto;
+    }
+    @page {
+      size: ${props => props.pageSize.width} ${props => props.pageSize.height};
+    }
+    &:before {
+      position: fixed;
+    }
+    .workflow-action .btn {
+      display: inline-block !important;
+    }
+  }
+`
+
 export const CompactHeaderContent = ({ sensitiveInformation }) => {
   const { appSettings } = useContext(AppContext)
   return (
@@ -369,3 +439,8 @@ const CompactSubTitleS = styled(CompactRowS)`
     font-weight: normal;
   }
 `
+
+const getBackgroundIndent = (pageWidth, textWidth) => {
+  // Takes page width in "NNNmm", text width in number format and returns left indentation to center the text
+  return `${(parseInt(pageWidth) - textWidth) / 2}mm`
+}

--- a/client/src/components/Compact.js
+++ b/client/src/components/Compact.js
@@ -206,7 +206,7 @@ CompactTable.propTypes = {
 
 export default CompactTable
 
-const InnerTable = styled.table`
+export const InnerTable = styled.table`
   display: flex;
   flex-flow: row wrap;
   width: 100%;
@@ -247,12 +247,12 @@ export const CompactRow = ({ label, content, ...otherProps }) => {
   `
 
   // top level th have different width
-  const isTopLevelTh = className === "reportField"
+  const isHeaderRow = className === "reportField"
 
   return (
     <CustomStyled className={className || null}>
-      <RowLabelS isTopLevelTh={isTopLevelTh}>{label}</RowLabelS>
-      <CompactRowContentS>{content}</CompactRowContentS>
+      {label && <RowLabelS isHeaderRow={isHeaderRow}>{label}</RowLabelS>}
+      <CompactRowContentS colSpan={label ? 1 : 2}>{content}</CompactRowContentS>
     </CustomStyled>
   )
 }
@@ -274,12 +274,10 @@ const RowLabelS = styled.th`
   color: grey;
   max-width: 50%;
   font-weight: 300;
-  width: ${props => (props.isTopLevelTh ? "15%" : "auto")};
+  width: ${props => (props.isHeaderRow ? "15%" : "auto")};
 `
 
 export const CompactRowContentS = styled.td`
-  display: flex;
-  justify-content: space-between;
   padding: 4px 1rem;
   & .form-control-static {
     margin-bottom: 0;

--- a/client/src/pages/people/Compact.js
+++ b/client/src/pages/people/Compact.js
@@ -9,7 +9,8 @@ import CompactTable, {
   CompactHeaderContent,
   CompactRow,
   FullColumn,
-  HalfColumn
+  HalfColumn,
+  PAGE_SIZES
 } from "components/Compact"
 import { mapReadonlyCustomFieldsToComps } from "components/CustomFields"
 import { parseHtmlWithLinkTo } from "components/editor/LinkAnet"
@@ -97,38 +98,6 @@ const GQL_GET_PERSON = gql`
     }
   }
 `
-const PAGE_SIZES = {
-  A4: {
-    name: "A4 (210 x 297 mm)",
-    width: "210mm",
-    height: "297mm",
-    avatarSize: 256
-  },
-  A5: {
-    name: "A5 (148 x 210 mm)",
-    width: "148mm",
-    height: "210mm",
-    avatarSize: 128
-  },
-  letter: {
-    name: "Letter (8.5 x 11 inches)",
-    width: "216mm",
-    height: "279mm",
-    avatarSize: 256
-  },
-  juniorLegal: {
-    name: "Junior Legal (5 x 8 inches)",
-    width: "127mm",
-    height: "203mm",
-    avatarSize: 128
-  },
-  legal: {
-    name: "Legal (8.5 x 14 inches)",
-    width: "216mm",
-    height: "356mm",
-    avatarSize: 256
-  }
-}
 
 // Redundant fields to print
 const DEFAULT_FIELD_GROUP_EXCEPTIONS = [

--- a/client/src/pages/people/Compact.js
+++ b/client/src/pages/people/Compact.js
@@ -7,6 +7,7 @@ import AvatarDisplayComponent from "components/AvatarDisplayComponent"
 import CompactTable, {
   CompactFooterContent,
   CompactHeaderContent,
+  CompactRow,
   FullColumn,
   HalfColumn
 } from "components/Compact"
@@ -265,15 +266,15 @@ const CompactPersonView = ({ pageDispatchers }) => {
   const rightColumn = orderedFields.slice(numberOfFieldsUnderAvatar)
   const leftColumn = [
     optionalFields.name.active && (
-      <tr key="fullName">
-        <td colSpan="4">
-          <Name>{`${person.rank} ${person.name}`}</Name>
-        </td>
-      </tr>
+      <CompactRow
+        key="fullName"
+        content={<Name>{`${person.rank} ${person.name}`}</Name>}
+      />
     ),
     optionalFields.avatar.active && (
-      <tr key="avatar">
-        <td colSpan="4">
+      <CompactRow
+        key="avatar"
+        content={
           <AvatarDisplayComponent
             avatar={person.avatar}
             height={pageSize.avatarSize}
@@ -285,8 +286,8 @@ const CompactPersonView = ({ pageDispatchers }) => {
               marginBottom: "10px"
             }}
           />
-        </td>
-      </tr>
+        }
+      />
     ),
     ...leftColumUnderAvatar
   ]

--- a/client/src/pages/people/Compact.js
+++ b/client/src/pages/people/Compact.js
@@ -8,6 +8,7 @@ import CompactTable, {
   CompactFooterContent,
   CompactHeaderContent,
   CompactRow,
+  CompactView,
   FullColumn,
   HalfColumn,
   PAGE_SIZES
@@ -279,7 +280,7 @@ const CompactPersonView = ({ pageDispatchers }) => {
             leftColumnFields={leftColumnFields}
             setLeftColumnFields={setLeftColumnFields}
           />
-          <CompactPersonViewS className="compact-view" pageSize={pageSize}>
+          <CompactView className="compact-view" pageSize={pageSize}>
             <CompactHeaderContent
               sensitiveInformation={containsSensitiveInformation}
             />
@@ -304,7 +305,7 @@ const CompactPersonView = ({ pageDispatchers }) => {
               }
             >
             </CompactTable>
-          </CompactPersonViewS>
+          </CompactView>
         </>
       )}
     </Formik>
@@ -486,30 +487,6 @@ CompactPersonView.propTypes = {
 }
 
 export default connect(null, mapPageDispatchersToProps)(CompactPersonView)
-
-const CompactPersonViewS = styled.div`
-  position: relative;
-  outline: 2px solid grey;
-  padding: 0 1rem;
-  width: ${props => props.pageSize.width};
-  @media print {
-    outline: none;
-    .banner {
-      display: inline-block !important;
-      -webkit-print-color-adjust: exact;
-      color-adjust: exact !important;
-    }
-    table {
-      page-break-inside: auto;
-    }
-    tr {
-      page-break-inside: auto;
-    }
-    @page {
-      size: ${props => props.pageSize.width} ${props => props.pageSize.height};
-    }
-  }
-`
 
 const CompactPersonViewHeader = ({
   onPrintClick,

--- a/client/src/pages/people/Compact.js
+++ b/client/src/pages/people/Compact.js
@@ -6,7 +6,9 @@ import AppContext from "components/AppContext"
 import AvatarDisplayComponent from "components/AvatarDisplayComponent"
 import CompactTable, {
   CompactFooterContent,
-  CompactHeaderContent
+  CompactHeaderContent,
+  FullColumn,
+  HalfColumn
 } from "components/Compact"
 import { mapReadonlyCustomFieldsToComps } from "components/CustomFields"
 import { parseHtmlWithLinkTo } from "components/editor/LinkAnet"
@@ -315,25 +317,19 @@ const CompactPersonView = ({ pageDispatchers }) => {
             <CompactTable
               children={
                 <>
-                  <PersonContainer>
-                    {(_isEmpty(rightColumn) && (
-                      <FullColumn className="full-table">
+                  {(_isEmpty(rightColumn) && (
+                    <FullColumn className="full-table">{leftColumn}</FullColumn>
+                  )) || (
+                    <>
+                      <HalfColumn className="left-table">
                         {leftColumn}
-                      </FullColumn>
-                    )) || (
-                      <>
-                        <HalfColumn className="left-table">
-                          {leftColumn}
-                        </HalfColumn>
-                        <HalfColumn className="right-table">
-                          {rightColumn}
-                        </HalfColumn>
-                      </>
-                    )}
-                  </PersonContainer>
-                  <table>
-                    <tbody>{twoColumnFields}</tbody>
-                  </table>
+                      </HalfColumn>
+                      <HalfColumn className="right-table">
+                        {rightColumn}
+                      </HalfColumn>
+                    </>
+                  )}
+                  <FullColumn>{twoColumnFields}</FullColumn>
                 </>
               }
             >
@@ -545,14 +541,6 @@ const CompactPersonViewS = styled.div`
   }
 `
 
-const HalfColumn = styled.tbody`
-  flex: 1 1 50%;
-`
-
-const FullColumn = styled.tbody`
-  flex: 1 1 100%;
-`
-
 const CompactPersonViewHeader = ({
   onPrintClick,
   returnToDefaultPage,
@@ -677,13 +665,6 @@ function onPresetSelect(fields, optionalFields, setOptionalFields) {
   )
   setOptionalFields({ ...activeFields })
 }
-
-const PersonContainer = styled.table`
-  display: flex;
-  flex-flow: row wrap;
-  width: 100%;
-  margin-bottom: 10px;
-`
 
 const HeaderTitle = styled.h3`
   margin: 0;

--- a/client/src/pages/reports/Compact.js
+++ b/client/src/pages/reports/Compact.js
@@ -10,7 +10,8 @@ import CompactTable, {
   CompactRowS,
   CompactSubTitle,
   CompactTitle,
-  HalfColumn
+  FullColumn,
+  InnerTable
 } from "components/Compact"
 import { ReadonlyCustomFields } from "components/CustomFields"
 import { parseHtmlWithLinkTo } from "components/editor/LinkAnet"
@@ -277,7 +278,7 @@ const CompactReportView = ({ pageDispatchers }) => {
             <CompactTable
               children={
                 <>
-                  <HalfColumn>
+                  <FullColumn>
                     <CompactTitle
                       label={getReportTitle()}
                       className="reportField"
@@ -362,7 +363,7 @@ const CompactReportView = ({ pageDispatchers }) => {
                         isCompact
                       />
                     ) : null}
-                  </HalfColumn>
+                  </FullColumn>
                 </>
               }
             >
@@ -433,8 +434,8 @@ const CompactReportView = ({ pageDispatchers }) => {
 
   function getTasksAndAssessments() {
     return (
-      <table>
-        <tbody>
+      <InnerTable>
+        <FullColumn>
           {report.tasks.map(task => {
             const taskInstantAssessmentConfig = Model.filterAssessmentConfig(
               task.getInstantAssessmentConfig(),
@@ -447,8 +448,8 @@ const CompactReportView = ({ pageDispatchers }) => {
                 key={task.uuid}
                 label={<LinkTo modelType={Task.resourceName} model={task} />}
                 content={
-                  <table>
-                    <tbody>
+                  <InnerTable>
+                    <FullColumn>
                       <CompactRow
                         label={Settings.fields.task.topLevel.shortLabel}
                         content={
@@ -472,14 +473,14 @@ const CompactReportView = ({ pageDispatchers }) => {
                             isCompact
                           />
                       )}
-                    </tbody>
-                  </table>
+                    </FullColumn>
+                  </InnerTable>
                 }
               />
             )
           })}
-        </tbody>
-      </table>
+        </FullColumn>
+      </InnerTable>
     )
   }
 
@@ -489,8 +490,8 @@ const CompactReportView = ({ pageDispatchers }) => {
     // to keep track of different organization, if it is same consecutively, don't show for compactness
     let prevDiffOrgName = ""
     return (
-      <table>
-        <tbody>
+      <InnerTable>
+        <FullColumn>
           {attendees.map(attendee => {
             const attendeeInstantAssessmentConfig = Model.filterAssessmentConfig(
               attendee.getInstantAssessmentConfig(),
@@ -522,8 +523,8 @@ const CompactReportView = ({ pageDispatchers }) => {
                 content={
                   optionalFields.assessments.active &&
                   attendeeInstantAssessmentConfig && (
-                    <table>
-                      <tbody>
+                    <InnerTable>
+                      <FullColumn>
                         <ReadonlyCustomFields
                           parentFieldName={`${Report.ATTENDEES_ASSESSMENTS_PARENT_FIELD}.${attendee.uuid}`}
                           fieldsConfig={attendeeInstantAssessmentConfig}
@@ -531,8 +532,8 @@ const CompactReportView = ({ pageDispatchers }) => {
                           vertical
                           isCompact
                         />
-                      </tbody>
-                    </table>
+                      </FullColumn>
+                    </InnerTable>
                   )
                 }
                 style={`
@@ -547,8 +548,8 @@ const CompactReportView = ({ pageDispatchers }) => {
               />
             )
           })}
-        </tbody>
-      </table>
+        </FullColumn>
+      </InnerTable>
     )
   }
 

--- a/client/src/pages/reports/Compact.js
+++ b/client/src/pages/reports/Compact.js
@@ -10,6 +10,7 @@ import CompactTable, {
   CompactRowS,
   CompactSubTitle,
   CompactTitle,
+  CompactView,
   FullColumn,
   InnerTable,
   PAGE_SIZES
@@ -260,7 +261,7 @@ const CompactReportView = ({ pageDispatchers }) => {
   // Get initial tasks/attendees instant assessments values
   report = Object.assign(report, report.getTasksEngagementAssessments())
   report = Object.assign(report, report.getAttendeesEngagementAssessments())
-  const draftAttr = report.isDraft() ? "draft" : "not-draft"
+  const backgroundText = report.isDraft() ? "DRAFT" : ""
   return (
     <Formik
       validationSchema={Report.yupSchema}
@@ -276,10 +277,10 @@ const CompactReportView = ({ pageDispatchers }) => {
             setOptionalFields={setOptionalFields}
             setPageSize={setPageSize}
           />
-          <CompactReportViewS
+          <CompactView
             className="compact-view"
-            data-draft={draftAttr}
             pageSize={pageSize}
+            backgroundText={backgroundText}
           >
             <CompactHeaderContent />
             <CompactTable
@@ -376,7 +377,7 @@ const CompactReportView = ({ pageDispatchers }) => {
             >
             </CompactTable>
             <CompactFooterContent object={report} />
-          </CompactReportViewS>
+          </CompactView>
         </>
       )}
     </Formik>
@@ -618,53 +619,6 @@ const OPTIONAL_FIELDS_INIT = {
     active: false
   }
 }
-
-// color-adjust forces browsers to keep color values of the node
-// supported in most major browsers' new versions, but not in IE or some older versions
-const CompactReportViewS = styled.div`
-  position: relative;
-  outline: 2px solid grey;
-  padding: 0 1rem;
-  width: ${props => props.pageSize.width};
-
-  &[data-draft="draft"]:before {
-    content: "DRAFT";
-    z-index: -1000;
-    position: absolute;
-    font-weight: 100;
-    top: 300px;
-    left: 20%;
-    font-size: 150px;
-    color: rgba(161, 158, 158, 0.3) !important;
-    -webkit-print-color-adjust: exact;
-    color-adjust: exact !important;
-    transform: rotateZ(-45deg);
-  }
-  @media print {
-    outline: none;
-    &[data-draft="draft"]:before {
-      top: 40%;
-      position: fixed;
-    }
-    .banner {
-      display: inline-block !important;
-      -webkit-print-color-adjust: exact;
-      color-adjust: exact !important;
-    }
-    .workflow-action .btn {
-      display: inline-block !important;
-    }
-    table {
-      page-break-inside: auto;
-    }
-    tr {
-      page-break-inside: auto;
-    }
-    @page {
-      size: ${props => props.pageSize.width} ${props => props.pageSize.height};
-    }
-  }
-`
 
 const CompactReportViewHeader = ({
   onPrintClick,

--- a/client/src/pages/reports/Compact.js
+++ b/client/src/pages/reports/Compact.js
@@ -9,7 +9,8 @@ import CompactTable, {
   CompactRowContentS,
   CompactRowS,
   CompactSubTitle,
-  CompactTitle
+  CompactTitle,
+  HalfColumn
 } from "components/Compact"
 import { ReadonlyCustomFields } from "components/CustomFields"
 import { parseHtmlWithLinkTo } from "components/editor/LinkAnet"
@@ -273,84 +274,98 @@ const CompactReportView = ({ pageDispatchers }) => {
           />
           <CompactReportViewS className="compact-view" data-draft={draftAttr}>
             <CompactHeaderContent />
-            <CompactTable>
-              <CompactTitle label={getReportTitle()} className="reportField" />
-              <CompactSubTitle
-                label={getReportSubTitle()}
-                className="reportField"
-              />
-              <CompactRow
-                label="purpose"
-                content={report.intent}
-                className="reportField"
-              />
-              <CompactRow
-                label={Settings.fields.report.keyOutcomes || "key outcomes"}
-                content={report.keyOutcomes}
-                className="reportField"
-              />
-              {!report.cancelled ? (
-                <CompactRow
-                  label={Settings.fields.report.atmosphere}
-                  content={
-                    <>
-                      {utils.sentenceCase(report.atmosphere)}
-                      {report.atmosphereDetails &&
-                        ` – ${report.atmosphereDetails}`}
-                    </>
-                  }
-                  className="reportField"
-                />
-              ) : null}
-              <CompactRow
-                label={Settings.fields.report.nextSteps.label}
-                content={report.nextSteps}
-                className="reportField"
-              />
-              <CompactRow
-                label="principals"
-                content={getAttendeesAndAssessments(Person.ROLE.PRINCIPAL)}
-                className="reportField"
-              />
-              <CompactRow
-                label="advisors"
-                content={getAttendeesAndAssessments(Person.ROLE.ADVISOR)}
-                className="reportField"
-              />
-              <CompactRow
-                label={Settings.fields.task.subLevel.longLabel}
-                content={getTasksAndAssessments()}
-                className="reportField"
-              />
-              {report.cancelled ? (
-                <CompactRow
-                  label="cancelled reason"
-                  content={utils.sentenceCase(report.cancelledReason)}
-                  className="reportField"
-                />
-              ) : null}
-              {optionalFields.workflow.active && report.showWorkflow() ? (
-                <CompactRowReportWorkflow
-                  workflow={report.workflow}
-                  className="reportField"
-                  isCompact
-                />
-              ) : null}
-              {report.reportText ? (
-                <CompactRow
-                  label={Settings.fields.report.reportText}
-                  content={parseHtmlWithLinkTo(report.reportText)}
-                  className="reportField"
-                />
-              ) : null}
-              {Settings.fields.report.customFields ? (
-                <ReadonlyCustomFields
-                  fieldsConfig={Settings.fields.report.customFields}
-                  values={report}
-                  vertical
-                  isCompact
-                />
-              ) : null}
+            <CompactTable
+              children={
+                <>
+                  <HalfColumn>
+                    <CompactTitle
+                      label={getReportTitle()}
+                      className="reportField"
+                    />
+                    <CompactSubTitle
+                      label={getReportSubTitle()}
+                      className="reportField"
+                    />
+                    <CompactRow
+                      label="purpose"
+                      content={report.intent}
+                      className="reportField"
+                    />
+                    <CompactRow
+                      label={
+                        Settings.fields.report.keyOutcomes || "key outcomes"
+                      }
+                      content={report.keyOutcomes}
+                      className="reportField"
+                    />
+                    {!report.cancelled ? (
+                      <CompactRow
+                        label={Settings.fields.report.atmosphere}
+                        content={
+                          <>
+                            {utils.sentenceCase(report.atmosphere)}
+                            {report.atmosphereDetails &&
+                              ` – ${report.atmosphereDetails}`}
+                          </>
+                        }
+                        className="reportField"
+                      />
+                    ) : null}
+                    <CompactRow
+                      label={Settings.fields.report.nextSteps.label}
+                      content={report.nextSteps}
+                      className="reportField"
+                    />
+                    <CompactRow
+                      label="principals"
+                      content={getAttendeesAndAssessments(
+                        Person.ROLE.PRINCIPAL
+                      )}
+                      className="reportField"
+                    />
+                    <CompactRow
+                      label="advisors"
+                      content={getAttendeesAndAssessments(Person.ROLE.ADVISOR)}
+                      className="reportField"
+                    />
+                    <CompactRow
+                      label={Settings.fields.task.subLevel.longLabel}
+                      content={getTasksAndAssessments()}
+                      className="reportField"
+                    />
+                    {report.cancelled ? (
+                      <CompactRow
+                        label="cancelled reason"
+                        content={utils.sentenceCase(report.cancelledReason)}
+                        className="reportField"
+                      />
+                    ) : null}
+                    {optionalFields.workflow.active && report.showWorkflow() ? (
+                      <CompactRowReportWorkflow
+                        workflow={report.workflow}
+                        className="reportField"
+                        isCompact
+                      />
+                    ) : null}
+                    {report.reportText ? (
+                      <CompactRow
+                        label={Settings.fields.report.reportText}
+                        content={parseHtmlWithLinkTo(report.reportText)}
+                        className="reportField"
+                      />
+                    ) : null}
+                    {Settings.fields.report.customFields ? (
+                      <ReadonlyCustomFields
+                        fieldsConfig={Settings.fields.report.customFields}
+                        values={report}
+                        vertical
+                        isCompact
+                      />
+                    ) : null}
+                  </HalfColumn>
+                </>
+              }
+            >
             </CompactTable>
             <CompactFooterContent object={report} />
           </CompactReportViewS>
@@ -618,8 +633,6 @@ const CompactReportViewS = styled.div`
     transform: rotateZ(-45deg);
   }
   @media print {
-    position: fixed;
-    left: 0mm;
     outline: none;
     &[data-draft="draft"]:before {
       top: 40%;
@@ -632,6 +645,12 @@ const CompactReportViewS = styled.div`
     }
     .workflow-action .btn {
       display: inline-block !important;
+    }
+    table {
+      page-break-inside: auto;
+    }
+    tr {
+      page-break-inside: auto;
     }
   }
 `

--- a/client/src/pages/reports/Compact.js
+++ b/client/src/pages/reports/Compact.js
@@ -11,7 +11,8 @@ import CompactTable, {
   CompactSubTitle,
   CompactTitle,
   FullColumn,
-  InnerTable
+  InnerTable,
+  PAGE_SIZES
 } from "components/Compact"
 import { ReadonlyCustomFields } from "components/CustomFields"
 import { parseHtmlWithLinkTo } from "components/editor/LinkAnet"
@@ -33,7 +34,7 @@ import { Person, Report, Task } from "models"
 import moment from "moment"
 import PropTypes from "prop-types"
 import React, { useState } from "react"
-import { Button } from "react-bootstrap"
+import { Button, DropdownButton, MenuItem } from "react-bootstrap"
 import { connect } from "react-redux"
 import { useHistory, useParams } from "react-router-dom"
 import Settings from "settings"
@@ -217,6 +218,7 @@ const GQL_GET_REPORT = gql`
 const CompactReportView = ({ pageDispatchers }) => {
   const history = useHistory()
   const { uuid } = useParams()
+  const [pageSize, setPageSize] = useState(PAGE_SIZES.A4)
   const { loading, error, data } = API.useApiQuery(GQL_GET_REPORT, {
     uuid
   })
@@ -272,8 +274,13 @@ const CompactReportView = ({ pageDispatchers }) => {
             returnToDefaultPage={returnToDefaultPage}
             optionalFields={optionalFields}
             setOptionalFields={setOptionalFields}
+            setPageSize={setPageSize}
           />
-          <CompactReportViewS className="compact-view" data-draft={draftAttr}>
+          <CompactReportViewS
+            className="compact-view"
+            data-draft={draftAttr}
+            pageSize={pageSize}
+          >
             <CompactHeaderContent />
             <CompactTable
               children={
@@ -618,7 +625,7 @@ const CompactReportViewS = styled.div`
   position: relative;
   outline: 2px solid grey;
   padding: 0 1rem;
-  width: 21cm;
+  width: ${props => props.pageSize.width};
 
   &[data-draft="draft"]:before {
     content: "DRAFT";
@@ -653,6 +660,9 @@ const CompactReportViewS = styled.div`
     tr {
       page-break-inside: auto;
     }
+    @page {
+      size: ${props => props.pageSize.width} ${props => props.pageSize.height};
+    }
   }
 `
 
@@ -661,11 +671,28 @@ const CompactReportViewHeader = ({
   returnToDefaultPage,
   noReport,
   optionalFields,
-  setOptionalFields
+  setOptionalFields,
+  setPageSize
 }) => {
   return (
     <Header>
       <HeaderTitle value="title">Summary / Print</HeaderTitle>
+      <DropdownButton
+        title="Page Size"
+        bsStyle="primary"
+        id="pageSizeButton"
+        onSelect={setPageSize}
+      >
+        {Object.keys(PAGE_SIZES).map(pageSize => (
+          <MenuItem
+            key={PAGE_SIZES[pageSize].name}
+            eventKey={PAGE_SIZES[pageSize]}
+            style={{ minWidth: "205px" }}
+          >
+            {PAGE_SIZES[pageSize].name}
+          </MenuItem>
+        ))}
+      </DropdownButton>
       <SimpleMultiCheckboxDropdown
         label="Optional Fields ⇓"
         options={optionalFields}
@@ -705,7 +732,8 @@ CompactReportViewHeader.propTypes = {
       active: PropTypes.bool.isRequired
     })
   ).isRequired,
-  setOptionalFields: PropTypes.func
+  setOptionalFields: PropTypes.func,
+  setPageSize: PropTypes.func
 }
 
 CompactReportViewHeader.defaultProps = {


### PR DESCRIPTION
Added page size selection to report print view.
Fixed invalid dom warnings in compact view of reports.

Closes #3701 

#### User changes
- Users can now select a page size for printing reports.

#### Super User changes
- none

#### Admin changes
- none

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [ ] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here