### PR TITLE
Replace saved searches with My Subscription Updates on the home page

### DIFF
--- a/client/src/components/MySubscriptionUpdates.js
+++ b/client/src/components/MySubscriptionUpdates.js
@@ -243,7 +243,8 @@ const MySubscriptionUpdates = ({
                             updatedAt={null}
                             refetch={() => {
                               refetch()
-                              refetchCallback()
+                              typeof refetchCallback === "function" &&
+                                refetchCallback()
                             }}
                             setError={error => setSaveError(error)}
                           />
@@ -266,9 +267,9 @@ const MySubscriptionUpdates = ({
 }
 
 MySubscriptionUpdates.propTypes = {
-  forceRefetch: PropTypes.bool.isRequired,
-  setForceRefetch: PropTypes.func.isRequired,
-  refetchCallback: PropTypes.func.isRequired,
+  forceRefetch: PropTypes.bool,
+  setForceRefetch: PropTypes.func,
+  refetchCallback: PropTypes.func,
   pageDispatchers: PageDispatchersPropType
 }
 

--- a/client/src/pages/Home.js
+++ b/client/src/pages/Home.js
@@ -10,6 +10,7 @@ import AppContext from "components/AppContext"
 import Fieldset from "components/Fieldset"
 import GuidedTour from "components/GuidedTour"
 import Messages from "components/Messages"
+import MySubscriptionUpdates from "components/MySubscriptionUpdates"
 import {
   mapPageDispatchersToProps,
   PageDispatchersPropType,
@@ -19,7 +20,6 @@ import { deserializeQueryParams } from "components/SearchFilters"
 import { LAST_WEEK } from "dateUtils"
 import { Person, Report } from "models"
 import { superUserTour, userTour } from "pages/HopscotchTour"
-import MySavedSearches from "pages/searches/MySavedSearches"
 import PropTypes from "prop-types"
 import React, { useContext } from "react"
 import { Button, Grid, Row } from "react-bootstrap"
@@ -330,10 +330,7 @@ const Home = ({ setSearchQuery, pageDispatchers }) => {
         />
       </Fieldset>
 
-      <MySavedSearches
-        setSearchQuery={setSearchQuery}
-        pageDispatchers={pageDispatchers}
-      />
+      <MySubscriptionUpdates />
     </div>
   )
 }


### PR DESCRIPTION
The _Saved searces_ field on the home page is replaced with _My Subscription Updates_. 

Closes #3801 

#### User changes
- Home page will display _My Subscription Updates_ instead of _Saved searces_

#### Super User changes
- None

#### Admin changes
- None

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [ ] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
