### PR TITLE
Prepare first steps of implementing attachments

### DIFF
--- a/src/main/java/mil/dds/anet/beans/Attachment.java
+++ b/src/main/java/mil/dds/anet/beans/Attachment.java
@@ -1,0 +1,138 @@
+package mil.dds.anet.beans;
+
+import io.leangen.graphql.annotations.GraphQLInputField;
+import io.leangen.graphql.annotations.GraphQLQuery;
+import io.leangen.graphql.annotations.GraphQLRootContext;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import mil.dds.anet.utils.IdDataLoaderKey;
+import mil.dds.anet.views.AbstractAnetBean;
+import mil.dds.anet.views.UuidFetcher;
+
+public class Attachment extends AbstractAnetBean {
+
+  @GraphQLQuery
+  @GraphQLInputField
+  private String mimeType;
+
+  @GraphQLQuery
+  @GraphQLInputField
+  private byte[] content;
+
+  @GraphQLQuery
+  @GraphQLInputField
+  private String fileName;
+
+  @GraphQLQuery
+  @GraphQLInputField
+  private String description;
+
+  @GraphQLQuery
+  @GraphQLInputField
+  private String classificationUuid;
+
+  // annotated below
+  private AttachmentClassification classification;
+
+  @GraphQLQuery
+  @GraphQLInputField
+  private String relatedObjectType;
+
+  @GraphQLQuery
+  @GraphQLInputField
+  private String relatedObjectUuid;
+
+  // annotated below
+  private RelatableObject relatedObject;
+
+  public byte[] getContent() {
+    return content;
+  }
+
+  public void setContent(byte[] content) {
+    this.content = content;
+  }
+
+  public String getMimeType() {
+    return mimeType;
+  }
+
+  public void setMimeType(String mimeType) {
+    this.mimeType = mimeType;
+  }
+
+  public String getFileName() {
+    return fileName;
+  }
+
+  public void setFileName(String fileName) {
+    this.fileName = fileName;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+
+  public void setDescription(String description) {
+    this.description = description;
+  }
+
+  public String getClassificationUuid() {
+    return classificationUuid;
+  }
+
+  public void setClassificationUuid(String classificationUuid) {
+    this.classificationUuid = classificationUuid;
+  }
+
+  public String getRelatedObjectType() {
+    return relatedObjectType;
+  }
+
+  public void setRelatedObjectType(String relatedObjectType) {
+    this.relatedObjectType = relatedObjectType;
+  }
+
+  public String getRelatedObjectUuid() {
+    return relatedObjectUuid;
+  }
+
+  public void setRelatedObjectUuid(String relatedObjectUuid) {
+    this.relatedObjectUuid = relatedObjectUuid;
+  }
+
+  @GraphQLQuery(name = "classification")
+  public CompletableFuture<AttachmentClassification> loadAttachmentClassification(
+      @GraphQLRootContext Map<String, Object> context) {
+    if (classification != null) {
+      return CompletableFuture.completedFuture(classification);
+    }
+    return new UuidFetcher<AbstractAnetBean>()
+        .load(context, IdDataLoaderKey.ATTACHMENT_CLASSIFICATION, classificationUuid)
+        .thenApply(o -> {
+          classification = (AttachmentClassification) o;
+          return classification;
+        });
+  }
+
+  @GraphQLQuery(name = "relatedObject")
+  public CompletableFuture<RelatableObject> loadRelatedObject(
+      @GraphQLRootContext Map<String, Object> context) {
+    if (relatedObject != null) {
+      return CompletableFuture.completedFuture(relatedObject);
+    }
+    return new UuidFetcher<AbstractAnetBean>()
+        .load(context, IdDataLoaderKey.valueOfTableName(relatedObjectType), relatedObjectUuid)
+        .thenApply(o -> {
+          relatedObject = (RelatableObject) o;
+          return relatedObject;
+        });
+  }
+
+  @Override
+  public String toString() {
+    return String.format(
+        "[uuid:%s fileName:%s mime:%s description:%s relatedObjectType:%s relatedObjectUuid:%s]",
+        uuid, fileName, mimeType, description, relatedObjectType, relatedObjectUuid);
+  }
+}

--- a/src/main/java/mil/dds/anet/beans/AttachmentClassification.java
+++ b/src/main/java/mil/dds/anet/beans/AttachmentClassification.java
@@ -1,0 +1,30 @@
+package mil.dds.anet.beans;
+
+import io.leangen.graphql.annotations.GraphQLInputField;
+import io.leangen.graphql.annotations.GraphQLQuery;
+import mil.dds.anet.views.AbstractAnetBean;
+
+public class AttachmentClassification extends AbstractAnetBean {
+
+  public static enum Classification {
+    COSMIC_TOP_SECRET, NATO_SECRET, NATO_CONFIDENTIAL, NATO_RESTRICTED, COSMIC_TOP_SECRET_ATOMAL,
+    NATO_SECRET_ATOMAL, NATO_CONFIDENTIAL_ATOMAL, NATO_UNCLASSIFIED
+  }
+
+  public Classification getClassification() {
+    return classification;
+  }
+
+  public void setClassification(Classification classification) {
+    this.classification = classification;
+  }
+
+  @GraphQLQuery
+  // @GraphQLInputField
+  private Classification classification;
+
+  @Override
+  public String toString() {
+    return String.format("[uuid:%s classification:%s]", uuid, classification);
+  }
+}

--- a/src/main/java/mil/dds/anet/beans/FileUpload.java
+++ b/src/main/java/mil/dds/anet/beans/FileUpload.java
@@ -1,0 +1,25 @@
+package mil.dds.anet.beans;
+
+public class FileUpload {
+  private final String contentType;
+  private final String name;
+  private final byte[] content;
+
+  public FileUpload(String contentType, String name, byte[] content) {
+    this.contentType = contentType;
+    this.name = name;
+    this.content = content;
+  }
+
+  public String getContentType() {
+    return contentType;
+  }
+
+  public byte[] getContent() {
+    return content;
+  }
+
+  public String getName() {
+    return name;
+  }
+}

--- a/src/main/java/mil/dds/anet/database/AttachmentClassificationDao.java
+++ b/src/main/java/mil/dds/anet/database/AttachmentClassificationDao.java
@@ -1,0 +1,55 @@
+package mil.dds.anet.database;
+
+import java.util.Arrays;
+import java.util.List;
+import mil.dds.anet.AnetObjectEngine;
+import mil.dds.anet.beans.AttachmentClassification;
+import mil.dds.anet.beans.search.AbstractSearchQuery;
+import mil.dds.anet.database.mappers.AttachmentClassificationMapper;
+import mil.dds.anet.utils.DaoUtils;
+
+public class AttachmentClassificationDao
+    extends AnetBaseDao<AttachmentClassification, AbstractSearchQuery<?>> {
+
+  public static final String TABLE_NAME = "attachmentClassification";
+
+  @Override
+  public AttachmentClassification getByUuid(String uuid) {
+    return getByIds(Arrays.asList(uuid)).get(0);
+  }
+
+  static class SelfIdBatcher extends IdBatcher<AttachmentClassification> {
+    private static final String sql = "/* batch.getAttachmentClassificationByUuids */ "
+        + "SELECT * FROM \"attachmentClassification\" WHERE uuid IN ( <uuids> )";
+
+    public SelfIdBatcher() {
+      super(sql, "uuids", new AttachmentClassificationMapper());
+    }
+  }
+
+  @Override
+  public List<AttachmentClassification> getByIds(List<String> uuids) {
+    final IdBatcher<AttachmentClassification> idBatcher = AnetObjectEngine.getInstance()
+        .getInjector().getInstance(AttachmentClassificationDao.SelfIdBatcher.class);
+    return idBatcher.getByIds(uuids);
+  }
+
+  @Override
+  public AttachmentClassification insertInternal(AttachmentClassification obj) {
+    getDbHandle().createUpdate("/* insertAttachment */ "
+        + "INSERT INTO \"attachmentClassification\" (uuid, \"classification\", \"createdAt\", \"updatedAt\") VALUES (:uuid, :classification, "
+        + " :createdAt, :updatedAt)").bindBean(obj)
+        .bind("createdAt", DaoUtils.asLocalDateTime(obj.getCreatedAt()))
+        .bind("updatedAt", DaoUtils.asLocalDateTime(obj.getUpdatedAt())).execute();
+    return obj;
+  }
+
+  @Override
+  public int updateInternal(AttachmentClassification obj) {
+    return getDbHandle()
+        .createUpdate("/* updateAttachment */ "
+            + "UPDATE \"attachmentClassification\" SET \"classification\" = :classification "
+            + "WHERE uuid = :uuid")
+        .bindBean(obj).bind("updatedAt", DaoUtils.asLocalDateTime(obj.getUpdatedAt())).execute();
+  }
+}

--- a/src/main/java/mil/dds/anet/database/AttachmentDao.java
+++ b/src/main/java/mil/dds/anet/database/AttachmentDao.java
@@ -1,0 +1,101 @@
+package mil.dds.anet.database;
+
+import io.leangen.graphql.annotations.GraphQLRootContext;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+import mil.dds.anet.AnetObjectEngine;
+import mil.dds.anet.beans.Attachment;
+import mil.dds.anet.beans.Person;
+import mil.dds.anet.beans.search.AbstractSearchQuery;
+import mil.dds.anet.database.mappers.AttachmentMapper;
+import mil.dds.anet.utils.DaoUtils;
+import mil.dds.anet.utils.FkDataLoaderKey;
+import mil.dds.anet.views.ForeignKeyFetcher;
+import ru.vyarus.guicey.jdbi3.tx.InTransaction;
+
+public class AttachmentDao extends AnetBaseDao<Attachment, AbstractSearchQuery<?>> {
+  @Override
+  public Attachment getByUuid(String uuid) {
+    return getByIds(Arrays.asList(uuid)).get(0);
+  }
+
+  static class SelfIdBatcher extends IdBatcher<Attachment> {
+    private static final String sql = "/* batch.getAttachmentByUuids */ "
+        + "SELECT * FROM \"attachments\" WHERE uuid IN ( <uuids> )";
+
+    public SelfIdBatcher() {
+      super(sql, "uuids", new AttachmentMapper());
+    }
+  }
+
+  @Override
+  public List<Attachment> getByIds(List<String> uuids) {
+    final IdBatcher<Attachment> idBatcher =
+        AnetObjectEngine.getInstance().getInjector().getInstance(SelfIdBatcher.class);
+    return idBatcher.getByIds(uuids);
+  }
+
+  @Override
+  public Attachment insertInternal(Attachment obj) {
+    getDbHandle()
+        .createUpdate("/* insertAttachment */ "
+            + "INSERT INTO \"attachments\" (uuid, \"mimeType\", \"content\","
+            + "\"fileName\", \"description\", \"classification\", \"relatedObjectType\", "
+            + " \"relatedObjectUuid\", \"createdAt\", \"updatedAt\") VALUES (:uuid, :mimeType, "
+            + " :content, :fileName, :description, :classification, :relatedObjectType, "
+            + " :relatedObjectUuid, :createdAt, :updatedAt)")
+        .bindBean(obj).bind("createdAt", DaoUtils.asLocalDateTime(obj.getCreatedAt()))
+        .bind("updatedAt", DaoUtils.asLocalDateTime(obj.getUpdatedAt())).execute();
+    return obj;
+  }
+
+  @Override
+  public int updateInternal(Attachment obj) {
+    return getDbHandle()
+        .createUpdate(
+            "/* updateAttachment */ " + "UPDATE \"attachments\" SET \"mimeType\" = :mimeType, "
+                + "\"content\" = :content, " + "\"fileName\" = :fileName, "
+                + "\"description\" = :description, " + "\"classification\" = :classification, "
+                + "\"relatedObjectType\" = :relatedObjectType, "
+                + "\"relatedObjectUuid\" = :relatedObjectUuid, \"updatedAt\" = :updatedAt "
+                + "WHERE uuid = :uuid")
+        .bindBean(obj).bind("updatedAt", DaoUtils.asLocalDateTime(obj.getUpdatedAt())).execute();
+  }
+
+  @InTransaction
+  public int deleteFor(String relatedObjectUuid) {
+    return getDbHandle().execute(
+        "/* deleteAttachment */ " + "DELETE FROM \"attachments\" WHERE \"relatedObjectUuid\" = ?",
+        relatedObjectUuid);
+  }
+
+  public CompletableFuture<List<Attachment>> getAttachmentsForRelatedObject(
+      @GraphQLRootContext Map<String, Object> context, String relatedObjectUuid) {
+    final Person user = DaoUtils.getUserFromContext(context);
+    return new ForeignKeyFetcher<Attachment>()
+        .load(context, FkDataLoaderKey.RELATED_OBJECT_ATTACHMENTS, relatedObjectUuid)
+        .thenApply(attList -> attList.stream()
+            // TODO .filter(att -> hasAttachmentAuthorization(user, att))
+            .collect(Collectors.toList()));
+  }
+
+  static class AttachmentBatcher extends ForeignKeyBatcher<Attachment> {
+    private static final String sql =
+        "/* batch.getAttachmentsForRelatedObject */ " + "SELECT * FROM \"attachment\" "
+            + "WHERE \"attachment\".\"relatedObjectUuid\" IN ( <foreignKeys> ) "
+            + "ORDER BY \"attachment\".\"fileName\"";
+
+    public AttachmentBatcher() {
+      super(sql, "foreignKeys", new AttachmentMapper(), "relatedObjectUuid");
+    }
+  }
+
+  public List<List<Attachment>> getAttachments(List<String> foreignKeys) {
+    final ForeignKeyBatcher<Attachment> attachmentBatcher = AnetObjectEngine.getInstance()
+        .getInjector().getInstance(AttachmentDao.AttachmentBatcher.class);
+    return attachmentBatcher.getByForeignKeys(foreignKeys);
+  }
+}

--- a/src/main/java/mil/dds/anet/database/mappers/AttachmentClassificationMapper.java
+++ b/src/main/java/mil/dds/anet/database/mappers/AttachmentClassificationMapper.java
@@ -1,0 +1,18 @@
+package mil.dds.anet.database.mappers;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import mil.dds.anet.beans.AttachmentClassification;
+import mil.dds.anet.beans.AttachmentClassification.Classification;
+import org.jdbi.v3.core.mapper.RowMapper;
+import org.jdbi.v3.core.statement.StatementContext;
+
+public class AttachmentClassificationMapper implements RowMapper<AttachmentClassification> {
+  @Override
+  public AttachmentClassification map(ResultSet rs, StatementContext ctx) throws SQLException {
+    final AttachmentClassification a = new AttachmentClassification();
+    MapperUtils.setCommonBeanFields(a, rs, null);
+    a.setClassification(MapperUtils.getEnumIdx(rs, "classification", Classification.class));
+    return a;
+  }
+}

--- a/src/main/java/mil/dds/anet/database/mappers/AttachmentMapper.java
+++ b/src/main/java/mil/dds/anet/database/mappers/AttachmentMapper.java
@@ -1,0 +1,23 @@
+package mil.dds.anet.database.mappers;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import mil.dds.anet.beans.Attachment;
+import org.jdbi.v3.core.mapper.RowMapper;
+import org.jdbi.v3.core.statement.StatementContext;
+
+public class AttachmentMapper implements RowMapper<Attachment> {
+  @Override
+  public Attachment map(ResultSet rs, StatementContext ctx) throws SQLException {
+    final Attachment a = new Attachment();
+    MapperUtils.setCommonBeanFields(a, rs, null);
+    a.setMimeType(rs.getString("mimeType"));
+    a.setContent(rs.getBytes("content"));
+    a.setFileName(rs.getString("fileName"));
+    a.setDescription(rs.getString("description"));
+    a.setClassificationUuid(rs.getString("classification"));
+    a.setRelatedObjectType(rs.getString("relatedObjectType"));
+    a.setRelatedObjectUuid(rs.getString("relatedObjectUuid"));
+    return a;
+  }
+}

--- a/src/main/java/mil/dds/anet/graphql/FileUploadMapper.java
+++ b/src/main/java/mil/dds/anet/graphql/FileUploadMapper.java
@@ -1,0 +1,41 @@
+package mil.dds.anet.graphql;
+
+import graphql.schema.GraphQLScalarType;
+import io.leangen.graphql.generator.BuildContext;
+import io.leangen.graphql.generator.mapping.TypeMappingEnvironment;
+import io.leangen.graphql.generator.mapping.common.CachingMapper;
+import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.AnnotatedType;
+import mil.dds.anet.beans.FileUpload;
+
+public class FileUploadMapper extends CachingMapper<GraphQLScalarType, GraphQLScalarType> {
+
+  public static final GraphQLScalarType GraphQLFileUpload = GraphQlFileUploadType.getInstance();
+
+  @Override
+  protected GraphQLScalarType toGraphQLType(String typeName, AnnotatedType javaType,
+      TypeMappingEnvironment env) {
+    return GraphQLFileUpload;
+  }
+
+  @Override
+  protected GraphQLScalarType toGraphQLInputType(String typeName, AnnotatedType javaType,
+      TypeMappingEnvironment env) {
+    return GraphQLFileUpload;
+  }
+
+  @Override
+  public boolean supports(AnnotatedElement element, AnnotatedType type) {
+    return type.getType().equals(FileUpload.class);
+  }
+
+  @Override
+  protected String getTypeName(AnnotatedType type, BuildContext buildContext) {
+    return GraphQLFileUpload.getName();
+  }
+
+  @Override
+  protected String getInputTypeName(AnnotatedType type, BuildContext buildContext) {
+    return getTypeName(type, buildContext);
+  }
+}

--- a/src/main/java/mil/dds/anet/graphql/GraphQlFileUploadType.java
+++ b/src/main/java/mil/dds/anet/graphql/GraphQlFileUploadType.java
@@ -1,0 +1,53 @@
+package mil.dds.anet.graphql;
+
+import graphql.schema.Coercing;
+import graphql.schema.CoercingParseLiteralException;
+import graphql.schema.CoercingParseValueException;
+import graphql.schema.CoercingSerializeException;
+import graphql.schema.GraphQLScalarType;
+import java.io.IOException;
+import javax.servlet.http.Part;
+import mil.dds.anet.beans.FileUpload;
+
+public final class GraphQlFileUploadType {
+
+  private GraphQlFileUploadType() {}
+
+  private static final Coercing<FileUpload, Void> coercing = new Coercing<FileUpload, Void>() {
+    @Override
+    public Void serialize(Object dataFetcherResult) {
+      throw new CoercingSerializeException("Upload is an input-only type");
+    }
+
+    @Override
+    public FileUpload parseValue(Object input) {
+      if (input instanceof Part) {
+        Part part = (Part) input;
+        try {
+          String contentType = part.getContentType();
+          String name = part.getName();
+          byte[] content = new byte[part.getInputStream().available()];
+          part.delete();
+          return new FileUpload(contentType, name, content);
+
+        } catch (IOException e) {
+          throw new CoercingParseValueException("Couldn't read content of the uploaded file");
+        }
+      } else if (null == input) {
+        return null;
+      } else {
+        throw new CoercingParseValueException(
+            "Expected type " + Part.class.getName() + " but was " + input.getClass().getName());
+      }
+    }
+
+    @Override
+    public FileUpload parseLiteral(Object input) {
+      throw new CoercingParseLiteralException("Must use variables to specify Upload values");
+    }
+  };
+
+  public static GraphQLScalarType getInstance() {
+    return GraphQLScalarType.newScalar().name("FileUpload").coercing(coercing).build();
+  }
+}

--- a/src/main/java/mil/dds/anet/resources/AttachmentResource.java
+++ b/src/main/java/mil/dds/anet/resources/AttachmentResource.java
@@ -1,0 +1,31 @@
+package mil.dds.anet.resources;
+
+import io.leangen.graphql.annotations.GraphQLArgument;
+import io.leangen.graphql.annotations.GraphQLMutation;
+import io.leangen.graphql.annotations.GraphQLRootContext;
+import java.lang.invoke.MethodHandles;
+import java.util.Map;
+import mil.dds.anet.AnetObjectEngine;
+import mil.dds.anet.beans.FileUpload;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class AttachmentResource {
+  private static final Logger logger =
+      LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+  private final AnetObjectEngine engine;
+
+  public AttachmentResource(AnetObjectEngine engine) {
+    this.engine = engine;
+  }
+
+  // @Consumes(MediaType.MULTIPART_FORM_DATA)
+  @GraphQLMutation(name = "uploadFile")
+  public boolean fileUpload(@GraphQLRootContext Map<String, Object> context,
+      @GraphQLArgument(name = "file") FileUpload fileUpload) {
+    // get byte[] from fileUpload.getContent();
+    // Use Attachment.dao to persist the data received from fileUpload into the database
+    return true;
+  }
+}


### PR DESCRIPTION
Things that are missing:

- Relations between objects and attachments should be implemented.
- uploadFile mutation returns an 415 Unsupported Media Type error that needs to be fixed.
- Classifications must be persisted in the database when the application starts or there should be a way to customize the process.
- Mime type validation must be implemented.
- Maximum attachment size and allowed types configurations must be implemented.
- Server side tests must be implemented.

Closes #23 

#### User changes
-

#### Super User changes
-

#### Admin changes
-

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [x] db needs migration
- [ ] documentation has changed
- [x] graphql schema has changed

### Checklist
  - [ ] Described the user behavior in PR body
  - [ ] Referenced/updated all related issues
  - [ ] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [ ] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [x] Added and/or updated data migrations
  - [ ] Updated documentation
  - [ ] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
