### PR TITLE
Assessment titles can be configured through the dictionary

### DIFF
--- a/anet-dictionary.yml
+++ b/anet-dictionary.yml
@@ -1268,6 +1268,7 @@ fields:
         principalOndemandScreeningAndVetting:
           recurrence: ondemand
           onDemandAssessmentExpirationDays: 108
+          label: "Screening & Vetting"
           questions:
             assessmentDate:
               type: date

--- a/client/src/components/assessments/AssessmentResultsTable.js
+++ b/client/src/components/assessments/AssessmentResultsTable.js
@@ -142,7 +142,9 @@ const AssessmentResultsTable = ({
       {showAssessmentResults && (
         <div style={{ ...style }}>
           <Fieldset
-            title={`Assessment results - ${recurrence}`}
+            title={`Assessment results - ${
+              assessmentConfig.label || recurrence
+            }`}
             id={`entity-assessments-results-${recurrence}`}
           >
             <PeriodsNavigation offset={offset} onChange={setOffset} />

--- a/client/src/components/assessments/OnDemandAssessments/OndemandAssessment.js
+++ b/client/src/components/assessments/OnDemandAssessments/OndemandAssessment.js
@@ -46,7 +46,6 @@ const OnDemandAssessment = ({
       ondemand assessment table. Recalculated according to the screensize. */
   const { recurrence, numberOfPeriods } = periodsDetails
   // Button text.
-  const addAssessmentLabel = `Make a new ${entity?.toString()} assessment`
   const [showModal, setShowModal] = useState(false)
   // Used to determine if the AssessmentModal is in edit mode or create mode.
   const [editModeObject, setEditModeObject] = useState({
@@ -59,6 +58,9 @@ const OnDemandAssessment = ({
     () => entity.getPeriodicAssessmentDetails(recurrence),
     [entity, recurrence]
   )
+  const addAssessmentLabel = `Add ${
+    assessmentConfig.label || "a new assessment"
+  }`
 
   const filteredAssessmentConfig = useMemo(
     () => Model.filterAssessmentConfig(assessmentConfig, entity),
@@ -261,7 +263,9 @@ const OnDemandAssessment = ({
     return (
       <div style={{ ...style }}>
         <Fieldset
-          title={"Assessment results - on demand"}
+          title={`Assessment results - ${
+            assessmentConfig.label || "on demand"
+          }`}
           id={`entity-assessments-results-${recurrence}`}
         >
           <PeriodsNavigation

--- a/client/src/components/assessments/PeriodicAssessmentResults.js
+++ b/client/src/components/assessments/PeriodicAssessmentResults.js
@@ -245,7 +245,9 @@ export const PeriodicAssessmentsRows = ({
         <tr>
           {periods.map((period, index) => {
             const periodDisplay = periodToString(period)
-            const addAssessmentLabel = `Make a new ${entity?.toString()} assessment for ${periodDisplay}`
+            const addAssessmentLabel = `Add ${
+              assessmentConfig.label || "a new assessment"
+            } for ${periodDisplay}`
             const modalKey = `${entity.uuid}-${periodDisplay}`
             return (
               <td key={index}>

--- a/src/main/resources/anet-schema.yml
+++ b/src/main/resources/anet-schema.yml
@@ -246,6 +246,10 @@ $defs:
         minimum: 1
         title: The number of days before an on-demand assessment expires
         description: Used in the UI to determine which on-demand assessments have expired
+      label:
+        title: assessment label
+        type: string
+        description: Used in the title of the assessment. If not specified, recurrence type is used instead and the assessments with the same recurrence type will have the same title!
       questions:
         "$ref": "#/$defs/questions"
       questionSets:


### PR DESCRIPTION
Assessment labels can be configured through the dictionary with the label property. This property is optional and recurrence type will be used in the title if label is not declerad.

Closes [AB#309](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/309), [AB#310](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/310)

#### User changes
- Users will see specific titles for assessments.

#### Super User changes
- None

#### Admin changes
- Admins can configure assessment titles through the dictionary.

#### System admin changes
- [x] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
