### PR TITLE
Singular column titles for advisor attendee attributes

### DIFF
--- a/client/src/pages/reports/ReportPeople.js
+++ b/client/src/pages/reports/ReportPeople.js
@@ -279,24 +279,13 @@ TableContainer.propTypes = {
 const TableHeader = ({ showDelete, hide }) => (
   <thead>
     <tr>
-      <th
-        className={"col-xs-1" + (hide ? " empty-cell-header" : "")}
-        style={{ textAlign: "center" }}
-      >
+      <th className={"col-xs-1" + (hide ? " empty-cell-header" : "")}>
         <div style={{ minWidth: "80px" }}>{!hide && "Primary"}</div>
       </th>
-      <th
-        className={"col-xs-1" + (hide ? " empty-cell-header" : "")}
-        style={{ textAlign: "center" }}
-      >
+      <th className={"col-xs-1" + (hide ? " empty-cell-header" : "")}>
         <div style={{ minWidth: "80px" }}>{!hide && "Attendee"}</div>
       </th>
-      <th
-        className={
-          "col-xs-1 report-author" + (hide ? " empty-cell-header" : "")
-        }
-        style={{ textAlign: "center" }}
-      >
+      <th className={"col-xs-1 report-author" + (hide ? " empty-cell-header" : "")}>
         <div style={{ minWidth: "70px" }}>{!hide && "Author"}</div>
       </th>
       <th className={"col-xs-1" + (hide ? " empty-cell-header" : "")}>

--- a/client/src/pages/reports/ReportPeople.js
+++ b/client/src/pages/reports/ReportPeople.js
@@ -289,7 +289,7 @@ const TableHeader = ({ showDelete, hide }) => (
         className={"col-xs-1" + (hide ? " empty-cell-header" : "")}
         style={{ textAlign: "center" }}
       >
-        <div style={{ minWidth: "80px" }}>{!hide && "Attendees"}</div>
+        <div style={{ minWidth: "80px" }}>{!hide && "Attendee"}</div>
       </th>
       <th
         className={
@@ -297,7 +297,7 @@ const TableHeader = ({ showDelete, hide }) => (
         }
         style={{ textAlign: "center" }}
       >
-        <div style={{ minWidth: "70px" }}>{!hide && "Authors"}</div>
+        <div style={{ minWidth: "70px" }}>{!hide && "Author"}</div>
       </th>
       <th className={"col-xs-1" + (hide ? " empty-cell-header" : "")}>
         <div style={{ width: showDelete ? "35px" : "120px" }} />


### PR DESCRIPTION
Changes:
1. Singular column titles for advisor attendee attributes
2. Left align column titles: "Primary", "Attendee" & "Author"

From:
![image](https://user-images.githubusercontent.com/45197818/152822255-e2bb5315-11f5-448e-82ed-9f65268e7533.png)

To:
![left-allign-column-titles-attendees](https://user-images.githubusercontent.com/45197818/152994291-ededb5a8-4da9-4cee-ae58-0f4b5ba5683e.png)

Resolves [AB#327](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/327)

