### PR TITLE
Allow super users to edit organisations they are responsible for

### DIFF
--- a/anet-dictionary.yml
+++ b/anet-dictionary.yml
@@ -1204,6 +1204,9 @@ fields:
       identificationCode:
         label: UIC
         placeholder: the six character code
+      responsiblePositions:
+        label: Responsible positions
+        placeholder: Search for a position...
 
   principal:
     person:
@@ -1427,6 +1430,9 @@ fields:
       identificationCode:
         label: UIC
         placeholder: the six character code
+      responsiblePositions:
+        label: Responsible positions
+        placeholder: Search for a position...
 
   superUser:
 

--- a/anet-dictionary.yml
+++ b/anet-dictionary.yml
@@ -1194,8 +1194,8 @@ fields:
         placeholder: the CE post number for this position
       location:
         filter: [POINT_LOCATION]
-      responsibleOrganizations:
-        label: Responsible organizations
+      organizationsAdministrated:
+        label: Organizations administrated
         placeholder: Search for an organization...
 
     org:

--- a/anet-dictionary.yml
+++ b/anet-dictionary.yml
@@ -1194,6 +1194,9 @@ fields:
         placeholder: the CE post number for this position
       location:
         filter: [POINT_LOCATION]
+      responsibleOrganizations:
+        label: Responsible organizations
+        placeholder: Search for an organization...
 
     org:
       name: Advisor Organization

--- a/anet-dictionary.yml
+++ b/anet-dictionary.yml
@@ -1207,8 +1207,8 @@ fields:
       identificationCode:
         label: UIC
         placeholder: the six character code
-      responsiblePositions:
-        label: Responsible positions
+      administratingPositions:
+        label: Administrating positions
         placeholder: Search for a position...
 
   principal:
@@ -1433,8 +1433,8 @@ fields:
       identificationCode:
         label: UIC
         placeholder: the six character code
-      responsiblePositions:
-        label: Responsible positions
+      administratingPositions:
+        label: Administrating positions
         placeholder: Search for a position...
 
   superUser:

--- a/client/src/components/EditAdministratingPositionsModal.js
+++ b/client/src/components/EditAdministratingPositionsModal.js
@@ -24,7 +24,7 @@ const GQL_UPDATE_ORGANIZATION = gql`
   }
 `
 
-const EditResponsiblePositionsModal = ({
+const EditAdministratingPositionsModal = ({
   organization,
   showModal,
   onCancel,
@@ -32,7 +32,7 @@ const EditResponsiblePositionsModal = ({
 }) => {
   const [error, setError] = useState(null)
 
-  const ResponsiblePositionsMultiSelect = DictionaryField(FastField)
+  const AdministratingPositionsMultiSelect = DictionaryField(FastField)
   const positionsFilters = {
     allAdvisorPositions: {
       label: "All advisor positions",
@@ -60,7 +60,7 @@ const EditResponsiblePositionsModal = ({
           >
             <Modal.Header closeButton>
               <Modal.Title>
-                Edit {utils.noCase(orgSettings.responsiblePositions.label)}
+                Edit {utils.noCase(orgSettings.administratingPositions.label)}
               </Modal.Title>
             </Modal.Header>
             <Modal.Body>
@@ -69,26 +69,30 @@ const EditResponsiblePositionsModal = ({
                 <Container fluid>
                   <Row>
                     <Col md={12}>
-                      <ResponsiblePositionsMultiSelect
-                        name="responsiblePositions"
+                      <AdministratingPositionsMultiSelect
+                        name="administratingPositions"
                         component={FieldHelper.SpecialField}
-                        dictProps={orgSettings.responsiblePositions}
+                        dictProps={orgSettings.administratingPositions}
                         onChange={value => {
                           // validation will be done by setFieldValue
                           value = value.map(position =>
                             Position.filterClientSideFields(position)
                           )
-                          setFieldTouched("responsiblePositions", true, false) // onBlur doesn't work when selecting an option
-                          setFieldValue("responsiblePositions", value)
+                          setFieldTouched(
+                            "administratingPositions",
+                            true,
+                            false
+                          ) // onBlur doesn't work when selecting an option
+                          setFieldValue("administratingPositions", value)
                         }}
                         vertical
                         widget={
                           <AdvancedMultiSelect
-                            fieldName="responsiblePositions"
-                            value={values.responsiblePositions}
+                            fieldName="administratingPositions"
+                            value={values.administratingPositions}
                             renderSelected={
                               <PositionTable
-                                positions={values.responsiblePositions || []}
+                                positions={values.administratingPositions || []}
                                 showDelete
                               />
                             }
@@ -130,7 +134,10 @@ const EditResponsiblePositionsModal = ({
   function close(setFieldValue) {
     // Reset state before closing (cancel)
     setError(null)
-    setFieldValue("responsiblePositions", organization.responsiblePositions)
+    setFieldValue(
+      "administratingPositions",
+      organization.administratingPositions
+    )
     onCancel()
   }
 
@@ -156,11 +163,11 @@ const EditResponsiblePositionsModal = ({
   }
 }
 
-EditResponsiblePositionsModal.propTypes = {
+EditAdministratingPositionsModal.propTypes = {
   organization: PropTypes.object.isRequired,
   showModal: PropTypes.bool,
   onCancel: PropTypes.func.isRequired,
   onSuccess: PropTypes.func.isRequired
 }
 
-export default EditResponsiblePositionsModal
+export default EditAdministratingPositionsModal

--- a/client/src/components/EditOrganizationsAdministratedModal.js
+++ b/client/src/components/EditOrganizationsAdministratedModal.js
@@ -23,7 +23,7 @@ const GQL_UPDATE_POSITION = gql`
   }
 `
 
-const EditResponsibleOrganizationsModal = ({
+const EditOrganizationsAdministratedModal = ({
   position,
   showModal,
   onCancel,
@@ -31,7 +31,7 @@ const EditResponsibleOrganizationsModal = ({
 }) => {
   const [error, setError] = useState(null)
 
-  const ResponsibleOrganizationsMultiSelect = DictionaryField(FastField)
+  const OrganizationsAdministratedMultiSelect = DictionaryField(FastField)
   const organizationsFilters = {
     allOrganizations: {
       label: "All organizations",
@@ -44,8 +44,8 @@ const EditResponsibleOrganizationsModal = ({
   return (
     <Formik enableReinitialize onSubmit={onSubmit} initialValues={position}>
       {({ setFieldValue, values, submitForm, setFieldTouched }) => {
-        const responsibleOrgSettings =
-          Settings.fields.advisor.position.responsibleOrganizations
+        const organizationsAdministratedSettings =
+          Settings.fields.advisor.position.organizationsAdministrated
         return (
           <Modal
             centered
@@ -56,7 +56,7 @@ const EditResponsibleOrganizationsModal = ({
           >
             <Modal.Header closeButton>
               <Modal.Title>
-                Edit {utils.noCase(responsibleOrgSettings.label)}
+                Edit {utils.noCase(organizationsAdministratedSettings.label)}
               </Modal.Title>
             </Modal.Header>
             <Modal.Body>
@@ -65,31 +65,31 @@ const EditResponsibleOrganizationsModal = ({
                 <Container fluid>
                   <Row>
                     <Col md={12}>
-                      <ResponsibleOrganizationsMultiSelect
-                        name="responsibleOrganizations"
+                      <OrganizationsAdministratedMultiSelect
+                        name="organizationsAdministrated"
                         component={FieldHelper.SpecialField}
-                        dictProps={responsibleOrgSettings}
+                        dictProps={organizationsAdministratedSettings}
                         onChange={value => {
                           // validation will be done by setFieldValue
                           value = value.map(organization =>
                             Organization.filterClientSideFields(organization)
                           )
                           setFieldTouched(
-                            "responsibleOrganizations",
+                            "organizationsAdministrated",
                             true,
                             false
                           ) // onBlur doesn't work when selecting an option
-                          setFieldValue("responsibleOrganizations", value)
+                          setFieldValue("organizationsAdministrated", value)
                         }}
                         vertical
                         widget={
                           <AdvancedMultiSelect
-                            fieldName="responsibleOrganizations"
-                            value={values.responsibleOrganizations}
+                            fieldName="organizationsAdministrated"
+                            value={values.organizationsAdministrated}
                             renderSelected={
                               <OrganizationTable
                                 organizations={
-                                  values.responsibleOrganizations || []
+                                  values.organizationsAdministrated || []
                                 }
                                 showDelete
                               />
@@ -128,7 +128,10 @@ const EditResponsibleOrganizationsModal = ({
   function close(setFieldValue) {
     // Reset state before closing (cancel)
     setError(null)
-    setFieldValue("responsibleOrganizations", position.responsiblePositions)
+    setFieldValue(
+      "organizationsAdministrated",
+      position.organizationsAdministrated
+    )
     onCancel()
   }
 
@@ -148,11 +151,11 @@ const EditResponsibleOrganizationsModal = ({
   }
 }
 
-EditResponsibleOrganizationsModal.propTypes = {
+EditOrganizationsAdministratedModal.propTypes = {
   position: PropTypes.object.isRequired,
   showModal: PropTypes.bool,
   onCancel: PropTypes.func.isRequired,
   onSuccess: PropTypes.func.isRequired
 }
 
-export default EditResponsibleOrganizationsModal
+export default EditOrganizationsAdministratedModal

--- a/client/src/components/EditResponsibleOrganizationsModal.js
+++ b/client/src/components/EditResponsibleOrganizationsModal.js
@@ -7,12 +7,15 @@ import Messages from "components/Messages"
 import Model from "components/Model"
 import OrganizationTable from "components/OrganizationTable"
 import { FastField, Form, Formik } from "formik"
+import DictionaryField from "HOC/DictionaryField"
 import Organization from "models/Organization"
 import Position from "models/Position"
 import PropTypes from "prop-types"
 import React, { useState } from "react"
 import { Button, Col, Container, Modal, Row } from "react-bootstrap"
 import ORGANIZATIONS_ICON from "resources/organizations.png"
+import Settings from "settings"
+import utils from "utils"
 
 const GQL_UPDATE_POSITION = gql`
   mutation ($position: PositionInput!) {
@@ -28,6 +31,7 @@ const EditResponsibleOrganizationsModal = ({
 }) => {
   const [error, setError] = useState(null)
 
+  const ResponsibleOrganizationsMultiSelect = DictionaryField(FastField)
   const organizationsFilters = {
     allOrganizations: {
       label: "All organizations",
@@ -40,6 +44,8 @@ const EditResponsibleOrganizationsModal = ({
   return (
     <Formik enableReinitialize onSubmit={onSubmit} initialValues={position}>
       {({ setFieldValue, values, submitForm, setFieldTouched }) => {
+        const responsibleOrgSettings =
+          Settings.fields.advisor.position.responsibleOrganizations
         return (
           <Modal
             centered
@@ -49,7 +55,9 @@ const EditResponsibleOrganizationsModal = ({
             style={{ zIndex: "1300" }}
           >
             <Modal.Header closeButton>
-              <Modal.Title>Edit responsible organizations</Modal.Title>
+              <Modal.Title>
+                Edit {utils.noCase(responsibleOrgSettings.label)}
+              </Modal.Title>
             </Modal.Header>
             <Modal.Body>
               <Messages error={error} />
@@ -57,9 +65,10 @@ const EditResponsibleOrganizationsModal = ({
                 <Container fluid>
                   <Row>
                     <Col md={12}>
-                      <FastField
+                      <ResponsibleOrganizationsMultiSelect
                         name="responsibleOrganizations"
                         component={FieldHelper.SpecialField}
+                        dictProps={responsibleOrgSettings}
                         onChange={value => {
                           // validation will be done by setFieldValue
                           value = value.map(organization =>

--- a/client/src/components/EditResponsibleOrganizationsModal.js
+++ b/client/src/components/EditResponsibleOrganizationsModal.js
@@ -132,18 +132,19 @@ const EditResponsibleOrganizationsModal = ({
     onCancel()
   }
 
-  function onSubmit(values, form) {
-    return save(values, form)
-      .then(response => onSuccess())
-      .catch(error => {
-        form.setSubmitting(false)
-        setError(error)
-      })
+  async function onSubmit(values, form) {
+    try {
+      await save(values, form)
+      return onSuccess()
+    } catch (error) {
+      form.setSubmitting(false)
+      setError(error)
+    }
   }
 
   function save(values, form) {
     const position = Position.filterClientSideFields(new Position(values))
-    return API.mutation(GQL_UPDATE_POSITION, { position }).then()
+    return API.mutation(GQL_UPDATE_POSITION, { position })
   }
 }
 

--- a/client/src/components/EditResponsiblePositionsModal.js
+++ b/client/src/components/EditResponsiblePositionsModal.js
@@ -19,7 +19,7 @@ import Settings from "settings"
 import utils from "utils"
 
 const GQL_UPDATE_ORGANIZATION = gql`
-  mutation($organization: OrganizationInput!) {
+  mutation ($organization: OrganizationInput!) {
     updateOrganization(organization: $organization)
   }
 `
@@ -59,7 +59,9 @@ const EditResponsiblePositionsModal = ({
             size="lg"
           >
             <Modal.Header closeButton>
-              <Modal.Title>Edit responsible positions</Modal.Title>
+              <Modal.Title>
+                Edit {utils.noCase(orgSettings.responsiblePositions.label)}
+              </Modal.Title>
             </Modal.Header>
             <Modal.Body>
               <Messages error={error} />

--- a/client/src/components/EditResponsiblePositionsModal.js
+++ b/client/src/components/EditResponsiblePositionsModal.js
@@ -1,0 +1,163 @@
+import { gql } from "@apollo/client"
+import API from "api"
+import AdvancedMultiSelect from "components/advancedSelectWidget/AdvancedMultiSelect"
+import { PositionOverlayRow } from "components/advancedSelectWidget/AdvancedSelectOverlayRow"
+import { customFieldsJSONString } from "components/CustomFields"
+import * as FieldHelper from "components/FieldHelper"
+import Messages from "components/Messages"
+import Model from "components/Model"
+import PositionTable from "components/PositionTable"
+import { FastField, Form, Formik } from "formik"
+import DictionaryField from "HOC/DictionaryField"
+import Organization from "models/Organization"
+import Position from "models/Position"
+import PropTypes from "prop-types"
+import React, { useState } from "react"
+import { Button, Col, Container, Modal, Row } from "react-bootstrap"
+import POSITIONS_ICON from "resources/positions.png"
+import Settings from "settings"
+import utils from "utils"
+
+const GQL_UPDATE_ORGANIZATION = gql`
+  mutation($organization: OrganizationInput!) {
+    updateOrganization(organization: $organization)
+  }
+`
+
+const EditResponsiblePositionsModal = ({
+  organization,
+  showModal,
+  onCancel,
+  onSuccess
+}) => {
+  const [error, setError] = useState(null)
+
+  const ResponsiblePositionsMultiSelect = DictionaryField(FastField)
+  const positionsFilters = {
+    allAdvisorPositions: {
+      label: "All advisor positions",
+      queryVars: {
+        status: Model.STATUS.ACTIVE,
+        type: [Position.TYPE.SUPER_USER],
+        matchPersonName: true
+      }
+    }
+  }
+
+  return (
+    <Formik enableReinitialize onSubmit={onSubmit} initialValues={organization}>
+      {({ setFieldValue, values, submitForm, setFieldTouched }) => {
+        const isAdvisorOrg = values.type === Organization.TYPE.ADVISOR_ORG
+        const orgSettings = isAdvisorOrg
+          ? Settings.fields.advisor.org
+          : Settings.fields.principal.org
+        return (
+          <Modal
+            centered
+            show={showModal}
+            onHide={() => close(setFieldValue)}
+            size="lg"
+          >
+            <Modal.Header closeButton>
+              <Modal.Title>Edit responsible positions</Modal.Title>
+            </Modal.Header>
+            <Modal.Body>
+              <Messages error={error} />
+              <Form className="form-horizontal" method="post">
+                <Container fluid>
+                  <Row>
+                    <Col md={12}>
+                      <ResponsiblePositionsMultiSelect
+                        name="responsiblePositions"
+                        component={FieldHelper.SpecialField}
+                        dictProps={orgSettings.responsiblePositions}
+                        onChange={value => {
+                          // validation will be done by setFieldValue
+                          value = value.map(position =>
+                            Position.filterClientSideFields(position)
+                          )
+                          setFieldTouched("responsiblePositions", true, false) // onBlur doesn't work when selecting an option
+                          setFieldValue("responsiblePositions", value)
+                        }}
+                        vertical
+                        widget={
+                          <AdvancedMultiSelect
+                            fieldName="responsiblePositions"
+                            value={values.responsiblePositions}
+                            renderSelected={
+                              <PositionTable
+                                positions={values.responsiblePositions || []}
+                                showDelete
+                              />
+                            }
+                            overlayColumns={[
+                              "Position",
+                              "Organization",
+                              "Current Occupant"
+                            ]}
+                            overlayRenderRow={PositionOverlayRow}
+                            filterDefs={positionsFilters}
+                            objectType={Position}
+                            fields={Position.autocompleteQuery}
+                            addon={POSITIONS_ICON}
+                          />
+                        }
+                      />
+                    </Col>
+                  </Row>
+                </Container>
+              </Form>
+            </Modal.Body>
+            <Modal.Footer className="justify-content-between">
+              <Button
+                onClick={() => close(setFieldValue)}
+                variant="outline-secondary"
+              >
+                Cancel
+              </Button>
+              <Button onClick={submitForm} variant="primary">
+                Save
+              </Button>
+            </Modal.Footer>
+          </Modal>
+        )
+      }}
+    </Formik>
+  )
+
+  function close(setFieldValue) {
+    // Reset state before closing (cancel)
+    setError(null)
+    setFieldValue("responsiblePositions", organization.responsiblePositions)
+    onCancel()
+  }
+
+  function onSubmit(values, form) {
+    return save(values, form)
+      .then(response => onSuccess())
+      .catch(error => {
+        form.setSubmitting(false)
+        setError(error)
+      })
+  }
+
+  function save(values, form) {
+    const organization = Organization.filterClientSideFields(
+      new Organization(values)
+    )
+    // strip tasks fields not in data model
+    organization.tasks = values.tasks.map(t => utils.getReference(t))
+    organization.parentOrg = utils.getReference(organization.parentOrg)
+    organization.customFields = customFieldsJSONString(values)
+    return API.mutation(GQL_UPDATE_ORGANIZATION, { organization }).then()
+  }
+}
+
+EditResponsiblePositionsModal.propTypes = {
+  organization: PropTypes.object.isRequired,
+  showModal: PropTypes.bool,
+  onCancel: PropTypes.func.isRequired,
+  onSuccess: PropTypes.func.isRequired
+}
+
+export default EditResponsiblePositionsModal

--- a/client/src/components/EditResponsiblePositionsModal.js
+++ b/client/src/components/EditResponsiblePositionsModal.js
@@ -134,13 +134,14 @@ const EditResponsiblePositionsModal = ({
     onCancel()
   }
 
-  function onSubmit(values, form) {
-    return save(values, form)
-      .then(response => onSuccess())
-      .catch(error => {
-        form.setSubmitting(false)
-        setError(error)
-      })
+  async function onSubmit(values, form) {
+    try {
+      await save(values, form)
+      return onSuccess()
+    } catch (error) {
+      form.setSubmitting(false)
+      setError(error)
+    }
   }
 
   function save(values, form) {
@@ -151,7 +152,7 @@ const EditResponsiblePositionsModal = ({
     organization.tasks = values.tasks.map(t => utils.getReference(t))
     organization.parentOrg = utils.getReference(organization.parentOrg)
     organization.customFields = customFieldsJSONString(values)
-    return API.mutation(GQL_UPDATE_ORGANIZATION, { organization }).then()
+    return API.mutation(GQL_UPDATE_ORGANIZATION, { organization })
   }
 }
 

--- a/client/src/components/previews/OrganizationPreview.js
+++ b/client/src/components/previews/OrganizationPreview.js
@@ -68,13 +68,13 @@ const GQL_GET_ORGANIZATION = gql`
         code
         type
         status
-        organization {
-          uuid
-          shortName
-        }
         location {
           uuid
           name
+        }
+        organization {
+          uuid
+          shortName
         }
         person {
           uuid

--- a/client/src/components/previews/OrganizationPreview.js
+++ b/client/src/components/previews/OrganizationPreview.js
@@ -62,7 +62,7 @@ const GQL_GET_ORGANIZATION = gql`
           }
         }
       }
-      responsiblePositions {
+      administratingPositions {
         uuid
         name
         code

--- a/client/src/components/previews/OrganizationPreview.js
+++ b/client/src/components/previews/OrganizationPreview.js
@@ -62,6 +62,28 @@ const GQL_GET_ORGANIZATION = gql`
           }
         }
       }
+      responsiblePositions {
+        uuid
+        name
+        code
+        type
+        status
+        organization {
+          uuid
+          shortName
+        }
+        location {
+          uuid
+          name
+        }
+        person {
+          uuid
+          name
+          rank
+          role
+          avatar(size: 32)
+        }
+      }
     }
   }
 `

--- a/client/src/components/previews/PersonPreview.js
+++ b/client/src/components/previews/PersonPreview.js
@@ -100,7 +100,7 @@ const PersonPreview = ({ className, uuid }) => {
 
   // User can always edit themselves
   // Admins can always edit anybody
-  // SuperUsers can edit people in their org, their descendant orgs, or un-positioned people.
+  // Super users can edit people in their org, their descendant orgs, or un-positioned people.
   const isAdmin = currentUser && currentUser.isAdmin()
   const hasPosition = position && position.uuid
 

--- a/client/src/components/previews/TaskPreview.js
+++ b/client/src/components/previews/TaskPreview.js
@@ -39,13 +39,13 @@ const GQL_GET_TASK = gql`
         code
         type
         status
-        organization {
-          uuid
-          shortName
-        }
         location {
           uuid
           name
+        }
+        organization {
+          uuid
+          shortName
         }
         person {
           uuid

--- a/client/src/models/Person.js
+++ b/client/src/models/Person.js
@@ -332,12 +332,6 @@ export default class Person extends Model {
     if (!this.position || !this.position.organization) {
       return false
     }
-    const ownOrgs = this.position.organization.descendantOrgs || []
-    ownOrgs.push(this.position.organization)
-    const isOwnOrg = ownOrgs.map(o => o.uuid).includes(org.uuid)
-    if (isOwnOrg) {
-      return true
-    }
     if (this.position.responsibleOrganizations) {
       const responsibleOrgUuids = this.position.responsibleOrganizations.reduce(
         (acc, org) => {

--- a/client/src/models/Person.js
+++ b/client/src/models/Person.js
@@ -317,8 +317,8 @@ export default class Person extends Model {
   // - An Administrator
   // - A super user for this organization
   // - A super user for this orgs parents.
-  // - A super user responsible for this org
-  // - A super user responsible for this orgs parent
+  // - A super user administrating this org
+  // - A super user administrating this orgs parent
   isSuperUserForOrg(org) {
     if (!org) {
       return false
@@ -332,18 +332,16 @@ export default class Person extends Model {
     if (!this.position || !this.position.organization) {
       return false
     }
-    if (this.position.responsibleOrganizations) {
-      const responsibleOrgUuids = this.position.responsibleOrganizations.reduce(
-        (acc, org) => {
+    if (this.position.organizationsAdministrated) {
+      const orgsAdministratedUuids =
+        this.position.organizationsAdministrated.reduce((acc, org) => {
           acc.push(org.uuid)
           org.descendantOrgs.forEach(descOrg => {
             acc.push(descOrg.uuid)
           })
           return acc
-        },
-        []
-      )
-      return responsibleOrgUuids.includes(org.uuid)
+        }, [])
+      return orgsAdministratedUuids.includes(org.uuid)
     }
     return false
   }

--- a/client/src/models/Person.js
+++ b/client/src/models/Person.js
@@ -314,22 +314,20 @@ export default class Person extends Model {
 
   // Checks if this user is a valid super user for a particular organization
   // Must be either
-  // - An Administrator
-  // - A super user for this organization
-  // - A super user for this orgs parents.
-  // - A super user administrating this org
-  // - A super user administrating this orgs parent
-  isSuperUserForOrg(org) {
+  // - an administrator
+  // - a super user administrating this organization
+  // - a super user administrating this organization's (transitive) parent
+  hasAdministrativePermissionsForOrganization(org) {
     if (!org) {
       return false
     }
-    if (this.position && this.position.type === Position.TYPE.ADMINISTRATOR) {
+    if (this.position?.type === Position.TYPE.ADMINISTRATOR) {
       return true
     }
-    if (this.position && this.position.type !== Position.TYPE.SUPER_USER) {
-      return false
-    }
-    if (!this.position || !this.position.organization) {
+    if (
+      this.position?.type !== Position.TYPE.SUPER_USER ||
+      !this.position?.organization
+    ) {
       return false
     }
     if (this.position.organizationsAdministrated) {

--- a/client/src/models/Position.js
+++ b/client/src/models/Position.js
@@ -86,7 +86,7 @@ export default class Position extends Model {
     .concat(Model.yupSchema)
 
   static autocompleteQuery =
-    "uuid, name, code, type, status, organization { uuid, shortName}, person { uuid, name, rank, role, avatar(size: 32) }"
+    "uuid name code type status location { uuid name } organization { uuid shortName} person { uuid name rank role avatar(size: 32) }"
 
   static autocompleteQueryWithNotes = `${this.autocompleteQuery} ${GRAPHQL_NOTES_FIELDS}`
 

--- a/client/src/models/Position.js
+++ b/client/src/models/Position.js
@@ -145,6 +145,12 @@ export default class Position extends Model {
         }
       }
     }
+    responsibleOrganizations {
+      uuid
+      shortName
+      longName
+      identificationCode
+    }
     location {
       uuid
       name

--- a/client/src/models/Position.js
+++ b/client/src/models/Position.js
@@ -145,7 +145,7 @@ export default class Position extends Model {
         }
       }
     }
-    responsibleOrganizations {
+    organizationsAdministrated {
       uuid
       shortName
       longName

--- a/client/src/pages/App.js
+++ b/client/src/pages/App.js
@@ -106,7 +106,7 @@ const GQL_GET_APP_DATA = gql`
           }
           ${GRAPHQL_NOTIFICATIONS_NOTE_FIELDS}
         }
-        responsibleOrganizations {
+        organizationsAdministrated {
           uuid
           descendantOrgs {
             uuid

--- a/client/src/pages/App.js
+++ b/client/src/pages/App.js
@@ -106,6 +106,12 @@ const GQL_GET_APP_DATA = gql`
           }
           ${GRAPHQL_NOTIFICATIONS_NOTE_FIELDS}
         }
+        responsibleOrganizations {
+          uuid
+          descendantOrgs {
+            uuid
+          }
+        }
         authorizationGroups {
           uuid
           name

--- a/client/src/pages/admin/merge/MergePositions.js
+++ b/client/src/pages/admin/merge/MergePositions.js
@@ -40,8 +40,8 @@ import useMergeObjects, {
   unassignedPerson
 } from "mergeUtils"
 import { Position } from "models"
+import OrganizationsAdministrated from "pages/positions/OrganizationsAdministrated"
 import PreviousPeople from "pages/positions/PreviousPeople"
-import ResponsibleOrganizations from "pages/positions/ResponsibleOrganizations"
 import PropTypes from "prop-types"
 import React, { useState } from "react"
 import { Button, Col, Container, FormGroup, Row } from "react-bootstrap"
@@ -288,19 +288,19 @@ const MergePositions = ({ pageDispatchers }) => {
               />
               {mergeState?.merged?.type === Position.TYPE.SUPER_USER && (
                 <PositionField
-                  label="Responsible Organizations"
-                  fieldName="responsibleOrganizations"
+                  label="Organizations Administrated"
+                  fieldName="organizationsAdministrated"
                   value={
-                    <ResponsibleOrganizations
+                    <OrganizationsAdministrated
                       organizations={
-                        mergedPosition.responsibleOrganizations || []
+                        mergedPosition.organizationsAdministrated || []
                       }
                     />
                   }
                   align={ALIGN_OPTIONS.CENTER}
                   action={getClearButton(() =>
                     dispatchMergeActions(
-                      setAMergedField("responsibleOrganizations", [], null)
+                      setAMergedField("organizationsAdministrated", [], null)
                     )
                   )}
                   mergeState={mergeState}
@@ -624,11 +624,11 @@ const PositionColumn = ({ align, label, mergeState, dispatchMergeActions }) => {
           />
           {position.type === Position.TYPE.SUPER_USER && (
             <PositionField
-              label="Responsible Organizations"
-              fieldName="responsibleOrganizations"
+              label="Organizations Administrated"
+              fieldName="organizationsAdministrated"
               value={
-                <ResponsibleOrganizations
-                  organizations={position.responsibleOrganizations}
+                <OrganizationsAdministrated
+                  organizations={position.organizationsAdministrated}
                 />
               }
               align={align}
@@ -636,14 +636,14 @@ const PositionColumn = ({ align, label, mergeState, dispatchMergeActions }) => {
                 () =>
                   dispatchMergeActions(
                     setAMergedField(
-                      "responsibleOrganizations",
-                      position.responsibleOrganizations,
+                      "organizationsAdministrated",
+                      position.organizationsAdministrated,
                       align
                     )
                   ),
                 align,
                 mergeState,
-                "responsibleOrganizations"
+                "organizationsAdministrated"
               )}
               mergeState={mergeState}
               dispatchMergeActions={dispatchMergeActions}

--- a/client/src/pages/admin/merge/MergePositions.js
+++ b/client/src/pages/admin/merge/MergePositions.js
@@ -41,6 +41,7 @@ import useMergeObjects, {
 } from "mergeUtils"
 import { Position } from "models"
 import PreviousPeople from "pages/positions/PreviousPeople"
+import ResponsibleOrganizations from "pages/positions/ResponsibleOrganizations"
 import PropTypes from "prop-types"
 import React, { useState } from "react"
 import { Button, Col, Container, FormGroup, Row } from "react-bootstrap"
@@ -285,6 +286,27 @@ const MergePositions = ({ pageDispatchers }) => {
                 mergeState={mergeState}
                 dispatchMergeActions={dispatchMergeActions}
               />
+              {mergeState?.merged?.type === Position.TYPE.SUPER_USER && (
+                <PositionField
+                  label="Responsible Organizations"
+                  fieldName="responsibleOrganizations"
+                  value={
+                    <ResponsibleOrganizations
+                      organizations={
+                        mergedPosition.responsibleOrganizations || []
+                      }
+                    />
+                  }
+                  align={ALIGN_OPTIONS.CENTER}
+                  action={getClearButton(() =>
+                    dispatchMergeActions(
+                      setAMergedField("responsibleOrganizations", [], null)
+                    )
+                  )}
+                  mergeState={mergeState}
+                  dispatchMergeActions={dispatchMergeActions}
+                />
+              )}
               {Settings.fields.position.customFields &&
                 Object.entries(Settings.fields.position.customFields).map(
                   ([fieldName, fieldConfig]) => {
@@ -413,7 +435,8 @@ function getPositionFilters(mergeState, align) {
       label: "All",
       queryVars: {
         status: Position.STATUS.ACTIVE,
-        organizationUuid: mergeState[getOtherSide(align)]?.organization?.uuid
+        organizationUuid: mergeState[getOtherSide(align)]?.organization?.uuid,
+        type: mergeState[getOtherSide(align)]?.type
       }
     }
   }
@@ -599,6 +622,33 @@ const PositionColumn = ({ align, label, mergeState, dispatchMergeActions }) => {
             mergeState={mergeState}
             dispatchMergeActions={dispatchMergeActions}
           />
+          {position.type === Position.TYPE.SUPER_USER && (
+            <PositionField
+              label="Responsible Organizations"
+              fieldName="responsibleOrganizations"
+              value={
+                <ResponsibleOrganizations
+                  organizations={position.responsibleOrganizations}
+                />
+              }
+              align={align}
+              action={getActionButton(
+                () =>
+                  dispatchMergeActions(
+                    setAMergedField(
+                      "responsibleOrganizations",
+                      position.responsibleOrganizations,
+                      align
+                    )
+                  ),
+                align,
+                mergeState,
+                "responsibleOrganizations"
+              )}
+              mergeState={mergeState}
+              dispatchMergeActions={dispatchMergeActions}
+            />
+          )}
           {Settings.fields.position.customFields &&
             Object.entries(Settings.fields.position.customFields).map(
               ([fieldName, fieldConfig]) => {

--- a/client/src/pages/organizations/Edit.js
+++ b/client/src/pages/organizations/Edit.js
@@ -50,6 +50,23 @@ const GQL_GET_ORGANIZATION = gql`
           }
         }
       }
+      responsiblePositions {
+        uuid
+        name
+        status
+        person {
+          uuid
+          name
+        }
+        location {
+          uuid
+          name
+        }
+        organization {
+          uuid
+          shortName
+        }
+      }
       approvalSteps {
         uuid
         name

--- a/client/src/pages/organizations/Edit.js
+++ b/client/src/pages/organizations/Edit.js
@@ -50,7 +50,7 @@ const GQL_GET_ORGANIZATION = gql`
           }
         }
       }
-      responsiblePositions {
+      administratingPositions {
         uuid
         name
         code

--- a/client/src/pages/organizations/Edit.js
+++ b/client/src/pages/organizations/Edit.js
@@ -53,11 +53,9 @@ const GQL_GET_ORGANIZATION = gql`
       responsiblePositions {
         uuid
         name
+        code
+        type
         status
-        person {
-          uuid
-          name
-        }
         location {
           uuid
           name
@@ -65,6 +63,13 @@ const GQL_GET_ORGANIZATION = gql`
         organization {
           uuid
           shortName
+        }
+        person {
+          uuid
+          name
+          rank
+          role
+          avatar(size: 32)
         }
       }
       approvalSteps {

--- a/client/src/pages/organizations/Form.js
+++ b/client/src/pages/organizations/Form.js
@@ -193,7 +193,6 @@ const OrganizationForm = ({ edit, title, initialValues, notesComponent }) => {
             <Form className="form-horizontal" method="post">
               <Fieldset title={title} action={action} />
               <Fieldset>
-                {/* TODO: First condition can be removed when the privileges are clear. */}
                 {!isSuperUserForOrg ? (
                   <>
                     <FastField

--- a/client/src/pages/organizations/Form.js
+++ b/client/src/pages/organizations/Form.js
@@ -99,9 +99,13 @@ const OrganizationForm = ({ edit, title, initialValues, notesComponent }) => {
         const isAdvisorOrg = values.type === Organization.TYPE.ADVISOR_ORG
         const isSuperUserForParentOrg =
           _isEmpty(values.parentOrg) ||
-          (currentUser && currentUser.isSuperUserForOrg(values.parentOrg))
+          (currentUser &&
+            currentUser.hasAdministrativePermissionsForOrganization(
+              values.parentOrg
+            ))
         const isSuperUserForOrg = edit
-          ? currentUser && currentUser.isSuperUserForOrg(values)
+          ? currentUser &&
+            currentUser.hasAdministrativePermissionsForOrganization(values)
           : isSuperUserForParentOrg
         const orgSettings = isAdvisorOrg
           ? Settings.fields.advisor.org

--- a/client/src/pages/organizations/Form.js
+++ b/client/src/pages/organizations/Form.js
@@ -97,16 +97,16 @@ const OrganizationForm = ({ edit, title, initialValues, notesComponent }) => {
       }) => {
         const isAdmin = currentUser && currentUser.isAdmin()
         const isAdvisorOrg = values.type === Organization.TYPE.ADVISOR_ORG
-        const isSuperUserForParentOrg =
+        const canAdministrateParentOrg =
           _isEmpty(values.parentOrg) ||
           (currentUser &&
             currentUser.hasAdministrativePermissionsForOrganization(
               values.parentOrg
             ))
-        const isSuperUserForOrg = edit
+        const canAdministrateOrg = edit
           ? currentUser &&
             currentUser.hasAdministrativePermissionsForOrganization(values)
-          : isSuperUserForParentOrg
+          : canAdministrateParentOrg
         const orgSettings = isAdvisorOrg
           ? Settings.fields.advisor.org
           : Settings.fields.principal.org
@@ -132,7 +132,7 @@ const OrganizationForm = ({ edit, title, initialValues, notesComponent }) => {
         ) {
           values.parentOrg = {}
         }
-        const action = isSuperUserForOrg && (
+        const action = canAdministrateOrg && (
           <div>
             <Button
               key="submit"
@@ -197,7 +197,7 @@ const OrganizationForm = ({ edit, title, initialValues, notesComponent }) => {
             <Form className="form-horizontal" method="post">
               <Fieldset title={title} action={action} />
               <Fieldset>
-                {!isSuperUserForOrg ? (
+                {!canAdministrateOrg ? (
                   <>
                     <FastField
                       name="type"
@@ -262,7 +262,7 @@ const OrganizationForm = ({ edit, title, initialValues, notesComponent }) => {
                         setFieldTouched("parentOrg", true, false) // onBlur doesn't work when selecting an option
                         setFieldValue("parentOrg", value)
                       }}
-                      disabled={!isSuperUserForParentOrg}
+                      disabled={!canAdministrateParentOrg}
                       widget={
                         <AdvancedSingleSelect
                           fieldName="parentOrg"
@@ -397,7 +397,7 @@ const OrganizationForm = ({ edit, title, initialValues, notesComponent }) => {
                     Cancel
                   </Button>
                 </div>
-                {isSuperUserForOrg && (
+                {canAdministrateOrg && (
                   <div>
                     <Button
                       id="formBottomSubmit"

--- a/client/src/pages/organizations/Form.js
+++ b/client/src/pages/organizations/Form.js
@@ -110,13 +110,13 @@ const OrganizationForm = ({ edit, title, initialValues, notesComponent }) => {
           status: Model.STATUS.ACTIVE,
           type: values.type
         }
-        // Super users can select parent organizations among the ones they are responsible from
+        // Super users can select parent organizations among the ones their position is administrating
         if (!isAdmin) {
-          const respOrgsUuids =
-            currentUser.position.responsibleOrganizations.map(org => org.uuid)
+          const orgsAdministratedUuids =
+            currentUser.position.organizationsAdministrated.map(org => org.uuid)
           orgSearchQuery.parentOrgUuid = [
             currentUser.position.organization.uuid,
-            ...respOrgsUuids
+            ...orgsAdministratedUuids
           ]
           orgSearchQuery.orgRecurseStrategy = RECURSE_STRATEGY.CHILDREN
         }

--- a/client/src/pages/organizations/Form.js
+++ b/client/src/pages/organizations/Form.js
@@ -52,7 +52,7 @@ const GQL_UPDATE_ORGANIZATION = gql`
 `
 
 const OrganizationForm = ({ edit, title, initialValues, notesComponent }) => {
-  const { currentUser } = useContext(AppContext)
+  const { loadAppData, currentUser } = useContext(AppContext)
   const navigate = useNavigate()
   const [error, setError] = useState(null)
   const statusButtons = [
@@ -127,9 +127,8 @@ const OrganizationForm = ({ edit, title, initialValues, notesComponent }) => {
         }
         // Super users can select parent organizations among the ones they are responsible from
         if (!isAdmin) {
-          const respOrgsUuids = currentUser.position.responsibleOrganizations.map(
-            org => org.uuid
-          )
+          const respOrgsUuids =
+            currentUser.position.responsibleOrganizations.map(org => org.uuid)
           orgSearchQuery.parentOrgUuid = [
             currentUser.position.organization.uuid,
             ...respOrgsUuids
@@ -490,6 +489,7 @@ const OrganizationForm = ({ edit, title, initialValues, notesComponent }) => {
     // reset the form to latest values
     // to avoid unsaved changes prompt if it somehow becomes dirty
     form.resetForm({ values, isSubmitting: true })
+    loadAppData()
     if (!edit) {
       navigate(Organization.pathForEdit(organization), { replace: true })
     }

--- a/client/src/pages/organizations/Form.js
+++ b/client/src/pages/organizations/Form.js
@@ -3,7 +3,6 @@ import API from "api"
 import AdvancedMultiSelect from "components/advancedSelectWidget/AdvancedMultiSelect"
 import {
   OrganizationOverlayRow,
-  PositionOverlayRow,
   TaskSimpleOverlayRow
 } from "components/advancedSelectWidget/AdvancedSelectOverlayRow"
 import AdvancedSingleSelect from "components/advancedSelectWidget/AdvancedSingleSelect"
@@ -21,7 +20,6 @@ import Model from "components/Model"
 import NavigationWarning from "components/NavigationWarning"
 import NoPaginationTaskTable from "components/NoPaginationTaskTable"
 import { jumpToTop } from "components/Page"
-import PositionTable from "components/PositionTable"
 import { FastField, Field, Form, Formik } from "formik"
 import _isEmpty from "lodash/isEmpty"
 import { Organization, Position, Task } from "models"
@@ -31,7 +29,6 @@ import React, { useContext, useState } from "react"
 import { Button } from "react-bootstrap"
 import { useNavigate } from "react-router-dom"
 import ORGANIZATIONS_ICON from "resources/organizations.png"
-import POSITIONS_ICON from "resources/positions.png"
 import TASKS_ICON from "resources/tasks.png"
 import { RECURSE_STRATEGY } from "searchUtils"
 import Settings from "settings"
@@ -81,18 +78,6 @@ const OrganizationForm = ({ edit, title, initialValues, notesComponent }) => {
   ]
   const IdentificationCodeFieldWithLabel = DictionaryField(FastField)
   const LongNameWithLabel = DictionaryField(FastField)
-  const ResponsiblePositionsMultiSelect = DictionaryField(FastField)
-
-  const positionsFilters = {
-    allAdvisorPositions: {
-      label: "All advisor positions",
-      queryVars: {
-        status: Model.STATUS.ACTIVE,
-        type: [Position.TYPE.SUPER_USER],
-        matchPersonName: true
-      }
-    }
-  }
 
   return (
     <Formik
@@ -313,42 +298,6 @@ const OrganizationForm = ({ edit, title, initialValues, notesComponent }) => {
                       dictProps={orgSettings.identificationCode}
                       name="identificationCode"
                       component={FieldHelper.InputField}
-                    />
-                    <ResponsiblePositionsMultiSelect
-                      name="responsiblePositions"
-                      component={FieldHelper.SpecialField}
-                      dictProps={orgSettings.responsiblePositions}
-                      disabled={!isAdmin}
-                      onChange={value => {
-                        // validation will be done by setFieldValue
-                        value = value.map(position =>
-                          Position.filterClientSideFields(position)
-                        )
-                        setFieldTouched("responsiblePositions", true, false) // onBlur doesn't work when selecting an option
-                        setFieldValue("responsiblePositions", value)
-                      }}
-                      widget={
-                        <AdvancedMultiSelect
-                          fieldName="responsiblePositions"
-                          value={values.responsiblePositions}
-                          renderSelected={
-                            <PositionTable
-                              positions={values.responsiblePositions || []}
-                              showDelete={isAdmin}
-                            />
-                          }
-                          overlayColumns={[
-                            "Position",
-                            "Organization",
-                            "Current Occupant"
-                          ]}
-                          overlayRenderRow={PositionOverlayRow}
-                          filterDefs={positionsFilters}
-                          objectType={Position}
-                          fields={Position.autocompleteQuery}
-                          addon={POSITIONS_ICON}
-                        />
-                      }
                     />
                   </>
                 )}

--- a/client/src/pages/organizations/Laydown.js
+++ b/client/src/pages/organizations/Laydown.js
@@ -3,6 +3,7 @@ import Fieldset from "components/Fieldset"
 import OrganizationalChart from "components/graphs/OrganizationalChart"
 import LinkTo from "components/LinkTo"
 import Model from "components/Model"
+import PositionTable from "components/PositionTable"
 import { Organization, Person, Position } from "models"
 import PropTypes from "prop-types"
 import React, { useContext, useState } from "react"
@@ -14,8 +15,10 @@ import Settings from "settings"
 const OrganizationLaydown = ({ organization }) => {
   const { currentUser } = useContext(AppContext)
   const [showInactivePositions, setShowInactivePositions] = useState(false)
-  const isSuperUser = currentUser && currentUser.isSuperUserForOrg(organization)
-
+  const isSuperUserForOrg =
+    currentUser && currentUser.isSuperUserForOrg(organization)
+  const isSuperUser = currentUser && currentUser.isSuperUser()
+  const isPrincipalOrg = organization.type === Organization.TYPE.PRINCIPAL_ORG
   const numInactivePos = organization.positions.filter(
     p => p.status === Model.STATUS.INACTIVE
   ).length
@@ -26,6 +29,8 @@ const OrganizationLaydown = ({ organization }) => {
   const supportedPositions = organization.positions.filter(
     position => positionsNeedingAttention.indexOf(position) === -1
   )
+  const canCreatePositions =
+    isSuperUserForOrg || (isSuperUser && isPrincipalOrg)
 
   return (
     <Element name="laydown">
@@ -60,7 +65,7 @@ const OrganizationLaydown = ({ organization }) => {
         title="Supported positions"
         action={
           <div>
-            {isSuperUser && (
+            {canCreatePositions && (
               <LinkTo
                 modelType="Position"
                 model={Position.pathForNew({
@@ -99,6 +104,9 @@ const OrganizationLaydown = ({ organization }) => {
         {positionsNeedingAttention.length === 0 && (
           <em>There are no vacant positions</em>
         )}
+      </Fieldset>
+      <Fieldset id="responsiblePositions" title="Responsible Positions">
+        <PositionTable positions={organization.responsiblePositions} />
       </Fieldset>
     </Element>
   )

--- a/client/src/pages/organizations/Laydown.js
+++ b/client/src/pages/organizations/Laydown.js
@@ -1,4 +1,5 @@
 import AppContext from "components/AppContext"
+import EditResponsiblePositionsModal from "components/EditResponsiblePositionsModal"
 import Fieldset from "components/Fieldset"
 import OrganizationalChart from "components/graphs/OrganizationalChart"
 import LinkTo from "components/LinkTo"
@@ -12,9 +13,14 @@ import ContainerDimensions from "react-container-dimensions"
 import { Element } from "react-scroll"
 import Settings from "settings"
 
-const OrganizationLaydown = ({ organization }) => {
+const OrganizationLaydown = ({ organization, refetch }) => {
   const { currentUser } = useContext(AppContext)
   const [showInactivePositions, setShowInactivePositions] = useState(false)
+  const [
+    showResponsiblePositionsModal,
+    setShowResponsiblePositionsModal
+  ] = useState(false)
+  const isAdmin = currentUser && currentUser.isAdmin()
   const isSuperUserForOrg =
     currentUser && currentUser.isSuperUserForOrg(organization)
   const isSuperUser = currentUser && currentUser.isSuperUser()
@@ -105,8 +111,27 @@ const OrganizationLaydown = ({ organization }) => {
           <em>There are no vacant positions</em>
         )}
       </Fieldset>
-      <Fieldset id="responsiblePositions" title="Responsible Positions">
+      <Fieldset
+        id="responsiblePositions"
+        title="Responsible Positions"
+        action={
+          isAdmin && (
+            <Button
+              onClick={() => setShowResponsiblePositionsModal(true)}
+              variant="outline-secondary"
+            >
+              Edit Responsible Positions
+            </Button>
+          )
+        }
+      >
         <PositionTable positions={organization.responsiblePositions} />
+        <EditResponsiblePositionsModal
+          organization={organization}
+          showModal={showResponsiblePositionsModal}
+          onCancel={() => hideResponsiblePositionsModal(false)}
+          onSuccess={() => hideResponsiblePositionsModal(true)}
+        />
       </Fieldset>
     </Element>
   )
@@ -230,10 +255,18 @@ const OrganizationLaydown = ({ organization }) => {
   function toggleShowInactive() {
     setShowInactivePositions(!showInactivePositions)
   }
+
+  function hideResponsiblePositionsModal(success) {
+    setShowResponsiblePositionsModal(false)
+    if (success) {
+      refetch()
+    }
+  }
 }
 
 OrganizationLaydown.propTypes = {
-  organization: PropTypes.instanceOf(Organization).isRequired
+  organization: PropTypes.instanceOf(Organization).isRequired,
+  refetch: PropTypes.func.isRequired
 }
 
 export default OrganizationLaydown

--- a/client/src/pages/organizations/Laydown.js
+++ b/client/src/pages/organizations/Laydown.js
@@ -22,7 +22,7 @@ const OrganizationLaydown = ({ organization, refetch }) => {
     setShowAdministratingPositionsModal
   ] = useState(false)
   const isAdmin = currentUser && currentUser.isAdmin()
-  const isSuperUserForOrg =
+  const canAdministrateOrg =
     currentUser &&
     currentUser.hasAdministrativePermissionsForOrganization(organization)
   const isSuperUser = currentUser && currentUser.isSuperUser()
@@ -38,7 +38,7 @@ const OrganizationLaydown = ({ organization, refetch }) => {
     position => positionsNeedingAttention.indexOf(position) === -1
   )
   const canCreatePositions =
-    isSuperUserForOrg || (isSuperUser && isPrincipalOrg)
+    canAdministrateOrg || (isSuperUser && isPrincipalOrg)
 
   const orgSettings = isPrincipalOrg
     ? Settings.fields.principal.org

--- a/client/src/pages/organizations/Laydown.js
+++ b/client/src/pages/organizations/Laydown.js
@@ -23,7 +23,8 @@ const OrganizationLaydown = ({ organization, refetch }) => {
   ] = useState(false)
   const isAdmin = currentUser && currentUser.isAdmin()
   const isSuperUserForOrg =
-    currentUser && currentUser.isSuperUserForOrg(organization)
+    currentUser &&
+    currentUser.hasAdministrativePermissionsForOrganization(organization)
   const isSuperUser = currentUser && currentUser.isSuperUser()
   const isPrincipalOrg = organization.type === Organization.TYPE.PRINCIPAL_ORG
   const numInactivePos = organization.positions.filter(

--- a/client/src/pages/organizations/Laydown.js
+++ b/client/src/pages/organizations/Laydown.js
@@ -12,14 +12,13 @@ import { Button, Table } from "react-bootstrap"
 import ContainerDimensions from "react-container-dimensions"
 import { Element } from "react-scroll"
 import Settings from "settings"
+import utils from "utils"
 
 const OrganizationLaydown = ({ organization, refetch }) => {
   const { currentUser } = useContext(AppContext)
   const [showInactivePositions, setShowInactivePositions] = useState(false)
-  const [
-    showResponsiblePositionsModal,
-    setShowResponsiblePositionsModal
-  ] = useState(false)
+  const [showResponsiblePositionsModal, setShowResponsiblePositionsModal] =
+    useState(false)
   const isAdmin = currentUser && currentUser.isAdmin()
   const isSuperUserForOrg =
     currentUser && currentUser.isSuperUserForOrg(organization)
@@ -37,6 +36,10 @@ const OrganizationLaydown = ({ organization, refetch }) => {
   )
   const canCreatePositions =
     isSuperUserForOrg || (isSuperUser && isPrincipalOrg)
+
+  const orgSettings = isPrincipalOrg
+    ? Settings.fields.principal.org
+    : Settings.fields.advisor.org
 
   return (
     <Element name="laydown">
@@ -113,14 +116,14 @@ const OrganizationLaydown = ({ organization, refetch }) => {
       </Fieldset>
       <Fieldset
         id="responsiblePositions"
-        title="Responsible Positions"
+        title={utils.sentenceCase(orgSettings.responsiblePositions.label)}
         action={
           isAdmin && (
             <Button
               onClick={() => setShowResponsiblePositionsModal(true)}
               variant="outline-secondary"
             >
-              Edit Responsible Positions
+              Edit {utils.noCase(orgSettings.responsiblePositions.label)}
             </Button>
           )
         }

--- a/client/src/pages/organizations/Laydown.js
+++ b/client/src/pages/organizations/Laydown.js
@@ -1,5 +1,5 @@
 import AppContext from "components/AppContext"
-import EditResponsiblePositionsModal from "components/EditResponsiblePositionsModal"
+import EditAdministratingPositionsModal from "components/EditAdministratingPositionsModal"
 import Fieldset from "components/Fieldset"
 import OrganizationalChart from "components/graphs/OrganizationalChart"
 import LinkTo from "components/LinkTo"
@@ -17,8 +17,10 @@ import utils from "utils"
 const OrganizationLaydown = ({ organization, refetch }) => {
   const { currentUser } = useContext(AppContext)
   const [showInactivePositions, setShowInactivePositions] = useState(false)
-  const [showResponsiblePositionsModal, setShowResponsiblePositionsModal] =
-    useState(false)
+  const [
+    showAdministratingPositionsModal,
+    setShowAdministratingPositionsModal
+  ] = useState(false)
   const isAdmin = currentUser && currentUser.isAdmin()
   const isSuperUserForOrg =
     currentUser && currentUser.isSuperUserForOrg(organization)
@@ -115,25 +117,25 @@ const OrganizationLaydown = ({ organization, refetch }) => {
         )}
       </Fieldset>
       <Fieldset
-        id="responsiblePositions"
-        title={utils.sentenceCase(orgSettings.responsiblePositions.label)}
+        id="administratingPositions"
+        title={utils.sentenceCase(orgSettings.administratingPositions.label)}
         action={
           isAdmin && (
             <Button
-              onClick={() => setShowResponsiblePositionsModal(true)}
+              onClick={() => setShowAdministratingPositionsModal(true)}
               variant="outline-secondary"
             >
-              Edit {utils.noCase(orgSettings.responsiblePositions.label)}
+              Edit {utils.noCase(orgSettings.administratingPositions.label)}
             </Button>
           )
         }
       >
-        <PositionTable positions={organization.responsiblePositions} />
-        <EditResponsiblePositionsModal
+        <PositionTable positions={organization.administratingPositions} />
+        <EditAdministratingPositionsModal
           organization={organization}
-          showModal={showResponsiblePositionsModal}
-          onCancel={() => hideResponsiblePositionsModal(false)}
-          onSuccess={() => hideResponsiblePositionsModal(true)}
+          showModal={showAdministratingPositionsModal}
+          onCancel={() => hideAdministratingPositionsModal(false)}
+          onSuccess={() => hideAdministratingPositionsModal(true)}
         />
       </Fieldset>
     </Element>
@@ -259,8 +261,8 @@ const OrganizationLaydown = ({ organization, refetch }) => {
     setShowInactivePositions(!showInactivePositions)
   }
 
-  function hideResponsiblePositionsModal(success) {
-    setShowResponsiblePositionsModal(false)
+  function hideAdministratingPositionsModal(success) {
+    setShowAdministratingPositionsModal(false)
     if (success) {
       refetch()
     }

--- a/client/src/pages/organizations/Show.js
+++ b/client/src/pages/organizations/Show.js
@@ -196,7 +196,7 @@ const OrganizationShow = ({ pageDispatchers }) => {
   const IdentificationCodeFieldWithLabel = DictionaryField(Field)
   const LongNameWithLabel = DictionaryField(Field)
 
-  const isSuperUserForOrg =
+  const canAdministrateOrg =
     currentUser &&
     currentUser.hasAdministrativePermissionsForOrganization(organization)
   const isAdvisorOrg = organization.type === Organization.TYPE.ADVISOR_ORG
@@ -269,7 +269,7 @@ const OrganizationShow = ({ pageDispatchers }) => {
       {({ values }) => {
         const action = (
           <div>
-            {isSuperUserForOrg && (
+            {canAdministrateOrg && (
               <LinkTo
                 modelType="Organization"
                 model={Organization.pathForNew({
@@ -281,7 +281,7 @@ const OrganizationShow = ({ pageDispatchers }) => {
               </LinkTo>
             )}
 
-            {isSuperUserForOrg && (
+            {canAdministrateOrg && (
               <LinkTo
                 modelType="Organization"
                 model={organization}

--- a/client/src/pages/organizations/Show.js
+++ b/client/src/pages/organizations/Show.js
@@ -104,12 +104,19 @@ const GQL_GET_ORGANIZATION = gql`
         uuid
         name
         code
-        status
         type
+        status
+        location {
+          uuid
+          name
+        }
+        organization {
+          uuid
+          shortName
+        }
         person {
           uuid
           name
-          status
           rank
           role
           avatar(size: 32)

--- a/client/src/pages/organizations/Show.js
+++ b/client/src/pages/organizations/Show.js
@@ -100,7 +100,7 @@ const GQL_GET_ORGANIZATION = gql`
           }
         }
       }
-      responsiblePositions {
+      administratingPositions {
         uuid
         name
         code
@@ -231,8 +231,8 @@ const OrganizationShow = ({ pageDispatchers }) => {
           <AnchorNavItem to="vacantPositions">Vacant positions</AnchorNavItem>
         </Nav.Item>
         <Nav.Item>
-          <AnchorNavItem to="responsiblePositions">
-            Responsible positions
+          <AnchorNavItem to="administratingPositions">
+            {orgSettings.administratingPositions.label}
           </AnchorNavItem>
         </Nav.Item>
         {!isPrincipalOrg && (

--- a/client/src/pages/organizations/Show.js
+++ b/client/src/pages/organizations/Show.js
@@ -100,6 +100,21 @@ const GQL_GET_ORGANIZATION = gql`
           }
         }
       }
+      responsiblePositions {
+        uuid
+        name
+        code
+        status
+        type
+        person {
+          uuid
+          name
+          status
+          rank
+          role
+          avatar(size: 32)
+        }
+      }
       planningApprovalSteps {
         uuid
         name
@@ -174,7 +189,8 @@ const OrganizationShow = ({ pageDispatchers }) => {
   const IdentificationCodeFieldWithLabel = DictionaryField(Field)
   const LongNameWithLabel = DictionaryField(Field)
 
-  const isSuperUser = currentUser && currentUser.isSuperUserForOrg(organization)
+  const isSuperUserForOrg =
+    currentUser && currentUser.isSuperUserForOrg(organization)
   const isAdmin = currentUser && currentUser.isAdmin()
   const isAdvisorOrg = organization.type === Organization.TYPE.ADVISOR_ORG
   const isPrincipalOrg = organization.type === Organization.TYPE.PRINCIPAL_ORG
@@ -207,6 +223,11 @@ const OrganizationShow = ({ pageDispatchers }) => {
         </Nav.Item>
         <Nav.Item>
           <AnchorNavItem to="vacantPositions">Vacant positions</AnchorNavItem>
+        </Nav.Item>
+        <Nav.Item>
+          <AnchorNavItem to="responsiblePositions">
+            Responsible positions
+          </AnchorNavItem>
         </Nav.Item>
         {!isPrincipalOrg && (
           <Nav.Item>
@@ -253,7 +274,7 @@ const OrganizationShow = ({ pageDispatchers }) => {
               </LinkTo>
             )}
 
-            {(isAdmin || (isSuperUser && isAdvisorOrg)) && (
+            {isSuperUserForOrg && (
               <LinkTo
                 modelType="Organization"
                 model={organization}

--- a/client/src/pages/organizations/Show.js
+++ b/client/src/pages/organizations/Show.js
@@ -456,7 +456,10 @@ const OrganizationShow = ({ pageDispatchers }) => {
                 )}
               </Fieldset>
 
-              <OrganizationLaydown organization={organization} />
+              <OrganizationLaydown
+                organization={organization}
+                refetch={refetch}
+              />
               {!isPrincipalOrg && <Approvals relatedObject={organization} />}
               {organization.isTaskEnabled() && (
                 <OrganizationTasks

--- a/client/src/pages/organizations/Show.js
+++ b/client/src/pages/organizations/Show.js
@@ -191,7 +191,6 @@ const OrganizationShow = ({ pageDispatchers }) => {
 
   const isSuperUserForOrg =
     currentUser && currentUser.isSuperUserForOrg(organization)
-  const isAdmin = currentUser && currentUser.isAdmin()
   const isAdvisorOrg = organization.type === Organization.TYPE.ADVISOR_ORG
   const isPrincipalOrg = organization.type === Organization.TYPE.PRINCIPAL_ORG
   const orgSettings = isPrincipalOrg
@@ -262,7 +261,7 @@ const OrganizationShow = ({ pageDispatchers }) => {
       {({ values }) => {
         const action = (
           <div>
-            {isAdmin && (
+            {isSuperUserForOrg && (
               <LinkTo
                 modelType="Organization"
                 model={Organization.pathForNew({

--- a/client/src/pages/organizations/Show.js
+++ b/client/src/pages/organizations/Show.js
@@ -197,7 +197,8 @@ const OrganizationShow = ({ pageDispatchers }) => {
   const LongNameWithLabel = DictionaryField(Field)
 
   const isSuperUserForOrg =
-    currentUser && currentUser.isSuperUserForOrg(organization)
+    currentUser &&
+    currentUser.hasAdministrativePermissionsForOrganization(organization)
   const isAdvisorOrg = organization.type === Organization.TYPE.ADVISOR_ORG
   const isPrincipalOrg = organization.type === Organization.TYPE.PRINCIPAL_ORG
   const orgSettings = isPrincipalOrg

--- a/client/src/pages/people/Show.js
+++ b/client/src/pages/people/Show.js
@@ -174,7 +174,7 @@ const PersonShow = ({ pageDispatchers }) => {
 
   // User can always edit themselves
   // Admins can always edit anybody
-  // SuperUsers can edit people in their org, their descendant orgs, or un-positioned people.
+  // Super users can edit people in their org, their descendant orgs, or un-positioned people.
   const isAdmin = currentUser && currentUser.isAdmin()
   const hasPosition = position && position.uuid
   const canEdit =

--- a/client/src/pages/people/Show.js
+++ b/client/src/pages/people/Show.js
@@ -180,13 +180,19 @@ const PersonShow = ({ pageDispatchers }) => {
   const canEdit =
     Person.isEqual(currentUser, person) ||
     isAdmin ||
-    (hasPosition && currentUser.isSuperUserForOrg(position.organization)) ||
+    (hasPosition &&
+      currentUser.hasAdministrativePermissionsForOrganization(
+        position.organization
+      )) ||
     (!hasPosition && currentUser.isSuperUser()) ||
     (person.role === Person.ROLE.PRINCIPAL && currentUser.isSuperUser())
   const canChangePosition =
     isAdmin ||
     (!hasPosition && currentUser.isSuperUser()) ||
-    (hasPosition && currentUser.isSuperUserForOrg(position.organization)) ||
+    (hasPosition &&
+      currentUser.hasAdministrativePermissionsForOrganization(
+        position.organization
+      )) ||
     (person.role === Person.ROLE.PRINCIPAL && currentUser.isSuperUser())
   const canAddPeriodicAssessment =
     Position.isAdvisor(position) ||

--- a/client/src/pages/positions/Form.js
+++ b/client/src/pages/positions/Form.js
@@ -150,19 +150,18 @@ const PositionForm = ({ edit, title, initialValues, notesComponent }) => {
         const permissionsButtons = isAdmin
           ? adminPermissionsButtons
           : nonAdminPermissionsButtons
-        const respOrgsUuids = currentUser.position.responsibleOrganizations.map(
-          org => org.uuid
-        )
+        const administratingOrgUuids =
+          currentUser.position.organizationsAdministrated.map(org => org.uuid)
         const isSuperUser =
           currentUser && currentUser.isSuperUser() && !currentUser.isAdmin()
-        const isSuperUserWithoutRespOrgs =
-          isSuperUser && _isEmpty(respOrgsUuids)
-        // Super users without responsible organizations cannot create advisor positions
-        const typeButtons = isSuperUserWithoutRespOrgs
+        const isSuperUserWithoutAdministratingOrgs =
+          isSuperUser && _isEmpty(administratingOrgUuids)
+        // Super users without organizations administrated cannot create advisor positions
+        const typeButtons = isSuperUserWithoutAdministratingOrgs
           ? advisorDisabledTypeButtons
           : regularTypeButtons
         if (
-          isSuperUserWithoutRespOrgs &&
+          isSuperUserWithoutAdministratingOrgs &&
           values.type !== Position.TYPE.PRINCIPAL
         ) {
           setFieldValue("type", Position.TYPE.PRINCIPAL)
@@ -173,7 +172,7 @@ const PositionForm = ({ edit, title, initialValues, notesComponent }) => {
         } else {
           orgSearchQuery.type = Organization.TYPE.ADVISOR_ORG
           if (isSuperUser) {
-            orgSearchQuery.parentOrgUuid = [...respOrgsUuids]
+            orgSearchQuery.parentOrgUuid = [...administratingOrgUuids]
             orgSearchQuery.orgRecurseStrategy = RECURSE_STRATEGY.CHILDREN
           }
         }

--- a/client/src/pages/positions/Form.js
+++ b/client/src/pages/positions/Form.js
@@ -136,7 +136,9 @@ const PositionForm = ({ edit, title, initialValues, notesComponent }) => {
         const permissionsButtons = isAdmin
           ? adminPermissionsButtons
           : nonAdminPermissionsButtons
-
+        const respOrgsUuids = currentUser.position.responsibleOrganizations.map(
+          org => org.uuid
+        )
         const orgSearchQuery = { status: Model.STATUS.ACTIVE }
         if (isPrincipal) {
           orgSearchQuery.type = Organization.TYPE.PRINCIPAL_ORG
@@ -148,7 +150,8 @@ const PositionForm = ({ edit, title, initialValues, notesComponent }) => {
             currentUser.position.type === Position.TYPE.SUPER_USER
           ) {
             orgSearchQuery.parentOrgUuid = [
-              currentUser.position.organization.uuid
+              currentUser.position.organization.uuid,
+              ...respOrgsUuids
             ]
             orgSearchQuery.orgRecurseStrategy = RECURSE_STRATEGY.CHILDREN
           }

--- a/client/src/pages/positions/OrganizationsAdministrated.js
+++ b/client/src/pages/positions/OrganizationsAdministrated.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types"
 import React from "react"
 import { Table } from "react-bootstrap"
 
-const ResponsibleOrganizations = ({ organizations }) => {
+const OrganizationsAdministrated = ({ organizations }) => {
   return (
     <Table>
       <thead>
@@ -26,8 +26,8 @@ const ResponsibleOrganizations = ({ organizations }) => {
   )
 }
 
-ResponsibleOrganizations.propTypes = {
+OrganizationsAdministrated.propTypes = {
   organizations: PropTypes.arrayOf(PropTypes.object).isRequired
 }
 
-export default ResponsibleOrganizations
+export default OrganizationsAdministrated

--- a/client/src/pages/positions/ResponsibleOrganizations.js
+++ b/client/src/pages/positions/ResponsibleOrganizations.js
@@ -1,0 +1,33 @@
+import LinkTo from "components/LinkTo"
+import PropTypes from "prop-types"
+import React from "react"
+import { Table } from "react-bootstrap"
+
+const ResponsibleOrganizations = ({ organizations }) => {
+  return (
+    <Table>
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>UIC</th>
+        </tr>
+      </thead>
+      <tbody>
+        {organizations.map(org => (
+          <tr key={org.uuid}>
+            <td>
+              <LinkTo modelType="Organization" model={org} />
+            </td>
+            <td>{org.identificationCode}</td>
+          </tr>
+        ))}
+      </tbody>
+    </Table>
+  )
+}
+
+ResponsibleOrganizations.propTypes = {
+  organizations: PropTypes.arrayOf(PropTypes.object).isRequired
+}
+
+export default ResponsibleOrganizations

--- a/client/src/pages/positions/Show.js
+++ b/client/src/pages/positions/Show.js
@@ -8,7 +8,7 @@ import ConfirmDestructive from "components/ConfirmDestructive"
 import { ReadonlyCustomFields } from "components/CustomFields"
 import EditAssociatedPositionsModal from "components/EditAssociatedPositionsModal"
 import EditHistory from "components/EditHistory"
-import EditResponsibleOrganizationsModal from "components/EditResponsibleOrganizationsModal"
+import EditOrganizationsAdministratedModal from "components/EditOrganizationsAdministratedModal"
 import * as FieldHelper from "components/FieldHelper"
 import Fieldset from "components/Fieldset"
 import GuidedTour from "components/GuidedTour"
@@ -69,8 +69,8 @@ const PositionShow = ({ pageDispatchers }) => {
     routerLocation.state && routerLocation.state.error
   )
   const [
-    showResponsibleOrganizationsModal,
-    setShowResponsibleOrganizationsModal
+    showOrganizationsAdministratedModal,
+    setShowOrganizationsAdministratedModal
   ] = useState(false)
   const { uuid } = useParams()
   const { loading, error, data, refetch } = API.useApiQuery(GQL_GET_POSITION, {
@@ -370,34 +370,34 @@ const PositionShow = ({ pageDispatchers }) => {
               </Fieldset>
               {isSuperUser && (
                 <Fieldset
-                  id="responsibleOrganizations"
+                  id="organizationsAdministrated"
                   title={utils.sentenceCase(
-                    positionSettings.responsibleOrganizations.label
+                    positionSettings.organizationsAdministrated.label
                   )}
                   action={
                     currentUser.isAdmin() && (
                       <Button
                         onClick={() =>
-                          setShowResponsibleOrganizationsModal(true)
+                          setShowOrganizationsAdministratedModal(true)
                         }
                         variant="outline-secondary"
                       >
                         Edit{" "}
                         {utils.noCase(
-                          positionSettings.responsibleOrganizations.label
+                          positionSettings.organizationsAdministrated.label
                         )}
                       </Button>
                     )
                   }
                 >
                   <OrganizationTable
-                    organizations={position.responsibleOrganizations}
+                    organizations={position.organizationsAdministrated}
                   />
-                  <EditResponsibleOrganizationsModal
+                  <EditOrganizationsAdministratedModal
                     position={position}
-                    showModal={showResponsibleOrganizationsModal}
-                    onCancel={() => hideResponsiblePositionsModal(false)}
-                    onSuccess={() => hideResponsiblePositionsModal(true)}
+                    showModal={showOrganizationsAdministratedModal}
+                    onCancel={() => hideOrganizationsAdministratedModal(false)}
+                    onSuccess={() => hideOrganizationsAdministratedModal(true)}
                   />
                 </Fieldset>
               )}
@@ -445,8 +445,8 @@ const PositionShow = ({ pageDispatchers }) => {
     }
   }
 
-  function hideResponsiblePositionsModal(success) {
-    setShowResponsibleOrganizationsModal(false)
+  function hideOrganizationsAdministratedModal(success) {
+    setShowOrganizationsAdministratedModal(false)
     if (success) {
       refetch()
     }

--- a/client/src/pages/positions/Show.js
+++ b/client/src/pages/positions/Show.js
@@ -116,7 +116,9 @@ const PositionShow = ({ pageDispatchers }) => {
     // Super users can edit positions within their own organization
     (position.organization &&
       position.organization.uuid &&
-      currentUser.isSuperUserForOrg(position.organization))
+      currentUser.hasAdministrativePermissionsForOrganization(
+        position.organization
+      ))
   const canDelete =
     currentUser.isAdmin() &&
     position.status === Model.STATUS.INACTIVE &&

--- a/client/src/pages/positions/Show.js
+++ b/client/src/pages/positions/Show.js
@@ -113,7 +113,7 @@ const PositionShow = ({ pageDispatchers }) => {
     (currentUser.isSuperUser() && isPrincipal) ||
     // Admins can edit anybody
     currentUser.isAdmin() ||
-    // Super users can edit positions within their own organization
+    // Super users can edit positions if they have administrative permissions for the organization of the position
     (position.organization &&
       position.organization.uuid &&
       currentUser.hasAdministrativePermissionsForOrganization(

--- a/client/src/pages/positions/Show.js
+++ b/client/src/pages/positions/Show.js
@@ -371,7 +371,9 @@ const PositionShow = ({ pageDispatchers }) => {
               {isSuperUser && (
                 <Fieldset
                   id="responsibleOrganizations"
-                  title="Responsible Organizations"
+                  title={utils.sentenceCase(
+                    positionSettings.responsibleOrganizations.label
+                  )}
                   action={
                     currentUser.isAdmin() && (
                       <Button
@@ -380,7 +382,10 @@ const PositionShow = ({ pageDispatchers }) => {
                         }
                         variant="outline-secondary"
                       >
-                        Edit Responsible Organizations
+                        Edit{" "}
+                        {utils.noCase(
+                          positionSettings.responsibleOrganizations.label
+                        )}
                       </Button>
                     )
                   }

--- a/client/src/pages/tasks/Edit.js
+++ b/client/src/pages/tasks/Edit.js
@@ -49,6 +49,10 @@ const GQL_GET_TASK = gql`
         code
         type
         status
+        location {
+          uuid
+          name
+        }
         organization {
           uuid
           shortName

--- a/client/src/pages/tasks/Show.js
+++ b/client/src/pages/tasks/Show.js
@@ -63,13 +63,13 @@ const GQL_GET_TASK = gql`
         code
         type
         status
-        organization {
-          uuid
-          shortName
-        }
         location {
           uuid
           name
+        }
+        organization {
+          uuid
+          shortName
         }
         person {
           uuid

--- a/client/tests/e2e/permissions.js
+++ b/client/tests/e2e/permissions.js
@@ -2,7 +2,7 @@ const uuidv4 = require("uuid").v4
 const test = require("../util/test")
 
 test.serial("checking super user permissions", async t => {
-  t.plan(12)
+  t.plan(13)
 
   const {
     pageHelpers,
@@ -54,8 +54,8 @@ test.serial("checking super user permissions", async t => {
 
   await validateUserCanEditUserForCurrentPage(t)
 
-  // User is super user, he/she may edit position of type super user for
-  // his/her own organization
+  // User is super user, they may edit position of type super user for
+  // the organization they are responsible for
   await editAndSavePositionFromCurrentUserPage(t, true)
 
   await t.context.logout()
@@ -69,11 +69,12 @@ test.serial("checking super user permissions", async t => {
 
   await validateUserCanEditUserForCurrentPage(t)
 
-  // User is super user, he/she may edit position of type super user for
-  // his/her own organization
+  // User is super user, they may edit position of type super user for
+  // the organization they are responsible for
   await editAndSavePositionFromCurrentUserPage(t, true)
 
-  // User is super user, he/she may edit positions only for his/her own organization
+  // User is super user, they may edit positions only for
+  // the organization they are responsible for
   const $otherOrgPositionLink = await getFromSearchResults(
     t,
     "EF 1 Manager",
@@ -88,7 +89,7 @@ test.serial("checking super user permissions", async t => {
   await assertElementNotPresent(
     t,
     ".edit-position",
-    "super user should not be able to edit positions of another organization than his/her own",
+    "super user should not be able to edit positions of the organization they are not responsible for",
     shortWaitMs
   )
 
@@ -111,6 +112,23 @@ test.serial("checking super user permissions", async t => {
   await validateSuperUserLocationPermissions(t)
 
   await t.context.logout()
+
+  await t.context.get("/", "jacob")
+  const $ownOrgPositionLink = await getFromSearchResults(
+    t,
+    "EF 2.2 Final Reviewer",
+    "EF 2.2 Final Reviewer",
+    "positions"
+  )
+  await $ownOrgPositionLink.click()
+  await t.context.driver.wait(t.context.until.stalenessOf($ownOrgPositionLink))
+
+  await assertElementNotPresent(
+    t,
+    ".edit-position",
+    "super user should not be able to edit positions of the organization they are not responsible for",
+    shortWaitMs
+  )
 })
 
 validateUserCannotEditOtherUser(
@@ -119,6 +137,14 @@ validateUserCannotEditOtherUser(
   "arthur",
   "CIV DMIN, Arthur",
   "ANET Administrator"
+)
+
+validateUserCannotEditOtherUser(
+  "super user cannot edit people from the organizations they are not responsible for",
+  "jacob",
+  "rebecca",
+  "CTR BECCABON, Rebecca",
+  "EF 2.2 Final Reviewer"
 )
 
 test.serial("checking regular user permissions", async t => {

--- a/client/tests/e2e/permissions.js
+++ b/client/tests/e2e/permissions.js
@@ -55,7 +55,7 @@ test.serial("checking super user permissions", async t => {
   await validateUserCanEditUserForCurrentPage(t)
 
   // User is super user, they may edit position of type super user for
-  // the organization they are responsible for
+  // the organization their position is administrating
   await editAndSavePositionFromCurrentUserPage(t, true)
 
   await t.context.logout()
@@ -70,11 +70,11 @@ test.serial("checking super user permissions", async t => {
   await validateUserCanEditUserForCurrentPage(t)
 
   // User is super user, they may edit position of type super user for
-  // the organization they are responsible for
+  // the organization their position is administrating
   await editAndSavePositionFromCurrentUserPage(t, true)
 
   // User is super user, they may edit positions only for
-  // the organization they are responsible for
+  // the organization their position is administrating
   const $otherOrgPositionLink = await getFromSearchResults(
     t,
     "EF 1 Manager",
@@ -89,7 +89,7 @@ test.serial("checking super user permissions", async t => {
   await assertElementNotPresent(
     t,
     ".edit-position",
-    "super user should not be able to edit positions of the organization they are not responsible for",
+    "super user should not be able to edit positions of the organization their position is not administrating",
     shortWaitMs
   )
 
@@ -126,7 +126,7 @@ test.serial("checking super user permissions", async t => {
   await assertElementNotPresent(
     t,
     ".edit-position",
-    "super user should not be able to edit positions of the organization they are not responsible for",
+    "super user should not be able to edit positions of the organization their position is not administrating",
     shortWaitMs
   )
 })
@@ -140,7 +140,7 @@ validateUserCannotEditOtherUser(
 )
 
 validateUserCannotEditOtherUser(
-  "super user cannot edit people from the organizations they are not responsible for",
+  "super user cannot edit people from the organizations their position is not administrating",
   "jacob",
   "rebecca",
   "CTR BECCABON, Rebecca",

--- a/insertBaseData-psql.sql
+++ b/insertBaseData-psql.sql
@@ -42,6 +42,7 @@ TRUNCATE TABLE "reportAuthorizationGroups";
 TRUNCATE TABLE "noteRelatedObjects";
 TRUNCATE TABLE "taskTaskedOrganizations";
 TRUNCATE TABLE "taskResponsiblePositions";
+TRUNCATE TABLE "organizationResponsiblePositions";
 DELETE FROM positions;
 DELETE FROM tasks WHERE "customFieldRef1Uuid" IS NOT NULL;
 DELETE FROM tasks WHERE "customFieldRef1Uuid" IS NULL;

--- a/insertBaseData-psql.sql
+++ b/insertBaseData-psql.sql
@@ -42,7 +42,7 @@ TRUNCATE TABLE "reportAuthorizationGroups";
 TRUNCATE TABLE "noteRelatedObjects";
 TRUNCATE TABLE "taskTaskedOrganizations";
 TRUNCATE TABLE "taskResponsiblePositions";
-TRUNCATE TABLE "organizationResponsiblePositions";
+TRUNCATE TABLE "organizationAdministrativePositions";
 DELETE FROM positions;
 DELETE FROM tasks WHERE "customFieldRef1Uuid" IS NOT NULL;
 DELETE FROM tasks WHERE "customFieldRef1Uuid" IS NULL;
@@ -370,7 +370,7 @@ UPDATE positions SET "organizationUuid" = (SELECT uuid FROM organizations WHERE 
 UPDATE positions SET "organizationUuid" = (SELECT uuid FROM organizations WHERE "shortName" ='ANET Administrators') where name = 'ANET Administrator';
 
 -- Assign responsible positions for organizations
-INSERT INTO "organizationResponsiblePositions" ("organizationUuid", "positionUuid")
+INSERT INTO "organizationAdministrativePositions" ("organizationUuid", "positionUuid")
 	VALUES
 		((SELECT uuid FROM organizations WHERE "shortName" = 'EF 2.1'), (SELECT uuid FROM positions WHERE name = 'EF 2.1 SuperUser')),
 		((SELECT uuid FROM organizations WHERE "shortName" = 'EF 2.2'), (SELECT uuid FROM positions WHERE name = 'EF 2.2 Final Reviewer'));

--- a/insertBaseData-psql.sql
+++ b/insertBaseData-psql.sql
@@ -368,6 +368,12 @@ UPDATE positions SET "organizationUuid" = (SELECT uuid FROM organizations WHERE 
 UPDATE positions SET "organizationUuid" = (SELECT uuid FROM organizations WHERE "shortName" ='LNG') WHERE name LIKE 'LNG%';
 UPDATE positions SET "organizationUuid" = (SELECT uuid FROM organizations WHERE "shortName" ='ANET Administrators') where name = 'ANET Administrator';
 
+-- Assign responsible positions for organizations
+INSERT INTO "organizationResponsiblePositions" ("organizationUuid", "positionUuid")
+	VALUES
+		((SELECT uuid FROM organizations WHERE "shortName" = 'EF 2.1'), (SELECT uuid FROM positions WHERE name = 'EF 2.1 SuperUser')),
+		((SELECT uuid FROM organizations WHERE "shortName" = 'EF 2.2'), (SELECT uuid FROM positions WHERE name = 'EF 2.2 Final Reviewer'));
+
 
 -- Create the EF 1.1 approval process
 INSERT INTO "approvalSteps" (uuid, "relatedObjectUuid", name, type)

--- a/src/main/java/mil/dds/anet/beans/Organization.java
+++ b/src/main/java/mil/dds/anet/beans/Organization.java
@@ -57,6 +57,8 @@ public class Organization extends AbstractCustomizableAnetBean
   List<ApprovalStep> approvalSteps; /* Approval process for this Org */
   // annotated below
   List<Task> tasks;
+  // annotated below
+  List<Position> responsiblePositions;
 
   public String getShortName() {
     return shortName;
@@ -255,6 +257,28 @@ public class Organization extends AbstractCustomizableAnetBean
   @GraphQLInputField(name = "tasks")
   public void setTasks(List<Task> tasks) {
     this.tasks = tasks;
+  }
+
+  @GraphQLQuery(name = "responsiblePositions")
+  public CompletableFuture<List<Position>> loadResponsiblePositions(
+      @GraphQLRootContext Map<String, Object> context) {
+    if (responsiblePositions != null) {
+      return CompletableFuture.completedFuture(responsiblePositions);
+    }
+    return AnetObjectEngine.getInstance().getOrganizationDao()
+        .getResponsiblePositionsForOrganization(context, uuid).thenApply(o -> {
+          responsiblePositions = o;
+          return o;
+        });
+  }
+
+  public List<Position> getResponsiblePositions() {
+    return responsiblePositions;
+  }
+
+  @GraphQLInputField(name = "responsiblePositions")
+  public void setResponsiblePositions(List<Position> responsiblePositions) {
+    this.responsiblePositions = responsiblePositions;
   }
 
   @Override

--- a/src/main/java/mil/dds/anet/beans/Organization.java
+++ b/src/main/java/mil/dds/anet/beans/Organization.java
@@ -58,7 +58,7 @@ public class Organization extends AbstractCustomizableAnetBean
   // annotated below
   List<Task> tasks;
   // annotated below
-  List<Position> responsiblePositions;
+  List<Position> administratingPositions;
 
   public String getShortName() {
     return shortName;
@@ -259,26 +259,26 @@ public class Organization extends AbstractCustomizableAnetBean
     this.tasks = tasks;
   }
 
-  @GraphQLQuery(name = "responsiblePositions")
-  public CompletableFuture<List<Position>> loadResponsiblePositions(
+  @GraphQLQuery(name = "administratingPositions")
+  public CompletableFuture<List<Position>> loadAdministratingPositions(
       @GraphQLRootContext Map<String, Object> context) {
-    if (responsiblePositions != null) {
-      return CompletableFuture.completedFuture(responsiblePositions);
+    if (administratingPositions != null) {
+      return CompletableFuture.completedFuture(administratingPositions);
     }
     return AnetObjectEngine.getInstance().getOrganizationDao()
-        .getResponsiblePositionsForOrganization(context, uuid).thenApply(o -> {
-          responsiblePositions = o;
+        .getAdministratingPositionsForOrganization(context, uuid).thenApply(o -> {
+          administratingPositions = o;
           return o;
         });
   }
 
-  public List<Position> getResponsiblePositions() {
-    return responsiblePositions;
+  public List<Position> getAdministratingPositions() {
+    return administratingPositions;
   }
 
-  @GraphQLInputField(name = "responsiblePositions")
-  public void setResponsiblePositions(List<Position> responsiblePositions) {
-    this.responsiblePositions = responsiblePositions;
+  @GraphQLInputField(name = "administratingPositions")
+  public void setAdministratingPositions(List<Position> administratingPositions) {
+    this.administratingPositions = administratingPositions;
   }
 
   @Override

--- a/src/main/java/mil/dds/anet/beans/Position.java
+++ b/src/main/java/mil/dds/anet/beans/Position.java
@@ -55,7 +55,7 @@ public class Position extends AbstractCustomizableAnetBean
   // annotated below
   private List<AuthorizationGroup> authorizationGroups;
   // annotated below
-  private List<Organization> responsibleOrganizations;
+  private List<Organization> organizationsAdministrated;
 
   public String getName() {
     return name;
@@ -220,13 +220,13 @@ public class Position extends AbstractCustomizableAnetBean
     return location.getForeignObject();
   }
 
-  @GraphQLInputField(name = "responsibleOrganizations")
-  public void setResponsiblePositions(List<Organization> responsibleOrganizations) {
-    this.responsibleOrganizations = responsibleOrganizations;
+  @GraphQLInputField(name = "organizationsAdministrated")
+  public void setOrganizationsAdministrated(List<Organization> organizationsAdministrated) {
+    this.organizationsAdministrated = organizationsAdministrated;
   }
 
-  public List<Organization> getResponsibleOrganizations() {
-    return responsibleOrganizations;
+  public List<Organization> getOrganizationsAdministrated() {
+    return organizationsAdministrated;
   }
 
   @GraphQLQuery(name = "previousPeople")
@@ -291,18 +291,18 @@ public class Position extends AbstractCustomizableAnetBean
         });
   }
 
-  @GraphQLQuery(name = "responsibleOrganizations")
-  public CompletableFuture<List<Organization>> loadResponsibleOrganizations(
+  @GraphQLQuery(name = "organizationsAdministrated")
+  public CompletableFuture<List<Organization>> loadOrganizationsAdministrated(
       @GraphQLRootContext Map<String, Object> context) {
-    if (responsibleOrganizations != null) {
-      return CompletableFuture.completedFuture(responsibleOrganizations);
+    if (organizationsAdministrated != null) {
+      return CompletableFuture.completedFuture(organizationsAdministrated);
     }
     final OrganizationSearchQuery query = new OrganizationSearchQuery();
     query.setBatchParams(new M2mBatchParams<Organization, OrganizationSearchQuery>("organizations",
-        "\"organizationResponsiblePositions\"", "\"organizationUuid\"", "\"positionUuid\""));
+        "\"organizationAdministrativePositions\"", "\"organizationUuid\"", "\"positionUuid\""));
     return AnetObjectEngine.getInstance().getOrganizationDao()
         .getOrganizationsBySearch(context, uuid, query).thenApply(o -> {
-          responsibleOrganizations = o;
+          organizationsAdministrated = o;
           return o;
         });
   }

--- a/src/main/java/mil/dds/anet/beans/Position.java
+++ b/src/main/java/mil/dds/anet/beans/Position.java
@@ -11,6 +11,7 @@ import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import mil.dds.anet.AnetObjectEngine;
 import mil.dds.anet.beans.search.M2mBatchParams;
+import mil.dds.anet.beans.search.OrganizationSearchQuery;
 import mil.dds.anet.beans.search.TaskSearchQuery;
 import mil.dds.anet.utils.IdDataLoaderKey;
 import mil.dds.anet.utils.Utils;
@@ -53,6 +54,8 @@ public class Position extends AbstractCustomizableAnetBean
   private List<Task> responsibleTasks;
   // annotated below
   private List<AuthorizationGroup> authorizationGroups;
+  // annotated below
+  private List<Organization> responsibleOrganizations;
 
   public String getName() {
     return name;
@@ -275,6 +278,22 @@ public class Position extends AbstractCustomizableAnetBean
     return AnetObjectEngine.getInstance().getAuthorizationGroupDao()
         .getAuthorizationGroupsForPosition(context, uuid).thenApply(o -> {
           authorizationGroups = o;
+          return o;
+        });
+  }
+
+  @GraphQLQuery(name = "responsibleOrganizations")
+  public CompletableFuture<List<Organization>> loadResponsibleOrganizations(
+      @GraphQLRootContext Map<String, Object> context) {
+    if (responsibleOrganizations != null) {
+      return CompletableFuture.completedFuture(responsibleOrganizations);
+    }
+    final OrganizationSearchQuery query = new OrganizationSearchQuery();
+    query.setBatchParams(new M2mBatchParams<Organization, OrganizationSearchQuery>("organizations",
+        "\"organizationResponsiblePositions\"", "\"organizationUuid\"", "\"positionUuid\""));
+    return AnetObjectEngine.getInstance().getOrganizationDao()
+        .getOrganizationsBySearch(context, uuid, query).thenApply(o -> {
+          responsibleOrganizations = o;
           return o;
         });
   }

--- a/src/main/java/mil/dds/anet/beans/Position.java
+++ b/src/main/java/mil/dds/anet/beans/Position.java
@@ -220,6 +220,15 @@ public class Position extends AbstractCustomizableAnetBean
     return location.getForeignObject();
   }
 
+  @GraphQLInputField(name = "responsibleOrganizations")
+  public void setResponsiblePositions(List<Organization> responsibleOrganizations) {
+    this.responsibleOrganizations = responsibleOrganizations;
+  }
+
+  public List<Organization> getResponsibleOrganizations() {
+    return responsibleOrganizations;
+  }
+
   @GraphQLQuery(name = "previousPeople")
   public CompletableFuture<List<PersonPositionHistory>> loadPreviousPeople(
       @GraphQLRootContext Map<String, Object> context) {

--- a/src/main/java/mil/dds/anet/database/OrganizationDao.java
+++ b/src/main/java/mil/dds/anet/database/OrganizationDao.java
@@ -105,7 +105,7 @@ public class OrganizationDao
         "/* batch.getResponsiblePositionsForOrganization */ SELECT \"organizationResponsiblePositions\".\"organizationUuid\", "
             + PositionDao.POSITIONS_FIELDS + " FROM \"organizationResponsiblePositions\" "
             + "INNER JOIN positions on positions.uuid = \"organizationResponsiblePositions\".\"positionUuid\" "
-            + "AND \"organizationResponsiblePositions\".\"organizationUuid\" IN ( <foreignKeys> ) ";
+            + "WHERE \"organizationResponsiblePositions\".\"organizationUuid\" IN ( <foreignKeys> ) ";
 
     public ResponsiblePositionsBatcher() {
       super(sql, "foreignKeys", new PositionMapper(), "organizationUuid");

--- a/src/main/java/mil/dds/anet/database/OrganizationDao.java
+++ b/src/main/java/mil/dds/anet/database/OrganizationDao.java
@@ -100,22 +100,22 @@ public class OrganizationDao
         personUuid);
   }
 
-  static class ResponsiblePositionsBatcher extends ForeignKeyBatcher<Position> {
+  static class AdministratingPositionsBatcher extends ForeignKeyBatcher<Position> {
     private static final String sql =
-        "/* batch.getResponsiblePositionsForOrganization */ SELECT \"organizationResponsiblePositions\".\"organizationUuid\", "
-            + PositionDao.POSITIONS_FIELDS + " FROM \"organizationResponsiblePositions\" "
-            + "INNER JOIN positions on positions.uuid = \"organizationResponsiblePositions\".\"positionUuid\" "
-            + "WHERE \"organizationResponsiblePositions\".\"organizationUuid\" IN ( <foreignKeys> ) ";
+        "/* batch.getAdministratingPositionsForOrganization */ SELECT \"organizationAdministrativePositions\".\"organizationUuid\", "
+            + PositionDao.POSITION_FIELDS + " FROM \"organizationAdministrativePositions\" "
+            + "INNER JOIN positions on positions.uuid = \"organizationAdministrativePositions\".\"positionUuid\" "
+            + "WHERE \"organizationAdministrativePositions\".\"organizationUuid\" IN ( <foreignKeys> ) ";
 
-    public ResponsiblePositionsBatcher() {
+    public AdministratingPositionsBatcher() {
       super(sql, "foreignKeys", new PositionMapper(), "organizationUuid");
     }
   }
 
-  public List<List<Position>> getResponsiblePositions(List<String> foreignKeys) {
-    final ForeignKeyBatcher<Position> responsiblePositionsBatcher =
-        AnetObjectEngine.getInstance().getInjector().getInstance(ResponsiblePositionsBatcher.class);
-    return responsiblePositionsBatcher.getByForeignKeys(foreignKeys);
+  public List<List<Position>> getAdministratingPositions(List<String> foreignKeys) {
+    final ForeignKeyBatcher<Position> administratingPositionsBatcher = AnetObjectEngine
+        .getInstance().getInjector().getInstance(AdministratingPositionsBatcher.class);
+    return administratingPositionsBatcher.getByForeignKeys(foreignKeys);
   }
 
   public interface OrgListQueries {
@@ -154,16 +154,17 @@ public class OrganizationDao
         .bind("type", DaoUtils.getEnumId(org.getType()))
         .bind("parentOrgUuid", DaoUtils.getUuid(org.getParentOrg())).execute();
     final OrganizationBatch ob = getDbHandle().attach(OrganizationBatch.class);
-    if (org.getResponsiblePositions() != null) {
-      ob.insertOrganizationResponsiblePositions(org.getUuid(), org.getResponsiblePositions());
+    if (org.getAdministratingPositions() != null) {
+      ob.insertOrganizationAdministratingPositions(org.getUuid(), org.getAdministratingPositions());
     }
     return org;
   }
 
   public interface OrganizationBatch {
-    @SqlBatch("INSERT INTO \"organizationResponsiblePositions\" (\"organizationUuid\", \"positionUuid\") VALUES (:organizationUuid, :uuid)")
-    void insertOrganizationResponsiblePositions(@Bind("organizationUuid") String organizationUuid,
-        @BindBean List<Position> responsiblePositions);
+    @SqlBatch("INSERT INTO \"organizationAdministrativePositions\" (\"organizationUuid\", \"positionUuid\") VALUES (:organizationUuid, :uuid)")
+    void insertOrganizationAdministratingPositions(
+        @Bind("organizationUuid") String organizationUuid,
+        @BindBean List<Position> administratingPositions);
   }
 
   @Override
@@ -183,7 +184,7 @@ public class OrganizationDao
   @InTransaction
   public int addPositionToOrganization(Position p, Organization o) {
     return getDbHandle().createUpdate(
-        "/* addPositionToOrganization */ INSERT INTO \"organizationResponsiblePositions\" (\"organizationUuid\", \"positionUuid\") "
+        "/* addPositionToOrganization */ INSERT INTO \"organizationAdministrativePositions\" (\"organizationUuid\", \"positionUuid\") "
             + "VALUES (:organizationUuid, :positionUuid)")
         .bind("organizationUuid", o.getUuid()).bind("positionUuid", p.getUuid()).execute();
   }
@@ -191,15 +192,15 @@ public class OrganizationDao
   @InTransaction
   public int removePositionFromOrganization(String positionUuid, Organization o) {
     return getDbHandle().createUpdate(
-        "/* removePositionFromOrganization*/ DELETE FROM \"organizationResponsiblePositions\" "
+        "/* removePositionFromOrganization*/ DELETE FROM \"organizationAdministrativePositions\" "
             + "WHERE \"organizationUuid\" = :organizationUuid AND \"positionUuid\" = :positionUuid")
         .bind("organizationUuid", o.getUuid()).bind("positionUuid", positionUuid).execute();
   }
 
-  public CompletableFuture<List<Position>> getResponsiblePositionsForOrganization(
+  public CompletableFuture<List<Position>> getAdministratingPositionsForOrganization(
       Map<String, Object> context, String organizationUuid) {
     return new ForeignKeyFetcher<Position>().load(context,
-        FkDataLoaderKey.ORGANIZATION_RESPONSIBLE_POSITIONS, organizationUuid);
+        FkDataLoaderKey.ORGANIZATION_ADMINISTRATIVE_POSITIONS, organizationUuid);
   }
 
   @Override

--- a/src/main/java/mil/dds/anet/database/PositionDao.java
+++ b/src/main/java/mil/dds/anet/database/PositionDao.java
@@ -253,7 +253,7 @@ public class PositionDao extends AnetSubscribableObjectDao<Position, PositionSea
   @InTransaction
   public int addOrganizationToPosition(Position p, Organization o) {
     return getDbHandle().createUpdate(
-        "/* addOrganizationToPosition */ INSERT INTO \"organizationResponsiblePositions\" (\"organizationUuid\", \"positionUuid\") "
+        "/* addOrganizationToPosition */ INSERT INTO \"organizationAdministrativePositions\" (\"organizationUuid\", \"positionUuid\") "
             + "VALUES (:organizationUuid, :positionUuid)")
         .bind("organizationUuid", o.getUuid()).bind("positionUuid", p.getUuid()).execute();
   }
@@ -261,7 +261,7 @@ public class PositionDao extends AnetSubscribableObjectDao<Position, PositionSea
   @InTransaction
   public int removeOrganizationFromPosition(String orgUuid, Position p) {
     return getDbHandle().createUpdate(
-        "/* removeOrganizationToPosition*/ DELETE FROM \"organizationResponsiblePositions\" "
+        "/* removeOrganizationToPosition*/ DELETE FROM \"organizationAdministrativePositions\" "
             + "WHERE \"organizationUuid\" = :organizationUuid AND \"positionUuid\" = :positionUuid")
         .bind("organizationUuid", orgUuid).bind("positionUuid", p.getUuid()).execute();
   }
@@ -575,8 +575,8 @@ public class PositionDao extends AnetSubscribableObjectDao<Position, PositionSea
     updateM2mForMerge("authorizationGroupPositions", "authorizationGroupUuid", "positionUuid",
         winnerUuid, loserUuid);
 
-    // Update organizationResponsiblePositions
-    updateM2mForMerge("organizationResponsiblePositions", "organizationUuid", "positionUuid",
+    // Update organizationAdministrativePositions
+    updateM2mForMerge("organizationAdministrativePositions", "organizationUuid", "positionUuid",
         winnerUuid, loserUuid);
 
     // Update customSensitiveInformation for winner

--- a/src/main/java/mil/dds/anet/database/PositionDao.java
+++ b/src/main/java/mil/dds/anet/database/PositionDao.java
@@ -575,6 +575,10 @@ public class PositionDao extends AnetSubscribableObjectDao<Position, PositionSea
     updateM2mForMerge("authorizationGroupPositions", "authorizationGroupUuid", "positionUuid",
         winnerUuid, loserUuid);
 
+    // Update organizationResponsiblePositions
+    updateM2mForMerge("organizationResponsiblePositions", "organizationUuid", "positionUuid",
+        winnerUuid, loserUuid);
+
     // Update customSensitiveInformation for winner
     DaoUtils.saveCustomSensitiveInformation(null, PositionDao.TABLE_NAME, winnerUuid,
         winner.getCustomSensitiveInformation());

--- a/src/main/java/mil/dds/anet/database/PositionDao.java
+++ b/src/main/java/mil/dds/anet/database/PositionDao.java
@@ -13,6 +13,7 @@ import java.util.stream.Collectors;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response.Status;
 import mil.dds.anet.AnetObjectEngine;
+import mil.dds.anet.beans.Organization;
 import mil.dds.anet.beans.PersonPositionHistory;
 import mil.dds.anet.beans.Position;
 import mil.dds.anet.beans.Position.PositionType;
@@ -247,6 +248,22 @@ public class PositionDao extends AnetSubscribableObjectDao<Position, PositionSea
 
     // GraphQL mutations *have* to return something, so we return the number of inserted rows
     return nr;
+  }
+
+  @InTransaction
+  public int addOrganizationToPosition(Position p, Organization o) {
+    return getDbHandle().createUpdate(
+        "/* addOrganizationToPosition */ INSERT INTO \"organizationResponsiblePositions\" (\"organizationUuid\", \"positionUuid\") "
+            + "VALUES (:organizationUuid, :positionUuid)")
+        .bind("organizationUuid", o.getUuid()).bind("positionUuid", p.getUuid()).execute();
+  }
+
+  @InTransaction
+  public int removeOrganizationFromPosition(String orgUuid, Position p) {
+    return getDbHandle().createUpdate(
+        "/* removeOrganizationToPosition*/ DELETE FROM \"organizationResponsiblePositions\" "
+            + "WHERE \"organizationUuid\" = :organizationUuid AND \"positionUuid\" = :positionUuid")
+        .bind("organizationUuid", orgUuid).bind("positionUuid", p.getUuid()).execute();
   }
 
   @InTransaction

--- a/src/main/java/mil/dds/anet/resources/OrganizationResource.java
+++ b/src/main/java/mil/dds/anet/resources/OrganizationResource.java
@@ -88,12 +88,6 @@ public class OrganizationResource {
         engine.getApprovalStepDao().insertAtEnd(step);
       }
     }
-    if (AuthUtils.isAdmin(user) && org.getResponsiblePositions() != null) {
-      // Assign all of these positions to this organization.
-      for (final Position position : org.getResponsiblePositions()) {
-        dao.addPositionToOrganization(position, org);
-      }
-    }
 
     DaoUtils.saveCustomSensitiveInformation(user, OrganizationDao.TABLE_NAME, created.getUuid(),
         org.getCustomSensitiveInformation());

--- a/src/main/java/mil/dds/anet/resources/OrganizationResource.java
+++ b/src/main/java/mil/dds/anet/resources/OrganizationResource.java
@@ -14,7 +14,6 @@ import mil.dds.anet.AnetObjectEngine;
 import mil.dds.anet.beans.ApprovalStep;
 import mil.dds.anet.beans.Organization;
 import mil.dds.anet.beans.Person;
-import mil.dds.anet.beans.Position;
 import mil.dds.anet.beans.Task;
 import mil.dds.anet.beans.lists.AnetBeanList;
 import mil.dds.anet.beans.search.OrganizationSearchQuery;
@@ -55,9 +54,9 @@ public class OrganizationResource {
       @GraphQLArgument(name = "organization") Organization org) {
     org.checkAndFixCustomFields();
     final Person user = DaoUtils.getUserFromContext(context);
-    // Check if super user is authorized to create a sub organization
+    // Check if user is authorized to create a sub organization
     if (!AuthUtils.isAdmin(user)) {
-      AuthUtils.assertSuperUserForOrg(user, org.getParentOrgUuid(), false);
+      AuthUtils.assertCanAdministrateOrg(user, org.getParentOrgUuid(), false);
     }
     final Organization created;
     try {
@@ -104,7 +103,7 @@ public class OrganizationResource {
     org.checkAndFixCustomFields();
     final Person user = DaoUtils.getUserFromContext(context);
     // Verify correct Organization
-    AuthUtils.assertSuperUserForOrg(user, DaoUtils.getUuid(org), false);
+    AuthUtils.assertCanAdministrateOrg(user, DaoUtils.getUuid(org), false);
 
     // Load the existing organization, so we can check for differences.
     final Organization existing = dao.getByUuid(org.getUuid());
@@ -117,9 +116,8 @@ public class OrganizationResource {
     }
 
     if (!AuthUtils.isAdmin(user)) {
-      // Check if superuser has administrative permission for the organizations that will be
-      // modified with the
-      // parent organization update
+      // Check if user has administrative permission for the organizations that will be
+      // modified with the parent organization update
       if (!Objects.equals(org.getParentOrgUuid(), existing.getParentOrgUuid())) {
         if (org.getParentOrgUuid() != null) {
           final Organization parentOrg = dao.getByUuid(org.getParentOrgUuid());
@@ -128,13 +126,13 @@ public class OrganizationResource {
                 "You cannot assign a different type of organization as the parent",
                 Status.FORBIDDEN);
           }
-          AuthUtils.assertSuperUserForOrg(user, org.getParentOrgUuid(), false);
+          AuthUtils.assertCanAdministrateOrg(user, org.getParentOrgUuid(), false);
         }
         if (existing.getParentOrgUuid() != null) {
-          AuthUtils.assertSuperUserForOrg(user, existing.getParentOrgUuid(), false);
+          AuthUtils.assertCanAdministrateOrg(user, existing.getParentOrgUuid(), false);
         }
       }
-      // Super user is not authorized to change the organization type
+      // User is not authorized to change the organization type
       if (org.getType() != existing.getType()) {
         throw new WebApplicationException(
             "You do not have permissions to change the type of this organization",

--- a/src/main/java/mil/dds/anet/resources/OrganizationResource.java
+++ b/src/main/java/mil/dds/anet/resources/OrganizationResource.java
@@ -117,7 +117,8 @@ public class OrganizationResource {
     }
 
     if (!AuthUtils.isAdmin(user)) {
-      // Check if super user is responsible for the organizations that will be modified with the
+      // Check if superuser has administrative permission for the organizations that will be
+      // modified with the
       // parent organization update
       if (!Objects.equals(org.getParentOrgUuid(), existing.getParentOrgUuid())) {
         if (org.getParentOrgUuid() != null) {
@@ -171,10 +172,11 @@ public class OrganizationResource {
           oldTaskUuid -> engine.getTaskDao().removeTaskedOrganizationsFromTask(org, oldTaskUuid));
     }
 
-    if (AuthUtils.isAdmin(user) && org.getResponsiblePositions() != null) {
-      logger.debug("Editing responsible positions for {}", org);
-      Utils.addRemoveElementsByUuid(existing.loadResponsiblePositions(engine.getContext()).join(),
-          org.getResponsiblePositions(),
+    if (AuthUtils.isAdmin(user) && org.getAdministratingPositions() != null) {
+      logger.debug("Editing administrating positions for {}", org);
+      Utils.addRemoveElementsByUuid(
+          existing.loadAdministratingPositions(engine.getContext()).join(),
+          org.getAdministratingPositions(),
           newPosition -> dao.addPositionToOrganization(newPosition, org),
           oldPositionUuid -> dao.removePositionFromOrganization(oldPositionUuid, org));
     }

--- a/src/main/java/mil/dds/anet/resources/PersonResource.java
+++ b/src/main/java/mil/dds/anet/resources/PersonResource.java
@@ -110,7 +110,7 @@ public class PersonResource {
         // Super Users can edit position-less people.
         return true;
       }
-      return AuthUtils.isSuperUserForOrg(editor, subjectPos.getOrganizationUuid(), true);
+      return AuthUtils.canAdministrateOrg(editor, subjectPos.getOrganizationUuid(), true);
     }
     return false;
   }

--- a/src/main/java/mil/dds/anet/resources/PersonResource.java
+++ b/src/main/java/mil/dds/anet/resources/PersonResource.java
@@ -96,18 +96,18 @@ public class PersonResource {
       return true;
     }
     if (editorPos.getType() == PositionType.SUPER_USER) {
-      // Super Users can edit any principal
+      // Super users can edit any principal
       if (subject.getRole().equals(Role.PRINCIPAL)) {
         return true;
       }
-      // Ensure that the editor is the Super User for the subject's organization.
+      // Ensure that the editor is the super user for the subject's organization.
       final Position subjectPos =
           create
               ? AnetObjectEngine.getInstance().getPositionDao()
                   .getByUuid(DaoUtils.getUuid(subject.getPosition()))
               : DaoUtils.getPosition(subject);
       if (subjectPos == null) {
-        // Super Users can edit position-less people.
+        // Super users can edit position-less people.
         return true;
       }
       return AuthUtils.canAdministrateOrg(editor, subjectPos.getOrganizationUuid(), true);

--- a/src/main/java/mil/dds/anet/resources/PositionResource.java
+++ b/src/main/java/mil/dds/anet/resources/PositionResource.java
@@ -132,10 +132,10 @@ public class PositionResource {
 
     final Position current = dao.getByUuid(pos.getUuid());
 
-    if (AuthUtils.isAdmin(user) && pos.getResponsibleOrganizations() != null) {
+    if (AuthUtils.isAdmin(user) && pos.getOrganizationsAdministrated() != null) {
       Utils.addRemoveElementsByUuid(
-          current.loadResponsibleOrganizations(engine.getContext()).join(),
-          pos.getResponsibleOrganizations(), newOrg -> dao.addOrganizationToPosition(pos, newOrg),
+          current.loadOrganizationsAdministrated(engine.getContext()).join(),
+          pos.getOrganizationsAdministrated(), newOrg -> dao.addOrganizationToPosition(pos, newOrg),
           oldOrgUuid -> dao.removeOrganizationFromPosition(oldOrgUuid, pos));
     }
 

--- a/src/main/java/mil/dds/anet/resources/PositionResource.java
+++ b/src/main/java/mil/dds/anet/resources/PositionResource.java
@@ -273,7 +273,12 @@ public class PositionResource {
       @GraphQLArgument(name = "loserUuid") String loserUuid) {
     final Person user = DaoUtils.getUserFromContext(context);
     final Position loserPosition = dao.getByUuid(loserUuid);
-    assertCanUpdatePosition(user, winnerPosition);
+    AuthUtils.assertAdministrator(user);
+
+    if (winnerPosition.getOrganizationUuid() == null) {
+      throw new WebApplicationException("A Position must belong to an organization",
+          Status.BAD_REQUEST);
+    }
 
     final String winnerPersonUuid = DaoUtils.getUuid(winnerPosition.getPerson());
     ResourceUtils.validateHistoryInput(winnerPosition.getUuid(), winnerPosition.getPreviousPeople(),

--- a/src/main/java/mil/dds/anet/resources/PositionResource.java
+++ b/src/main/java/mil/dds/anet/resources/PositionResource.java
@@ -53,7 +53,7 @@ public class PositionResource {
       final Position existingPos = dao.getByUuid(pos.getUuid());
       if (existingPos.getType() != PositionType.SUPER_USER) {
         throw new WebApplicationException(
-            "You are not allowed to change the position type to SUPER USER", Status.FORBIDDEN);
+            "You are not allowed to change the position type to SUPER_USER", Status.FORBIDDEN);
       }
     }
   }
@@ -66,7 +66,7 @@ public class PositionResource {
       throw new WebApplicationException("A Position must belong to an organization",
           Status.BAD_REQUEST);
     }
-    AuthUtils.assertSuperUserForOrg(user, pos.getOrganizationUuid(), true);
+    AuthUtils.assertCanAdministrateOrg(user, pos.getOrganizationUuid(), true);
   }
 
   @GraphQLMutation(name = "createPosition")
@@ -94,7 +94,7 @@ public class PositionResource {
   public Integer updateAssociatedPosition(@GraphQLRootContext Map<String, Object> context,
       @GraphQLArgument(name = "position") Position pos) {
     final Person user = DaoUtils.getUserFromContext(context);
-    AuthUtils.assertSuperUserForOrg(user, pos.getOrganizationUuid(), true);
+    AuthUtils.assertCanAdministrateOrg(user, pos.getOrganizationUuid(), true);
 
     final Position current = dao.getByUuid(pos.getUuid());
     if (current == null) {
@@ -205,7 +205,7 @@ public class PositionResource {
     if (pos == null) {
       throw new WebApplicationException("Position not found", Status.NOT_FOUND);
     }
-    AuthUtils.assertSuperUserForOrg(user, pos.getOrganizationUuid(), true);
+    AuthUtils.assertCanAdministrateOrg(user, pos.getOrganizationUuid(), true);
 
     final int numRows = dao.setPersonInPosition(DaoUtils.getUuid(person), positionUuid);
     AnetAuditLogger.log("Person {} put in Position {} by {}", person, pos, user);
@@ -220,7 +220,7 @@ public class PositionResource {
     if (pos == null) {
       throw new WebApplicationException("Position not found", Status.NOT_FOUND);
     }
-    AuthUtils.assertSuperUserForOrg(user, pos.getOrganizationUuid(), true);
+    AuthUtils.assertCanAdministrateOrg(user, pos.getOrganizationUuid(), true);
 
     final int numRows = dao.removePersonFromPosition(positionUuid);
     if (numRows == 0) {

--- a/src/main/java/mil/dds/anet/resources/ReportResource.java
+++ b/src/main/java/mil/dds/anet/resources/ReportResource.java
@@ -362,7 +362,7 @@ public class ReportResource {
         r, r.getAdvisorOrg(), r.getPrimaryAdvisor());
 
     final boolean isAuthor = r.isAuthor(user);
-    if (!isAuthor && !AuthUtils.isSuperUserForOrg(user, r.getAdvisorOrgUuid(), true)
+    if (!isAuthor && !AuthUtils.canAdministrateOrg(user, r.getAdvisorOrgUuid(), true)
         && !AuthUtils.isAdmin(user)) {
       throw new WebApplicationException(
           "Cannot submit report unless you are a report's author, his/her super user or an admin",

--- a/src/main/java/mil/dds/anet/utils/AuthUtils.java
+++ b/src/main/java/mil/dds/anet/utils/AuthUtils.java
@@ -33,8 +33,8 @@ public class AuthUtils {
   public static boolean canAdministrateOrg(final Person user, final String organizationUuid,
       boolean allowPrincipalOrgs) {
     if (organizationUuid == null) {
-      logger.error("Organization {} is null or has a null UUID in SuperUser check for {}",
-          organizationUuid, user); // DANGER: possible log injection vector here?
+      logger.error("Organization {} is null or has a null UUID in canAdministrateOrg check for {}",
+          organizationUuid, user);
       return false;
     }
     Position position = DaoUtils.getPosition(user);
@@ -43,7 +43,7 @@ public class AuthUtils {
       return false;
     }
     if (position.getType() == PositionType.ADMINISTRATOR) {
-      logger.debug("User {} is an administrator, automatically a superuser", user);
+      logger.debug("User {} is an administrator, can automatically administrate org", user);
       return true;
     }
     logger.debug("Position for user {} is {}", user, position);
@@ -78,10 +78,10 @@ public class AuthUtils {
     return false;
   }
 
-  public static void assertSuperUserForOrg(Person user, String organizationUuid,
+  public static void assertCanAdministrateOrg(Person user, String organizationUuid,
       boolean allowPrincipalOrgs) {
     // log injection possibility here?
-    logger.debug("Asserting superuser status for {} in {}", user, organizationUuid);
+    logger.debug("Asserting canAdministrateOrg status for {} in {}", user, organizationUuid);
     if (canAdministrateOrg(user, organizationUuid, allowPrincipalOrgs)) {
       return;
     }
@@ -89,7 +89,7 @@ public class AuthUtils {
   }
 
   public static void assertSuperUser(Person user) {
-    logger.debug("Asserting some superuser status for {}", user);
+    logger.debug("Asserting super user position for {}", user);
     Position position = DaoUtils.getPosition(user);
     if (position != null && (position.getType() == PositionType.SUPER_USER
         || position.getType() == PositionType.ADMINISTRATOR)) {

--- a/src/main/java/mil/dds/anet/utils/AuthUtils.java
+++ b/src/main/java/mil/dds/anet/utils/AuthUtils.java
@@ -60,17 +60,17 @@ public class AuthUtils {
 
     // Check the responsible organizations.
     final Map<String, Object> context = AnetObjectEngine.getInstance().getContext();
-    final List<Organization> responsibleOrgs =
-        position.loadResponsibleOrganizations(context).join();
-    if (responsibleOrgs.stream().anyMatch(o -> o.getUuid().equals(organizationUuid))) {
+    final List<Organization> administratedOrgs =
+        position.loadOrganizationsAdministrated(context).join();
+    if (administratedOrgs.stream().anyMatch(o -> o.getUuid().equals(organizationUuid))) {
       return true;
     }
 
     // As a final resort, check the descendant orgs of the position's responsible orgs.
     final OrganizationSearchQuery osQuery = new OrganizationSearchQuery();
     osQuery.setPageSize(0);
-    for (final Organization responsibleOrg : responsibleOrgs) {
-      if (responsibleOrg.loadDescendantOrgs(context, osQuery).join().stream()
+    for (final Organization administratedOrg : administratedOrgs) {
+      if (administratedOrg.loadDescendantOrgs(context, osQuery).join().stream()
           .anyMatch(o -> o.getUuid().equals(organizationUuid))) {
         return true;
       }

--- a/src/main/java/mil/dds/anet/utils/AuthUtils.java
+++ b/src/main/java/mil/dds/anet/utils/AuthUtils.java
@@ -30,7 +30,7 @@ public class AuthUtils {
     throw new WebApplicationException(UNAUTH_MESSAGE, Status.FORBIDDEN);
   }
 
-  public static boolean isSuperUserForOrg(final Person user, final String organizationUuid,
+  public static boolean canAdministrateOrg(final Person user, final String organizationUuid,
       boolean allowPrincipalOrgs) {
     if (organizationUuid == null) {
       logger.error("Organization {} is null or has a null UUID in SuperUser check for {}",
@@ -82,7 +82,7 @@ public class AuthUtils {
       boolean allowPrincipalOrgs) {
     // log injection possibility here?
     logger.debug("Asserting superuser status for {} in {}", user, organizationUuid);
-    if (isSuperUserForOrg(user, organizationUuid, allowPrincipalOrgs)) {
+    if (canAdministrateOrg(user, organizationUuid, allowPrincipalOrgs)) {
       return;
     }
     throw new WebApplicationException(UNAUTH_MESSAGE, Status.FORBIDDEN);

--- a/src/main/java/mil/dds/anet/utils/AuthUtils.java
+++ b/src/main/java/mil/dds/anet/utils/AuthUtils.java
@@ -58,25 +58,11 @@ public class AuthUtils {
       return true;
     }
 
-    if (position.getOrganizationUuid() == null) {
-      return false;
-    }
-
-    if (Objects.equals(organizationUuid, position.getOrganizationUuid())) {
-      return true;
-    }
-
-    // Check the descendant organizations of the position's own organization.
+    // Check the responsible organizations.
     final Map<String, Object> context = AnetObjectEngine.getInstance().getContext();
-    final Organization posOrg = position.loadOrganization(context).join();
     final OrganizationSearchQuery osQuery = new OrganizationSearchQuery();
     osQuery.setPageSize(0);
-    if (posOrg.loadDescendantOrgs(context, osQuery).join().stream()
-        .anyMatch(o -> o.getUuid().equals(organizationUuid))) {
-      return true;
-    }
 
-    // Check the responsible organizations.
     final List<Organization> responsibleOrgs =
         position.loadResponsibleOrganizations(context).join();
     if (responsibleOrgs.stream().anyMatch(o -> o.getUuid().equals(organizationUuid))) {

--- a/src/main/java/mil/dds/anet/utils/AuthUtils.java
+++ b/src/main/java/mil/dds/anet/utils/AuthUtils.java
@@ -60,15 +60,15 @@ public class AuthUtils {
 
     // Check the responsible organizations.
     final Map<String, Object> context = AnetObjectEngine.getInstance().getContext();
-    final OrganizationSearchQuery osQuery = new OrganizationSearchQuery();
-    osQuery.setPageSize(0);
-
     final List<Organization> responsibleOrgs =
         position.loadResponsibleOrganizations(context).join();
     if (responsibleOrgs.stream().anyMatch(o -> o.getUuid().equals(organizationUuid))) {
       return true;
     }
+
     // As a final resort, check the descendant orgs of the position's responsible orgs.
+    final OrganizationSearchQuery osQuery = new OrganizationSearchQuery();
+    osQuery.setPageSize(0);
     for (final Organization responsibleOrg : responsibleOrgs) {
       if (responsibleOrg.loadDescendantOrgs(context, osQuery).join().stream()
           .anyMatch(o -> o.getUuid().equals(organizationUuid))) {

--- a/src/main/java/mil/dds/anet/utils/BatchingUtils.java
+++ b/src/main/java/mil/dds/anet/utils/BatchingUtils.java
@@ -140,6 +140,15 @@ public final class BatchingUtils {
                 dispatcherService);
           }
         }, dataLoaderOptions));
+    dataLoaderRegistry.register(FkDataLoaderKey.ORGANIZATION_RESPONSIBLE_POSITIONS.toString(),
+        new DataLoader<>(new BatchLoader<String, List<Position>>() {
+          @Override
+          public CompletionStage<List<List<Position>>> load(List<String> foreignKeys) {
+            return CompletableFuture.supplyAsync(
+                () -> engine.getOrganizationDao().getResponsiblePositions(foreignKeys),
+                dispatcherService);
+          }
+        }, dataLoaderOptions));
     dataLoaderRegistry.register(IdDataLoaderKey.ORGANIZATIONS.toString(),
         new DataLoader<>(new BatchLoader<String, Organization>() {
           @Override

--- a/src/main/java/mil/dds/anet/utils/BatchingUtils.java
+++ b/src/main/java/mil/dds/anet/utils/BatchingUtils.java
@@ -140,15 +140,6 @@ public final class BatchingUtils {
                 dispatcherService);
           }
         }, dataLoaderOptions));
-    dataLoaderRegistry.register(FkDataLoaderKey.ORGANIZATION_RESPONSIBLE_POSITIONS.toString(),
-        new DataLoader<>(new BatchLoader<String, List<Position>>() {
-          @Override
-          public CompletionStage<List<List<Position>>> load(List<String> foreignKeys) {
-            return CompletableFuture.supplyAsync(
-                () -> engine.getOrganizationDao().getResponsiblePositions(foreignKeys),
-                dispatcherService);
-          }
-        }, dataLoaderOptions));
     dataLoaderRegistry.register(IdDataLoaderKey.ORGANIZATIONS.toString(),
         new DataLoader<>(new BatchLoader<String, Organization>() {
           @Override
@@ -164,6 +155,15 @@ public final class BatchingUtils {
               List<ImmutablePair<String, OrganizationSearchQuery>> foreignKeys) {
             return CompletableFuture.supplyAsync(
                 () -> engine.getOrganizationDao().getOrganizationsBySearch(foreignKeys),
+                dispatcherService);
+          }
+        }, dataLoaderOptions));
+    dataLoaderRegistry.register(FkDataLoaderKey.ORGANIZATION_RESPONSIBLE_POSITIONS.toString(),
+        new DataLoader<>(new BatchLoader<String, List<Position>>() {
+          @Override
+          public CompletionStage<List<List<Position>>> load(List<String> foreignKeys) {
+            return CompletableFuture.supplyAsync(
+                () -> engine.getOrganizationDao().getResponsiblePositions(foreignKeys),
                 dispatcherService);
           }
         }, dataLoaderOptions));

--- a/src/main/java/mil/dds/anet/utils/BatchingUtils.java
+++ b/src/main/java/mil/dds/anet/utils/BatchingUtils.java
@@ -158,12 +158,12 @@ public final class BatchingUtils {
                 dispatcherService);
           }
         }, dataLoaderOptions));
-    dataLoaderRegistry.register(FkDataLoaderKey.ORGANIZATION_RESPONSIBLE_POSITIONS.toString(),
+    dataLoaderRegistry.register(FkDataLoaderKey.ORGANIZATION_ADMINISTRATIVE_POSITIONS.toString(),
         new DataLoader<>(new BatchLoader<String, List<Position>>() {
           @Override
           public CompletionStage<List<List<Position>>> load(List<String> foreignKeys) {
             return CompletableFuture.supplyAsync(
-                () -> engine.getOrganizationDao().getResponsiblePositions(foreignKeys),
+                () -> engine.getOrganizationDao().getAdministratingPositions(foreignKeys),
                 dispatcherService);
           }
         }, dataLoaderOptions));

--- a/src/main/java/mil/dds/anet/utils/FkDataLoaderKey.java
+++ b/src/main/java/mil/dds/anet/utils/FkDataLoaderKey.java
@@ -6,7 +6,7 @@ public enum FkDataLoaderKey {
   AUTHORIZATION_GROUP_POSITIONS, // authorizationGroup.positions
   NOTE_NOTE_RELATED_OBJECTS, // note.noteRelatedObjects
   NOTE_RELATED_OBJECT_NOTES, // noteRelatedObject.notes
-  ORGANIZATION_RESPONSIBLE_POSITIONS, // organization.responsiblePositions
+  ORGANIZATION_ADMINISTRATIVE_POSITIONS, // organization.responsiblePositions
   PERSON_ORGANIZATIONS, // person.organizations
   PERSON_PERSON_POSITION_HISTORY, // person.personPositionHistory
   POSITION_ASSOCIATED_POSITIONS, // position.associatedPositions

--- a/src/main/java/mil/dds/anet/utils/FkDataLoaderKey.java
+++ b/src/main/java/mil/dds/anet/utils/FkDataLoaderKey.java
@@ -6,6 +6,7 @@ public enum FkDataLoaderKey {
   AUTHORIZATION_GROUP_POSITIONS, // authorizationGroup.positions
   NOTE_NOTE_RELATED_OBJECTS, // note.noteRelatedObjects
   NOTE_RELATED_OBJECT_NOTES, // noteRelatedObject.notes
+  ORGANIZATION_RESPONSIBLE_POSITIONS, // organization.responsiblePositions
   PERSON_ORGANIZATIONS, // person.organizations
   PERSON_PERSON_POSITION_HISTORY, // person.personPositionHistory
   POSITION_ASSOCIATED_POSITIONS, // position.associatedPositions

--- a/src/main/resources/anet-schema.yml
+++ b/src/main/resources/anet-schema.yml
@@ -811,7 +811,7 @@ properties:
                 "$ref": "#/$defs/inputField"
               identificationCode:
                 "$ref": "#/$defs/inputField"
-              responsiblePositions:
+              administratingPositions:
                 "$ref": "#/$defs/inputField"
 
       principal:
@@ -890,7 +890,7 @@ properties:
           org:
             type: object
             additionalProperties: false
-            required: [name, allOrgName, longName, responsiblePositions]
+            required: [name, allOrgName, longName, administratingPositions]
             properties:
               name:
                 type: string
@@ -904,7 +904,7 @@ properties:
                 "$ref": "#/$defs/inputField"
               identificationCode:
                 "$ref": "#/$defs/inputField"
-              responsiblePositions:
+              administratingPositions:
                 "$ref": "#/$defs/inputField"
 
       superUser:

--- a/src/main/resources/anet-schema.yml
+++ b/src/main/resources/anet-schema.yml
@@ -791,6 +791,8 @@ properties:
                       type: string
                       enum:
                         [VIRTUAL_LOCATION, PHYSICAL_LOCATION, GEOGRAPHICAL_AREA, POINT_LOCATION, ADVISOR_LOCATION, PRINCIPAL_LOCATION]
+              responsibleOrganizations:
+                "$ref": "#/$defs/inputField"
 
           org:
             type: object

--- a/src/main/resources/anet-schema.yml
+++ b/src/main/resources/anet-schema.yml
@@ -791,7 +791,7 @@ properties:
                       type: string
                       enum:
                         [VIRTUAL_LOCATION, PHYSICAL_LOCATION, GEOGRAPHICAL_AREA, POINT_LOCATION, ADVISOR_LOCATION, PRINCIPAL_LOCATION]
-              responsibleOrganizations:
+              organizationsAdministrated:
                 "$ref": "#/$defs/inputField"
 
           org:

--- a/src/main/resources/anet-schema.yml
+++ b/src/main/resources/anet-schema.yml
@@ -809,6 +809,8 @@ properties:
                 "$ref": "#/$defs/inputField"
               identificationCode:
                 "$ref": "#/$defs/inputField"
+              responsiblePositions:
+                "$ref": "#/$defs/inputField"
 
       principal:
         type: object
@@ -886,7 +888,7 @@ properties:
           org:
             type: object
             additionalProperties: false
-            required: [name, allOrgName, longName]
+            required: [name, allOrgName, longName, responsiblePositions]
             properties:
               name:
                 type: string
@@ -899,6 +901,8 @@ properties:
               longName:
                 "$ref": "#/$defs/inputField"
               identificationCode:
+                "$ref": "#/$defs/inputField"
+              responsiblePositions:
                 "$ref": "#/$defs/inputField"
 
       superUser:

--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -4114,31 +4114,6 @@
 	</changeSet>
 
 	<!-- From this point on, mssql is no longer supported, so only postgresql migrations are needed -->
-	<changeSet id="add_organization_responsible_positions" author="nur.yilmaz">
-		<createTable tableName="organizationResponsiblePositions">
-			<column name="organizationUuid" type="${uuid_type}">
-				<constraints nullable="false"/>
-			</column>
-			<column name="positionUuid" type="${uuid_type}">
-				<constraints nullable="false"/>
-			</column>
-		</createTable>
-		<addUniqueConstraint tableName="organizationResponsiblePositions" columnNames="organizationUuid, positionUuid" constraintName="uniqueOrganizationResponsiblePositions" />
-		<addForeignKeyConstraint baseColumnNames="organizationUuid" baseTableName="organizationResponsiblePositions"
-			constraintName="fk_organizationResponsiblePositions_organization" onDelete="NO ACTION" onUpdate="NO ACTION"
-			referencedColumnNames="uuid" referencedTableName="organizations" />
-		<addForeignKeyConstraint baseColumnNames="positionUuid" baseTableName="organizationResponsiblePositions"
-			constraintName="fk_organizationResponsiblePositions_position" onDelete="NO ACTION" onUpdate="NO ACTION"
-			referencedColumnNames="uuid" referencedTableName="positions" />
-		<createIndex
-			indexName="IDX_organizationResponsiblePositions_organizationUuid" tableName="organizationResponsiblePositions">
-			<column name="organizationUuid"/>
-		</createIndex>
-		<createIndex
-			indexName="IDX_organizationResponsiblePositions_positionUuid" tableName="organizationResponsiblePositions">
-			<column name="positionUuid"/>
-		</createIndex>
-	</changeSet>
 
 	<changeSet id="add-assessmentKey-to-notes" author="gjvoosten">
 		<addColumn tableName="notes">
@@ -4175,6 +4150,32 @@
 		<!-- Make sure rows with a NULL positionUuid or a NULL personUuid are no longer allowed -->
 		<addNotNullConstraint tableName="peoplePositions" columnName="positionUuid" columnDataType="${uuid_type}" />
 		<addNotNullConstraint tableName="peoplePositions" columnName="personUuid" columnDataType="${uuid_type}" />
+	</changeSet>
+
+	<changeSet id="add_organization_responsible_positions" author="nur.yilmaz">
+		<createTable tableName="organizationResponsiblePositions">
+			<column name="organizationUuid" type="${uuid_type}">
+				<constraints nullable="false"/>
+			</column>
+			<column name="positionUuid" type="${uuid_type}">
+				<constraints nullable="false"/>
+			</column>
+		</createTable>
+		<addUniqueConstraint tableName="organizationResponsiblePositions" columnNames="organizationUuid, positionUuid" constraintName="UQ_uniqueOrganizationResponsiblePositions" />
+		<addForeignKeyConstraint baseColumnNames="organizationUuid" baseTableName="organizationResponsiblePositions"
+								 constraintName="FK_organizationResponsiblePositions_organization" onDelete="NO ACTION" onUpdate="NO ACTION"
+								 referencedColumnNames="uuid" referencedTableName="organizations" />
+		<addForeignKeyConstraint baseColumnNames="positionUuid" baseTableName="organizationResponsiblePositions"
+								 constraintName="FK_organizationResponsiblePositions_position" onDelete="NO ACTION" onUpdate="NO ACTION"
+								 referencedColumnNames="uuid" referencedTableName="positions" />
+		<createIndex
+				indexName="IDX_organizationResponsiblePositions_organizationUuid" tableName="organizationResponsiblePositions">
+			<column name="organizationUuid"/>
+		</createIndex>
+		<createIndex
+				indexName="IDX_organizationResponsiblePositions_positionUuid" tableName="organizationResponsiblePositions">
+			<column name="positionUuid"/>
+		</createIndex>
 	</changeSet>
 
 </databaseChangeLog>

--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -4114,6 +4114,31 @@
 	</changeSet>
 
 	<!-- From this point on, mssql is no longer supported, so only postgresql migrations are needed -->
+	<changeSet id="add_organization_responsible_positions" author="nur.yilmaz">
+		<createTable tableName="organizationResponsiblePositions">
+			<column name="organizationUuid" type="${uuid_type}">
+				<constraints nullable="false"/>
+			</column>
+			<column name="positionUuid" type="${uuid_type}">
+				<constraints nullable="false"/>
+			</column>
+		</createTable>
+		<addUniqueConstraint tableName="organizationResponsiblePositions" columnNames="organizationUuid, positionUuid" constraintName="uniqueOrganizationResponsiblePositions" />
+		<addForeignKeyConstraint baseColumnNames="organizationUuid" baseTableName="organizationResponsiblePositions"
+			constraintName="fk_organizationResponsiblePositions_organization" onDelete="NO ACTION" onUpdate="NO ACTION"
+			referencedColumnNames="uuid" referencedTableName="organizations" />
+		<addForeignKeyConstraint baseColumnNames="positionUuid" baseTableName="organizationResponsiblePositions"
+			constraintName="fk_organizationResponsiblePositions_position" onDelete="NO ACTION" onUpdate="NO ACTION"
+			referencedColumnNames="uuid" referencedTableName="positions" />
+		<createIndex
+			indexName="IDX_organizationResponsiblePositions_organizationUuid" tableName="organizationResponsiblePositions">
+			<column name="organizationUuid"/>
+		</createIndex>
+		<createIndex
+			indexName="IDX_organizationResponsiblePositions_positionUuid" tableName="organizationResponsiblePositions">
+			<column name="positionUuid"/>
+		</createIndex>
+	</changeSet>
 
 	<changeSet id="add-assessmentKey-to-notes" author="gjvoosten">
 		<addColumn tableName="notes">

--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -4152,8 +4152,8 @@
 		<addNotNullConstraint tableName="peoplePositions" columnName="personUuid" columnDataType="${uuid_type}" />
 	</changeSet>
 
-	<changeSet id="add_organization_responsible_positions" author="nur.yilmaz">
-		<createTable tableName="organizationResponsiblePositions">
+	<changeSet id="add_organization_administrative_positions" author="nur.yilmaz">
+		<createTable tableName="organizationAdministrativePositions">
 			<column name="organizationUuid" type="${uuid_type}">
 				<constraints nullable="false"/>
 			</column>
@@ -4161,19 +4161,19 @@
 				<constraints nullable="false"/>
 			</column>
 		</createTable>
-		<addUniqueConstraint tableName="organizationResponsiblePositions" columnNames="organizationUuid, positionUuid" constraintName="UQ_uniqueOrganizationResponsiblePositions" />
-		<addForeignKeyConstraint baseColumnNames="organizationUuid" baseTableName="organizationResponsiblePositions"
-								 constraintName="FK_organizationResponsiblePositions_organization" onDelete="NO ACTION" onUpdate="NO ACTION"
+		<addUniqueConstraint tableName="organizationAdministrativePositions" columnNames="organizationUuid, positionUuid" constraintName="UQ_uniqueOrganizationAdministrativePositions" />
+		<addForeignKeyConstraint baseColumnNames="organizationUuid" baseTableName="organizationAdministrativePositions"
+								 constraintName="FK_organizationAdministrativePositions_organization" onDelete="NO ACTION" onUpdate="NO ACTION"
 								 referencedColumnNames="uuid" referencedTableName="organizations" />
-		<addForeignKeyConstraint baseColumnNames="positionUuid" baseTableName="organizationResponsiblePositions"
-								 constraintName="FK_organizationResponsiblePositions_position" onDelete="NO ACTION" onUpdate="NO ACTION"
+		<addForeignKeyConstraint baseColumnNames="positionUuid" baseTableName="organizationAdministrativePositions"
+								 constraintName="FK_organizationAdministrativePositions_position" onDelete="NO ACTION" onUpdate="NO ACTION"
 								 referencedColumnNames="uuid" referencedTableName="positions" />
 		<createIndex
-				indexName="IDX_organizationResponsiblePositions_organizationUuid" tableName="organizationResponsiblePositions">
+				indexName="IDX_organizationAdministrativePositions_organizationUuid" tableName="organizationAdministrativePositions">
 			<column name="organizationUuid"/>
 		</createIndex>
 		<createIndex
-				indexName="IDX_organizationResponsiblePositions_positionUuid" tableName="organizationResponsiblePositions">
+				indexName="IDX_organizationAdministrativePositions_positionUuid" tableName="organizationAdministrativePositions">
 			<column name="positionUuid"/>
 		</createIndex>
 	</changeSet>

--- a/src/test/java/mil/dds/anet/test/resources/OrganizationResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/OrganizationResourceTest.java
@@ -371,7 +371,7 @@ public class OrganizationResourceTest extends AbstractResourceTest {
     failCreateOrganization(superUserMutationExecutor, childOrgInput);
 
     // Set super-user as responsible for the parent organization
-    parentOrg.setResponsiblePositions(Lists.newArrayList(superUserPosition));
+    parentOrg.setAdministratingPositions(Lists.newArrayList(superUserPosition));
     succeedUpdateOrganization(adminMutationExecutor, getOrganizationInput(parentOrg));
 
     final Organization createdChildOrg =
@@ -391,12 +391,12 @@ public class OrganizationResourceTest extends AbstractResourceTest {
     failUpdateOrganization(superUserMutationExecutor, getOrganizationInput(superUserOrg));
 
     // Given responsibility now they can edit their organization
-    superUserOrg.setResponsiblePositions(Lists.newArrayList(superUserPosition));
+    superUserOrg.setAdministratingPositions(Lists.newArrayList(superUserPosition));
     succeedUpdateOrganization(adminMutationExecutor, getOrganizationInput(superUserOrg));
     succeedUpdateOrganization(superUserMutationExecutor, getOrganizationInput(superUserOrg));
 
     // Remove position
-    superUserOrg.setResponsiblePositions(new ArrayList<>());
+    superUserOrg.setAdministratingPositions(new ArrayList<>());
     succeedUpdateOrganization(adminMutationExecutor, getOrganizationInput(superUserOrg));
   }
 
@@ -429,7 +429,7 @@ public class OrganizationResourceTest extends AbstractResourceTest {
     createdChildOrg.setParentOrg(createdParentOrg);
 
     // Set super-user as responsible for the child organization
-    createdChildOrg.setResponsiblePositions(Lists.newArrayList(superUserPosition));
+    createdChildOrg.setAdministratingPositions(Lists.newArrayList(superUserPosition));
     succeedUpdateOrganization(adminMutationExecutor, getOrganizationInput(createdChildOrg));
 
     // Cannot set parent as null because they're not responsible for the parent organization
@@ -437,7 +437,7 @@ public class OrganizationResourceTest extends AbstractResourceTest {
     failUpdateOrganization(superUserMutationExecutor, getOrganizationInput(createdChildOrg));
     createdChildOrg.setParentOrg(createdParentOrg);
     // Set super-user as responsible for the parent organization
-    createdParentOrg.setResponsiblePositions(Lists.newArrayList(superUserPosition));
+    createdParentOrg.setAdministratingPositions(Lists.newArrayList(superUserPosition));
     succeedUpdateOrganization(adminMutationExecutor, getOrganizationInput(createdParentOrg));
     // Now super-user can set the parent organization as null
     createdChildOrg.setParentOrg(null);
@@ -460,7 +460,7 @@ public class OrganizationResourceTest extends AbstractResourceTest {
     createdChildOrg.setParentOrg(createdParentOrg);
 
     // Update responsible position
-    createdNewParentOrg.setResponsiblePositions(Lists.newArrayList(superUserPosition));
+    createdNewParentOrg.setAdministratingPositions(Lists.newArrayList(superUserPosition));
     succeedUpdateOrganization(adminMutationExecutor, getOrganizationInput(createdNewParentOrg));
 
     // Now they can assign the new parent

--- a/src/test/resources/anet.graphql
+++ b/src/test/resources/anet.graphql
@@ -454,6 +454,7 @@ type Organization {
   parentOrg: Organization
   planningApprovalSteps: [ApprovalStep]
   positions(query: PositionSearchQueryInput): [Position]
+  responsiblePositions: [Position]
   shortName: String
   status: Status
   tasks: [Task]
@@ -472,6 +473,7 @@ input OrganizationInput {
   longName: String
   parentOrg: OrganizationInput
   planningApprovalSteps: [ApprovalStepInput]
+  responsiblePositions: [PositionInput]
   shortName: String
   status: Status
   tasks: [TaskInput]
@@ -632,6 +634,7 @@ type Position {
   organization: Organization
   person: Person
   previousPeople: [PersonPositionHistory]
+  responsibleOrganizations: [Organization]
   responsibleTasks(query: TaskSearchQueryInput): [Task]
   status: Status
   type: PositionType

--- a/src/test/resources/anet.graphql
+++ b/src/test/resources/anet.graphql
@@ -454,7 +454,7 @@ type Organization {
   parentOrg: Organization
   planningApprovalSteps: [ApprovalStep]
   positions(query: PositionSearchQueryInput): [Position]
-  responsiblePositions: [Position]
+  administratingPositions: [Position]
   shortName: String
   status: Status
   tasks: [Task]
@@ -473,7 +473,7 @@ input OrganizationInput {
   longName: String
   parentOrg: OrganizationInput
   planningApprovalSteps: [ApprovalStepInput]
-  responsiblePositions: [PositionInput]
+  administratingPositions: [PositionInput]
   shortName: String
   status: Status
   tasks: [TaskInput]

--- a/testDictionaries/no-custom-fields.yml
+++ b/testDictionaries/no-custom-fields.yml
@@ -689,6 +689,9 @@ fields:
       identificationCode:
         label: UIC
         placeholder: the six character code
+      responsiblePositions:
+        label: Responsible positions
+        placeholder: Search for a position...
 
   principal:
     person:
@@ -901,6 +904,9 @@ fields:
       identificationCode:
         label: UIC
         placeholder: the six character code
+      responsiblePositions:
+        label: Responsible positions
+        placeholder: Search for a position...
 
   superUser:
 

--- a/testDictionaries/no-custom-fields.yml
+++ b/testDictionaries/no-custom-fields.yml
@@ -679,6 +679,9 @@ fields:
         placeholder: the CE post number for this position
       location:
         filter: [POINT_LOCATION]
+      organizationsAdministrated:
+        label: Responsible organizations
+        placeholder: Search for an organization...
 
     org:
       name: Advisor Organization
@@ -689,8 +692,8 @@ fields:
       identificationCode:
         label: UIC
         placeholder: the six character code
-      responsiblePositions:
-        label: Responsible positions
+      administratingPositions:
+        label: Administrating positions
         placeholder: Search for a position...
 
   principal:
@@ -904,8 +907,8 @@ fields:
       identificationCode:
         label: UIC
         placeholder: the six character code
-      responsiblePositions:
-        label: Responsible positions
+      administratingPositions:
+        label: Administrating positions
         placeholder: Search for a position...
 
   superUser:


### PR DESCRIPTION
Admins can assign super users to organizations so that they can manage other organizations in addition to their own organization. They can now edit organization fields like _Name, Description, Status and UIC_. _Parent Organization_ field can only be edited if the super user is also responsible from both current and new _Parent Organization_. Super users can also create sub-organizations for the organizations they are responsible for.

Closes [AB#334](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/334)

#### User changes
- None

#### Super User changes
- Super users can edit organisation fields and create sub-organizations

#### Admin changes
- Admins can assign super users to organizations.

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [x] db needs migration
- [ ] documentation has changed
- [x] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [x] Added and/or updated unit tests
  - [x] Added and/or updated e2e tests
  - [x] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
