### PR TITLE
Group some items in the navigation menu

### DIFF
--- a/anet-dictionary.yml
+++ b/anet-dictionary.yml
@@ -23,6 +23,9 @@ dateFormats:
       date: dddd, D MMMM YYYY
       withTime: dddd, D MMMM YYYY @ HH:mm
 
+menuOptions:
+  menuLinksDropdownTitle: My Work
+
 printOptions:
   sensitiveInformationText: Sensitive Information
   sensitiveInformationTooltipText: Releasability Information

--- a/client/src/components/Nav.js
+++ b/client/src/components/Nav.js
@@ -146,7 +146,7 @@ const Nav = ({
         style={{ paddingTop: "2px" }}
         onClick={() => setIsMenuLinksOpened(!isMenuLinksOpened)}
       >
-        My Links
+        {Settings?.menuOptions?.menuLinksDropdownTitle ?? "My Work"}
         <span
           className={isMenuLinksOpened ? "caret caret-rotate" : "caret"}
           style={{ marginLeft: "0.5rem" }}

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -324,15 +324,28 @@ button.home-tile.btn {
   text-align: center;
 }
 
+.caret {
+  transition: 0.3s ease;
+}
+
+.caret-rotate {
+  transform: rotate(180deg);
+  transition: transform 0.3s ease;
+}
+
 .nav img {
   width: 16px;
   margin-right: 6px;
 }
 
-.nav .nav > li > a {
+.nav-pills li.active > #nav-links-button {
+  background-color: #e0e0e0;
+  color: #337ab7;
+}
+
+.nav > .nav > li > a {
   border-left: 4px solid rgba(0, 0, 0, 0);
-  padding: 4px 0 4px 38px;
-  padding-right: 4px;
+  padding: 4px 4px 4px 38px;
 }
 
 .nav .nav > li.active > a {

--- a/client/tests/e2e/home.js
+++ b/client/tests/e2e/home.js
@@ -50,7 +50,7 @@ test("Home Page", async t => {
   const $hopscotchNext = await $(".hopscotch-next")
   await $hopscotchNext.click()
 
-  const $myReportsLink = await $("#leftNav > li:nth-child(3) > a")
+  const $myReportsLink = await $("#leftNav > li:nth-child(10) > a")
   await $myReportsLink.click()
   await t.context.driver.sleep(shortWaitMs) // wait for transition
   await assertElementNotPresent(

--- a/client/tests/e2e/permissions.js
+++ b/client/tests/e2e/permissions.js
@@ -7,6 +7,7 @@ test.serial("checking super user permissions", async t => {
   const { pageHelpers, assertElementNotPresent, shortWaitMs } = t.context
 
   await t.context.get("/", "rebecca")
+  await pageHelpers.clickMenuLinksButton()
   await pageHelpers.clickMyOrgLink()
 
   const $rebeccaLink = await findSuperUserLink(t, "CTR BECCABON, Rebecca")
@@ -21,6 +22,7 @@ test.serial("checking super user permissions", async t => {
   await editAndSavePositionFromCurrentUserPage(t, true)
 
   await t.context.get("/", "rebecca")
+  await pageHelpers.clickMenuLinksButton()
   await pageHelpers.clickMyOrgLink()
   const $jacobLink = await findSuperUserLink(t, "CIV JACOBSON, Jacob")
   await $jacobLink.click()
@@ -84,6 +86,7 @@ test("checking regular user permissions", async t => {
   const { pageHelpers, $, assertElementNotPresent, shortWaitMs } = t.context
 
   await t.context.get("/", "jack")
+  await pageHelpers.clickMenuLinksButton()
   await pageHelpers.clickMyOrgLink()
   await pageHelpers.clickPersonNameFromSupportedPositionsFieldset(
     "OF-9 JACKSON, Jack"
@@ -122,6 +125,7 @@ test("checking admin permissions", async t => {
   t.plan(11)
 
   await t.context.get("/", "arthur")
+  await t.context.pageHelpers.clickMenuLinksButton()
   await t.context.pageHelpers.clickMyOrgLink()
   const $arthurLink = await findSuperUserLink(t, "CIV DMIN, Arthur")
   await $arthurLink.click()

--- a/client/tests/e2e/position.js
+++ b/client/tests/e2e/position.js
@@ -15,6 +15,7 @@ test("Move someone in and out of a position", async t => {
 
   await t.context.get("/", "rebecca")
 
+  await t.context.pageHelpers.clickMenuLinksButton()
   await t.context.pageHelpers.clickMyOrgLink()
 
   const positionName = "EF 2.2 Advisor C"

--- a/client/tests/util/test.js
+++ b/client/tests/util/test.js
@@ -316,6 +316,10 @@ test.beforeEach(t => {
         text
       )
     },
+    async clickMenuLinksButton() {
+      const $menuLinksButton = await t.context.$("#nav-links-button")
+      await $menuLinksButton.click()
+    },
     async clickMyOrgLink() {
       const $myOrgLink = await t.context.$("#my-organization")
       await t.context.driver.wait(t.context.until.elementIsVisible($myOrgLink))

--- a/client/tests/webdriver/baseSpecs/myCounterparts.spec.js
+++ b/client/tests/webdriver/baseSpecs/myCounterparts.spec.js
@@ -6,6 +6,7 @@ describe("Home page", () => {
   describe("When checking the navigation items", () => {
     it("Should see a link to my counterparts page when the user is an advisor", () => {
       Home.open()
+      Home.linksMenuButton.click()
       Home.myCounterpartsLink.waitForDisplayed()
     })
   })

--- a/client/tests/webdriver/baseSpecs/myTasks.spec.js
+++ b/client/tests/webdriver/baseSpecs/myTasks.spec.js
@@ -6,6 +6,7 @@ describe("Home page", () => {
   describe("When checking the navigation items", () => {
     it("Should see a link to my tasks page when the user is an advisor", () => {
       Home.open()
+      Home.linksMenuButton.click()
       Home.myTasksLink.waitForDisplayed()
     })
   })

--- a/client/tests/webdriver/customFieldsSpecs/myOrg.spec.js
+++ b/client/tests/webdriver/customFieldsSpecs/myOrg.spec.js
@@ -5,6 +5,7 @@ import MyOrg from "../pages/myOrg.page"
 describe("My Organization page", () => {
   beforeEach("Open the My Organization page", () => {
     Home.openAsAdminUser()
+    Home.linksMenuButton.click()
     const myOrgUrl = Home.myOrgLink.getAttribute("href")
     MyOrg.openAsAdminUser(myOrgUrl)
   })

--- a/client/tests/webdriver/customFieldsSpecs/notifications.spec.js
+++ b/client/tests/webdriver/customFieldsSpecs/notifications.spec.js
@@ -6,6 +6,7 @@ describe("Home page", () => {
   describe("When checking the notification numbers", () => {
     it("Should see that Erin has 1 counterpart and no tasks with pending assessments", () => {
       Home.open()
+      Home.linksMenuButton.click()
       Home.myCounterpartsLink.waitForDisplayed()
       Home.myTasksLink.waitForDisplayed()
       expect(Home.myCounterpartsNotifications.getText()).to.equal("1")
@@ -14,6 +15,7 @@ describe("Home page", () => {
     })
     it("Should see that Bob has no counterparts and 1 task with pending assessments", () => {
       Home.open("/", "bob")
+      Home.linksMenuButton.click()
       Home.myCounterpartsLink.waitForDisplayed()
       Home.myTasksLink.waitForDisplayed()
       // eslint-disable-next-line no-unused-expressions
@@ -22,6 +24,7 @@ describe("Home page", () => {
     })
     it("Should see that Jack has no counterpart and 1 task with pending assessments", () => {
       Home.open("/", "jack")
+      Home.linksMenuButton.click()
       Home.myCounterpartsLink.waitForDisplayed()
       Home.myTasksLink.waitForDisplayed()
       // eslint-disable-next-line no-unused-expressions
@@ -30,6 +33,7 @@ describe("Home page", () => {
     })
     it("Should see that Nick has no counterparts and no tasks with pending assessments", () => {
       Home.open("/", "nick")
+      Home.linksMenuButton.click()
       Home.myCounterpartsLink.waitForDisplayed()
       Home.myTasksLink.waitForDisplayed()
       /* eslint-disable no-unused-expressions */

--- a/client/tests/webdriver/pages/home.page.js
+++ b/client/tests/webdriver/pages/home.page.js
@@ -37,6 +37,10 @@ class Home extends Page {
     return browser.$("#topbar #searchBarSubmit")
   }
 
+  get linksMenuButton() {
+    return browser.$("#nav-links-button")
+  }
+
   get myOrgLink() {
     return browser.$("#my-organization")
   }

--- a/src/main/resources/anet-schema.yml
+++ b/src/main/resources/anet-schema.yml
@@ -374,6 +374,14 @@ properties:
                 title: The long date/time format if `engagementsIncludeTimeAndDuration` is `true`
                 description: Used to show the report engagement date/time in the user interface; should be easy to read, e.g. "Sunday, 6 December 1998 @ 15:30"; see https://momentjs.com/docs/#/displaying/format/ for format specifiers.
 
+  menuOptions:
+    type: object
+    additionalProperties: false
+    required: [menuLinksDropdownTitle]
+    properties:
+      menuLinksDropdownTitle:
+        type: string
+
   printOptions:
     type: object
     additionalProperties: false


### PR DESCRIPTION
Navigation menu is too long and grouping is required to make it more compact.

Closes #3729 

#### User changes
- *"My X..."* links in the menu are grouped in an accordion like component.

#### Super User changes
- None

#### Admin changes
- None

#### System admin changes
- [x] anet.yml or anet-dictionary.yml needs change
  Add this section to your dictionary:
  ```
  menuOptions:
    menuLinksDropdownTitle: My Work
  ```
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [x] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
