### PR TITLE
Add styling when displaying enum values

### DIFF
--- a/client/src/components/CustomFields.js
+++ b/client/src/components/CustomFields.js
@@ -28,7 +28,7 @@ import _upperFirst from "lodash/upperFirst"
 import moment from "moment"
 import PropTypes from "prop-types"
 import React, { useEffect, useMemo } from "react"
-import { Button, HelpBlock, Table } from "react-bootstrap"
+import { Badge, Button, HelpBlock, Table } from "react-bootstrap"
 import Settings from "settings"
 import { useDebouncedCallback } from "use-debounce"
 import utils from "utils"
@@ -286,9 +286,42 @@ const EnumField = fieldProps => {
 
 const enumHumanValue = (choices, fieldVal) => {
   if (Array.isArray(fieldVal)) {
-    return fieldVal && fieldVal.map(k => choices[k]?.label).join(", ")
+    return (
+      <div>
+        {fieldVal.map((k, index) => (
+          <span key={k}>
+            <Badge
+              style={{
+                fontSize: "inherit",
+                fontWeight: "inherit",
+                lineHeight: "inherit",
+                color: "black",
+                backgroundColor: choices[k]?.color || "white"
+              }}
+            >
+              {choices[k]?.label}
+            </Badge>
+            {index < fieldVal.length - 1 && ", "}
+          </span>
+        ))}
+      </div>
+    )
   } else {
-    return fieldVal && choices[fieldVal]?.label
+    return (
+      fieldVal && (
+        <Badge
+          style={{
+            fontSize: "inherit",
+            fontWeight: "inherit",
+            lineHeight: "inherit",
+            color: "black",
+            backgroundColor: choices[fieldVal]?.color || "white"
+          }}
+        >
+          {choices[fieldVal]?.label}
+        </Badge>
+      )
+    )
   }
 }
 


### PR DESCRIPTION
Colors of enum values are displayed on read-only views.

Closes #3799 

#### User changes
- Users can see the corresponding color of enum choices on read-only views.

#### Super User changes
- None

#### Admin changes
- None

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [ ] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
