### PR TITLE
Fix name conflict while importing bootstrap component

### DIFF
--- a/client/src/pages/positions/Form.js
+++ b/client/src/pages/positions/Form.js
@@ -25,7 +25,7 @@ import DictionaryField from "HOC/DictionaryField"
 import { Location, Organization, Position } from "models"
 import PropTypes from "prop-types"
 import React, { useContext, useState } from "react"
-import { Button } from "react-bootstrap"
+import { Button, Form as FormBS } from "react-bootstrap"
 import { useHistory } from "react-router-dom"
 import LOCATIONS_ICON from "resources/locations.png"
 import ORGANIZATIONS_ICON from "resources/organizations.png"
@@ -214,14 +214,14 @@ const PositionForm = ({ edit, title, initialValues, notesComponent }) => {
                   onChange={value => setFieldValue("status", value)}
                 >
                   {willAutoKickPerson && (
-                    <Form.Text>
+                    <FormBS.Text>
                       <span className="text-danger">
                         Setting this position to inactive will automatically
                         remove{" "}
                         <LinkTo modelType="Person" model={values.person} /> from
                         this position.
                       </span>
-                    </Form.Text>
+                    </FormBS.Text>
                   )}
                 </FastField>
 


### PR DESCRIPTION
Closes [AB#295](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/295)

#### User changes
- None

#### Super User changes
-  Super users can see the warning when trying to inactivate a filled position without the page crashing

#### Admin changes
- Admins can see the warning when trying to inactivate a filled position without the page crashing

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
