### PR TITLE
Allow editing deprecated fields

### DIFF
--- a/anet-dictionary.yml
+++ b/anet-dictionary.yml
@@ -491,6 +491,7 @@ fields:
         label: Not later than date
         helpText: Help text for date field
         deprecated: true
+        tooltipText: "This field is deprecated. When cleared, it won't be displayed!"
       nlt_dt:
         type: datetime
         label: Not later than datetime


### PR DESCRIPTION
Deprecated fields can be edited if they have a value. Field disappears when the value is cleared, and then its value can no longer be set.

Closes [AB#321](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/321)

#### User changes
- Users can edit deprecated field values if they were previously set.

#### Super User changes
- None

#### Admin changes
- None

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [ ] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
