### PR TITLE
Show field validation errors for button groups and links to ANET objects

### DIFF
--- a/client/src/components/FieldHelper.js
+++ b/client/src/components/FieldHelper.js
@@ -449,7 +449,7 @@ const ButtonToggleGroupField = ({
         {!_isEmpty(buttons) && enableClear && (
           <RemoveButton
             title="Clear choice"
-            onClick={() => form.setFieldValue(field.name, "", false)}
+            onClick={() => form.setFieldValue(field.name, "", true)}
           />
         )}
       </>

--- a/client/src/components/FieldHelper.js
+++ b/client/src/components/FieldHelper.js
@@ -387,6 +387,11 @@ const ButtonToggleGroupField = ({
   enableClear,
   ...otherProps
 }) => {
+  let { className } = otherProps
+  const { validationState } = getFormGroupValidationState(field, form)
+  if (validationState) {
+    className = classNames(className, "is-invalid")
+  }
   const widgetElem = useMemo(
     () => (
       <>
@@ -398,6 +403,7 @@ const ButtonToggleGroupField = ({
           // but you forgot to pass an `id` or `name` attribute to your input"
           onBlur={null}
           {...otherProps}
+          className={className}
         >
           {buttons.map((button, index) => {
             if (!button) {
@@ -448,7 +454,7 @@ const ButtonToggleGroupField = ({
         )}
       </>
     ),
-    [buttons, field, form, disabled, enableClear, otherProps, type]
+    [buttons, field, form, disabled, enableClear, otherProps, type, className]
   )
   return (
     <Field

--- a/client/src/components/advancedSelectWidget/MultiTypeAdvancedSelectComponent.js
+++ b/client/src/components/advancedSelectWidget/MultiTypeAdvancedSelectComponent.js
@@ -142,7 +142,8 @@ const MultiTypeAdvancedSelectComponent = ({
   entityTypes,
   value,
   isMultiSelect,
-  filters
+  filters,
+  className
 }) => {
   const [entityType, setEntityType] = useState(
     objectType ||
@@ -213,6 +214,7 @@ const MultiTypeAdvancedSelectComponent = ({
         queryParams={advancedSelectProps.queryParams}
         fields={advancedSelectProps.fields}
         addon={advancedSelectProps.addon}
+        className={className}
         {...extraSelectProps}
       />
     </>
@@ -225,7 +227,8 @@ MultiTypeAdvancedSelectComponent.propTypes = {
   entityTypes: PropTypes.arrayOf(PropTypes.string).isRequired,
   value: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
   isMultiSelect: PropTypes.bool.isRequired,
-  filters: PropTypes.array
+  filters: PropTypes.array,
+  className: PropTypes.string
 }
 MultiTypeAdvancedSelectComponent.defaultProps = {
   fieldName: "entitySelect",


### PR DESCRIPTION
For certain types of (custom) fields, validation errors were not shown, but saving the form was not possible (because it contained invalid input). Fix this by properly showing these errors for button groups and links to ANET objects.

Closes [AB#259](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/259)

#### User changes
- Some validation errors that were previously missing are now shown.

#### Super User changes
- none

#### Admin changes
- none

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [ ] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here