### PR TITLE
Fix external documentation link

### DIFF
--- a/client/src/components/Nav.js
+++ b/client/src/components/Nav.js
@@ -345,8 +345,10 @@ const Navigation = ({
       )}
 
       {externalDocumentationUrl && externalDocumentationUrlText && (
-        <Nav.Item href={externalDocumentationUrl} target="_extdocs">
-          {externalDocumentationUrlText}
+        <Nav.Item>
+          <Nav.Link href={externalDocumentationUrl} target="_extdocs">
+            {externalDocumentationUrlText}
+          </Nav.Link>
         </Nav.Item>
       )}
 


### PR DESCRIPTION
External documentation link is fixed.

Closes [AB#341](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/341)

#### User changes
- External documentation link redirects users to the URL specified on the admin panel as intended.

#### Super User changes
- None

#### Admin changes
- None

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
