### PR TITLE
Make tests run again on BrowserStack

### DIFF
--- a/.github/workflows/build-gradle.yml
+++ b/.github/workflows/build-gradle.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
     - '**'
+    tags:
+    - '**'
   pull_request:
     branches:
     - candidate
@@ -157,7 +159,7 @@ jobs:
     - run: |
         ./gradlew -PtestEnv run &
         sleep 15
-    - uses: olegtarasov/get-tag@v2
+    - uses: olegtarasov/get-tag@v2.1.1
       id: tagName
     - name: Set local identifier for BrowserStack
       id: browserstack-local

--- a/.github/workflows/build-gradle.yml
+++ b/.github/workflows/build-gradle.yml
@@ -162,12 +162,6 @@ jobs:
     - name: Set local identifier for BrowserStack
       id: browserstack-local
       run: echo ::set-output name=identifier::github-${GITHUB_RUN_ID}-${DB_DRIVER}
-    - name: Start BrowserStackLocal if needed
-      run: |
-        curl -qso bsl.zip https://www.browserstack.com/browserstack-local/BrowserStackLocal-linux-x64.zip
-        unzip -q bsl.zip
-        ./BrowserStackLocal --local-identifier ${{ steps.browserstack-local.outputs.identifier }} --key ${{ secrets.BROWSERSTACK_ACCESS_KEY }} &
-      if: steps.tagName.outputs.tag != ''
     - run: ./gradlew yarn_run_${CLIENT_TESTS}
       env:
         GIT_TAG_NAME: ${{ steps.tagName.outputs.tag }}

--- a/.github/workflows/build-gradle.yml
+++ b/.github/workflows/build-gradle.yml
@@ -161,7 +161,7 @@ jobs:
       id: tagName
     - name: Set local identifier for BrowserStack
       id: browserstack-local
-      run: echo ::set-output name=identifier::github-${GITHUB_RUN_ID}-${DB_DRIVER}
+      run: echo ::set-output name=identifier::github-${GITHUB_RUN_ID}-${DB_DRIVER}-${CLIENT_TESTS}
     - run: ./gradlew yarn_run_${CLIENT_TESTS}
       env:
         GIT_TAG_NAME: ${{ steps.tagName.outputs.tag }}

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build ANET](https://github.com/NCI-Agency/anet/workflows/Build%20ANET/badge.svg)](https://github.com/NCI-Agency/anet/actions)
 [![Build Status](https://dev.azure.com/advisornetwork/anet/_apis/build/status/NCI-Agency.anet)](https://dev.azure.com/advisornetwork/anet/_build/latest?definitionId=1)
-[![BrowserStack Status](https://www.browserstack.com/automate/badge.svg?badge_key=M0lYTkZHY0hkNmJoWEZ1MEJOS2diNkxUY3JuZXA5ZmhnNjRpTDVPVmoxTT0tLXRaZTE5c3JOVHZ6RXZzZG9BZWlSMEE9PQ==--a8bd7129094a0bce9d168e27a45b3d1a4a6c03dc)](https://www.browserstack.com/automate/public-build/M0lYTkZHY0hkNmJoWEZ1MEJOS2diNkxUY3JuZXA5ZmhnNjRpTDVPVmoxTT0tLXRaZTE5c3JOVHZ6RXZzZG9BZWlSMEE9PQ==--a8bd7129094a0bce9d168e27a45b3d1a4a6c03dc)
+[![BrowserStack Status](https://www.browserstack.com/automate/badge.svg?badge_key=dm9UUkRidFh3ekFrMFpvRWZnWHQxZmlYNnJWbVlVdTJTNW1OQ3IxYW9CMD0tLTNQeGNlajhLRzlDYlpTOW1ZR3VWN2c9PQ==--8758d27fb131132fdff84e521835a90c203ee88e)](https://www.browserstack.com/automate/public-build/dm9UUkRidFh3ekFrMFpvRWZnWHQxZmlYNnJWbVlVdTJTNW1OQ3IxYW9CMD0tLTNQeGNlajhLRzlDYlpTOW1ZR3VWN2c9PQ==--8758d27fb131132fdff84e521835a90c203ee88e)
 [![Docker Pulls](https://img.shields.io/docker/pulls/ncia/anet-app-server.svg)](https://hub.docker.com/r/ncia/anet-app-server/)
 
 [![Language grade: JavaScript](https://img.shields.io/lgtm/grade/javascript/g/NCI-Agency/anet.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/NCI-Agency/anet/context:javascript)

--- a/build.gradle
+++ b/build.gradle
@@ -219,6 +219,7 @@ task buildClient(dependsOn: 'yarn', type: YarnTask) {
 	inputs.dir("client/public").withPathSensitivity(PathSensitivity.RELATIVE)
 	outputs.dir("$buildDir/resources/main/assets/client")
 	outputs.cacheIf { true }
+	environment = [ "ANET_TEST_MODE": isTestEnv ? "true" : "false" ]
 	args = ['run', 'build']
 }
 

--- a/client/.gitignore
+++ b/client/.gitignore
@@ -5,6 +5,7 @@ node_modules
 
 # testing
 coverage
+local.log
 
 # production
 build

--- a/client/config/wdio.config.ie.js
+++ b/client/config/wdio.config.ie.js
@@ -1,3 +1,4 @@
+const util = require("util")
 const config = require("./wdio.config.js").config
 
 /*
@@ -12,19 +13,18 @@ config.exclude = []
 
 const capabilities = config.capabilities[0]
 delete capabilities["goog:chromeOptions"]
-
 capabilities.browserName = "IE"
-capabilities.browser_version = "11.0"
-capabilities.build = require("git-describe").gitDescribeSync(".", {
-  match: "[0-9]*"
-}).semverString
+capabilities.browserVersion = "11.0"
 
-capabilities.build = require("util").format(
-  capabilities.build,
-  capabilities.os,
-  capabilities.os_version,
+const bstackOptions = capabilities["bstack:options"]
+bstackOptions.resolution = "1024x768"
+bstackOptions.buildName = util.format(
+  require("git-describe").gitDescribeSync(".", { match: "[0-9]*" })
+    .semverString,
+  bstackOptions.os,
+  bstackOptions.osVersion,
   capabilities.browserName,
-  capabilities.browser_version
+  capabilities.browserVersion
 )
 
 exports.config = config

--- a/client/config/wdio.config.js
+++ b/client/config/wdio.config.js
@@ -275,18 +275,26 @@ if (testEnv === "local") {
   config.path = "/"
 } else {
   const capabilities = require("./browserstack.config.js")
+  const bsOptions = capabilities["bstack:options"]
   config.services = [
     [
       "browserstack",
       {
+        opts: {
+          force: true,
+          forceLocal: true,
+          onlyAutomate: true,
+          key: bsOptions.accessKey,
+          localIdentifier: bsOptions.localIdentifier
+        },
         browserstackLocal: true
       }
     ]
   ]
   config.capabilities = [capabilities]
   config.maxInstances = 1
-  config.user = capabilities["bstack:options"].userName
-  config.key = capabilities["bstack:options"].accessKey
-  // config.browserstackLocal = true -- already started by the GitHub Actions workflow
+  // Set required config options for browserstack service
+  config.user = bsOptions.userName
+  config.key = bsOptions.accessKey
 }
 exports.config = config

--- a/client/config/webpack.common.js
+++ b/client/config/webpack.common.js
@@ -106,6 +106,9 @@ module.exports = {
     plugins: [
       new webpack.DefinePlugin({
         "process.env.NODE_ENV": JSON.stringify(process.env.NODE_ENV),
+        "process.env.ANET_TEST_MODE": JSON.stringify(
+          process.env.ANET_TEST_MODE
+        ),
         // Work-around for https://github.com/palantir/blueprint/issues/3739
         // and https://github.com/palantir/blueprint/issues/4393
         "process.env.BLUEPRINT_NAMESPACE": JSON.stringify("bp3")

--- a/client/package.json
+++ b/client/package.json
@@ -50,6 +50,7 @@
     "babel-jest": "27.3.1",
     "babel-loader": "8.2.3",
     "babel-preset-react-app": "10.0.0",
+    "browserstack-local": "1.4.8",
     "chai": "4.3.4",
     "chalk": "4.1.2",
     "chromatic": "6.0.5",

--- a/client/src/pages/reports/Form.js
+++ b/client/src/pages/reports/Form.js
@@ -151,6 +151,8 @@ const GQL_UPDATE_REPORT_ASSESSMENTS = gql`
   }
 `
 
+const AUTOSAVE_TIMEOUT = process.env.ANET_TEST_MODE === "true" ? 300 : 30
+
 const ReportForm = ({
   pageDispatchers,
   edit,
@@ -169,7 +171,7 @@ const ReportForm = ({
   const [reportTasks, setReportTasks] = useState(initialValues.tasks)
   const [reportPeople, setReportPeople] = useState(initialValues.reportPeople)
   // some autosave settings
-  const defaultTimeout = moment.duration(30, "seconds")
+  const defaultTimeout = moment.duration(AUTOSAVE_TIMEOUT, "seconds")
   const autoSaveSettings = useRef({
     autoSaveTimeout: defaultTimeout.clone(),
     timeoutId: null,

--- a/client/tests/e2e/report.js
+++ b/client/tests/e2e/report.js
@@ -403,280 +403,271 @@ async function approveReport(t, user) {
   await $ApproveButton.click()
   await t.context.driver.wait(until.stalenessOf($ApproveButton), mediumWaitMs)
 }
-test.serial(
-  "Verify that validation and other reports/new interactions work",
-  async t => {
-    t.plan(27)
+test.serial("Verify that validations work", async t => {
+  t.plan(27)
 
-    const {
-      assertElementText,
-      $,
-      $$,
-      assertElementNotPresent,
-      pageHelpers,
-      shortWaitMs,
-      By,
-      until
-    } = t.context
+  const {
+    assertElementText,
+    $,
+    $$,
+    assertElementNotPresent,
+    pageHelpers,
+    shortWaitMs,
+    By,
+    until
+  } = t.context
 
-    await pageHelpers.goHomeAndThenToReportsPage()
-    await assertElementText(
-      t,
-      await $(".legend .title-text"),
-      "Create a new Report"
+  await pageHelpers.goHomeAndThenToReportsPage()
+  await assertElementText(
+    t,
+    await $(".legend .title-text"),
+    "Create a new Report"
+  )
+
+  const $searchBarInput = await $("#searchBarInput")
+
+  async function verifyFieldIsRequired($input, id, type, fieldName) {
+    await $input.click()
+    await $input.clear()
+    await $searchBarInput.click()
+
+    await t.context.driver.wait(
+      until.elementLocated(
+        By.css(`${type}[id="${id}"] ~ div[class="invalid-feedback"]`)
+      )
     )
 
-    const $searchBarInput = await $("#searchBarInput")
-
-    async function verifyFieldIsRequired($input, id, type, fieldName) {
-      await $input.click()
-      await $input.clear()
-      await $searchBarInput.click()
-
-      await t.context.driver.wait(
-        until.elementLocated(
-          By.css(`${type}[id="${id}"] ~ div[class="invalid-feedback"]`)
-        )
-      )
-
-      await $input.sendKeys("user input")
-      await $input.sendKeys(t.context.Key.TAB) // fire blur event
-      t.false(
-        (await t.context.driver.findElements(
-          By.css(`textarea[id="${id}"] ~ div[class="invalid-feedback"]`)
-        ).length) > 0,
-        `After typing in ${fieldName} field, warning state goes away`
-      )
-    }
-
-    const $meetingGoalInput = await $("#intent")
-    // check that parent div.form-group does not have class 'has-error'
+    await $input.sendKeys("user input")
+    await $input.sendKeys(t.context.Key.TAB) // fire blur event
     t.false(
       (await t.context.driver.findElements(
-        By.css('textarea[id="intent"] ~ div[class="invalid-feedback"]')
+        By.css(`textarea[id="${id}"] ~ div[class="invalid-feedback"]`)
       ).length) > 0,
-      "Meeting goal does not start in an invalid state"
-    )
-    t.is(
-      await $meetingGoalInput.getAttribute("value"),
-      "",
-      "Meeting goal field starts blank"
-    )
-
-    // check that parent div.form-group now has a class 'has-error'
-    await verifyFieldIsRequired(
-      $meetingGoalInput,
-      "intent",
-      "textarea",
-      "Meeting goal"
-    )
-
-    const $engagementDate = await $("#engagementDate")
-    t.is(
-      await $engagementDate.getAttribute("value"),
-      "",
-      "Engagement date field starts blank"
-    )
-    await $engagementDate.click()
-    await t.context.driver.sleep(shortWaitMs) // wait for the datepicker to pop up
-
-    await pageHelpers.clickTodayButton()
-
-    // set time as well
-    const $hourInput = await $("input.bp3-timepicker-input.bp3-timepicker-hour")
-    // clear field, enter data, fire blur event
-    await $hourInput.sendKeys(
-      t.context.Key.END +
-        t.context.Key.BACK_SPACE.repeat(2) +
-        "23" +
-        t.context.Key.TAB
-    )
-    const $minuteInput = await $(
-      "input.bp3-timepicker-input.bp3-timepicker-minute"
-    )
-    // clear field, enter data, fire blur event
-    await $minuteInput.sendKeys(
-      t.context.Key.END +
-        t.context.Key.BACK_SPACE.repeat(2) +
-        "45" +
-        t.context.Key.TAB
-    )
-
-    // check date and time
-    const dateTimeFormat = "DD-MM-YYYY HH:mm"
-    const dateTimeValue = await $engagementDate.getAttribute("value")
-    const expectedDateTime = moment().hour(23).minute(45).format(dateTimeFormat)
-    t.is(
-      dateTimeValue,
-      expectedDateTime,
-      'Clicking the "today" button puts the current date in the engagement field'
-    )
-
-    const $locationInput = await $("#location")
-    t.is(
-      await $locationInput.getAttribute("value"),
-      "",
-      "Location field starts blank"
-    )
-
-    const $locationShortcutButton = await $("#location-shortcut-list button")
-    await $locationShortcutButton.click()
-    t.is(
-      await $locationInput.getAttribute("value"),
-      "General Hospital",
-      "Clicking the shortcut adds a location"
-    )
-
-    await assertElementNotPresent(
-      t,
-      "#cancelledReason",
-      "Cancelled reason should not be present initially",
-      shortWaitMs
-    )
-    const $atmosphereFormGroup = await $(".atmosphere-form-group")
-    t.true(
-      await $atmosphereFormGroup.isDisplayed(),
-      "Atmospherics form group should be shown by default"
-    )
-
-    await assertElementNotPresent(
-      t,
-      "#atmosphere-details",
-      "Atmospherics details should not be displayed before choosing atmospherics",
-      shortWaitMs
-    )
-
-    const $positiveAtmosphereButton = await $(
-      'label[for="atmosphere_POSITIVE"]'
-    )
-    await $positiveAtmosphereButton.click()
-
-    const $atmosphereDetails = await $("#atmosphereDetails")
-    t.is(
-      await $atmosphereDetails.getAttribute("placeholder"),
-      "Why was this engagement positive? (optional)"
-    )
-
-    const $neutralAtmosphereButton = await $('label[for="atmosphere_NEUTRAL"]')
-    await $neutralAtmosphereButton.click()
-    t.is(
-      (await $atmosphereDetails.getAttribute("placeholder")).trim(),
-      "Why was this engagement neutral?"
-    )
-
-    const $negativeAtmosphereButton = await $(
-      'label[for="atmosphere_NEGATIVE"]'
-    )
-    await $negativeAtmosphereButton.click()
-    t.is(
-      (await $atmosphereDetails.getAttribute("placeholder")).trim(),
-      "Why was this engagement negative?"
-    )
-
-    const $atmosphereDetailsInput = await t.context.driver.findElement(
-      By.css('input[id="atmosphereDetails"]')
-    )
-
-    await $neutralAtmosphereButton.click()
-    // check that parent div.form-group now has a class 'has-error'
-    await verifyFieldIsRequired(
-      $atmosphereDetailsInput,
-      "atmosphereDetails",
-      "input",
-      "Neutral atmospherics details"
-    )
-
-    const $reportPeopleFieldsetTitle = await $(
-      "#reportPeople-fieldset .title-text"
-    )
-    await assertElementText(
-      t,
-      $reportPeopleFieldsetTitle,
-      "People involved in this engagement",
-      "People fieldset should have correct title for an uncancelled enagement"
-    )
-
-    const $cancelledCheckbox = await $(".cancelled-checkbox input")
-    // Move element into view
-    const actions = t.context.driver.actions({ async: true })
-    await actions.move({ origin: $cancelledCheckbox }).perform()
-    await $cancelledCheckbox.click()
-
-    await assertElementNotPresent(
-      t,
-      ".atmosphere-form-group",
-      "After cancelling the enagement, the atmospherics should be hidden",
-      shortWaitMs
-    )
-    const $cancelledReason = await $(".cancelled-reason-form-group")
-    t.true(
-      await $cancelledReason.isDisplayed(),
-      "After cancelling the engagement, the cancellation reason should appear"
-    )
-    await assertElementText(
-      t,
-      $reportPeopleFieldsetTitle,
-      "People who will be involved in this planned engagement",
-      "People fieldset should have correct title for a cancelled enagement"
-    )
-
-    let $advisorAttendeesRows = await $$(".advisorAttendeesTable tbody tr")
-    t.is(
-      $advisorAttendeesRows.length,
-      1,
-      "Advisor attendees table starts with 1 body rows"
-    )
-
-    let $principalAttendeesRows = await $$(".principalAttendeesTable tbody tr")
-    t.is(
-      $principalAttendeesRows.length,
-      1,
-      "Principal attendees table starts with 1 body rows"
-    )
-
-    const [
-      $advisorPrimaryCheckbox,
-      /* eslint-disable no-unused-vars */ $advisorAttendeeCheckbox /* eslint-enable no-unused-vars */,
-      /* eslint-disable no-unused-vars */ $advisorAuthorCheckbox /* eslint-enable no-unused-vars */,
-      /* eslint-disable no-unused-vars */ $advisorConflictBtn /* eslint-enable no-unused-vars */,
-      $advisorName,
-      $advisorPosition,
-      /* eslint-disable no-unused-vars */ $advisorLocation /* eslint-enable no-unused-vars */,
-      $advisorOrg
-    ] = await $$(".advisorAttendeesTable tbody tr:first-child td")
-
-    t.is(
-      await $advisorPrimaryCheckbox
-        .findElement(By.css("input"))
-        .getAttribute("value"),
-      "on",
-      "Advisor primary attendee checkbox should be checked"
-    )
-    await assertElementText(t, $advisorName, "CIV ERINSON, Erin")
-    await assertElementText(t, $advisorPosition, "EF 2.2 Advisor D")
-    await assertElementText(t, $advisorOrg, "EF 2.2")
-
-    const $addAttendeeShortcutButtons = await $$(
-      "#reportPeople-shortcut-list button"
-    )
-    // Add all recent attendees
-    await Promise.all(
-      $addAttendeeShortcutButtons.map($button => $button.click())
-    )
-
-    $advisorAttendeesRows = await $$(".advisorAttendeesTable tbody tr")
-    $principalAttendeesRows = await $$(".principalAttendeesTable tbody tr")
-    t.is(
-      $advisorAttendeesRows.length + $principalAttendeesRows.length,
-      5,
-      "Clicking the shortcut buttons adds rows to the table"
-    )
-
-    const $submitButton = await $("#formBottomSubmit")
-    await $submitButton.click()
-    await pageHelpers.assertReportShowStatusText(
-      t,
-      "This is a DRAFT report and hasn't been submitted."
+      `After typing in ${fieldName} field, warning state goes away`
     )
   }
-)
+
+  const $meetingGoalInput = await $("#intent")
+  // check that parent div.form-group does not have class 'has-error'
+  t.false(
+    (await t.context.driver.findElements(
+      By.css('textarea[id="intent"] ~ div[class="invalid-feedback"]')
+    ).length) > 0,
+    "Meeting goal does not start in an invalid state"
+  )
+  t.is(
+    await $meetingGoalInput.getAttribute("value"),
+    "",
+    "Meeting goal field starts blank"
+  )
+
+  // check that parent div.form-group now has a class 'has-error'
+  await verifyFieldIsRequired(
+    $meetingGoalInput,
+    "intent",
+    "textarea",
+    "Meeting goal"
+  )
+
+  const $engagementDate = await $("#engagementDate")
+  t.is(
+    await $engagementDate.getAttribute("value"),
+    "",
+    "Engagement date field starts blank"
+  )
+  await $engagementDate.click()
+  await t.context.driver.sleep(shortWaitMs) // wait for the datepicker to pop up
+
+  await pageHelpers.clickTodayButton()
+
+  // set time as well
+  const $hourInput = await $("input.bp3-timepicker-input.bp3-timepicker-hour")
+  // clear field, enter data, fire blur event
+  await $hourInput.sendKeys(
+    t.context.Key.END +
+      t.context.Key.BACK_SPACE.repeat(2) +
+      "23" +
+      t.context.Key.TAB
+  )
+  const $minuteInput = await $(
+    "input.bp3-timepicker-input.bp3-timepicker-minute"
+  )
+  // clear field, enter data, fire blur event
+  await $minuteInput.sendKeys(
+    t.context.Key.END +
+      t.context.Key.BACK_SPACE.repeat(2) +
+      "45" +
+      t.context.Key.TAB
+  )
+
+  // check date and time
+  const dateTimeFormat = "DD-MM-YYYY HH:mm"
+  const dateTimeValue = await $engagementDate.getAttribute("value")
+  const expectedDateTime = moment().hour(23).minute(45).format(dateTimeFormat)
+  t.is(
+    dateTimeValue,
+    expectedDateTime,
+    'Clicking the "today" button puts the current date in the engagement field'
+  )
+
+  const $locationInput = await $("#location")
+  t.is(
+    await $locationInput.getAttribute("value"),
+    "",
+    "Location field starts blank"
+  )
+
+  const $locationShortcutButton = await $("#location-shortcut-list button")
+  await $locationShortcutButton.click()
+  t.is(
+    await $locationInput.getAttribute("value"),
+    "General Hospital",
+    "Clicking the shortcut adds a location"
+  )
+
+  await assertElementNotPresent(
+    t,
+    "#cancelledReason",
+    "Cancelled reason should not be present initially",
+    shortWaitMs
+  )
+  const $atmosphereFormGroup = await $(".atmosphere-form-group")
+  t.true(
+    await $atmosphereFormGroup.isDisplayed(),
+    "Atmospherics form group should be shown by default"
+  )
+
+  await assertElementNotPresent(
+    t,
+    "#atmosphere-details",
+    "Atmospherics details should not be displayed before choosing atmospherics",
+    shortWaitMs
+  )
+
+  const $positiveAtmosphereButton = await $('label[for="atmosphere_POSITIVE"]')
+  await $positiveAtmosphereButton.click()
+
+  const $atmosphereDetails = await $("#atmosphereDetails")
+  t.is(
+    await $atmosphereDetails.getAttribute("placeholder"),
+    "Why was this engagement positive? (optional)"
+  )
+
+  const $neutralAtmosphereButton = await $('label[for="atmosphere_NEUTRAL"]')
+  await $neutralAtmosphereButton.click()
+  t.is(
+    (await $atmosphereDetails.getAttribute("placeholder")).trim(),
+    "Why was this engagement neutral?"
+  )
+
+  const $negativeAtmosphereButton = await $('label[for="atmosphere_NEGATIVE"]')
+  await $negativeAtmosphereButton.click()
+  t.is(
+    (await $atmosphereDetails.getAttribute("placeholder")).trim(),
+    "Why was this engagement negative?"
+  )
+
+  const $atmosphereDetailsInput = await t.context.driver.findElement(
+    By.css('input[id="atmosphereDetails"]')
+  )
+
+  await $neutralAtmosphereButton.click()
+  // check that parent div.form-group now has a class 'has-error'
+  await verifyFieldIsRequired(
+    $atmosphereDetailsInput,
+    "atmosphereDetails",
+    "input",
+    "Neutral atmospherics details"
+  )
+
+  const $reportPeopleFieldsetTitle = await $(
+    "#reportPeople-fieldset .title-text"
+  )
+  await assertElementText(
+    t,
+    $reportPeopleFieldsetTitle,
+    "People involved in this engagement",
+    "People fieldset should have correct title for an uncancelled enagement"
+  )
+
+  const $cancelledCheckbox = await $(".cancelled-checkbox input")
+  // Move element into view
+  const actions = t.context.driver.actions({ async: true })
+  await actions.move({ origin: $cancelledCheckbox }).perform()
+  await $cancelledCheckbox.click()
+
+  await assertElementNotPresent(
+    t,
+    ".atmosphere-form-group",
+    "After cancelling the enagement, the atmospherics should be hidden",
+    shortWaitMs
+  )
+  const $cancelledReason = await $(".cancelled-reason-form-group")
+  t.true(
+    await $cancelledReason.isDisplayed(),
+    "After cancelling the engagement, the cancellation reason should appear"
+  )
+  await assertElementText(
+    t,
+    $reportPeopleFieldsetTitle,
+    "People who will be involved in this planned engagement",
+    "People fieldset should have correct title for a cancelled enagement"
+  )
+
+  let $advisorAttendeesRows = await $$(".advisorAttendeesTable tbody tr")
+  t.is(
+    $advisorAttendeesRows.length,
+    1,
+    "Advisor attendees table starts with 1 body rows"
+  )
+
+  let $principalAttendeesRows = await $$(".principalAttendeesTable tbody tr")
+  t.is(
+    $principalAttendeesRows.length,
+    1,
+    "Principal attendees table starts with 1 body rows"
+  )
+
+  const [
+    $advisorPrimaryCheckbox,
+    /* eslint-disable no-unused-vars */ $advisorAttendeeCheckbox /* eslint-enable no-unused-vars */,
+    /* eslint-disable no-unused-vars */ $advisorAuthorCheckbox /* eslint-enable no-unused-vars */,
+    /* eslint-disable no-unused-vars */ $advisorConflictBtn /* eslint-enable no-unused-vars */,
+    $advisorName,
+    $advisorPosition,
+    /* eslint-disable no-unused-vars */ $advisorLocation /* eslint-enable no-unused-vars */,
+    $advisorOrg
+  ] = await $$(".advisorAttendeesTable tbody tr:first-child td")
+
+  t.is(
+    await $advisorPrimaryCheckbox
+      .findElement(By.css("input"))
+      .getAttribute("value"),
+    "on",
+    "Advisor primary attendee checkbox should be checked"
+  )
+  await assertElementText(t, $advisorName, "CIV ERINSON, Erin")
+  await assertElementText(t, $advisorPosition, "EF 2.2 Advisor D")
+  await assertElementText(t, $advisorOrg, "EF 2.2")
+
+  const $addAttendeeShortcutButtons = await $$(
+    "#reportPeople-shortcut-list button"
+  )
+  // Add all recent attendees
+  await Promise.all($addAttendeeShortcutButtons.map($button => $button.click()))
+
+  $advisorAttendeesRows = await $$(".advisorAttendeesTable tbody tr")
+  $principalAttendeesRows = await $$(".principalAttendeesTable tbody tr")
+  t.is(
+    $advisorAttendeesRows.length + $principalAttendeesRows.length,
+    5,
+    "Clicking the shortcut buttons adds rows to the table"
+  )
+
+  const $submitButton = await $("#formBottomSubmit")
+  await $submitButton.click()
+  await pageHelpers.assertReportShowStatusText(
+    t,
+    "This is a DRAFT report and hasn't been submitted."
+  )
+})

--- a/client/tests/e2e/report.js
+++ b/client/tests/e2e/report.js
@@ -596,7 +596,7 @@ test.serial(
       "People fieldset should have correct title for an uncancelled enagement"
     )
 
-    const $cancelledCheckbox = await $(".cancelled-checkbox")
+    const $cancelledCheckbox = await $(".cancelled-checkbox input")
     // Move element into view
     const actions = t.context.driver.actions({ async: true })
     await actions.move({ origin: $cancelledCheckbox }).perform()

--- a/client/tests/util/test.js
+++ b/client/tests/util/test.js
@@ -43,6 +43,52 @@ function debugLog(...args) {
   }
 }
 
+let bsLocal
+
+test.before(async t => {
+  if (testEnv !== "local") {
+    const browserstack = require("browserstack-local")
+    bsLocal = new browserstack.Local()
+    const bsOptions = capabilities["bstack:options"]
+    const bsLocalArgs = {
+      force: true,
+      forceLocal: true,
+      onlyAutomate: true,
+      key: bsOptions.accessKey,
+      localIdentifier: bsOptions.localIdentifier
+    }
+    console.log("Starting BrowserStackLocal")
+    await new Promise((resolve, reject) => {
+      bsLocal.start(bsLocalArgs, error => {
+        if (error) {
+          console.error("Failed to start BrowserStackLocal:", error)
+          reject(error)
+        } else {
+          console.log("Started BrowserStackLocal")
+          resolve(bsLocal)
+        }
+      })
+    })
+  }
+})
+
+test.after.always(async t => {
+  if (bsLocal) {
+    console.log("Stopping BrowserStackLocal")
+    await new Promise((resolve, reject) => {
+      bsLocal.stop(error => {
+        if (error) {
+          console.error("Failed to stop BrowserStackLocal:", error)
+          reject(error)
+        } else {
+          console.log("Stopped BrowserStackLocal")
+          resolve(bsLocal)
+        }
+      })
+    })
+  }
+})
+
 // We use the before hook to put helpers on t.context and set up test scaffolding.
 test.beforeEach(t => {
   let builder = new webdriver.Builder()

--- a/client/tests/webdriver/baseSpecs/createReportWithPlanningConflict.spec.js
+++ b/client/tests/webdriver/baseSpecs/createReportWithPlanningConflict.spec.js
@@ -34,6 +34,7 @@ describe("When creating a Report with conflicts", () => {
 
   it("Should create first draft report without any conflicts", () => {
     CreateReport.open()
+    browser.pause(500) // wait for the page transition and rendering of custom fields
     CreateReport.fillForm(report01)
 
     expect(CreateReport.intent.getValue()).to.equal(report01.intent)
@@ -66,6 +67,7 @@ describe("When creating a Report with conflicts", () => {
 
   it("Should create second draft report with conflicts", () => {
     CreateReport.open()
+    browser.pause(500) // wait for the page transition and rendering of custom fields
     CreateReport.fillForm(report02)
 
     expect(CreateReport.intent.getValue()).to.equal(report02.intent)

--- a/client/tests/webdriver/baseSpecs/mergeLocations.spec.js
+++ b/client/tests/webdriver/baseSpecs/mergeLocations.spec.js
@@ -23,6 +23,7 @@ describe("Merge locations page", () => {
     MergeLocations.leftLocationField.setValue(EXAMPLE_LOCATIONS.left.search)
     MergeLocations.waitForAdvancedSelectLoading(EXAMPLE_LOCATIONS.left.fullName)
     MergeLocations.firstItemFromAdvancedSelect.click()
+    browser.pause(500) // wait for the rendering of custom fields
     MergeLocations.waitForColumnToChange(EXAMPLE_LOCATIONS.left.name, "left")
 
     expect(MergeLocations.getColumnLocationName("left").getText()).to.eq(
@@ -34,6 +35,7 @@ describe("Merge locations page", () => {
       EXAMPLE_LOCATIONS.right.fullName
     )
     MergeLocations.firstItemFromAdvancedSelect.click()
+    browser.pause(500) // wait for the rendering of custom fields
     MergeLocations.waitForColumnToChange(EXAMPLE_LOCATIONS.right.name, "right")
 
     expect(MergeLocations.getColumnLocationName("right").getText()).to.eq(
@@ -43,6 +45,7 @@ describe("Merge locations page", () => {
 
   it("Should be able to select all fields from left location", () => {
     MergeLocations.getUseAllButton("left").click()
+    browser.pause(500) // wait for the rendering of custom fields
     MergeLocations.waitForColumnToChange(EXAMPLE_LOCATIONS.left.name, "mid")
 
     expect(MergeLocations.getColumnLocationName("mid").getText()).to.eq(
@@ -52,6 +55,7 @@ describe("Merge locations page", () => {
 
   it("Should be able to select all fields from right location", () => {
     MergeLocations.getUseAllButton("right").click()
+    browser.pause(500) // wait for the rendering of custom fields
     MergeLocations.waitForColumnToChange(EXAMPLE_LOCATIONS.right.name, "mid")
 
     expect(MergeLocations.getColumnLocationName("mid").getText()).to.eq(
@@ -61,6 +65,7 @@ describe("Merge locations page", () => {
 
   it("Should be able to merge both locations when winner is left location", () => {
     MergeLocations.getUseAllButton("left").click()
+    browser.pause(500) // wait for the rendering of custom fields
     MergeLocations.waitForColumnToChange(EXAMPLE_LOCATIONS.left.name, "mid")
 
     MergeLocations.mergeLocationsButton.click()

--- a/client/tests/webdriver/baseSpecs/mergePositions.spec.js
+++ b/client/tests/webdriver/baseSpecs/mergePositions.spec.js
@@ -62,6 +62,7 @@ describe("Merge positions page", () => {
       EXAMPLE_POSITIONS.validLeft.fullName
     )
     MergePositions.firstItemFromAdvancedSelect.click()
+    browser.pause(500) // wait for the rendering of custom fields
     // Check if the fields displayed properly after selecting a position from left side.
     MergePositions.waitForColumnToChange(
       EXAMPLE_POSITIONS.validLeft.fullName,
@@ -124,6 +125,7 @@ describe("Merge positions page", () => {
       EXAMPLE_POSITIONS.validRight.fullName
     )
     MergePositions.firstItemFromAdvancedSelect.click()
+    browser.pause(500) // wait for the rendering of custom fields
     // Check if the fields displayed properly after selecting a position from left side.
     MergePositions.waitForColumnToChange(
       EXAMPLE_POSITIONS.validRight.fullName,
@@ -157,6 +159,7 @@ describe("Merge positions page", () => {
   })
   it("Should be able to select all fields from left position", () => {
     MergePositions.getUseAllButton("left").click()
+    browser.pause(500) // wait for the rendering of custom fields
 
     MergePositions.waitForColumnToChange(
       EXAMPLE_POSITIONS.validLeft.fullName,
@@ -193,6 +196,7 @@ describe("Merge positions page", () => {
   })
   it("Should be able to select all fields from right position", () => {
     MergePositions.getUseAllButton("right").click()
+    browser.pause(500) // wait for the rendering of custom fields
 
     MergePositions.waitForColumnToChange(
       EXAMPLE_POSITIONS.validRight.fullName,
@@ -260,6 +264,7 @@ describe("Merge positions page", () => {
   })
   it("Should display correct values on the left column", () => {
     MergePositions.getUseAllButton("left").click()
+    browser.pause(500) // wait for the rendering of custom fields
     MergePositions.waitForColumnToChange(
       EXAMPLE_POSITIONS.validLeft.fullName,
       "mid",

--- a/client/tests/webdriver/baseSpecs/mergePositions.spec.js
+++ b/client/tests/webdriver/baseSpecs/mergePositions.spec.js
@@ -231,7 +231,7 @@ describe("Merge positions page", () => {
       EXAMPLE_POSITIONS.validRight.location
     )
   })
-  it("Sould be able to select from both left and right side.", () => {
+  it("Should be able to select from both left and right side.", () => {
     MergePositions.getSelectButton("left", "Name").click()
     MergePositions.waitForColumnToChange(
       EXAMPLE_POSITIONS.validLeft.fullName,

--- a/client/tests/webdriver/baseSpecs/myTasks.spec.js
+++ b/client/tests/webdriver/baseSpecs/myTasks.spec.js
@@ -30,7 +30,7 @@ describe("My tasks page", () => {
       // table has a header and 5 task rows
       expect(myOrgAssignedTasksItems).to.have.length(6)
     })
-    it("Should see a table of the tasks being the reposnibility of the current user", () => {
+    it("Should see a table of the tasks being the responsibility of the current user", () => {
       MyTasks.myResponsibleTasks.waitForDisplayed()
       const myResponsibleTasksItems = MyTasks.myResponsibleTasks.$$("tr")
       expect(myResponsibleTasksItems).to.have.length(0)

--- a/client/tests/webdriver/baseSpecs/newUserUtils.js
+++ b/client/tests/webdriver/baseSpecs/newUserUtils.js
@@ -31,6 +31,7 @@ export function createOnboardingNewPerson(
   CreatePerson.endOfTourDate.setValue(personDetails.endOfTourDate)
 
   CreatePerson.submitForm()
+  Home.waitForAlertWarningToLoad()
   Home.onboardingPopover.waitForExist()
   Home.onboardingPopover.waitForDisplayed()
 }

--- a/client/tests/webdriver/baseSpecs/onboardNewUser.spec.js
+++ b/client/tests/webdriver/baseSpecs/onboardNewUser.spec.js
@@ -1,16 +1,20 @@
 import { expect } from "chai"
-import CreatePerson from "../pages/createNewPerson.page"
+import moment from "moment"
 import OnboardPage from "../pages/onboard.page"
-import { createOnboardingNewPerson } from "./newUserUtils"
+
+// Only required fields in onboarding/edit page
+const personDetails = {
+  lastName: "BONNSDOTTIR",
+  firstName: "Bonnie",
+  emailAddress: "bonny@cmil.mil",
+  rank: "CIV",
+  gender: "FEMALE",
+  country: "Albania",
+  endOfTourDate: moment().add(1, "days").format("DD-MM-YYYY")
+}
 
 describe("Onboard new user login", () => {
-  it("Should successfully create an account", () => {
-    // unique name if we want to run tests without resetting DB
-    OnboardPage.openAsOnboardUser("/", `bonny${Date.now()}`)
-    createOnboardingNewPerson()
-  })
-
-  it('Should show onboard welcome"', () => {
+  it("Should show onboard welcome", () => {
     // give unique name to avoid collision when running tests (without resetting DB)
     OnboardPage.openAsOnboardUser("/", `bonny${Date.now()}`)
     const welcomeText = "Welcome to ANET"
@@ -21,19 +25,21 @@ describe("Onboard new user login", () => {
   })
 
   it("Should click on create your account", () => {
+    OnboardPage.createYourAccountBtn.scrollIntoView()
     OnboardPage.createYourAccountBtn.click()
+    browser.pause(500) // wait for the page transition and rendering of custom fields
   })
 
   it("Should not save if endOfTourDate is not in the future", () => {
-    CreatePerson.endOfTourDate.waitForExist()
-    CreatePerson.endOfTourDate.click()
+    OnboardPage.endOfTourDate.waitForExist()
+    OnboardPage.endOfTourDate.click()
 
-    CreatePerson.endOfTourToday.waitForDisplayed()
-    CreatePerson.endOfTourToday.waitForExist()
+    OnboardPage.endOfTourToday.waitForDisplayed()
+    OnboardPage.endOfTourToday.waitForExist()
     // select a date
-    CreatePerson.endOfTourToday.click()
-    CreatePerson.lastName.click()
-    const errorMessage = CreatePerson.endOfTourDate
+    OnboardPage.endOfTourToday.click()
+    OnboardPage.lastName.click()
+    const errorMessage = OnboardPage.endOfTourDate
       .$("..")
       .$("..")
       .$("..")
@@ -44,5 +50,21 @@ describe("Onboard new user login", () => {
     expect(errorMessage.getText()).to.equal(
       "The End of tour date must be in the future"
     )
+  })
+
+  it("Should save if all fields properly filled", () => {
+    OnboardPage.lastName.setValue(personDetails.lastName)
+    OnboardPage.firstName.setValue(personDetails.firstName)
+    OnboardPage.emailAddress.setValue(personDetails.emailAddress)
+    OnboardPage.rank.selectByAttribute("value", personDetails.rank)
+    OnboardPage.gender.selectByAttribute("value", personDetails.gender)
+    OnboardPage.country.selectByAttribute("value", personDetails.country)
+    OnboardPage.endOfTourDate.setValue(personDetails.endOfTourDate)
+    browser.pause(500) // wait for the error message to disappear
+    OnboardPage.submitForm()
+
+    OnboardPage.waitForAlertWarningToLoad()
+    OnboardPage.onboardingPopover.waitForExist()
+    OnboardPage.onboardingPopover.waitForDisplayed()
   })
 })

--- a/client/tests/webdriver/customFieldsSpecs/createFutureReport.spec.js
+++ b/client/tests/webdriver/customFieldsSpecs/createFutureReport.spec.js
@@ -146,11 +146,7 @@ describe("Create report form page", () => {
       CreateFutureReport.attendeesFieldLabel.waitForDisplayed()
 
       // Set engagement date to tomorrow
-      CreateFutureReport.engagementDate.click()
-      // Clumsy way to clear input first…
-      browser.keys(
-        ["End"].concat(Array(ENGAGEMENT_DATE_FORMAT.length).fill("Backspace"))
-      )
+      CreateFutureReport.deleteInput(CreateFutureReport.engagementDate)
       CreateFutureReport.engagementDate.setValue(
         moment().add(1, "days").format(ENGAGEMENT_DATE_FORMAT)
       )

--- a/client/tests/webdriver/customFieldsSpecs/createReport.spec.js
+++ b/client/tests/webdriver/customFieldsSpecs/createReport.spec.js
@@ -31,6 +31,7 @@ describe("Create report form page", () => {
   describe("When creating a report", () => {
     it("Should be able to load the form", () => {
       CreateReport.open()
+      browser.pause(500) // wait for the page transition and rendering of custom fields
       CreateReport.form.waitForExist()
       CreateReport.form.waitForDisplayed()
     })
@@ -277,10 +278,12 @@ describe("Create report form page", () => {
         REPORT_VALUE
       )
       // Delete selected value
+      CreateReport.testReferenceFieldValue.scrollIntoView()
       CreateReport.testReferenceFieldValue.$("button").click()
 
       CreateReport.testMultiReferenceFieldLabel.waitForExist()
       CreateReport.testMultiReferenceFieldLabel.waitForDisplayed()
+      CreateReport.testMultiReferenceFieldLabel.scrollIntoView()
       // Default input type is People
       expect(
         CreateReport.testMultiReferenceField.getAttribute("placeholder")
@@ -300,9 +303,11 @@ describe("Create report form page", () => {
         CreateReport.getTestMultiReferenceFieldValueRow(4).getText()
       ).to.include(POSITION_VALUE_3)
       // Delete selected values
-      CreateReport.testMultiReferenceFieldValueRows.forEach(r =>
-        r.$("button").click()
-      )
+      CreateReport.testMultiReferenceFieldValueRows.forEach(r => {
+        const button = r.$("button")
+        button.scrollIntoView()
+        button.click()
+      })
     })
 
     it("Should be able to save a report without any ANET object references", () => {

--- a/client/tests/webdriver/customFieldsSpecs/customFields.spec.js
+++ b/client/tests/webdriver/customFieldsSpecs/customFields.spec.js
@@ -79,6 +79,7 @@ describe("When working with custom fields for different anet objects", () => {
     })
 
     it("Should persist previous invalid data when toggling field's visibility", () => {
+      CreateReport.deleteInput(CreateReport.numberTrainedField)
       CreateReport.numberTrainedField.setValue(INVALID_NUMBER_INPUT)
       CreateReport.numberTrainedErrorText.waitForExist()
       // Actually see the validation warning
@@ -101,6 +102,7 @@ describe("When working with custom fields for different anet objects", () => {
     })
 
     it("Should validate visible field", () => {
+      CreateReport.deleteInput(CreateReport.numberTrainedField)
       CreateReport.numberTrainedField.setValue(INVALID_NUMBER_INPUT)
       CreateReport.numberTrainedErrorText.waitForExist()
       expect(CreateReport.numberTrainedErrorText.getText()).to.include(
@@ -146,6 +148,7 @@ describe("When working with custom fields for different anet objects", () => {
       // turn on train option to make numberField visible
       trainButton.click()
       CreateReport.numberTrainedFormGroup.waitForExist()
+      CreateReport.deleteInput(CreateReport.numberTrainedField)
       CreateReport.numberTrainedField.setValue(VALID_NUMBER_INPUT)
 
       CreateReport.submitForm()
@@ -165,6 +168,7 @@ describe("When working with custom fields for different anet objects", () => {
         TRAIN_ENGAGEMENT_BUTTON
       )
       // give valid input before making invisible
+      CreateReport.deleteInput(CreateReport.numberTrainedField)
       CreateReport.numberTrainedField.setValue(VALID_NUMBER_INPUT)
       // goes invisible
       trainButton.click()
@@ -225,6 +229,7 @@ describe("When working with custom fields for different anet objects", () => {
     })
 
     it("Should persist previous invalid data when toggling field's visibility", () => {
+      CreateReport.deleteInput(CreateReport.numberCustomField)
       CreatePerson.numberCustomField.setValue(INVALID_NUMBER_INPUT)
       // Actually see the validation warning
       CreatePerson.numberCustomFieldHelpText.waitForExist()
@@ -241,6 +246,7 @@ describe("When working with custom fields for different anet objects", () => {
     })
 
     it("Should validate visible field", () => {
+      CreateReport.deleteInput(CreateReport.numberCustomField)
       CreatePerson.numberCustomField.setValue(INVALID_NUMBER_INPUT)
       CreatePerson.numberCustomFieldHelpText.waitForExist()
       expect(CreatePerson.numberCustomFieldHelpText.getText()).to.include(

--- a/client/tests/webdriver/customFieldsSpecs/pendingAssessments.spec.js
+++ b/client/tests/webdriver/customFieldsSpecs/pendingAssessments.spec.js
@@ -183,6 +183,8 @@ describe("In new report page", () => {
         tasks: ["1.2.A"]
       }
       CreateReport.fillForm(report)
+      browser.pause(SHORT_WAIT_MS) // wait for assessment questions to be updated
+      CreateReport.tasksAssessments.scrollIntoView()
       const taskAssessmentRows = CreateReport.taskAssessmentRows
       expect(taskAssessmentRows).to.have.length(2)
       for (let i = 0; i < 2; i += 2) {
@@ -211,6 +213,8 @@ describe("In new report page", () => {
         ]
       }
       CreateReport.fillForm(report)
+      browser.pause(SHORT_WAIT_MS) // wait for assessment questions to be updated
+      CreateReport.attendeesAssessments.scrollIntoView()
       const attendeeAssessmentRows = CreateReport.attendeeAssessmentRows
       expect(attendeeAssessmentRows).to.have.length(6)
       for (let i = 0; i < 6; i += 2) {
@@ -238,6 +242,8 @@ describe("In new report page", () => {
     })
     it("Should have an additional question for positive atmosphere", () => {
       CreateReport.positiveAtmosphere.click()
+      browser.pause(SHORT_WAIT_MS) // wait for assessment questions to be updated
+      CreateReport.attendeesAssessments.scrollIntoView()
       const attendeeAssessmentRows = CreateReport.attendeeAssessmentRows
       expect(attendeeAssessmentRows).to.have.length(6)
       for (let i = 0; i < 6; i += 2) {

--- a/client/tests/webdriver/ie/ie11RetiredBanner.spec.js
+++ b/client/tests/webdriver/ie/ie11RetiredBanner.spec.js
@@ -1,24 +1,21 @@
 import { expect } from "chai"
 import Home from "../pages/home.page"
 
-describe("Anet home page on IE 11", () => {
+describe("ANET home page on IE 11", () => {
   it("should have the correct title", () => {
-    Home.open()
+    Home.openWithoutWaiting() // no loading indicator appears
     expect(browser.getTitle()).to.equal("ANET")
   })
 
   it("should have the IE not supported banner", () => {
-    Home.open()
-    expect(Home.ie11BannerText).to.equal(
+    expect(Home.ieBannerText).to.equal(
       "Internet Explorer is not fully supported by ANET. Some features may not work. Please consider switching to a modern browser."
     )
   })
 
   it("should display banner text in one line when screen resolution is 1024x768", () => {
-    Home.open()
-    browser.setWindowSize(1024, 768)
-    const size = browser.$("#ieBanner").getSize()
-    expect(size.width).to.equal(1008) // 16px vertical scrollbar
+    const size = Home.ieBanner.getSize()
+    expect(size.width).to.equal(1024)
     expect(size.height).to.equal(32)
   })
 })

--- a/client/tests/webdriver/pages/createAuthorizationGroup.page.js
+++ b/client/tests/webdriver/pages/createAuthorizationGroup.page.js
@@ -56,13 +56,6 @@ class CreateAuthorizationGroup extends Page {
     super.openAsAdminUser(PAGE_URL)
   }
 
-  waitForAlertSuccessToLoad() {
-    if (!this.alertSuccess.isDisplayed()) {
-      this.alertSuccess.waitForExist()
-      this.alertSuccess.waitForDisplayed()
-    }
-  }
-
   waitForPositionsAdvancedSelectToChange(value) {
     this.positionsAdvancedSelectFirstItem.waitForExist()
     return browser.waitUntil(

--- a/client/tests/webdriver/pages/createNewOrganization.page.js
+++ b/client/tests/webdriver/pages/createNewOrganization.page.js
@@ -19,13 +19,6 @@ class CreateOrganization extends Page {
     super.openAsAdminUser(PAGE_URL)
   }
 
-  waitForAlertSuccessToLoad() {
-    if (!this.alertSuccess.isDisplayed()) {
-      this.alertSuccess.waitForExist()
-      this.alertSuccess.waitForDisplayed()
-    }
-  }
-
   submitForm() {
     this.submitButton.click()
   }

--- a/client/tests/webdriver/pages/createNewPerson.page.js
+++ b/client/tests/webdriver/pages/createNewPerson.page.js
@@ -187,13 +187,6 @@ class CreatePerson extends Page {
     super.openAsAdminUser(PAGE_URL)
   }
 
-  waitForAlertSuccessToLoad() {
-    if (!this.alertSuccess.isDisplayed()) {
-      this.alertSuccess.waitForExist()
-      this.alertSuccess.waitForDisplayed()
-    }
-  }
-
   submitForm() {
     this.submitButton.click()
   }

--- a/client/tests/webdriver/pages/createNewPerson.page.js
+++ b/client/tests/webdriver/pages/createNewPerson.page.js
@@ -12,7 +12,7 @@ const SENSITIVE_CUSTOM_FIELDS = {
   politicalPosition: "formSensitiveFields.politicalPosition"
 }
 
-class CreatePerson extends Page {
+export class CreatePerson extends Page {
   get form() {
     return browser.$("form.form-horizontal")
   }

--- a/client/tests/webdriver/pages/createNewPosition.page.js
+++ b/client/tests/webdriver/pages/createNewPosition.page.js
@@ -86,13 +86,6 @@ class CreatePosition extends Page {
     super.openAsAdminUser(PAGE_URL)
   }
 
-  waitForAlertSuccessToLoad() {
-    if (!this.alertSuccess.isDisplayed()) {
-      this.alertSuccess.waitForExist()
-      this.alertSuccess.waitForDisplayed()
-    }
-  }
-
   waitForOrgAdvancedSelectToChange(value) {
     this.orgAdvancedSelectFirstItem.waitForExist()
     return browser.waitUntil(

--- a/client/tests/webdriver/pages/createNewTask.page.js
+++ b/client/tests/webdriver/pages/createNewTask.page.js
@@ -60,13 +60,6 @@ class CreateTask extends Page {
     super.openAsAdminUser(PAGE_URL)
   }
 
-  waitForAlertSuccessToLoad() {
-    if (!this.alertSuccess.isDisplayed()) {
-      this.alertSuccess.waitForExist()
-      this.alertSuccess.waitForDisplayed()
-    }
-  }
-
   submitForm() {
     this.submitButton.click()
   }

--- a/client/tests/webdriver/pages/home.page.js
+++ b/client/tests/webdriver/pages/home.page.js
@@ -5,11 +5,12 @@ class Home extends Page {
     return browser.$("#topbar")
   }
 
-  get ie11BannerText() {
-    const ieBanner = browser.$("#ieBanner")
-    ieBanner.waitForExist()
-    ieBanner.waitForDisplayed()
-    return browser.$("#ieBanner > div:nth-child(2)").getText()
+  get ieBanner() {
+    return browser.$("#ieBanner")
+  }
+
+  get ieBannerText() {
+    return this.ieBanner.$("div:nth-child(2)").getText()
   }
 
   get securityBanner() {

--- a/client/tests/webdriver/pages/home.page.js
+++ b/client/tests/webdriver/pages/home.page.js
@@ -62,10 +62,6 @@ class Home extends Page {
     return this.myTasksLink.$("span.badge")
   }
 
-  get onboardingPopover() {
-    return browser.$(".hopscotch-bubble-container")
-  }
-
   waitForSecurityBannerValue(value) {
     this.securityBanner.waitForExist()
     this.securityBanner.waitForDisplayed()

--- a/client/tests/webdriver/pages/onboard.page.js
+++ b/client/tests/webdriver/pages/onboard.page.js
@@ -1,8 +1,12 @@
-import Page from "./page"
+import { CreatePerson } from "./createNewPerson.page"
 
-class Onboard extends Page {
+class Onboard extends CreatePerson {
   get welcomeText() {
     return browser.$(".onboarding-new h1")
+  }
+
+  get onboardingPopover() {
+    return browser.$(".hopscotch-bubble-container")
   }
 
   get createYourAccountBtn() {
@@ -10,8 +14,10 @@ class Onboard extends Page {
   }
 
   waitForWelcomeMessage(value) {
-    this.welcomeText.waitForExist()
-    this.welcomeText.waitForDisplayed()
+    if (!this.welcomeText.isDisplayed()) {
+      this.welcomeText.waitForExist()
+      this.welcomeText.waitForDisplayed()
+    }
     return browser.waitUntil(
       () => {
         return this.welcomeText.getText() === value

--- a/client/tests/webdriver/pages/page.js
+++ b/client/tests/webdriver/pages/page.js
@@ -59,6 +59,17 @@ class Page {
     this._open(pathName, uniqueName)
   }
 
+  get alertSuccess() {
+    return browser.$(".alert-success")
+  }
+
+  waitForAlertSuccessToLoad() {
+    if (!this.alertSuccess.isDisplayed()) {
+      this.alertSuccess.waitForExist()
+      this.alertSuccess.waitForDisplayed()
+    }
+  }
+
   getRandomOption(select) {
     const options = select.$$("option")
     // Ignore the first option, it is always the empty one

--- a/client/tests/webdriver/pages/page.js
+++ b/client/tests/webdriver/pages/page.js
@@ -58,6 +58,19 @@ class Page {
     const index = 1 + Math.floor(Math.random() * (options.length - 1))
     return options[index].getValue()
   }
+
+  deleteText(text = "") {
+    // Clumsy way to clear text…
+    browser.keys(["End"].concat(Array(text.length).fill("Backspace")))
+  }
+
+  deleteInput(inputField) {
+    // Clumsy way to clear input…
+    if (inputField && inputField.isDisplayed()) {
+      inputField.click()
+      this.deleteText(inputField.getValue())
+    }
+  }
 }
 
 export default Page

--- a/client/tests/webdriver/pages/page.js
+++ b/client/tests/webdriver/pages/page.js
@@ -70,6 +70,17 @@ class Page {
     }
   }
 
+  get alertWarning() {
+    return browser.$(".alert-warning")
+  }
+
+  waitForAlertWarningToLoad() {
+    if (!this.alertWarning.isDisplayed()) {
+      this.alertWarning.waitForExist()
+      this.alertWarning.waitForDisplayed()
+    }
+  }
+
   getRandomOption(select) {
     const options = select.$$("option")
     // Ignore the first option, it is always the empty one

--- a/client/tests/webdriver/pages/page.js
+++ b/client/tests/webdriver/pages/page.js
@@ -29,6 +29,13 @@ class Page {
     this.waitUntilLoaded()
   }
 
+  openWithoutWaiting(
+    pathName = "/",
+    credentials = Page.DEFAULT_CREDENTIALS.user
+  ) {
+    browser.url(this._buildUrl(pathName, credentials))
+  }
+
   open(pathName = "/", credentials = Page.DEFAULT_CREDENTIALS.user) {
     this._open(pathName, credentials)
   }

--- a/client/tests/webdriver/pages/report/editReport.page.js
+++ b/client/tests/webdriver/pages/report/editReport.page.js
@@ -21,10 +21,6 @@ class EditReport extends Page {
     return browser.$("div.triggerable-confirm-bootstrap-modal")
   }
 
-  get alertSuccess() {
-    return browser.$(".alert-success")
-  }
-
   confirmDeleteButton(uuid) {
     return browser.$('//button[text()="Yes, I am sure"]')
   }
@@ -64,13 +60,6 @@ class EditReport extends Page {
     if (!this.submitButton.isDisplayed()) {
       this.submitButton.waitForExist()
       this.submitButton.waitForDisplayed()
-    }
-  }
-
-  waitForAlertSuccessToLoad() {
-    if (!this.alertSuccess.isDisplayed()) {
-      this.alertSuccess.waitForExist()
-      this.alertSuccess.waitForDisplayed()
     }
   }
 }

--- a/client/tests/webdriver/pages/showPerson.page.js
+++ b/client/tests/webdriver/pages/showPerson.page.js
@@ -145,14 +145,10 @@ class ShowPerson extends Page {
     // Wait for the editor to be focused
     browser.pause(300)
     if (prevTextToClear) {
-      // remove previous text by deleting characters one by one
-      const chars = [...prevTextToClear]
-      browser.keys(chars.map(char => "Backspace"))
-      // maybe we clicked at the beginning of the text, Backspace doesn't clear
-      browser.keys(chars.map(char => "Delete"))
+      this.deleteText(prevTextToClear)
+      // Wait for the previous value to be deleted
+      browser.pause(300)
     }
-    // Wait for the previous value to be deleted
-    browser.pause(300)
     // fourth value is the text field
     browser.keys(valuesArr[3])
     browser.pause(300)

--- a/client/tests/webdriver/pages/showTask.page.js
+++ b/client/tests/webdriver/pages/showTask.page.js
@@ -65,14 +65,10 @@ class ShowTask extends Page {
     // Wait for the editor to be focused
     browser.pause(300)
     if (prevTextToClear) {
-      // remove previous text by deleting characters one by one
-      const chars = [...prevTextToClear]
-      browser.keys(chars.map(char => "Backspace"))
-      // maybe we clicked at the beginning of the text, Backspace doesn't clear
-      browser.keys(chars.map(char => "Delete"))
+      this.deleteText(prevTextToClear)
+      // Wait for the previous value to be deleted
+      browser.pause(300)
     }
-    // Wait for the previous value to be deleted
-    browser.pause(300)
     browser.keys(valuesArr[0])
 
     const button = this.assessmentModalForm

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -5958,7 +5958,7 @@ browserslist@^4.12.0, browserslist@^4.14.5, browserslist@^4.16.6, browserslist@^
     node-releases "^2.0.1"
     picocolors "^1.0.0"
 
-browserstack-local@^1.4.5:
+browserstack-local@1.4.8, browserstack-local@^1.4.5:
   version "1.4.8"
   resolved "https://registry.yarnpkg.com/browserstack-local/-/browserstack-local-1.4.8.tgz#07f74a19b324cf2de69ffe65f9c2baa3a2dd9a0e"
   integrity sha512-s+mc3gTOJwELdLWi4qFVKtGwMbb5JWsR+JxKlMaJkRJxoZ0gg3WREgPxAN0bm6iU5+S4Bi0sz0oxBRZT8BiNsQ==

--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -177,9 +177,8 @@ await t.context.waitForever()
 In rare circumstances, when using Chrome, the tests will hang on the `data:,` URL. I don't know why this is. If you re-run the test, you should not see the issue a second time.
 
 #### Client-side testing remotely
-To run the tests remotely, two things are needed:
-1. a [username and access key](https://www.browserstack.com/accounts/settings) for BrowserStack
-1. a [Local Testing connection](https://www.browserstack.com/local-testing#command-line) to BrowserStack
+To run the tests remotely, you need
+a [username and access key](https://www.browserstack.com/accounts/settings) for BrowserStack.
 
 Look up your settings and put them in `client/config/default.json`:
 ```json
@@ -194,14 +193,10 @@ If you want step-by-step screenshots from your tests (_Visual Logs_ on BrowserSt
 ```
 to your `default.json`.
 
-Then [download](https://www.browserstack.com/local-testing/releases) the appropriate `BrowserStackLocal`, unpack it.
+Note that both the E2E and the wdio tests will automatically start (and stop) BrowserStackLocal during the tests.
 
 When all is set up, run the remote tests:
-1. Run `BrowserStackLocal` with your key:
-    ```
-    $ ./BrowserStackLocal --key mYbRoWsErStAcKkEy
-   ```
-1. Configure scripts with `TEST_ENV` envrironment variable for remote testing:
+1. Configure scripts with `TEST_ENV` environment variable for remote testing:
     ```
     $ export TEST_ENV=remote
     ```

--- a/testDictionaries/no-custom-fields.yml
+++ b/testDictionaries/no-custom-fields.yml
@@ -290,21 +290,13 @@ fields:
         - prevPositions
         - domainUsername
         - emailAddress
-        - multipleButtons
-        - inputFieldName
         - phoneNumber
         - country
-        - colourOptions
-        - textareaFieldName
         - code
         - rank
-        - numberFieldName
-        - nlt
-        - nlt_dt
         - gender
         - endOfTourDate
         - biography
-        - arrayFieldName
     position:
       name: NATO Billet
       type: ANET User
@@ -431,22 +423,14 @@ fields:
         - phoneNumber
         - country
         - birthday
-        - colourOptions
-        - textareaFieldName
         - domainUsername
         - emailAddress
-        - multipleButtons
-        - inputFieldName
         - code
         - politicalPosition
         - rank
-        - numberFieldName
-        - nlt
-        - nlt_dt
         - gender
         - endOfTourDate
         - biography
-        - arrayFieldName
     position:
       name: Afghan Tashkil
       type: Afghan Partner


### PR DESCRIPTION
For tagged builds, tests will now again be run against BrowserStack.

Closes [AB#242](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/242)

#### User changes
- none

#### Super User changes
- none

#### Admin changes
- none

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [x] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [x] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here