### PR TITLE
Configure general banner through dropdown fields

### DIFF
--- a/client/src/components/GeneralBanner.js
+++ b/client/src/components/GeneralBanner.js
@@ -1,17 +1,24 @@
 import PropTypes from "prop-types"
 import React from "react"
 
+export const GENERAL_BANNER_LEVELS = {
+  NOTICE: { value: "notice", className: "alert-info", label: "Blue" },
+  SUCCESS: { value: "success", className: "alert-success", label: "Green" },
+  ERROR: { value: "error", className: "alert-danger", label: "Red" },
+  ALERT: { value: "alert", className: "alert-warning", label: "Yellow" }
+}
+
 function bannerClassName(level) {
-  let output = "general-banner"
+  let output = "general-banner "
   switch (level) {
-    case "notice":
-      return (output += " alert-info")
-    case "success":
-      return (output += " alert-success")
-    case "error":
-      return (output += " alert-danger")
-    case "alert":
-      return (output += " alert-warning")
+    case GENERAL_BANNER_LEVELS.NOTICE.value:
+      return (output += ` ${GENERAL_BANNER_LEVELS.NOTICE.className}`)
+    case GENERAL_BANNER_LEVELS.SUCCESS.value:
+      return (output += ` ${GENERAL_BANNER_LEVELS.SUCCESS.className}`)
+    case GENERAL_BANNER_LEVELS.ERROR.value:
+      return (output += ` ${GENERAL_BANNER_LEVELS.ERROR.className}`)
+    case GENERAL_BANNER_LEVELS.ALERT.value:
+      return (output += ` ${GENERAL_BANNER_LEVELS.ALERT.className}`)
     default:
       return output
   }

--- a/client/src/components/GeneralBanner.js
+++ b/client/src/components/GeneralBanner.js
@@ -1,11 +1,25 @@
 import PropTypes from "prop-types"
 import React from "react"
 
+export const GENERAL_BANNER_LEVEL = "GENERAL_BANNER_LEVEL"
+export const GENERAL_BANNER_TEXT = "GENERAL_BANNER_TEXT"
+export const GENERAL_BANNER_VISIBILITY = "GENERAL_BANNER_VISIBILITY"
+export const GENERAL_BANNER_TITLE = "Announcement"
+
 export const GENERAL_BANNER_LEVELS = {
   NOTICE: { value: "notice", className: "alert-info", label: "Blue" },
   SUCCESS: { value: "success", className: "alert-success", label: "Green" },
   ERROR: { value: "error", className: "alert-danger", label: "Red" },
   ALERT: { value: "alert", className: "alert-warning", label: "Yellow" }
+}
+
+export const GENERAL_BANNER_VISIBILITIES = {
+  USERS_ONLY: { value: 1, label: "Users only" },
+  SUPER_USERS_AND_ADMINISTRATORS: {
+    value: 2,
+    label: "Super users and administrators only"
+  },
+  ALL: { value: 3, label: "Users, super users and administrators" }
 }
 
 function bannerClassName(level) {

--- a/client/src/components/TopBar.js
+++ b/client/src/components/TopBar.js
@@ -1,22 +1,18 @@
 import { resetPages } from "actions"
 import AppContext from "components/AppContext"
-import GeneralBanner from "components/GeneralBanner"
+import GeneralBanner, {
+  GENERAL_BANNER_LEVEL,
+  GENERAL_BANNER_TEXT,
+  GENERAL_BANNER_TITLE,
+  GENERAL_BANNER_VISIBILITIES,
+  GENERAL_BANNER_VISIBILITY
+} from "components/GeneralBanner"
 import Header from "components/Header"
 import NoPositionBanner from "components/NoPositionBanner"
 import SecurityBanner from "components/SecurityBanner"
 import PropTypes from "prop-types"
 import React, { useContext, useEffect, useRef, useState } from "react"
 import { connect } from "react-redux"
-
-const GENERAL_BANNER_LEVEL = "GENERAL_BANNER_LEVEL"
-const GENERAL_BANNER_TEXT = "GENERAL_BANNER_TEXT"
-const GENERAL_BANNER_VISIBILITY = "GENERAL_BANNER_VISIBILITY"
-const GENERAL_BANNER_TITLE = "Announcement"
-const visible = {
-  USERS: 1,
-  SUPER_USERS: 2,
-  USERS_AND_SUPER_USERS: 3
-}
 
 const TopBar = ({
   handleTopbarHeight,
@@ -57,27 +53,14 @@ const TopBar = ({
   }, [height, handleTopbarHeight])
 
   useEffect(() => {
-    let output = false
-    if (
-      visibilitySetting === visible.USERS &&
+    const output =
       currentUser &&
-      !currentUser.isSuperUser()
-    ) {
-      output = true
-    }
-    if (
-      visibilitySetting === visible.SUPER_USERS &&
-      currentUser &&
-      currentUser.isSuperUser()
-    ) {
-      output = true
-    }
-    if (
-      visibilitySetting === visible.USERS_AND_SUPER_USERS &&
-      (currentUser || currentUser.isSuperUser())
-    ) {
-      output = true
-    }
+      ((visibilitySetting === GENERAL_BANNER_VISIBILITIES.USERS_ONLY.value &&
+        !currentUser.isSuperUser()) ||
+        (visibilitySetting ===
+          GENERAL_BANNER_VISIBILITIES.SUPER_USERS_AND_ADMINISTRATORS.value &&
+          currentUser.isSuperUser()) ||
+        visibilitySetting === GENERAL_BANNER_VISIBILITIES.ALL.value)
     if (bannerVisibility !== output) {
       setBannerVisibility(output)
     }

--- a/client/src/pages/admin/Index.js
+++ b/client/src/pages/admin/Index.js
@@ -4,7 +4,12 @@ import API from "api"
 import AppContext from "components/AppContext"
 import * as FieldHelper from "components/FieldHelper"
 import Fieldset from "components/Fieldset"
-import { GENERAL_BANNER_LEVELS } from "components/GeneralBanner"
+import {
+  GENERAL_BANNER_LEVEL,
+  GENERAL_BANNER_LEVELS,
+  GENERAL_BANNER_VISIBILITIES,
+  GENERAL_BANNER_VISIBILITY
+} from "components/GeneralBanner"
 import Messages from "components/Messages"
 import {
   jumpToTop,
@@ -23,8 +28,12 @@ import uuidv4 from "uuid/v4"
 
 const DROPDOWN_FIELDS = [
   {
-    name: "GENERAL_BANNER_LEVEL",
+    name: GENERAL_BANNER_LEVEL,
     options: GENERAL_BANNER_LEVELS
+  },
+  {
+    name: GENERAL_BANNER_VISIBILITY,
+    options: GENERAL_BANNER_VISIBILITIES
   }
 ]
 

--- a/client/src/pages/admin/Index.js
+++ b/client/src/pages/admin/Index.js
@@ -4,6 +4,7 @@ import API from "api"
 import AppContext from "components/AppContext"
 import * as FieldHelper from "components/FieldHelper"
 import Fieldset from "components/Fieldset"
+import { GENERAL_BANNER_LEVELS } from "components/GeneralBanner"
 import Messages from "components/Messages"
 import {
   jumpToTop,
@@ -19,6 +20,13 @@ import { Button, Col, Grid, Row } from "react-bootstrap"
 import { connect } from "react-redux"
 import { toast } from "react-toastify"
 import uuidv4 from "uuid/v4"
+
+const DROPDOWN_FIELDS = [
+  {
+    name: "GENERAL_BANNER_LEVEL",
+    options: GENERAL_BANNER_LEVELS
+  }
+]
 
 const GQL_GET_ADMIN_SETTINGS = gql`
   query {
@@ -132,13 +140,39 @@ const AdminIndex = ({ pageDispatchers }) => {
             <Form className="form-horizontal" method="post">
               <Fieldset title="Site settings" action={action} />
               <Fieldset>
-                {Object.map(settings, (key, value) => (
-                  <Field
-                    key={key}
-                    name={key}
-                    component={FieldHelper.InputField}
-                  />
-                ))}
+                {Object.map(settings, (key, value) => {
+                  const dropdownField = DROPDOWN_FIELDS.find(
+                    field => field.name === key
+                  )
+                  if (dropdownField) {
+                    return (
+                      <Field
+                        name={key}
+                        key={key}
+                        component={FieldHelper.SpecialField}
+                        widget={
+                          <Field component="select" className="form-control">
+                            {Object.values(dropdownField.options).map(
+                              option => (
+                                <option key={option.value} value={option.value}>
+                                  {option.label}
+                                </option>
+                              )
+                            )}
+                          </Field>
+                        }
+                      >
+                      </Field>
+                    )
+                  }
+                  return (
+                    <Field
+                      key={key}
+                      name={key}
+                      component={FieldHelper.InputField}
+                    />
+                  )
+                })}
               </Fieldset>
               <div className="submit-buttons">
                 <div />


### PR DESCRIPTION
_General banner level_ and _General banner visibility_ fields are converted to a dropdown menu.

Closes #3858 #586 #587

#### User changes
- None

#### Super User changes
- None

#### Admin changes
- Admins can configure general banner using dropdown menus

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [ ] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
