### PR TITLE
Span biography over 2 columns in people (person) page

### DIFF
--- a/anet-dictionary.yml
+++ b/anet-dictionary.yml
@@ -807,6 +807,8 @@ fields:
         - endOfTourDate
         - biography
         - arrayFieldName
+      showAsFullWidthFields:
+        - biography
       assessments:
         advisorQuarterly:
           recurrence: quarterly
@@ -1329,6 +1331,8 @@ fields:
         - endOfTourDate
         - biography
         - arrayFieldName
+      showAsFullWidthFields:
+        - biography
     position:
       name: Afghan Tashkil
       type: Afghan Partner

--- a/client/src/models/Person.js
+++ b/client/src/models/Person.js
@@ -413,6 +413,15 @@ export default class Person extends Model {
       : Person.advisorShowPageOrderedFields
   }
 
+  /**
+   * @returns Keys of fields which should span over 2 columns
+   */
+  getFullWidthFields() {
+    return (this.isPrincipal()
+      ? Settings.fields.principal.person.showAsFullWidthFields
+      : Settings.fields.advisor.person.showAsFullWidthFields) || []
+  }
+
   static initShowPageFieldsOrdered(isPrincipal) {
     const fieldsArrayFromConfig = isPrincipal
       ? Settings.fields.principal.person.showPageOrderedFields

--- a/client/src/pages/people/Compact.js
+++ b/client/src/pages/people/Compact.js
@@ -109,9 +109,6 @@ const DEFAULT_FIELD_GROUP_EXCEPTIONS = [
   "endOfTour"
 ]
 
-// Large fields that will be displayed at the end
-const WHOLE_WIDTH_FIELDS = ["biography"]
-
 const NORMAL_FIELD_OPTIONS = Object.entries(
   Object.without(
     Settings.fields.person,
@@ -219,14 +216,16 @@ const CompactPersonView = ({ pageDispatchers }) => {
   const isAdmin = currentUser && currentUser.isAdmin()
   const position = person.position
   const hasPosition = position && position.uuid
+  // Keys of fields which should span over 2 columns
+  const fullWidthFieldKeys = person.getFullWidthFields()
   const emailHumanValue = (
     <a href={`mailto:${person.emailAddress}`}>{person.emailAddress}</a>
   )
   const orderedFields = orderPersonFields().filter(
-    field => !WHOLE_WIDTH_FIELDS.includes(field.key)
+    field => !fullWidthFieldKeys.includes(field.key)
   )
   const twoColumnFields = orderPersonFields().filter(field =>
-    WHOLE_WIDTH_FIELDS.includes(field.key)
+    fullWidthFieldKeys.includes(field.key)
   )
   const containsSensitiveInformation = !!orderedFields.find(field =>
     Object.keys(Person.customSensitiveInformation).includes(field.key)

--- a/client/src/pages/people/Show.js
+++ b/client/src/pages/people/Show.js
@@ -229,10 +229,25 @@ const PersonShow = ({ pageDispatchers }) => {
     <a href={`mailto:${person.emailAddress}`}>{person.emailAddress}</a>
   )
 
-  const orderedFields = orderPersonFields()
+  const extraColElems = {
+    position: getPositionActions(),
+    prevPositions: getPreviousPositionsActions()
+  }
+
+  // Keys of fields which should span over 2 columns
+  const fullWidthFieldKeys = person.getFullWidthFields()
+
+  const fullWidthFields = []
+  const orderedFields = orderPersonFields().filter(([el, key]) => {
+    if (fullWidthFieldKeys.includes(key)) {
+      fullWidthFields.push(cloneField([el, key], 2))
+      return false
+    }
+    return true
+  }).map(field => cloneField(field, 4))
   const numberOfFieldsUnderAvatar = person.getNumberOfFieldsInLeftColumn() || 6
-  const leftColumUnderAvatar = orderedFields.slice(0, numberOfFieldsUnderAvatar)
-  const rightColum = orderedFields.slice(numberOfFieldsUnderAvatar)
+  const leftColumnUnderAvatar = orderedFields.slice(0, numberOfFieldsUnderAvatar)
+  const rightColumn = orderedFields.slice(numberOfFieldsUnderAvatar)
 
   return (
     <Formik enableReinitialize initialValues={person}>
@@ -289,9 +304,12 @@ const PersonShow = ({ pageDispatchers }) => {
                           marginBottom: "10px"
                         }}
                       />
-                      {leftColumUnderAvatar}
+                      {leftColumnUnderAvatar}
                     </Col>
-                    <Col md={6}>{rightColum}</Col>
+                    <Col md={6}>{rightColumn}</Col>
+                  </Row>
+                  <Row>
+                    <Col md={12}>{fullWidthFields}</Col>
                   </Row>
                 </Container>
               </Fieldset>
@@ -404,11 +422,6 @@ const PersonShow = ({ pageDispatchers }) => {
       }
     }
 
-    const extraColElems = {
-      position: getPositionActions(),
-      prevPositions: getPreviousPositionsActions()
-    }
-
     return (
       person
         .getShowPageFieldsOrdered()
@@ -442,14 +455,15 @@ const PersonShow = ({ pageDispatchers }) => {
             mappedSensitiveFields[key],
           key
         ])
-        .map(([el, key]) =>
-          React.cloneElement(el, {
-            key,
-            extraColElem: extraColElems[key] || el.props.extraColElem || null,
-            labelColumnWidth: 4
-          })
-        )
     )
+  }
+
+  function cloneField([el, key], columnWidth) {
+    return React.cloneElement(el, {
+      key,
+      extraColElem: extraColElems[key] || el.props.extraColElem || null,
+      labelColumnWidth: columnWidth
+    })
   }
 
   function mapNonCustomFields() {

--- a/src/main/resources/anet-schema.yml
+++ b/src/main/resources/anet-schema.yml
@@ -707,6 +707,14 @@ properties:
                 items:
                   type: string
                   description: Ordered fields to show in Person Page in the Person info section
+              showAsFullWidthFields:
+                type: array
+                uniqueItems: true
+                minItems: 1
+                items:
+                  type: string
+                  title: List of fields spanning over page width
+                  description: Fields from the ordered fields, which should span over 2 columns
               numberOfFieldsInLeftColumn:
                 type: number
                 description: Used for dividing fields into 2 columns, make sure the columns are balanced
@@ -790,6 +798,14 @@ properties:
                 items:
                   type: string
                   description: Ordered fields to show in Person Page in the Person info section
+              showAsFullWidthFields:
+                type: array
+                uniqueItems: true
+                minItems: 1
+                items:
+                  type: string
+                  title: List of fields spanning over page width
+                  description: Fields from the ordered fields, which should span over 2 columns
               numberOfFieldsInLeftColumn:
                 type: number
                 description: Used for dividing fields into 2 columns, make sure the columns are balanced

--- a/testDictionaries/no-custom-fields.yml
+++ b/testDictionaries/no-custom-fields.yml
@@ -333,6 +333,8 @@ fields:
         - gender
         - endOfTourDate
         - biography
+      showAsFullWidthFields:
+        - biography
     position:
       name: NATO Billet
       type: ANET User
@@ -353,7 +355,6 @@ fields:
         placeholder: the six character code
 
   principal:
-
     person:
       name: Afghan Partner
       countries: [Afghanistan]
@@ -488,6 +489,8 @@ fields:
         - rank
         - gender
         - endOfTourDate
+        - biography
+      showAsFullWidthFields:
         - biography
     position:
       name: Afghan Tashkil


### PR DESCRIPTION
Resolves [AB#322](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/322)

Requires dictionary change to activate:

Add property `showAsFullWidthFields:`:
```yml
      showAsFullWidthFields:
        - biography
``` 
to `fields.advisor.person.numberOfFieldsInLeftColumn` and / or `fields.principal.person.numberOfFieldsInLeftColumn`