### PR TITLE
Make sure buttons are disabled when they should be

### DIFF
--- a/client/src/components/FieldHelper.js
+++ b/client/src/components/FieldHelper.js
@@ -409,7 +409,15 @@ const ButtonToggleGroupField = ({
             if (!button) {
               return null
             }
-            let { label, value, color, style, ...props } = button
+            let {
+              label,
+              value,
+              color,
+              style,
+              title,
+              disabled: buttonDisabled,
+              ...props
+            } = button
             const textColor = utils.getContrastYIQ(color)
             if (color) {
               if (
@@ -424,11 +432,20 @@ const ButtonToggleGroupField = ({
                 borderWidth: "2px"
               }
             }
-            return (
+            if (buttonDisabled) {
+              style = {
+                ...style,
+                pointerEvents: "none"
+              }
+            }
+            const key = `${field.name}_${value}`
+            const toggleButton = (
               <ToggleButton
+                disabled={disabled || buttonDisabled}
+                title={title}
                 {...props}
-                disabled={disabled}
-                id={`${field.name}_${value}`}
+                id={key}
+                key={key}
                 className={
                   color
                     ? textColor === "black"
@@ -436,13 +453,19 @@ const ButtonToggleGroupField = ({
                       : "dark-colored-toggle-button"
                     : ""
                 }
-                key={`${field.name}_${value}`}
                 value={value}
                 style={style}
                 variant="outline-secondary"
               >
                 {label}
               </ToggleButton>
+            )
+            return buttonDisabled ? (
+              <span id={`${key}_tooltip`} key={`${key}_tooltip`} title={title}>
+                {toggleButton}
+              </span>
+            ) : (
+              toggleButton
             )
           })}
         </ToggleButtonGroup>

--- a/client/tests/e2e/permissions.js
+++ b/client/tests/e2e/permissions.js
@@ -2,11 +2,43 @@ const uuidv4 = require("uuid/v4")
 const test = require("../util/test")
 
 test.serial("checking super user permissions", async t => {
-  t.plan(10)
+  t.plan(12)
 
-  const { pageHelpers, assertElementNotPresent, shortWaitMs } = t.context
+  const {
+    pageHelpers,
+    $,
+    By,
+    driver,
+    assertElementDisabled,
+    assertElementNotPresent,
+    shortWaitMs
+  } = t.context
 
   await t.context.get("/", "rebecca")
+
+  const $createButton = await $("#createButton")
+  await $createButton.click()
+  const $createPersonButton = await $("#new-person")
+  await $createPersonButton.click()
+  await assertElementDisabled(
+    t,
+    "#role_ADVISOR",
+    "Advisor button should be disabled for super users"
+  )
+  const $tooltip = await $("#role_ADVISOR_tooltip")
+  t.regex(
+    await $tooltip.getAttribute("title"),
+    /^Super users cannot create .*$/,
+    "Expected tooltip for super users"
+  )
+
+  // Cancel Create Person
+  const $cancelButton = await driver.findElement(
+    By.xpath('//button[text()="Cancel"]')
+  )
+  await $cancelButton.click()
+  await driver.switchTo().alert().accept()
+
   await pageHelpers.clickMenuLinksButton()
   await pageHelpers.clickMyOrgLink()
 
@@ -122,9 +154,42 @@ validateUserCannotEditOtherUser(
 )
 
 test.serial("checking admin permissions", async t => {
-  t.plan(11)
+  t.plan(13)
+
+  const {
+    $,
+    By,
+    driver,
+    assertElementEnabled,
+    assertElementNotPresent,
+    shortWaitMs
+  } = t.context
 
   await t.context.get("/", "arthur")
+
+  const $createButton = await $("#createButton")
+  await $createButton.click()
+  const $createPersonButton = await $("#new-person")
+  await $createPersonButton.click()
+  await assertElementEnabled(
+    t,
+    "#role_ADVISOR",
+    "Advisor button should be enabled for admins"
+  )
+  await assertElementNotPresent(
+    t,
+    "#role_ADVISOR_tooltip",
+    "Unexpected tooltip for admins",
+    shortWaitMs
+  )
+
+  // Cancel Create Person
+  const $cancelButton = await driver.findElement(
+    By.xpath('//button[text()="Cancel"]')
+  )
+  await $cancelButton.click()
+  await driver.switchTo().alert().accept()
+
   await t.context.pageHelpers.clickMenuLinksButton()
   await t.context.pageHelpers.clickMyOrgLink()
   const $arthurLink = await findSuperUserLink(t, "CIV DMIN, Arthur")


### PR DESCRIPTION
When a super user creates a new person, the Advisor button was no longer disabled. In addition to that, the tooltip for this button (explaining why a super user can't create a new advisor) was no longer shown. This PR fixes that.

Closes [AB#300](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/300)

#### User changes
- None

#### Super User changes
- When creating a new person, the Advisor button is disabled again, and shows a tooltip with the reason.

#### Admin changes
- None

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [x] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here