### PR TITLE
Fix rich text fields displaying html tags

### DIFF
--- a/client/src/components/aggregations/AggregationWidgetContainer.js
+++ b/client/src/components/aggregations/AggregationWidgetContainer.js
@@ -4,6 +4,7 @@ import LikertScaleAndPieWidget from "components/aggregations/LikertScaleAndPieWi
 import PieWidget from "components/aggregations/PieWidget"
 import ReportsByTaskWidget from "components/aggregations/ReportsByTaskWidget"
 import ReportsMapWidget from "components/aggregations/ReportsMapWidget"
+import RichTextWidget from "components/aggregations/RichTextWidget"
 import {
   countPerDateAggregation,
   countPerValueAggregation,
@@ -11,6 +12,7 @@ import {
   numbersListAggregation,
   objectsListAggregation,
   reportsByTaskAggregation,
+  richTextAggregation,
   valuesListAggregation
 } from "components/aggregations/utils"
 import {
@@ -34,6 +36,7 @@ export const AGGERGATION_WIDGET_TYPE = {
   IQR_BOX_PLOT: "iqrBoxPlot",
   CALENDAR: "calendar",
   REPORTS_MAP: "reportsMap",
+  RICH_TEXT: "richText",
   DEFAULT: "default"
 }
 
@@ -45,6 +48,7 @@ const AGGREGATION_WIDGET_COMPONENTS = {
   [AGGERGATION_WIDGET_TYPE.REPORTS_BY_TASK]: ReportsByTaskWidget,
   [AGGERGATION_WIDGET_TYPE.REPORTS_MAP]: ReportsMapWidget,
   [AGGERGATION_WIDGET_TYPE.CALENDAR]: CalendarWidget,
+  [AGGERGATION_WIDGET_TYPE.RICH_TEXT]: RichTextWidget,
   [AGGERGATION_WIDGET_TYPE.DEFAULT]: DefaultAggWidget
 }
 
@@ -58,7 +62,7 @@ const DEFAULT_AGGREGATION_WIDGET_PER_FIELD_TYPE = {
   [CUSTOM_FIELD_TYPE.SPECIAL_FIELD]: {
     [SPECIAL_WIDGET_TYPES.LIKERT_SCALE]:
       AGGERGATION_WIDGET_TYPE.LIKERT_SCALE_AND_PIE,
-    [SPECIAL_WIDGET_TYPES.RICH_TEXT_EDITOR]: AGGERGATION_WIDGET_TYPE.DEFAULT
+    [SPECIAL_WIDGET_TYPES.RICH_TEXT_EDITOR]: AGGERGATION_WIDGET_TYPE.RICH_TEXT
   }
 }
 
@@ -69,7 +73,8 @@ export const AGGREGATION_TYPE = {
   NUMBERS_LIST: "numbersList",
   VALUES_LIST: "valuesList",
   OBJECTS_LIST: "objectsList",
-  LIKERT_SCALE_AND_PIE_AGG: "likertScaleAndPieAgg"
+  LIKERT_SCALE_AND_PIE_AGG: "likertScaleAndPieAgg",
+  RICH_TEXT_AGG: "richText"
 }
 
 const DEFAULT_AGGREGATION_TYPE_PER_WIDGET_TYPE = {
@@ -81,6 +86,7 @@ const DEFAULT_AGGREGATION_TYPE_PER_WIDGET_TYPE = {
   [AGGERGATION_WIDGET_TYPE.REPORTS_MAP]: AGGREGATION_TYPE.OBJECTS_LIST,
   [AGGERGATION_WIDGET_TYPE.IQR_BOX_PLOT]: AGGREGATION_TYPE.NUMBERS_LIST,
   [AGGERGATION_WIDGET_TYPE.CALENDAR]: AGGREGATION_TYPE.OBJECTS_LIST,
+  [AGGERGATION_WIDGET_TYPE.RICH_TEXT]: AGGREGATION_TYPE.RICH_TEXT_AGG,
   [AGGERGATION_WIDGET_TYPE.DEFAULT]: AGGREGATION_TYPE.VALUES_LIST
 }
 
@@ -91,7 +97,8 @@ const AGGREGATION_TYPE_FUNCTION = {
   [AGGREGATION_TYPE.NUMBERS_LIST]: numbersListAggregation,
   [AGGREGATION_TYPE.VALUES_LIST]: valuesListAggregation,
   [AGGREGATION_TYPE.OBJECTS_LIST]: objectsListAggregation,
-  [AGGREGATION_TYPE.LIKERT_SCALE_AND_PIE_AGG]: likertScaleAndPieAggregation
+  [AGGREGATION_TYPE.LIKERT_SCALE_AND_PIE_AGG]: likertScaleAndPieAggregation,
+  [AGGREGATION_TYPE.RICH_TEXT_AGG]: richTextAggregation
 }
 
 export const getAggregationWidget = (

--- a/client/src/components/aggregations/DefaultAggWidget.js
+++ b/client/src/components/aggregations/DefaultAggWidget.js
@@ -21,11 +21,12 @@ const DefaultAggWidget = ({ values, whenUnspecified, ...otherWidgetProps }) => {
         onClick={() => setShowValues(!showValues)}
         id="toggleShowValues"
       >
-        {showValues ? "Hide" : "Show"} {filteredValues.length} values
+        {showValues ? "Hide" : "Show"} {filteredValues.length}{" "}
+        {utils.pluralizeWord(filteredValues.length, "value")}
       </Button>
       <Collapse in={showValues}>
         <Table>
-          <tbody>
+          <tbody style={{ display: "table", width: "100%" }}>
             {filteredValues.map((val, index) => (
               <tr key={index}>
                 <td>{JSON.stringify(val)}</td>

--- a/client/src/components/aggregations/RichTextWidget.js
+++ b/client/src/components/aggregations/RichTextWidget.js
@@ -21,11 +21,12 @@ const RichTextWidget = ({ values, whenUnspecified, ...otherWidgetProps }) => {
         onClick={() => setShowValues(!showValues)}
         id="toggleShowValues"
       >
-        {showValues ? "Hide" : "Show"} {filteredValues.length} values
+        {showValues ? "Hide" : "Show"} {filteredValues.length}{" "}
+        {utils.pluralizeWord(filteredValues.length, "value")}
       </Button>
       <Collapse in={showValues}>
         <Table>
-          <tbody>
+          <tbody style={{ display: "table", width: "100%" }}>
             {filteredValues.map((val, index) => (
               <tr key={index}>
                 <td>{val}</td>

--- a/client/src/components/aggregations/RichTextWidget.js
+++ b/client/src/components/aggregations/RichTextWidget.js
@@ -1,0 +1,43 @@
+import {
+  aggregationWidgetDefaultProps,
+  aggregationWidgetPropTypes
+} from "components/aggregations/utils"
+import _isEmpty from "lodash/isEmpty"
+import React, { useState } from "react"
+import { Button, Collapse, Table } from "react-bootstrap"
+import utils from "utils"
+
+const RichTextWidget = ({ values, whenUnspecified, ...otherWidgetProps }) => {
+  const [showValues, setShowValues] = useState(false)
+  const filteredValues = values.filter(value => !utils.isNullOrUndefined(value))
+  if (_isEmpty(filteredValues)) {
+    return whenUnspecified
+  }
+  return (
+    <div>
+      <Button
+        className="toggle-section-button"
+        style={{ marginBottom: "1rem" }}
+        onClick={() => setShowValues(!showValues)}
+        id="toggleShowValues"
+      >
+        {showValues ? "Hide" : "Show"} {filteredValues.length} values
+      </Button>
+      <Collapse in={showValues}>
+        <Table>
+          <tbody>
+            {filteredValues.map((val, index) => (
+              <tr key={index}>
+                <td>{val}</td>
+              </tr>
+            ))}
+          </tbody>
+        </Table>
+      </Collapse>
+    </div>
+  )
+}
+RichTextWidget.propTypes = aggregationWidgetPropTypes
+RichTextWidget.defaultProps = aggregationWidgetDefaultProps
+
+export default RichTextWidget

--- a/client/src/components/aggregations/utils.js
+++ b/client/src/components/aggregations/utils.js
@@ -1,3 +1,4 @@
+import { parseHtmlWithLinkTo } from "components/editor/LinkAnet"
 import _clone from "lodash/clone"
 import _cloneDeep from "lodash/cloneDeep"
 import _isEmpty from "lodash/isEmpty"
@@ -190,6 +191,14 @@ export const likertScaleAndPieAggregation = (fieldName, fieldConfig, data) => {
       likertScaleValues: valuesListAggregation(fieldName, fieldConfig, data),
       pieValues: countPerLevelAggregation(fieldName, fieldConfig, data)
     }
+  }
+}
+
+export const richTextAggregation = (fieldName, fieldConfig, data) => {
+  return {
+    values: data
+      .map(item => Object.get(item, fieldName))
+      .map(htmlString => parseHtmlWithLinkTo(htmlString))
   }
 }
 

--- a/client/src/utils.js
+++ b/client/src/utils.js
@@ -228,6 +228,10 @@ export default {
 
   getMaxTextFieldLength: function(field) {
     return field?.maxTextFieldLength || Settings.maxTextFieldLength
+  },
+
+  pluralizeWord: function(count, word) {
+    return count > 1 ? pluralize.plural(word) : word
   }
 }
 


### PR DESCRIPTION
Rich text assessments are displayed with correct styling on `relatedObjectNotes` and instant assessment results.

Closes #3859 

#### User changes
- Users can display rich text assessment results with correct styling

#### Super User changes
- None

#### Admin changes
- None

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [ ] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
