### PR TITLE
Add deprecation feature to custom fields

### DIFF
--- a/anet-dictionary.yml
+++ b/anet-dictionary.yml
@@ -481,6 +481,7 @@ fields:
         type: date
         label: Not later than date
         helpText: Help text for date field
+        deprecated: true
       nlt_dt:
         type: datetime
         label: Not later than datetime

--- a/client/src/components/CustomFields.js
+++ b/client/src/components/CustomFields.js
@@ -846,13 +846,28 @@ export function getInvisibleFields(
   return curInvisibleFields
 }
 
+const filterDeprecatedFields = fieldsConfig => {
+  const deprecatedFields = Object.entries(fieldsConfig).reduce(
+    (accum, [fieldName, fieldConfig]) => {
+      fieldConfig.deprecated && accum.push(fieldName)
+      return accum
+    },
+    []
+  )
+  const deprecatedFieldsFiltered = Object.without(
+    fieldsConfig,
+    ...deprecatedFields
+  )
+  return deprecatedFieldsFiltered
+}
+
 export const CustomFieldsContainer = props => {
   const {
     parentFieldName,
     formikProps: { values, setFieldValue },
     fieldsConfig
   } = props
-
+  const deprecatedFieldsFiltered = filterDeprecatedFields(fieldsConfig)
   const invisibleFields = useMemo(
     () => getInvisibleFields(fieldsConfig, parentFieldName, values),
     [fieldsConfig, parentFieldName, values]
@@ -867,7 +882,11 @@ export const CustomFieldsContainer = props => {
 
   return (
     <>
-      <CustomFields invisibleFields={invisibleFields} {...props} />
+      <CustomFields
+        invisibleFields={invisibleFields}
+        {...props}
+        fieldsConfig={deprecatedFieldsFiltered}
+      />
     </>
   )
 }

--- a/src/main/resources/anet-schema.yml
+++ b/src/main/resources/anet-schema.yml
@@ -106,6 +106,7 @@ $defs:
               type: string
             filterValue:
               type: [array, string, number, boolean]
+      deprecated: boolean
       validations:
         type: array
         items:


### PR DESCRIPTION
Deprecated custom fields can be filtered on the form pages through the dictionary. Those fields will stay visible on show pages so that the previously entered values can be accessed.

Closes [AB#232](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/232)

#### User changes
- None

#### Super User changes
- None

#### Admin changes
- Admins can disable custom fields through the dictionary while keeping the previously entered values.

#### Dictionary changes
```
fields:
  task/report/people...
    customFields:
      exampleField:
        deprecated: true
```

#### System admin changes
- [x] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
