### PR TITLE
Fix typo in error handling

### DIFF
--- a/client/src/index-auth.js
+++ b/client/src/index-auth.js
@@ -22,7 +22,7 @@ import { initOptions, keycloak } from "keycloak"
     }
   } catch (error) {
     console.info("Error occurred during Keycloak client initialization")
-    console.err(error)
+    console.error(error)
     return
   }
 


### PR DESCRIPTION
Fix typo in error handling, preventing an error to be thrown while catching a top level error