### PR TITLE
Allow on-demand assessment expiration to be specified per assessment definition

### DIFF
--- a/anet-dictionary.yml
+++ b/anet-dictionary.yml
@@ -36,8 +36,6 @@ reportWorkflow:
 
 maxTextFieldLength: 250
 
-onDemandAssessmentExpirationDays: 108
-
 fields:
 
   task:
@@ -1261,6 +1259,7 @@ fields:
                   color: '#0000ff'
         principalOndemandScreeningAndVetting:
           recurrence: ondemand
+          onDemandAssessmentExpirationDays: 108
           questions:
             assessmentDate:
               type: date

--- a/client/src/components/Model.js
+++ b/client/src/components/Model.js
@@ -745,7 +745,11 @@ export default class Model {
 
   static filterAssessmentConfig(assessmentConfig, subject, relatedObject) {
     const testValue = { subject, relatedObject }
-    const filteredAssessmentConfig = { questions: {}, questionSets: {} }
+    const filteredAssessmentConfig = {
+      ...assessmentConfig,
+      questions: {},
+      questionSets: {}
+    }
     if (!_isEmpty(assessmentConfig?.questions)) {
       Object.entries(assessmentConfig.questions)
         .filter(

--- a/client/src/components/assessments/OnDemandAssessments/OndemandAssessment.js
+++ b/client/src/components/assessments/OnDemandAssessments/OndemandAssessment.js
@@ -65,12 +65,15 @@ const OnDemandAssessment = ({
     [assessmentConfig, entity]
   )
 
-  if (filteredAssessmentConfig.questions[ENTITY_ON_DEMAND_EXPIRATION_DATE]) {
+  if (
+    filteredAssessmentConfig.questions[ENTITY_ON_DEMAND_EXPIRATION_DATE] &&
+    filteredAssessmentConfig.onDemandAssessmentExpirationDays
+  ) {
     filteredAssessmentConfig.questions[
       ENTITY_ON_DEMAND_EXPIRATION_DATE
     ].helpText = `
       If this field is left empty, the assessment will be valid for
-      ${Settings.onDemandAssessmentExpirationDays} days.
+      ${filteredAssessmentConfig.onDemandAssessmentExpirationDays} days.
     `
   }
 
@@ -85,7 +88,9 @@ const OnDemandAssessment = ({
       cards.push(
         <React.Fragment>
           <ValidationBar
-            assessmentExpires={!!Settings.onDemandAssessmentExpirationDays}
+            assessmentExpirationDays={
+              filteredAssessmentConfig.onDemandAssessmentExpirationDays
+            }
             index={index}
             assessmentFieldsObject={assessmentFieldsObject}
             sortedOnDemandNotes={sortedOnDemandNotes}

--- a/client/src/components/assessments/OnDemandAssessments/ValidationBar.js
+++ b/client/src/components/assessments/OnDemandAssessments/ValidationBar.js
@@ -6,21 +6,20 @@ import moment from "moment"
 import PropTypes from "prop-types"
 import React from "react"
 import { Badge } from "react-bootstrap"
-import Settings from "settings"
 
 const ValidationBar = ({
-  assessmentExpires,
+  assessmentExpirationDays,
   index,
   assessmentFieldsObject,
   sortedOnDemandNotes
 }) => {
-  if (assessmentExpires) {
+  if (assessmentExpirationDays) {
     // Fill the 'expirationDate' field if it is empty
     if (!assessmentFieldsObject[ENTITY_ON_DEMAND_EXPIRATION_DATE]) {
       assessmentFieldsObject[ENTITY_ON_DEMAND_EXPIRATION_DATE] = moment(
         assessmentFieldsObject[ENTITY_ON_DEMAND_ASSESSMENT_DATE]
       )
-        .add(Settings.onDemandAssessmentExpirationDays, "days")
+        .add(assessmentExpirationDays, "days")
         .toDate()
         .toISOString()
     }
@@ -91,7 +90,7 @@ const ValidationBar = ({
   }
 }
 ValidationBar.propTypes = {
-  assessmentExpires: PropTypes.bool.isRequired,
+  assessmentExpirationDays: PropTypes.number,
   index: PropTypes.number.isRequired,
   assessmentFieldsObject: PropTypes.object.isRequired,
   sortedOnDemandNotes: PropTypes.array.isRequired

--- a/src/main/resources/anet-schema.yml
+++ b/src/main/resources/anet-schema.yml
@@ -10,7 +10,7 @@ $defs:
   describedValue:
     type: object
     additionalProperties: true
-    required: [value,description]
+    required: [value, description]
     properties:
       value:
         type: string
@@ -185,7 +185,7 @@ $defs:
               type: object
               additionalProperties:
                 "$ref": "#/$defs/customField"
-          required: [addButtonLabel,objectLabel,objectFields]
+          required: [addButtonLabel, objectLabel, objectFields]
         - properties:
             type:
               enum: [anet_object, array_of_anet_objects]
@@ -195,7 +195,7 @@ $defs:
               items:
                 type: string
                 enum: [Location, Organization, Person, Position, Report, Task]
-            required: [types]
+          required: [types]
         - properties:
             type:
               enum: [special_field]
@@ -264,6 +264,7 @@ $defs:
   assessmentDef:
     type: object
     additionalProperties: false
+    required: [recurrence]
     properties:
       recurrence:
         title: recurrence of an assessment
@@ -273,8 +274,12 @@ $defs:
       relatedObjectType:
         title: object type context in which the assessment will be made
         type: string
-        enum: [report, null]
-        default: null
+        enum: [report]
+      onDemandAssessmentExpirationDays:
+        type: integer
+        minimum: 1
+        title: The number of days before an on-demand assessment expires
+        description: Used in the UI to determine which on-demand assessments have expired
       questions:
         "$ref": "#/$defs/questions"
       questionSets:
@@ -284,15 +289,20 @@ $defs:
         oneOf:
         - properties:
             recurrence:
-              enum: [once, daily, weekly, biweekly, semimonthly, monthly, quarterly, semiannually, annually]
+              enum: [daily, weekly, biweekly, semimonthly, monthly, quarterly, semiannually, annually]
+        - properties:
+            recurrence:
+              enum: [once]
+          required: [relatedObjectType]
         - properties:
             recurrence:
               enum: [ondemand]
             questions:
-              assessmentDate:
-                type: date
-              expirationDate:
-                type: date
+              properties:
+                allOf:
+                - "$ref": "#/$defs/questions"
+                - assessmentDate: "#/$defs/customField"
+                - expirationDate: "#/$defs/customField"
               required: [assessmentDate]
 
 # definition for custom sensitive information
@@ -451,12 +461,6 @@ properties:
     title: The maximum number of characters allowed in selected text fields
     description: Used in the UI for report intent, report key outcomes, report next steps, authorization group description
 
-  onDemandAssessmentExpirationDays:
-    type: integer
-    minimum: 1
-    title: The number of days before an on-demand assessment expires
-    description: Used in the UI to determine which on-demand assessments have expired
-
   fields:
     type: object
     additionalProperties: false
@@ -523,7 +527,7 @@ properties:
       report:
         type: object
         additionalProperties: false
-        required: [intent,atmosphere,atmosphereDetails,cancelled,nextSteps,reportText]
+        required: [intent, atmosphere, atmosphereDetails, cancelled, nextSteps, reportText]
         properties:
           canUnpublishReports:
             type: boolean
@@ -719,8 +723,7 @@ properties:
                 items:
                   type: string
                   title: The list of possible countries
-                  description: Used in the UI where a country can be selected for
-                    a person inside an advisor organization.
+                  description: Used in the UI where a country can be selected for a person inside an advisor organization.
               showPageOrderedFields:
                 type: array
                 uniqueItems: true
@@ -735,6 +738,7 @@ properties:
                 type: object
                 additionalProperties:
                   "$ref": "#/$defs/assessmentDef"
+
           position:
             type: object
             additionalProperties: false


### PR DESCRIPTION
This makes it possible to have different expirations for different on-demand assessment definitions. And since the field is optional, you can now have on-demand assessment definitions without automatic expiration calculation, as well as definitions that do have one.

Closes [AB#299](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/299)

#### User changes
- None

#### Super User changes
- None

#### Admin changes
- None

#### System admin changes
- [x] anet.yml or anet-dictionary.yml needs change
  PR #3928 changed the dictionary to:
  ```
  onDemandAssessmentExpirationDays: 108
  ```
  but this one changes that to:
  ```
  fields:
    person:
      principal:
        assessments:
          principalOndemandScreeningAndVetting:
            recurrence: ondemand
            onDemandAssessmentExpirationDays: 108
            questions:
              assessmentDate:
                type: date
                label: Screening and vetting date
                validations:
                  - type: required
                    params: [You must provide the assessment date]
              expirationDate:
                type: date
                label: Expiration date
            <…question 1 etc…>
  ```
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here