### PR TITLE
Restrict access to assessment results

### DIFF
--- a/anet-dictionary.yml
+++ b/anet-dictionary.yml
@@ -856,6 +856,7 @@ fields:
                       color: '#ff8279'
         - recurrence: once
           relatedObjectType: report
+          authorizationGroupUuids: ['c21e7321-7ec5-4837-8805-a302f9575754']
           questions:
             linguistRole:
               test: $.subject.position.organization[?(@property === "shortName" && @.match(/^LNG/i))]

--- a/src/main/resources/anet-schema.yml
+++ b/src/main/resources/anet-schema.yml
@@ -281,6 +281,13 @@ $defs:
         type: string
         enum: [once, daily, weekly, biweekly, semimonthly, monthly, quarterly, semiannually, annually, ondemand]
         default: once
+      authorizationGroupUuids:
+        type: array
+        uniqueItems: true
+        minItems: 1
+        items:
+          type: string
+          description: The list of authorizationGroup uuid's that have access to this assessment
       relatedObjectType:
         title: object type context in which the assessment will be made
         type: string


### PR DESCRIPTION
Assessment results are only available for preview if the user is part of an authorization group specified in the dictionary file or is the author.

Closes [AB#273](https://dev.azure.com/ncia-anet/ANET/_workitems/edit/273)

#### User changes
- Assessment results are not available if not authorized. 

#### Super User changes
- Assessment results are not available if not authorized.

#### Admin changes
-

#### System admin changes
- [x] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [ ] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
