### PR TITLE
Prevent unnecessary scrollbar on roll-up page

### DIFF
--- a/client/src/index.css
+++ b/client/src/index.css
@@ -127,6 +127,7 @@ fieldset.danger {
 #cancelled-reports fieldset,
 #future-engagements-by-location fieldset,
 #not-approved-reports fieldset,
+#pending-assessments-by-position fieldset,
 #reports-by-task fieldset,
 #reports-by-day-of-week fieldset {
   margin-bottom: 0;

--- a/client/src/pages/insights/Show.js
+++ b/client/src/pages/insights/Show.js
@@ -120,7 +120,9 @@ const InsightsShow = ({ pageDispatchers, searchQuery, setSearchQuery }) => {
   }
   const fieldsetStyle = {
     height: "100%",
-    overflow: "auto"
+    overflow: "auto",
+    display: "flex",
+    flexDirection: "column"
   }
   const mosaicLayoutStyle = {
     display: "flex",

--- a/client/src/pages/rollup/Show.js
+++ b/client/src/pages/rollup/Show.js
@@ -314,7 +314,9 @@ const RollupShow = ({ pageDispatchers, searchQuery }) => {
   }
   const fieldsetStyle = {
     height: "100%",
-    overflow: "auto"
+    overflow: "auto",
+    display: "flex",
+    flexDirection: "column"
   }
   const mosaicLayoutStyle = {
     display: "flex",


### PR DESCRIPTION
The roll-up page can be displayed without a scrollbar if the view height is not very small.

Closes [AB#240](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/240)

#### User changes
- The roll-up page is displayed without a scrollbar on the top-level container.

#### Super User changes
- None

#### Admin changes
- None

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
