### PR TITLE
Show attendee options in single column

### DIFF
--- a/client/src/components/CustomFields.js
+++ b/client/src/components/CustomFields.js
@@ -586,7 +586,7 @@ const AnetObjectField = ({
               <td>
                 <LinkAnetEntity type={fieldValue.type} uuid={fieldValue.uuid} />
               </td>
-              <td className="col-xs-1">
+              <td className="col-1">
                 <RemoveButton
                   title={`Unlink this ${fieldValue.type}`}
                   onClick={() => setFieldValue(name, null)}
@@ -695,7 +695,7 @@ const ArrayOfAnetObjectsField = ({
                 <td>
                   <LinkAnetEntity type={entity.type} uuid={entity.uuid} />
                 </td>
-                <td className="col-xs-1">
+                <td className="col-1">
                   <RemoveButton
                     title={`Unlink this ${entity.type}`}
                     onClick={() => {

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -992,11 +992,11 @@ header.searchPagination {
   padding-bottom: 5px;
 }
 
-.advanced-search .col-xs-3 select {
+.advanced-search .col-3 select {
   margin-top: -8px;
 }
 
-.advanced-search .col-xs-1 .btn img,
+.advanced-search .col-1 .btn img,
 .advanced-search .col-sm-1 .btn img {
   vertical-align: baseline;
 }

--- a/client/src/pages/reports/ReportPeople.css
+++ b/client/src/pages/reports/ReportPeople.css
@@ -21,33 +21,14 @@ div.checkbox.primary > label > span {
   align-items: center;
 }
 
-.report-author .isCurrentEditor.checkbox.primary > label > span {
-  outline: 2px solid green;
-}
-
-.report-attendee .checkbox.primary > label > span,
-.report-author .checkbox.primary > label > span {
-  color: #337ab7;
-  background-color: white;
-  font-style: italic;
-}
-
-.primary-attendee .inActive.radio.primary > label > span,
-.report-attendee .inActive.checkbox.primary > label > span,
-.report-author .inActive.checkbox.primary > label > span {
+.primary-attendee .inActive.radio.primary > label > span {
   color: grey;
   background-color: white;
   font-style: italic;
 }
 
-
 .inActive.radio.disabled.primary > label > span {
   text-decoration: line-through;
-}
-@media print {
-  .report-author {
-    display: none;
-  }
 }
 .empty-cell-header{
   padding: 0 5px !important;
@@ -57,11 +38,8 @@ div.checkbox.primary > label > span {
 .deleteReportPeople {
   min-width: 50px;
 }
-.report-attendee {
-  text-align: center;
-}
 .primary-attendee {
-  text-align: center;
+  text-align: left;
 }
 .conflictButton {
   text-align: center;

--- a/client/src/pages/reports/ReportPeople.js
+++ b/client/src/pages/reports/ReportPeople.js
@@ -341,69 +341,86 @@ function sortReportPeople(reportPeople) {
   })
 }
 
-const PrimaryAttendeeRadioButton = ({ person, disabled, handleOnChange }) => (
-  <Form.Check
-    type="radio"
-    label={<Badge bg="primary">Primary</Badge>}
-    name={`primaryAttendee${person.role}`}
-    className={`primary${!person.primary ? " inActive" : ""}`}
-    checked={person.primary}
-    disabled={disabled || !person.attendee}
-    onChange={() => !disabled && handleOnChange(person)}
-  />
-)
-
+const PrimaryAttendeeRadioButton = ({ person, disabled, handleOnChange }) =>
+  disabled ? (
+    person.primary && <Badge bg="primary">Primary</Badge>
+  ) : (
+    <Form.Check
+      type="radio"
+      label={<Badge bg="primary">Primary</Badge>}
+      name={`primaryAttendee${person.role}`}
+      className={`primary${!person.primary ? " inActive" : ""}`}
+      checked={person.primary}
+      onChange={() => handleOnChange(person)}
+    />
+  )
 PrimaryAttendeeRadioButton.propTypes = {
   person: PropTypes.object,
   disabled: PropTypes.bool,
   handleOnChange: PropTypes.func
 }
+
 const ReportAuthorCheckbox = ({
   person,
   disabled,
   isCurrentEditor,
   handleOnChange
-}) => (
-  <Form.Check
-    type="checkbox"
-    label={
+}) =>
+  disabled ? (
+    !!person.author && (
       <OverlayTrigger overlay={<Tooltip id="author-tooltip">Author</Tooltip>}>
         <Icon iconSize={IconSize.LARGE} icon={IconNames.EDIT} />
       </OverlayTrigger>
-    }
-    name={`authorAttendee${person.role}`}
-    className={`primary${isCurrentEditor ? " isCurrentEditor" : ""}${
-      !person.author ? " inActive" : ""
-    }`}
-    checked={!!person.author}
-    disabled={disabled}
-    readOnly={isCurrentEditor}
-    onChange={() => !disabled && handleOnChange(person)}
-  />
-)
+    )
+  ) : (
+    <Form.Check
+      type="checkbox"
+      label={
+        <OverlayTrigger overlay={<Tooltip id="author-tooltip">Author</Tooltip>}>
+          <Icon iconSize={IconSize.LARGE} icon={IconNames.EDIT} />
+        </OverlayTrigger>
+      }
+      name={`authorAttendee${person.role}`}
+      className={`primary${isCurrentEditor ? " isCurrentEditor" : ""}${
+        !person.author ? " inActive" : ""
+      }`}
+      checked={!!person.author}
+      readOnly={isCurrentEditor}
+      onChange={() => handleOnChange(person)}
+    />
+  )
 ReportAuthorCheckbox.propTypes = {
   person: PropTypes.object,
   disabled: PropTypes.bool,
   isCurrentEditor: PropTypes.bool,
   handleOnChange: PropTypes.func
 }
-const ReportAttendeeCheckbox = ({ person, disabled, handleOnChange }) => (
-  <Form.Check
-    type="checkbox"
-    label={
+
+const ReportAttendeeCheckbox = ({ person, disabled, handleOnChange }) =>
+  disabled ? (
+    !!person.attendee && (
       <OverlayTrigger
         overlay={<Tooltip id="attendee-tooltip">Attendee</Tooltip>}
       >
         <Icon iconSize={IconSize.LARGE} icon={IconNames.PEOPLE} />
       </OverlayTrigger>
-    }
-    name={`authorAttendee${person.role}`}
-    className={`primary${!person.attendee ? " inActive" : ""}`}
-    checked={!!person.attendee}
-    disabled={disabled}
-    onChange={() => !disabled && handleOnChange(person)}
-  />
-)
+    )
+  ) : (
+    <Form.Check
+      type="checkbox"
+      label={
+        <OverlayTrigger
+          overlay={<Tooltip id="attendee-tooltip">Attendee</Tooltip>}
+        >
+          <Icon iconSize={IconSize.LARGE} icon={IconNames.PEOPLE} />
+        </OverlayTrigger>
+      }
+      name={`authorAttendee${person.role}`}
+      className={`primary${!person.attendee ? " inActive" : ""}`}
+      checked={!!person.attendee}
+      onChange={() => handleOnChange(person)}
+    />
+  )
 ReportAttendeeCheckbox.propTypes = {
   person: PropTypes.object,
   disabled: PropTypes.bool,

--- a/client/src/pages/reports/ReportPeople.js
+++ b/client/src/pages/reports/ReportPeople.js
@@ -275,26 +275,26 @@ TableContainer.propTypes = {
 const TableHeader = ({ showDelete, hide }) => (
   <thead>
     <tr>
-      <th className={"col-xs-1" + (hide ? " empty-cell-header" : "")}>
-        <div style={{ minWidth: "80px" }}>{!hide && "Roles"}</div>
+      <th className={"col-1" + (hide ? " empty-cell-header" : "")}>
+        <div style={{ minWidth: "100px" }}>{!hide && "Roles"}</div>
       </th>
-      <th className={"col-xs-1" + (hide ? " empty-cell-header" : "")}>
-        <div style={{ width: showDelete ? "35px" : "120px" }} />
+      <th className={"col-1" + (hide ? " empty-cell-header" : "")}>
+        <div style={{ width: showDelete ? "35px" : "100px" }} />
       </th>
-      <th className={"col-xs-3" + (hide ? " empty-cell-header" : "")}>
+      <th className={"col-3" + (hide ? " empty-cell-header" : "")}>
         <div style={{ minWidth: "120px" }}>{!hide && "Name"}</div>
       </th>
-      <th className={"col-xs-3" + (hide ? " empty-cell-header" : "")}>
+      <th className={"col-3" + (hide ? " empty-cell-header" : "")}>
         <div style={{ minWidth: "90px" }}>{!hide && "Position"}</div>
       </th>
-      <th className={"col-xs-2" + (hide ? " empty-cell-header" : "")}>
+      <th className={"col-2" + (hide ? " empty-cell-header" : "")}>
         <div style={{ minWidth: "90px" }}>{!hide && "Location"}</div>
       </th>
-      <th className={"col-xs-2" + (hide ? " empty-cell-header" : "")}>
+      <th className={"col-2" + (hide ? " empty-cell-header" : "")}>
         <div style={{ minWidth: "90px" }}>{!hide && "Organization"}</div>
       </th>
       {showDelete && (
-        <th className={"col-xs-1" + (hide ? " empty-cell-header" : "")} />
+        <th className={"col-1" + (hide ? " empty-cell-header" : "")} />
       )}
     </tr>
   </thead>

--- a/client/src/pages/reports/ReportPeople.js
+++ b/client/src/pages/reports/ReportPeople.js
@@ -10,7 +10,7 @@ import { Person } from "models"
 import Report from "models/Report"
 import PropTypes from "prop-types"
 import React, { useContext } from "react"
-import { Badge, Form, Table } from "react-bootstrap"
+import { Badge, Form, OverlayTrigger, Table, Tooltip } from "react-bootstrap"
 import { toast } from "react-toastify"
 import "./ReportPeople.css"
 
@@ -89,8 +89,6 @@ const ReportPeople = ({ report, disabled, onChange, showDelete, onDelete }) => {
               disabled={disabled}
             />
           )}
-        </td>
-        <td className="report-attendee">
           {/* // only advisors can be non-attending */}
           {Person.isAdvisor(person) && (
             <ReportAttendeeCheckbox
@@ -99,8 +97,6 @@ const ReportPeople = ({ report, disabled, onChange, showDelete, onDelete }) => {
               disabled={disabled}
             />
           )}
-        </td>
-        <td className="report-author">
           {/* // only advisors can be authors */}
           {Person.isAdvisor(person) && (
             <ReportAuthorCheckbox
@@ -280,17 +276,7 @@ const TableHeader = ({ showDelete, hide }) => (
   <thead>
     <tr>
       <th className={"col-xs-1" + (hide ? " empty-cell-header" : "")}>
-        <div style={{ minWidth: "80px" }}>{!hide && "Primary"}</div>
-      </th>
-      <th className={"col-xs-1" + (hide ? " empty-cell-header" : "")}>
-        <div style={{ minWidth: "80px" }}>{!hide && "Attendee"}</div>
-      </th>
-      <th
-        className={
-          "col-xs-1 report-author" + (hide ? " empty-cell-header" : "")
-        }
-      >
-        <div style={{ minWidth: "70px" }}>{!hide && "Author"}</div>
+        <div style={{ minWidth: "80px" }}>{!hide && "Roles"}</div>
       </th>
       <th className={"col-xs-1" + (hide ? " empty-cell-header" : "")}>
         <div style={{ width: showDelete ? "35px" : "120px" }} />
@@ -380,7 +366,11 @@ const ReportAuthorCheckbox = ({
 }) => (
   <Form.Check
     type="checkbox"
-    label={<Icon iconSize={IconSize.LARGE} icon={IconNames.EDIT} />}
+    label={
+      <OverlayTrigger overlay={<Tooltip id="author-tooltip">Author</Tooltip>}>
+        <Icon iconSize={IconSize.LARGE} icon={IconNames.EDIT} />
+      </OverlayTrigger>
+    }
     name={`authorAttendee${person.role}`}
     className={`primary${isCurrentEditor ? " isCurrentEditor" : ""}${
       !person.author ? " inActive" : ""
@@ -400,7 +390,13 @@ ReportAuthorCheckbox.propTypes = {
 const ReportAttendeeCheckbox = ({ person, disabled, handleOnChange }) => (
   <Form.Check
     type="checkbox"
-    label={<Icon iconSize={IconSize.LARGE} icon={IconNames.PEOPLE} />}
+    label={
+      <OverlayTrigger
+        overlay={<Tooltip id="attendee-tooltip">Attendee</Tooltip>}
+      >
+        <Icon iconSize={IconSize.LARGE} icon={IconNames.PEOPLE} />
+      </OverlayTrigger>
+    }
     name={`authorAttendee${person.role}`}
     className={`primary${!person.attendee ? " inActive" : ""}`}
     checked={!!person.attendee}

--- a/client/tests/e2e/report.js
+++ b/client/tests/e2e/report.js
@@ -66,9 +66,7 @@ test.serial("Draft and submit a report", async t => {
   )
 
   const [
-    $principalPrimary1,
-    /* eslint-disable no-unused-vars */ $principalAttendee1 /* eslint-enable no-unused-vars */,
-    /* eslint-disable no-unused-vars */ $principalAuthor1 /* eslint-enable no-unused-vars */,
+    $principalControls1,
     /* eslint-disable no-unused-vars */ $principalConflictBtn /* eslint-enable no-unused-vars */,
     $principalName1,
     $principalPosition1,
@@ -76,8 +74,8 @@ test.serial("Draft and submit a report", async t => {
     $principalOrg1
   ] = await $$(".principalAttendeesTable tbody tr:nth-child(2) td")
 
-  const $principalPrimaryInput1 = await $principalPrimary1.findElement(
-    By.css("input")
+  const $principalPrimaryInput1 = await $principalControls1.findElement(
+    By.css("[name = 'primaryAttendeePRINCIPAL']")
   )
   t.true(
     await $principalPrimaryInput1.isSelected(),
@@ -105,9 +103,7 @@ test.serial("Draft and submit a report", async t => {
   )
 
   const [
-    $principalPrimary2,
-    /* eslint-disable no-unused-vars */ $principalAttendeeCheckbox2 /* eslint-enable no-unused-vars */,
-    /* eslint-disable no-unused-vars */ $principalAuthorCheckbox2 /* eslint-enable no-unused-vars */,
+    $principalControls2,
     /* eslint-disable no-unused-vars */ $principalAuthorConflictBtn /* eslint-enable no-unused-vars */,
     $principalName2,
     /* eslint-disable no-unused-vars */
@@ -117,8 +113,8 @@ test.serial("Draft and submit a report", async t => {
   ] = await $$(".principalAttendeesTable tbody tr:last-child td")
 
   await assertElementText(t, $principalName2, "LtCol STEVESON, Steve")
-  const $principalPrimaryInput2 = await $principalPrimary2.findElement(
-    By.css("input")
+  const $principalPrimaryInput2 = await $principalControls2.findElement(
+    By.css("[name = 'primaryAttendeePRINCIPAL']")
   )
   t.false(
     await $principalPrimaryInput2.isSelected(),
@@ -636,9 +632,7 @@ test.serial("Verify that validations work", async t => {
   )
 
   const [
-    $advisorPrimaryCheckbox,
-    /* eslint-disable no-unused-vars */ $advisorAttendeeCheckbox /* eslint-enable no-unused-vars */,
-    /* eslint-disable no-unused-vars */ $advisorAuthorCheckbox /* eslint-enable no-unused-vars */,
+    $advisorControls,
     /* eslint-disable no-unused-vars */ $advisorConflictBtn /* eslint-enable no-unused-vars */,
     $advisorName,
     $advisorPosition,
@@ -647,8 +641,8 @@ test.serial("Verify that validations work", async t => {
   ] = await $$(".advisorAttendeesTable tbody tr:first-child td")
 
   t.is(
-    await $advisorPrimaryCheckbox
-      .findElement(By.css("input"))
+    await $advisorControls
+      .findElement(By.css("[name = 'primaryAttendeeADVISOR']"))
       .getAttribute("value"),
     "on",
     "Advisor primary attendee checkbox should be checked"


### PR DESCRIPTION
Attendee options are shown in a single column so horizontal scroll is not needed on smaller screen sizes

Closes [AB#338](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/338)

#### User changes
- Attendees section of report form is more suitable for smaller screen sizes

#### Super User changes
- None

#### Admin changes
- None

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
