### PR TITLE
Ensure location types fits all missions

### DIFF
--- a/anet-dictionary.yml
+++ b/anet-dictionary.yml
@@ -214,6 +214,8 @@ fields:
       maxTextFieldLength: 1000
     keyOutcomes: Key outcomes
     reportText: Key details
+    location:
+      filter: [PINPOINT_LOCATION, VIRTUAL_LOCATION]
     customFields:
       relatedReport:
         type: anet_object
@@ -532,6 +534,7 @@ fields:
             color: 'skyblue'
 
   location:
+    superUserTypeOptions: [PINPOINT_LOCATION]
     format: LAT_LON
     customFields:
       multipleButtons:
@@ -812,6 +815,8 @@ fields:
       code:
         label: CE Post Number
         placeholder: the CE post number for this position
+      location:
+        filter: [PINPOINT_LOCATION]
 
     org:
       name: Advisor Organization
@@ -953,6 +958,8 @@ fields:
       code:
         label: Tashkil
         placeholder: the Afghan taskhil ID for this position
+      location:
+          filter: [PINPOINT_LOCATION]
 
     org:
       name: Afghan Government Organization

--- a/client/src/components/advancedSelectWidget/AdvancedSelect.js
+++ b/client/src/components/advancedSelectWidget/AdvancedSelect.js
@@ -237,9 +237,10 @@ const AdvancedSelect = ({
     if (
       !_isEqualWith(latestFilterDefs, filterDefs, utils.treatFunctionsAsEqual)
     ) {
+      setFilterType(firstFilter)
       setLatestFilterDefs(filterDefs)
     }
-  }, [filterDefs, latestFilterDefs])
+  }, [filterDefs, latestFilterDefs, firstFilter])
 
   useEffect(() => {
     if (latestSelectedValueAsString.current !== selectedValueAsString) {

--- a/client/src/components/advancedSelectWidget/AdvancedSelect.js
+++ b/client/src/components/advancedSelectWidget/AdvancedSelect.js
@@ -139,7 +139,7 @@ const AdvancedSelect = ({
 
   const latestSelectedValueAsString = useRef(selectedValueAsString)
   const latestQueryParams = useRef(queryParams)
-  const latestFilterDefs = useRef(filterDefs)
+  const [latestFilterDefs, setLatestFilterDefs] = useState(filterDefs)
   const overlayContainer = useRef()
   const searchInput = useRef()
   const latestRequest = useRef()
@@ -155,7 +155,7 @@ const AdvancedSelect = ({
   const [fetchType, setFetchType] = useState(FETCH_TYPE.NONE)
   const [doReset, setDoReset] = useState(false)
 
-  const selectedFilter = latestFilterDefs.current[filterType]
+  const selectedFilter = latestFilterDefs[filterType]
   const renderSelectedWithDelete = renderSelected
     ? React.cloneElement(renderSelected, { onDelete: handleRemoveItem })
     : null
@@ -166,15 +166,15 @@ const AdvancedSelect = ({
 
   const fetchResults = useCallback(
     searchTerms => {
-      if (!selectedFilter.list) {
+      if (!selectedFilter?.list) {
         const resourceName = objectType.resourceName
-        const listName = selectedFilter.listName || objectType.listName
+        const listName = selectedFilter?.listName || objectType.listName
         const queryVars = { pageNum, pageSize }
         if (latestQueryParams.current) {
           Object.assign(queryVars, latestQueryParams.current)
         }
-        if (selectedFilter.queryVars) {
-          Object.assign(queryVars, selectedFilter.queryVars)
+        if (selectedFilter?.queryVars) {
+          Object.assign(queryVars, selectedFilter?.queryVars)
         }
         if (searchTerms) {
           Object.assign(queryVars, { text: searchTerms + "*" })
@@ -213,9 +213,9 @@ const AdvancedSelect = ({
       objectType.resourceName,
       pageNum,
       pageSize,
-      selectedFilter.list,
-      selectedFilter.listName,
-      selectedFilter.queryVars
+      selectedFilter?.list,
+      selectedFilter?.listName,
+      selectedFilter?.queryVars
     ]
   )
 
@@ -235,15 +235,11 @@ const AdvancedSelect = ({
 
   useEffect(() => {
     if (
-      !_isEqualWith(
-        latestFilterDefs.current,
-        filterDefs,
-        utils.treatFunctionsAsEqual
-      )
+      !_isEqualWith(latestFilterDefs, filterDefs, utils.treatFunctionsAsEqual)
     ) {
-      latestFilterDefs.current = filterDefs
+      setLatestFilterDefs(filterDefs)
     }
-  }, [filterDefs])
+  }, [filterDefs, latestFilterDefs])
 
   useEffect(() => {
     if (latestSelectedValueAsString.current !== selectedValueAsString) {
@@ -267,7 +263,7 @@ const AdvancedSelect = ({
         }
       }))
     }
-  }, [filterType, pageNum, pageSize, selectedFilter.list])
+  }, [filterType, pageNum, pageSize, selectedFilter?.list])
 
   useEffect(() => {
     if (fetchType === FETCH_TYPE.NORMAL) {

--- a/client/src/pages/locations/Form.js
+++ b/client/src/pages/locations/Form.js
@@ -51,10 +51,8 @@ const LOCATION_TYPES_ADMIN = [
 ]
 
 // Location types to be shown to super users in the new location page.
-const LOCATION_TYPES_SUPER_USER = [
-  Location.LOCATION_TYPES.ADVISOR_LOCATION,
-  Location.LOCATION_TYPES.PRINCIPAL_LOCATION
-]
+const LOCATION_TYPES_SUPER_USER =
+  Settings?.fields?.location?.superUserTypeOptions
 
 const LocationForm = ({ edit, title, initialValues }) => {
   const { currentUser } = useContext(AppContext)
@@ -204,7 +202,11 @@ const LocationForm = ({ edit, title, initialValues }) => {
                       component="select"
                       className="location-type-form-group form-control"
                     >
-                      <option value="">Please select a location type</option>
+                      <option value="">
+                        {!canEditName
+                          ? Location.humanNameOfType(values.type)
+                          : "Please select a location type"}
+                      </option>
                       {getDropdownOptionsForUser(currentUser).map(type => (
                         <option key={type} value={type}>
                           {Location.humanNameOfType(type)}

--- a/client/src/pages/positions/Form.js
+++ b/client/src/pages/positions/Form.js
@@ -306,7 +306,7 @@ const PositionForm = ({ edit, title, initialValues }) => {
                       value={values.location}
                       overlayColumns={["Name"]}
                       overlayRenderRow={LocationOverlayRow}
-                      filterDefs={getLocationFilters()}
+                      filterDefs={getLocationFilters(values)}
                       objectType={Location}
                       fields={Location.autocompleteQuery}
                       valueKey="name"
@@ -357,23 +357,21 @@ const PositionForm = ({ edit, title, initialValues }) => {
             </Form>
           </div>
         )
-
-        function getLocationFilters() {
-          const locationFilters = {}
-          Settings?.fields[
-            values.type === Position.TYPE.ADVISOR ? "advisor" : "principal"
-          ]?.position?.location?.filter.map(
-            filter =>
-              (locationFilters[filter] = {
-                label: Location.humanNameOfType(filter),
-                queryVars: { type: filter }
-              })
-          )
-          return locationFilters
-        }
       }}
     </Formik>
   )
+
+  function getLocationFilters(values) {
+    return Settings?.fields[
+      values.type === Position.TYPE.ADVISOR ? "advisor" : "principal"
+    ]?.position?.location?.filter.reduce((accummulator, filter) => {
+      accummulator[filter] = {
+        label: Location.humanNameOfType(filter),
+        queryVars: { type: filter }
+      }
+      return accummulator
+    }, {})
+  }
 
   function onCancel() {
     history.goBack()

--- a/client/src/pages/positions/Form.js
+++ b/client/src/pages/positions/Form.js
@@ -184,12 +184,7 @@ const PositionForm = ({ edit, title, initialValues }) => {
             queryVars: {}
           }
         }
-        const locationFilters = {
-          activeLocations: {
-            label: "All locations",
-            queryVars: { status: Model.STATUS.ACTIVE }
-          }
-        }
+
         return (
           <div>
             <NavigationWarning isBlocking={dirty} />
@@ -311,16 +306,9 @@ const PositionForm = ({ edit, title, initialValues }) => {
                       value={values.location}
                       overlayColumns={["Name"]}
                       overlayRenderRow={LocationOverlayRow}
-                      filterDefs={locationFilters}
+                      filterDefs={getLocationFilters()}
                       objectType={Location}
                       fields={Location.autocompleteQuery}
-                      queryParams={{
-                        status: Model.STATUS.ACTIVE,
-                        type:
-                          values.type === Position.TYPE.ADVISOR
-                            ? Location.LOCATION_TYPES.ADVISOR_LOCATION
-                            : Location.LOCATION_TYPES.PRINCIPAL_LOCATION
-                      }}
                       valueKey="name"
                       addon={LOCATIONS_ICON}
                     />
@@ -369,6 +357,20 @@ const PositionForm = ({ edit, title, initialValues }) => {
             </Form>
           </div>
         )
+
+        function getLocationFilters() {
+          const locationFilters = {}
+          Settings?.fields[
+            values.type === Position.TYPE.ADVISOR ? "advisor" : "principal"
+          ]?.position?.location?.filter.map(
+            filter =>
+              (locationFilters[filter] = {
+                label: Location.humanNameOfType(filter),
+                queryVars: { type: filter }
+              })
+          )
+          return locationFilters
+        }
       }}
     </Formik>
   )

--- a/client/src/pages/reports/Form.js
+++ b/client/src/pages/reports/Form.js
@@ -303,44 +303,6 @@ const ReportForm = ({
         }
         const currentOrg =
           currentUser.position && currentUser.position.organization
-        const locationFilters = {
-          virtual: {
-            label: Location.humanNameOfType(
-              Location.LOCATION_TYPES.VIRTUAL_LOCATION
-            ),
-            queryVars: {
-              status: Model.STATUS.ACTIVE,
-              type: Location.LOCATION_TYPES.VIRTUAL_LOCATION
-            }
-          },
-          principal: {
-            label: Location.humanNameOfType(
-              Location.LOCATION_TYPES.PRINCIPAL_LOCATION
-            ),
-            queryVars: {
-              status: Model.STATUS.ACTIVE,
-              type: Location.LOCATION_TYPES.PRINCIPAL_LOCATION
-            }
-          },
-          advisor: {
-            label: Location.humanNameOfType(
-              Location.LOCATION_TYPES.ADVISOR_LOCATION
-            ),
-            queryVars: {
-              status: Model.STATUS.ACTIVE,
-              type: Location.LOCATION_TYPES.ADVISOR_LOCATION
-            }
-          },
-          pinpoint: {
-            label: Location.humanNameOfType(
-              Location.LOCATION_TYPES.PINPOINT_LOCATION
-            ),
-            queryVars: {
-              status: Model.STATUS.ACTIVE,
-              type: Location.LOCATION_TYPES.PINPOINT_LOCATION
-            }
-          }
-        }
 
         const reportPeopleFilters = {
           all: {
@@ -579,7 +541,7 @@ const ReportForm = ({
                       value={values.location}
                       overlayColumns={["Name"]}
                       overlayRenderRow={LocationOverlayRow}
-                      filterDefs={locationFilters}
+                      filterDefs={getLocationFilters()}
                       objectType={Location}
                       fields={Location.autocompleteQuery}
                       valueKey="name"
@@ -1138,6 +1100,18 @@ const ReportForm = ({
             </Form>
           </div>
         )
+
+        function getLocationFilters() {
+          const locationFilters = {}
+          Settings?.fields?.report?.location?.filter.map(
+            filter =>
+              (locationFilters[filter] = {
+                label: Location.humanNameOfType(filter),
+                queryVars: { type: filter }
+              })
+          )
+          return locationFilters
+        }
       }}
     </Formik>
   )

--- a/client/src/pages/reports/Form.js
+++ b/client/src/pages/reports/Form.js
@@ -1100,21 +1100,22 @@ const ReportForm = ({
             </Form>
           </div>
         )
-
-        function getLocationFilters() {
-          const locationFilters = {}
-          Settings?.fields?.report?.location?.filter.map(
-            filter =>
-              (locationFilters[filter] = {
-                label: Location.humanNameOfType(filter),
-                queryVars: { type: filter }
-              })
-          )
-          return locationFilters
-        }
       }}
     </Formik>
   )
+
+  function getLocationFilters() {
+    return Settings?.fields?.report?.location?.filter.reduce(
+      (accumulator, filter) => {
+        accumulator[filter] = {
+          label: Location.humanNameOfType(filter),
+          queryVars: { type: filter }
+        }
+        return accumulator
+      },
+      {}
+    )
+  }
 
   function getReportType(values) {
     return values.engagementDate && Report.isFuture(values.engagementDate)

--- a/client/tests/e2e/report.js
+++ b/client/tests/e2e/report.js
@@ -37,12 +37,12 @@ test.serial("Draft and submit a report", async t => {
 
   const $locationAdvancedSelect = await pageHelpers.chooseAdvancedSelectOption(
     "#location",
-    "vt"
+    "ge"
   )
 
   t.is(
     await $locationAdvancedSelect.getAttribute("value"),
-    "VTC",
+    "General Hospital",
     "Clicking a location advanced single select widget suggestion populates the input field."
   )
 
@@ -529,7 +529,7 @@ test.serial(
     await $locationShortcutButton.click()
     t.is(
       await $locationInput.getAttribute("value"),
-      "VTC",
+      "General Hospital",
       "Clicking the shortcut adds a location"
     )
 

--- a/src/main/resources/anet-schema.yml
+++ b/src/main/resources/anet-schema.yml
@@ -427,7 +427,17 @@ properties:
       task:
         type: object
         additionalProperties: false
-        required: [shortLabel, shortName, longLabel, longName, topLevel, subLevel, taskedOrganizations, responsiblePositions]
+        required:
+          [
+            shortLabel,
+            shortName,
+            longLabel,
+            longName,
+            topLevel,
+            subLevel,
+            taskedOrganizations,
+            responsiblePositions,
+          ]
         properties:
           shortLabel:
             type: string
@@ -517,6 +527,18 @@ properties:
             type: string
             title: The label for report's engagement details
             description: Used in the UI where report's engagement details are shown.
+          location:
+            type: object
+            additionalProperties: false
+            required: [filter]
+            properties:
+              filter:
+                type: array
+                uniqueItems: true
+                items:
+                  type: string
+                  enum:
+                    [VIRTUAL_LOCATION, PHYSICAL_LOCATION, GEOGRAPHICAL_AREA, PINPOINT_LOCATION, ADVISOR_LOCATION, PRINCIPAL_LOCATION]
           customFields:
             type: object
             additionalProperties:
@@ -597,6 +619,13 @@ properties:
         additionalProperties: false
         required: [format]
         properties:
+          superUserTypeOptions:
+            type: array
+            uniqueItems: true
+            items:
+              type: string
+              enum:
+                [VIRTUAL_LOCATION, PHYSICAL_LOCATION, GEOGRAPHICAL_AREA, PINPOINT_LOCATION, ADVISOR_LOCATION, PRINCIPAL_LOCATION]
           format:
             type: string
             title: Default format for location
@@ -688,6 +717,18 @@ properties:
                 description: Used in the UI for the type/permissions of an advisor position.
               code:
                 "$ref": "#/$defs/inputField"
+              location:
+                type: object
+                additionalProperties: false
+                required: [filter]
+                properties:
+                  filter:
+                    type: array
+                    uniqueItems: true
+                    items:
+                      type: string
+                      enum:
+                        [VIRTUAL_LOCATION, PHYSICAL_LOCATION, GEOGRAPHICAL_AREA, PINPOINT_LOCATION, ADVISOR_LOCATION, PRINCIPAL_LOCATION]
 
           org:
             type: object
@@ -760,6 +801,18 @@ properties:
                 description: Used in the UI for the type/permissions of a principal position.
               code:
                 "$ref": "#/$defs/inputField"
+              location:
+                type: object
+                additionalProperties: false
+                required: [filter]
+                properties:
+                  filter:
+                    type: array
+                    uniqueItems: true
+                    items:
+                      type: string
+                      enum:
+                        [VIRTUAL_LOCATION, PHYSICAL_LOCATION, GEOGRAPHICAL_AREA, PINPOINT_LOCATION, ADVISOR_LOCATION, PRINCIPAL_LOCATION]
 
           org:
             type: object

--- a/src/main/resources/anet-schema.yml
+++ b/src/main/resources/anet-schema.yml
@@ -427,17 +427,7 @@ properties:
       task:
         type: object
         additionalProperties: false
-        required:
-          [
-            shortLabel,
-            shortName,
-            longLabel,
-            longName,
-            topLevel,
-            subLevel,
-            taskedOrganizations,
-            responsiblePositions,
-          ]
+        required: [shortLabel, shortName, longLabel, longName, topLevel, subLevel, taskedOrganizations, responsiblePositions]
         properties:
           shortLabel:
             type: string

--- a/testDictionaries/no-custom-fields.yml
+++ b/testDictionaries/no-custom-fields.yml
@@ -162,6 +162,8 @@ fields:
       maxTextFieldLength: 1000
     keyOutcomes: Key outcomes
     reportText: Key details
+    location:
+      filter: [PINPOINT_LOCATION, VIRTUAL_LOCATION]
 
   person:
     firstName: First name
@@ -262,6 +264,7 @@ fields:
             color: 'skyblue'
 
   location:
+    superUserTypeOptions: [PINPOINT_LOCATION]
     format: LAT_LON
 
   position:
@@ -308,6 +311,8 @@ fields:
       code:
         label: CE Post Number
         placeholder: the CE post number for this position
+      location:
+        filter: [PINPOINT_LOCATION]
 
     org:
       name: Advisor Organization
@@ -448,6 +453,8 @@ fields:
       code:
         label: Tashkil
         placeholder: the Afghan taskhil ID for this position
+      location:
+        filter: [PINPOINT_LOCATION]
 
     org:
       name: Afghan Government Organization


### PR DESCRIPTION
Locations filters in the dictionary can only take predetermined values. Random location type filter inputs are not allowed. Related controls are being made in the `anet-schema.yml`.

Closes #3782 

#### User changes
- In create/edit _report page_, location _advancedSingleSelect_ filters are customizable from the dictionary.
- In create/edit _position page_, location _advancedSingleSelect_ filters are customizable from the dictionary.

#### Super User changes
- In create location page, location type options are customizable from the dictionary.

#### Admin changes
- None

#### System admin changes
- [x] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

#### Dictionary changes
```
fields:
    reports:
        location:
            filter: [PINPOINT_LOCATION, VIRTUAL_LOCATION]
```

```
fields:
    location:
        superUserTypeOptions: [PINPOINT_LOCATION]
```

```
fields:
    advisor:
        person:
            position:
                location:
                    filter: [PINPOINT_LOCATION]
```

```
fields:
    principal:
        person:
            position:
                location:
                    filter: [PINPOINT_LOCATION]
```

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [x] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
