### PR TITLE
AB#337: Decrease min height of the rows on the calendar

### DIFF
--- a/client/src/components/Calendar.css
+++ b/client/src/components/Calendar.css
@@ -11,3 +11,6 @@
   color: var(--fc-button-disabled-text-color);
   background-color: var(--fc-button-disabled-bg-color);
 }
+.fc .fc-daygrid-body-unbalanced .fc-daygrid-day-events {
+  min-height: 1em;
+}

--- a/client/src/components/Calendar.js
+++ b/client/src/components/Calendar.js
@@ -47,7 +47,7 @@ const Calendar = ({ events, eventClick, calendarComponentRef }) => (
     height="auto" // assume a natural height, no scrollbars will be used
     aspectRatio={3} // ratio of width-to-height
     ref={calendarComponentRef}
-    dayMaxEvents={3} // workaround for https://github.com/fullcalendar/fullcalendar/issues/5595
+    dayMaxEvents={2} // workaround for https://github.com/fullcalendar/fullcalendar/issues/5595
     eventMaxStack={3}
     events={events}
     eventOverlap


### PR DESCRIPTION
The minimum height of rows is decreased and the maximum number of events displayed per day is decreased.

Closes [AB#337](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/337)

#### User changes
- Calendar is more compact so that users can see more of it without using the vertical scroll

#### Super User changes
- None

#### Admin changes
- None

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
