### PR TITLE
Replace "Add" hyperlink with button

### DIFF
--- a/client/src/components/FieldHelper.js
+++ b/client/src/components/FieldHelper.js
@@ -1,3 +1,5 @@
+import { Icon } from "@blueprintjs/core"
+import { IconNames } from "@blueprintjs/icons"
 import classNames from "classnames"
 import { CompactRow } from "components/Compact"
 import LinkTo from "components/LinkTo"
@@ -14,11 +16,13 @@ import {
   FormControl,
   FormGroup,
   InputGroup,
+  ListGroup,
   Row,
   ToggleButton,
   ToggleButtonGroup
 } from "react-bootstrap"
 import utils from "utils"
+
 const getFieldId = field => field.id || field.name // name property is required
 
 const getHumanValue = (field, humanValue) => {
@@ -609,21 +613,26 @@ export const FieldShortcuts = ({
   shortcuts.length > 0 && (
     <div id={`${fieldName}-shortcut-list`} className="shortcut-list">
       <h5>{title}</h5>
-      {objectType.map(shortcuts, (shortcut, idx) => (
-        <Button
-          key={shortcut.uuid}
-          variant="link"
-          onClick={() => handleAddItem(shortcut, onChange, curValue)}
-        >
-          Add{" "}
-          <LinkTo
-            modelType={objectType.resourceName}
-            model={shortcut}
-            isLink={false}
-            forShortcut
-          />
-        </Button>
-      ))}
+      <ListGroup>
+        {objectType.map(shortcuts, (shortcut, idx) => (
+          <ListGroup.Item>
+            <Button
+              key={shortcut.uuid}
+              onClick={() => handleAddItem(shortcut, onChange, curValue)}
+              variant="secondary"
+              size="sm"
+            >
+              <Icon icon={IconNames.DOUBLE_CHEVRON_LEFT} />
+            </Button>
+            <LinkTo
+              modelType={objectType.resourceName}
+              model={shortcut}
+              isLink={false}
+              forShortcut
+            />
+          </ListGroup.Item>
+        ))}
+      </ListGroup>
     </div>
   )
 

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -172,10 +172,18 @@ textarea.form-control {
   margin-top: -4px;
 }
 
-.shortcut-list .btn-link {
+.shortcut-list .list-group-item {
   text-align: left;
   white-space: initial;
-  padding: 0;
+  padding: 2px;
+}
+
+.shortcut-list .list-group-item .btn {
+  margin-right: 5px;
+}
+
+.shortcut-list .list-group-item .btn:focus {
+  box-shadow: none;
 }
 
 a.btn {


### PR DESCRIPTION
Replace "Add" hyperlink with button to add recent selected item, like an engagement attendee or recent efforts.

Resolves [AB#330](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/330)

Before:
![add-attendee-hyperlink](https://user-images.githubusercontent.com/45197818/152966850-e8cdafff-d6e4-464a-a0c1-5e0bdf380001.png)

After:
![add-attendee-button](https://user-images.githubusercontent.com/45197818/152966875-009ae52f-7948-400e-bee9-95671f8bc12e.png)


