### PR TITLE
Ensure we can use the on demand assessment without expiration

### DIFF
--- a/anet-dictionary.yml
+++ b/anet-dictionary.yml
@@ -36,6 +36,8 @@ reportWorkflow:
 
 maxTextFieldLength: 250
 
+onDemandAssessmentExpirationDays: 108
+
 fields:
 
   task:
@@ -1135,7 +1137,6 @@ fields:
         placeholder: the six character code
 
   principal:
-    onDemandAssessmentExpirationDays: 108
     person:
       name: Afghan Partner
       countries: [Afghanistan]

--- a/client/src/components/assessments/AssessmentResultsContainer.js
+++ b/client/src/components/assessments/AssessmentResultsContainer.js
@@ -1,5 +1,5 @@
 import AssessmentResultsTable from "components/assessments/AssessmentResultsTable"
-import OnDemandAssessments from "components/assessments/OndemandAssessments"
+import OnDemandAssessment from "components/assessments/OnDemandAssessments/OndemandAssessment"
 import Model from "components/Model"
 import {
   PERIOD_FACTORIES,
@@ -42,7 +42,7 @@ const AssessmentResultsContainer = ({
           />
         ) : (
           assessmentsType === RECURRENCE_TYPE.ON_DEMAND && (
-            <OnDemandAssessments
+            <OnDemandAssessment
               key={assessmentsType}
               style={{ flex: "0 0 100%" }}
               entity={entity}

--- a/client/src/components/assessments/OnDemandAssessments/Ondemand.css
+++ b/client/src/components/assessments/OnDemandAssessments/Ondemand.css
@@ -1,0 +1,23 @@
+.ondemand-grey-validation-text {
+  color: grey;
+  padding-bottom: 3px;
+  margin: 0 -1rem 1rem 0;
+  border-bottom: 2px solid lightgrey;
+  font-weight: bold;
+}
+
+.ondemand-green-validation-text {
+  color: green;
+  padding-bottom: 2px;
+  margin-bottom: 1rem;
+  border-bottom: 2px solid lightgrey;
+  font-weight: bold;
+}
+
+.ondemand-red-validation-text {
+  color: red;
+  padding-bottom: 3px;
+  margin: 0 -1rem 1rem 0;
+  border-bottom: 2px solid lightgrey;
+  font-weight: bold;
+}

--- a/client/src/components/assessments/OnDemandAssessments/OndemandAssessment.js
+++ b/client/src/components/assessments/OnDemandAssessments/OndemandAssessment.js
@@ -70,7 +70,7 @@ const OnDemandAssessment = ({
       ENTITY_ON_DEMAND_EXPIRATION_DATE
     ].helpText = `
       If this field is left empty, the assessment will be valid for
-      ${Settings.fields.principal.onDemandAssessmentExpirationDays} days.
+      ${Settings.onDemandAssessmentExpirationDays} days.
     `
   }
 
@@ -85,9 +85,7 @@ const OnDemandAssessment = ({
       cards.push(
         <React.Fragment>
           <ValidationBar
-            assessmentExpires={
-              !!Settings.fields.principal.onDemandAssessmentExpirationDays
-            }
+            assessmentExpires={!!Settings.onDemandAssessmentExpirationDays}
             index={index}
             assessmentFieldsObject={assessmentFieldsObject}
             sortedOnDemandNotes={sortedOnDemandNotes}

--- a/client/src/components/assessments/OnDemandAssessments/ValidationBar.js
+++ b/client/src/components/assessments/OnDemandAssessments/ValidationBar.js
@@ -1,0 +1,100 @@
+import {
+  ENTITY_ON_DEMAND_ASSESSMENT_DATE,
+  ENTITY_ON_DEMAND_EXPIRATION_DATE
+} from "components/Model"
+import moment from "moment"
+import PropTypes from "prop-types"
+import React from "react"
+import { Badge } from "react-bootstrap"
+import Settings from "settings"
+
+const ValidationBar = ({
+  assessmentExpires,
+  index,
+  assessmentFieldsObject,
+  sortedOnDemandNotes
+}) => {
+  if (assessmentExpires) {
+    // Fill the 'expirationDate' field if it is empty
+    if (!assessmentFieldsObject[ENTITY_ON_DEMAND_EXPIRATION_DATE]) {
+      assessmentFieldsObject[ENTITY_ON_DEMAND_EXPIRATION_DATE] = moment(
+        assessmentFieldsObject[ENTITY_ON_DEMAND_ASSESSMENT_DATE]
+      )
+        .add(Settings.fields.principal.onDemandAssessmentExpirationDays, "days")
+        .toDate()
+        .toISOString()
+    }
+    return (
+      <div
+        className={
+          moment(
+            assessmentFieldsObject[ENTITY_ON_DEMAND_EXPIRATION_DATE]
+          ).isBefore(moment())
+            ? index === sortedOnDemandNotes.length - 1
+              ? "ondemand-red-validation-text"
+              : "ondemand-grey-validation-text"
+            : index !== sortedOnDemandNotes.length - 1
+              ? "ondemand-grey-validation-text"
+              : "ondemand-green-validation-text"
+        }
+      >
+        {/* Only the last object in the sortedOnDemandNotes can be valid.
+                  If the expiration date of the last object is older than NOW,
+                  it is also expired. */}
+        {moment(
+          assessmentFieldsObject[ENTITY_ON_DEMAND_EXPIRATION_DATE]
+        ).isBefore(moment()) ? (
+            "Expired"
+          ) : index !== sortedOnDemandNotes.length - 1 ? (
+            "No longer valid"
+          ) : (
+            <>
+              Valid until{" "}
+              {moment(
+                assessmentFieldsObject[ENTITY_ON_DEMAND_EXPIRATION_DATE]
+              ).format("DD MMMM YYYY")}{" "}
+              <Badge bg="secondary" style={{ paddingBottom: "3px" }}>
+                {/* true flag in the diff function returns the precise days
+                          between two dates, e.g., '1,4556545' days. 'ceil' function
+                          from Math library is used to round it to the nearest greatest
+                          integer so that user sees an integer as the number of days left */}
+                {Math.ceil(
+                  moment(
+                    assessmentFieldsObject[ENTITY_ON_DEMAND_EXPIRATION_DATE]
+                  ).diff(moment(), "days", true)
+                )}{" "}
+                of{" "}
+                {moment(
+                  assessmentFieldsObject[ENTITY_ON_DEMAND_EXPIRATION_DATE]
+                ).diff(
+                  moment(
+                    assessmentFieldsObject[ENTITY_ON_DEMAND_ASSESSMENT_DATE]
+                  ),
+                  "days"
+                )}{" "}
+                days left
+              </Badge>
+            </>
+          )}
+      </div>
+    )
+  } else {
+    return (
+      <React.Fragment>
+        {index === sortedOnDemandNotes.length - 1 ? (
+          <div className="ondemand-green-validation-text">Valid</div>
+        ) : (
+          <div className="ondemand-grey-validation-text">No longer valid</div>
+        )}
+      </React.Fragment>
+    )
+  }
+}
+ValidationBar.propTypes = {
+  assessmentExpires: PropTypes.bool.isRequired,
+  index: PropTypes.number.isRequired,
+  assessmentFieldsObject: PropTypes.object.isRequired,
+  sortedOnDemandNotes: PropTypes.array.isRequired
+}
+
+export default ValidationBar

--- a/client/src/components/assessments/OnDemandAssessments/ValidationBar.js
+++ b/client/src/components/assessments/OnDemandAssessments/ValidationBar.js
@@ -20,7 +20,7 @@ const ValidationBar = ({
       assessmentFieldsObject[ENTITY_ON_DEMAND_EXPIRATION_DATE] = moment(
         assessmentFieldsObject[ENTITY_ON_DEMAND_ASSESSMENT_DATE]
       )
-        .add(Settings.fields.principal.onDemandAssessmentExpirationDays, "days")
+        .add(Settings.onDemandAssessmentExpirationDays, "days")
         .toDate()
         .toISOString()
     }

--- a/client/stories/1-user/VettingAndScreening.stories.js
+++ b/client/stories/1-user/VettingAndScreening.stories.js
@@ -1,4 +1,4 @@
-import OnDemandAssessments from "components/assessments/OndemandAssessments"
+import OnDemandAssessment from "components/assessments/OnDemandAssessments/OndemandAssessment"
 import { Person } from "models"
 import moment from "moment"
 import { useResponsiveNumberOfPeriods } from "periodUtils"
@@ -172,7 +172,7 @@ export const VettingAndScreening = () => {
   const contRef = useResponsiveNumberOfPeriods(setNumberOfPeriods)
   return (
     <div ref={contRef}>
-      <OnDemandAssessments
+      <OnDemandAssessment
         key="ondemand"
         style={{ flex: "0 0 100%" }}
         entity={person}

--- a/client/stories/1-user/vettingAndScreening.stories.mdx
+++ b/client/stories/1-user/vettingAndScreening.stories.mdx
@@ -28,9 +28,8 @@ the most recent `Screening and vetting date` information is placed in right-most
 Expiration of the assessments are calculated according to the `Expiration date` field. As the help
 text suggests below the field; in case you left the field empty, the default duration of 108 days is
 going to be applied which is configurable later if needed. Furthermore, the expiration date could be
-entered and the duration of the assessment will be calculated accordingly. In addition, the
-expiration date is excluded and assessments with an expiration date pointing to the current date are
-going to be considered as expired.
+entered and the duration of the assessment will be calculated accordingly. In addition, assessments
+with an expiration date pointing to the current date are going to be considered as expired.
 
 There can only be **one** valid assessment at a time. The validity of an assessment is shown on top
 of the corresponding assessment card. The most recent assessment is always shown right most and it
@@ -65,7 +64,7 @@ attention:
 3. Edit button
 4. Delete button
 
-Below the light grey area called card body, you can see the values of the corresponding assessment. 
+Below the light grey area called card body, you can see the values of the corresponding assessment.
 
 ### Final Remarks
 

--- a/src/main/resources/anet-schema.yml
+++ b/src/main/resources/anet-schema.yml
@@ -449,6 +449,12 @@ properties:
     title: The maximum number of characters allowed in selected text fields
     description: Used in the UI for report intent, report key outcomes, report next steps, authorization group description
 
+  onDemandAssessmentExpirationDays:
+    type: integer
+    minimum: 1
+    title: The number of days before an on-demand assessment expires
+    description: Used in the UI to determine which on-demand assessments have expired
+
   fields:
     type: object
     additionalProperties: false
@@ -778,9 +784,6 @@ properties:
         additionalProperties: false
         required: [person, position, org]
         properties:
-          onDemandAssessmentExpirationDays:
-            type: number
-            additionalProperties: false
           person:
             type: object
             additionalProperties: false

--- a/src/main/resources/anet-schema.yml
+++ b/src/main/resources/anet-schema.yml
@@ -291,7 +291,7 @@ $defs:
                 type: date
               expirationDate:
                 type: date
-              required: [assessmentDate, expirationDate]
+              required: [assessmentDate]
 
 # definition for custom sensitive information
   customSensitiveInformation:


### PR DESCRIPTION
It is possible to eliminate expirationDate field under onDemandAssessment definition and onDemandExpirationDays field inside `anet-dictionary.yml` to create an ondemand assessment fieldset without expiring assessments.

Closes [AB#243](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/243)

#### User changes
- Add assessments without entering expiration date and the last assessment card added is the one which is currently valid. All the remaining assessments become 'No longer valid'.

#### Super User changes
- None.

#### Admin changes
- None.

#### System admin changes
- [x] anet.yml or anet-dictionary.yml needs change
  The dictionary setting for `onDemandAssessmentExpirationDays` is now optional; also, it has been moved to the top-level, it used to be:
  ```
  fields:
    principal:
      onDemandAssessmentExpirationDays: 108
  ```
  but is now:
  ```
  onDemandAssessmentExpirationDays: 108
  ```
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [x] Opened debt issues for anything not resolved here