### PR TITLE
Update log4j2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,7 @@ sourceCompatibility = 1.8
 boolean isTestEnv = project.hasProperty("testEnv")
 String dropwizardVersion = "2.0.25"
 String logbackVersion = "1.2.7"
+String log4jVersion = "2.15.0"
 
 // If defined, load alternatives for variables
 if (!isTestEnv && file('localSettings.gradle').exists()) {
@@ -134,7 +135,8 @@ dependencies {
 
 	// Avoid "ERROR StatusLogger Log4j2 could not find a logging implementation.
 	// Please add log4j-core to the classpath. Using SimpleLogger to log to the console..."
-	runtimeOnly 'org.apache.logging.log4j:log4j-to-slf4j:2.14.1'
+	implementation "org.apache.logging.log4j:log4j-api:${log4jVersion}"
+	implementation "org.apache.logging.log4j:log4j-to-slf4j:${log4jVersion}"
 }
 
 configurations.all {


### PR DESCRIPTION
We only depend on `log4j-api` (which is then routed through `log4j-to-slf4j` to `logback`), but better to explicitly update.