### PR TITLE
Uniquely identify assessments in the dictionary by key

### DIFF
--- a/anet-dictionary.yml
+++ b/anet-dictionary.yml
@@ -65,7 +65,8 @@ fields:
         style:
           height: 400px
       assessments:
-        - recurrence: semiannually
+        topTaskSemiannually:
+          recurrence: semiannually
           questions:
             issues:
               type: special_field
@@ -91,7 +92,8 @@ fields:
         style:
           height: 400px
       assessments:
-        - recurrence: monthly
+        subTaskMonthly:
+          recurrence: monthly
           questions:
             issues:
               type: special_field
@@ -120,7 +122,8 @@ fields:
               validations:
                 - type: required
                   params: [You must provide the assessment status]
-        - recurrence: weekly
+        subTaskWeekly:
+          recurrence: weekly
           questions:
             issues:
               type: special_field
@@ -132,7 +135,8 @@ fields:
               validations:
                 - type: required
                   params: [You must provide the top 3 issues]
-        - recurrence: once
+        subTaskOnceReport:
+          recurrence: once
           relatedObjectType: report
           questions:
             question1:
@@ -804,7 +808,8 @@ fields:
         - biography
         - arrayFieldName
       assessments:
-        - recurrence: quarterly
+        advisorQuarterly:
+          recurrence: quarterly
           questions:
             test1:
               type: enum
@@ -836,7 +841,8 @@ fields:
                     "3":
                       label: three
                       color: '#ff8279'
-        - recurrence: once
+        advisorOnceReportLinguist:
+          recurrence: once
           relatedObjectType: report
           questions:
             linguistRole:
@@ -1142,7 +1148,8 @@ fields:
       name: Afghan Partner
       countries: [Afghanistan]
       assessments:
-        - recurrence: quarterly
+        principalQuarterly:
+          recurrence: quarterly
           questions:
             test1:
               test: $.subject.position.organization[?(@property === "identificationCode" && @.match(/^Z/i))]
@@ -1211,7 +1218,8 @@ fields:
                       validations:
                         - type: required
                           params: [You must provide Test question 3]
-        - recurrence: once
+        principalOnceReport:
+          recurrence: once
           relatedObjectType: report
           questions:
             question1:
@@ -1251,7 +1259,8 @@ fields:
                 yes:
                   label: 👍
                   color: '#0000ff'
-        - recurrence: ondemand
+        principalOndemandScreeningAndVetting:
+          recurrence: ondemand
           questions:
             assessmentDate:
               type: date

--- a/client/src/components/assessments/AssessmentResultsContainer.js
+++ b/client/src/components/assessments/AssessmentResultsContainer.js
@@ -22,7 +22,11 @@ const AssessmentResultsContainer = ({
   if (!entity) {
     return null
   }
-  const assessmentsTypes = Object.keys(entity.getAssessmentsConfig())
+  // TODO: in principle, there can be more than one assessment definition for each recurrence,
+  // so we should distinguish them here by key when we add that to the database.
+  const assessmentsTypes = Object.values(entity.getAssessmentsConfig()).map(
+    ac => ac.recurrence
+  )
   return (
     <div ref={contRef}>
       {assessmentsTypes.map(assessmentsType =>

--- a/client/src/models/Person.js
+++ b/client/src/models/Person.js
@@ -482,14 +482,14 @@ export default class Person extends Model {
     )
   }
 
-  generalAssessmentsConfig() {
+  getAssessmentsConfig() {
     let config
     if (this.isAdvisor()) {
       config = Person.advisorAssessmentConfig
     } else if (this.isPrincipal()) {
       config = Person.principalAssessmentConfig
     }
-    return config || []
+    return config || {}
   }
 
   static FILTERED_CLIENT_SIDE_FIELDS = ["firstName", "lastName"]

--- a/client/src/models/Task.js
+++ b/client/src/models/Task.js
@@ -178,8 +178,8 @@ export default class Task extends Model {
     return `${this.shortName}`
   }
 
-  generalAssessmentsConfig() {
-    return this.fieldSettings().assessments || []
+  getAssessmentsConfig() {
+    return this.fieldSettings().assessments || {}
   }
 
   static FILTERED_CLIENT_SIDE_FIELDS = ["assessment_customFieldEnum1"]

--- a/client/src/pages/dashboards/DiagramNode.js
+++ b/client/src/pages/dashboards/DiagramNode.js
@@ -119,6 +119,8 @@ export const DiagramNodeWidget = ({ size, node, engine }) => {
   const ModelClass = anetObjectType && Models[anetObjectType]
   const modelInstance = anetObject && ModelClass && new ModelClass(anetObject)
   const now = moment()
+  // TODO: in principle, there can be more than one assessment definition for each recurrence,
+  // so we should distinguish them here by key when we add that to the database.
   const period = PERIOD_FACTORIES[RECURRENCE_TYPE.MONTHLY](now, 0)
   const instantAssessmentConfig =
     anetObject && anetObject.getInstantAssessmentConfig()

--- a/src/main/java/mil/dds/anet/MaintenanceCommand.java
+++ b/src/main/java/mil/dds/anet/MaintenanceCommand.java
@@ -230,11 +230,14 @@ public class MaintenanceCommand extends EnvironmentCommand<AnetConfiguration> {
 
   private Map<String, Object> getAssessmentConfig(final AnetConfiguration configuration) {
     @SuppressWarnings("unchecked")
-    final List<Map<String, Object>> assessmentsConfig =
-        (List<Map<String, Object>>) configuration.getDictionaryEntry(PRINCIPAL_PERSON_ASSESSMENTS);
+    final Map<String, Map<String, Object>> assessmentsConfig =
+        (Map<String, Map<String, Object>>) configuration
+            .getDictionaryEntry(PRINCIPAL_PERSON_ASSESSMENTS);
     if (assessmentsConfig != null) {
-      for (final Map<String, Object> assessmentConfig : assessmentsConfig) {
+      for (final Map<String, Object> assessmentConfig : assessmentsConfig.values()) {
         // Find the first recurring assessment definition
+        // Note: in principle, there can be more than one "once" definition, but this code is
+        // obsolete anyway, so this case will never happen.
         final String recurrence = getAssessmentRecurrence(assessmentConfig);
         if (!"once".equals(recurrence)) {
           logger.info("Will change partner assessments to {} periodic assessments", recurrence);

--- a/src/main/java/mil/dds/anet/utils/PendingAssessmentsHelper.java
+++ b/src/main/java/mil/dds/anet/utils/PendingAssessmentsHelper.java
@@ -326,10 +326,12 @@ public class PendingAssessmentsHelper {
       final String keyPath) {
     final Set<Recurrence> assessmentRecurrence = new HashSet<>();
     @SuppressWarnings("unchecked")
-    final List<Map<String, Object>> assessmentDefinitions =
-        (List<Map<String, Object>>) config.getDictionaryEntry(keyPath);
+    final Map<String, Map<String, Object>> assessmentDefinitions =
+        (Map<String, Map<String, Object>>) config.getDictionaryEntry(keyPath);
     if (assessmentDefinitions != null) {
-      assessmentDefinitions.stream().forEach(pad -> {
+      assessmentDefinitions.values().stream().forEach(pad -> {
+        // TODO: in principle, there can be more than one assessment definition for each recurrence,
+        // so we should distinguish them here by key when we add that to the database.
         final Recurrence recurrence =
             Recurrence.valueOfRecurrence((String) pad.get(ASSESSMENT_RECURRENCE));
         if (shouldAddRecurrence(recurrenceSet, recurrence)) {

--- a/src/main/resources/anet-schema.yml
+++ b/src/main/resources/anet-schema.yml
@@ -494,8 +494,8 @@ properties:
               longName:
                 "$ref": "#/properties/fields/properties/task/properties/longName"
               assessments:
-                type: array
-                items:
+                type: object
+                additionalProperties:
                   "$ref": "#/$defs/assessmentDef"
           subLevel:
             "$ref": "#/properties/fields/properties/task/properties/topLevel"
@@ -732,8 +732,8 @@ properties:
                 type: number
                 description: Used for dividing fields into 2 columns, make sure the columns are balanced
               assessments:
-                type: array
-                items:
+                type: object
+                additionalProperties:
                   "$ref": "#/$defs/assessmentDef"
           position:
             type: object
@@ -814,8 +814,8 @@ properties:
                 type: number
                 description: Used for dividing fields into 2 columns, make sure the columns are balanced
               assessments:
-                type: array
-                items:
+                type: object
+                additionalProperties:
                   "$ref": "#/$defs/assessmentDef"
 
           position:

--- a/testDictionaries/no-custom-fields.yml
+++ b/testDictionaries/no-custom-fields.yml
@@ -62,7 +62,8 @@ fields:
         style:
           height: 400px
       assessments:
-        - recurrence: semiannually
+        topTaskSemiannually:
+          recurrence: semiannually
           questions:
             issues:
               type: special_field
@@ -88,7 +89,8 @@ fields:
         style:
           height: 400px
       assessments:
-        - recurrence: monthly
+        subTaskMonthly:
+          recurrence: monthly
           questions:
             issues:
               type: special_field
@@ -117,7 +119,8 @@ fields:
               validations:
                 - type: required
                   params: [You must provide the assessment status]
-        - recurrence: weekly
+        subTaskWeekly:
+          recurrence: weekly
           questions:
             issues:
               type: special_field
@@ -129,7 +132,8 @@ fields:
               validations:
                 - type: required
                   params: [You must provide the top 3 issues]
-        - recurrence: once
+        subTaskOnceReport:
+          recurrence: once
           relatedObjectType: report
           questions:
             question1:
@@ -352,7 +356,8 @@ fields:
       name: Afghan Partner
       countries: [Afghanistan]
       assessments:
-        - recurrence: quarterly
+        principalQuarterly:
+          recurrence: quarterly
           questions:
             test1:
               test: $.subject.position.organization[?(@property === "identificationCode" && @.match(/^Z/i))]
@@ -421,7 +426,8 @@ fields:
                       validations:
                         - type: required
                           params: [You must provide Test question 3]
-        - recurrence: once
+        principalOnceReport:
+          recurrence: once
           relatedObjectType: report
           questions:
             question1:


### PR DESCRIPTION
Assessments in the dictionary had no key, which meant at most one definition for each recurrence type was possible. Now they have a key that uniquely identifies them, which in future would allow multiple assessment definitions with the same recurrence, e.g. several ondemand assessments.

Closes [AB#296](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/296)

#### User changes
- None

#### Super User changes
- None

#### Admin changes
- None

#### System admin changes
- [x] anet.yml or anet-dictionary.yml needs change
  If the dictionary previously contained e.g.:
  ```
  fields:
    task:
      subLevel:
        assessments:
          - recurrence: monthly
            questions:
              …
   ```
   this must now become:
  ```
  fields:
    task:
      subLevel:
        assessments:
          subTaskMonthly:
            recurrence: monthly
            questions:
              …
  ```
  Carefully update all assessment definitions, and give each a unique (and meaningful) key.
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [x] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [ ] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here