### PR TITLE
Fix asset loading

### DIFF
--- a/client/config/webpack.common.js
+++ b/client/config/webpack.common.js
@@ -78,14 +78,7 @@ const commonConfig = {
       },
       {
         test: /\.(ico|jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2)(\?.*)?$/,
-        use: [
-          {
-            loader: "file-loader",
-            options: {
-              name: "static/media/[name].[hash:8].[ext]"
-            }
-          }
-        ]
+        type: "asset/resource"
       }
     ]
   }

--- a/client/package.json
+++ b/client/package.json
@@ -74,7 +74,6 @@
     "eslint-plugin-react-hooks": "4.2.0",
     "eslint-webpack-plugin": "3.0.1",
     "faker": "5.5.3",
-    "file-loader": "6.2.0",
     "git-describe": "4.0.4",
     "handlebars": "4.7.7",
     "handlebars-loader": "1.7.1",

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -9063,7 +9063,7 @@ file-entry-cache@^6.0.1:
   dependencies:
     flat-cache "^3.0.4"
 
-file-loader@6.2.0, file-loader@^6.2.0:
+file-loader@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/file-loader/-/file-loader-6.2.0.tgz#baef7cf8e1840df325e4390b4484879480eebe4d"
   integrity sha512-qo3glqyTa61Ytg4u73GultjHGjdRyig3tG6lPtyX/jOEJvHif9uB0/OCI2Kif6ctF3caQTW2G5gym21oAsI4pw==


### PR DESCRIPTION
Use the new Webpack 5 asset loader to load images and fonts; they were no longer loading correctly with the old file-loader.

#### User changes
- E.g. arrows in the report workflow should now display correctly again.

#### Super User changes
- none

#### Admin changes
- none

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [ ] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [ ] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here