### PR TITLE
Add ability to undo custom field of type choice

### DIFF
--- a/client/src/components/CustomFields.js
+++ b/client/src/components/CustomFields.js
@@ -277,6 +277,7 @@ const EnumField = fieldProps => {
   return (
     <FastField
       buttons={FieldHelper.customEnumButtons(choices)}
+      enableClear
       component={FieldHelper.RadioButtonToggleGroupField}
       {...otherFieldProps}
     />

--- a/client/src/components/FieldHelper.js
+++ b/client/src/components/FieldHelper.js
@@ -1,7 +1,9 @@
 import { CompactRow } from "components/Compact"
 import LinkTo from "components/LinkTo"
+import RemoveButton from "components/RemoveButton"
 import _cloneDeep from "lodash/cloneDeep"
 import _get from "lodash/get"
+import _isEmpty from "lodash/isEmpty"
 import PropTypes from "prop-types"
 import React, { useCallback, useMemo } from "react"
 import {
@@ -367,39 +369,49 @@ const ButtonToggleGroupField = ({
   addon,
   vertical,
   buttons,
+  enableClear,
   ...otherProps
 }) => {
   const widgetElem = useMemo(
     () => (
-      <ToggleButtonGroup
-        type={type}
-        defaultValue={field.value}
-        {...field}
-        {...otherProps}
-      >
-        {buttons.map((button, index) => {
-          if (!button) {
-            return null
-          }
-          let { label, value, color, style, ...props } = button
-          if (color) {
-            if (
-              field.value === value ||
-              (Array.isArray(field.value) && field.value.includes(value))
-            ) {
-              style = { ...style, backgroundColor: color }
+      <>
+        <ToggleButtonGroup
+          type={type}
+          defaultValue={field.value}
+          {...field}
+          {...otherProps}
+        >
+          {buttons.map((button, index) => {
+            if (!button) {
+              return null
             }
-            style = { ...style, borderColor: color, borderWidth: "2px" }
-          }
-          return (
-            <ToggleButton {...props} key={value} value={value} style={style}>
-              {label}
-            </ToggleButton>
-          )
-        })}
-      </ToggleButtonGroup>
+            let { label, value, color, style, ...props } = button
+            if (color) {
+              if (
+                field.value === value ||
+                (Array.isArray(field.value) && field.value.includes(value))
+              ) {
+                style = { ...style, backgroundColor: color }
+              }
+              style = { ...style, borderColor: color, borderWidth: "2px" }
+            }
+            return (
+              <ToggleButton {...props} key={value} value={value} style={style}>
+                {label}
+              </ToggleButton>
+            )
+          })}
+        </ToggleButtonGroup>
+        {!_isEmpty(buttons) && enableClear && (
+          <RemoveButton
+            title="Clear choice"
+            alt="Clear choice"
+            onClick={() => form.setFieldValue(field.name, "", false)}
+          />
+        )}
+      </>
     ),
-    [buttons, field, otherProps, type]
+    [buttons, field, form, enableClear, otherProps, type]
   )
   return (
     <Field
@@ -423,7 +435,8 @@ ButtonToggleGroupField.propTypes = {
   extraColElem: PropTypes.object,
   addon: PropTypes.object,
   vertical: PropTypes.bool,
-  buttons: PropTypes.array
+  buttons: PropTypes.array,
+  enableClear: PropTypes.bool
 }
 
 export const RadioButtonToggleGroupField = ({


### PR DESCRIPTION
Added clear option for custom fields of type choice. 

Closes #3804 

#### User changes
- None

#### Super User changes
- Super users can clear their choice for enum fields when creating or editing anet entities.

#### Admin changes
- None

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
