### PR TITLE
Do not sort attendees when editing

### DIFF
--- a/client/src/components/previews/ReportPreview.js
+++ b/client/src/components/previews/ReportPreview.js
@@ -106,7 +106,9 @@ const ReportPreview = ({ className, uuid }) => {
 
   data.report.cancelled = !!data.report.cancelledReason
   data.report.tasks = Task.fromArray(data.report.tasks)
-  data.report.reportPeople = Person.fromArray(data.report.reportPeople)
+  data.report.reportPeople = Report.sortReportPeople(
+    Person.fromArray(data.report.reportPeople)
+  )
   report = new Report(data.report)
   const reportType = report.isFuture() ? "planned engagement" : "report"
   const tasksLabel = pluralize(Settings.fields.task.subLevel.shortLabel)

--- a/client/src/models/Report.js
+++ b/client/src/models/Report.js
@@ -452,6 +452,18 @@ export default class Report extends Model {
     )
   }
 
+  static sortReportPeople(reportPeople) {
+    return [...reportPeople].sort((rp1, rp2) => {
+      // primary first, then authors, then alphabetical
+      if (rp1.primary !== rp2.primary) {
+        return rp1.primary ? -1 : 1
+      } else if (rp1.author !== rp2.author) {
+        return rp1.author ? -1 : 1
+      }
+      return (rp1.name || rp1.uuid).localeCompare(rp2.name || rp2.uuid)
+    })
+  }
+
   static getEngagementDateFormat() {
     return Settings.engagementsIncludeTimeAndDuration
       ? Settings.dateFormats.forms.displayLong.withTime

--- a/client/src/pages/reports/Edit.js
+++ b/client/src/pages/reports/Edit.js
@@ -136,6 +136,9 @@ const ReportEdit = ({ pageDispatchers }) => {
     data.report[DEFAULT_CUSTOM_FIELDS_PARENT] = utils.parseJsonSafe(
       data.report.customFields
     )
+    data.report.reportPeople = Report.sortReportPeople(
+      Person.fromArray(data.report.reportPeople)
+    )
   }
   const report = new Report(data ? data.report : {})
   const reportInitialValues = Object.assign(

--- a/client/src/pages/reports/ReportPeople.js
+++ b/client/src/pages/reports/ReportPeople.js
@@ -311,14 +311,15 @@ const TableBody = ({
   filterCb,
   enableDivider,
   showDelete
-}) => (
-  <tbody>
-    {enableDivider && <AttendeeDividerRow showDelete={showDelete} />}
-    {Person.map(sortReportPeople(reportPeople.filter(filterCb)), person =>
-      handleAttendeeRow(person)
-    )}
-  </tbody>
-)
+}) => {
+  const peopleFiltered = reportPeople.filter(filterCb)
+  return (
+    <tbody>
+      {enableDivider && <AttendeeDividerRow showDelete={showDelete} />}
+      {Person.map(peopleFiltered, person => handleAttendeeRow(person))}
+    </tbody>
+  )
+}
 TableBody.propTypes = {
   reportPeople: PropTypes.array.isRequired,
   handleAttendeeRow: PropTypes.func,
@@ -328,18 +329,6 @@ TableBody.propTypes = {
 }
 TableBody.defaultProps = {
   reportPeople: []
-}
-
-function sortReportPeople(reportPeople) {
-  return reportPeople.sort((rp1, rp2) => {
-    // primary first, then authors, then alphabetical
-    if (rp1.primary !== rp2.primary) {
-      return rp1.primary ? -1 : 1
-    } else if (rp1.author !== rp2.author) {
-      return rp1.author ? -1 : 1
-    }
-    return (rp1.name || rp1.uuid).localeCompare(rp2.name || rp2.uuid)
-  })
 }
 
 const PrimaryAttendeeRadioButton = ({ person, disabled, handleOnChange }) =>

--- a/client/src/pages/reports/Show.js
+++ b/client/src/pages/reports/Show.js
@@ -305,7 +305,9 @@ const ReportShow = ({ setSearchQuery, pageDispatchers }) => {
   } else {
     data.report.cancelled = !!data.report.cancelledReason
     data.report.tasks = Task.fromArray(data.report.tasks)
-    data.report.reportPeople = Person.fromArray(data.report.reportPeople)
+    data.report.reportPeople = Report.sortReportPeople(
+      Person.fromArray(data.report.reportPeople)
+    )
     data.report.to = ""
     data.report[DEFAULT_CUSTOM_FIELDS_PARENT] = utils.parseJsonSafe(
       data.report.customFields


### PR DESCRIPTION
Report attendees are not sorted according to their roles to prevent confusing feedback.

Closes [AB#328](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/328)

#### User changes
- Report attendees are only sorted on read-only pages

#### Super User changes
- None

#### Admin changes
- None

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [ ] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
