### PR TITLE
Update renovate config, group: Storybook, Babel, WebdriverIO & Slate …

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -24,6 +24,30 @@
         "com.microsoft.sqlserver:mssql-jdbc"
       ],
       "allowedVersions": "/^.*\\.jre8$/"
+    },
+    {
+      "groupName": "NPM, dev-dependencies, Storybook",
+      "matchManagers": ["npm"],
+      "matchDepTypes": ["devDependencies"],
+      "matchPackagePrefixes": ["@storybook/"]
+    },
+    {
+      "groupName": "NPM, dev-dependencies, Babel",
+      "matchManagers": ["npm"],
+      "matchDepTypes": ["devDependencies"],
+      "matchPackagePrefixes": ["@babel/"]
+    },
+    {
+      "groupName": "NPM, dev-dependencies, WebdriverIO",
+      "matchManagers": ["npm"],
+      "matchDepTypes": ["devDependencies"],
+      "matchPackagePrefixes": ["@wdio/"]
+    },
+    {
+      "groupName": "NPM, dependencies, Slate",
+      "matchManagers": ["npm"],
+      "matchDepTypes": ["dependencies"],
+      "matchPackagePrefixes": ["slate"]
     }
   ],
   "postUpdateOptions": [


### PR DESCRIPTION
Update renovate config, add dependency groups for: 
- Storybook
- Babel
- WebdriverIO 
- Slate

Increase granularity of dependencies PR's, by adding logical groups, to prevent updates getting stuck as the result of breaking patch/minor updates and to isolate show stoppers.