### PR TITLE
Show only summary in rollup

### DIFF
--- a/client/src/components/MosaicLayout.js
+++ b/client/src/components/MosaicLayout.js
@@ -141,7 +141,7 @@ MosaicLayout.propTypes = {
       renderer: PropTypes.func.isRequired
     })
   ).isRequired,
-  initialNode: PropTypes.object, // FIXME: actually MosaicNode
+  initialNode: PropTypes.oneOfType([PropTypes.object, PropTypes.string]), // FIXME: actually MosaicNode
   description: PropTypes.string,
   style: PropTypes.object
 }

--- a/client/src/pages/rollup/Show.js
+++ b/client/src/pages/rollup/Show.js
@@ -225,10 +225,10 @@ const Collection = ({ queryParams }) => (
       paginationKey="r_rollup"
       queryParams={queryParams}
       viewFormats={[
-        FORMAT_CALENDAR,
-        FORMAT_TABLE,
         FORMAT_SUMMARY,
-        FORMAT_STATISTICS
+        FORMAT_TABLE,
+        FORMAT_STATISTICS,
+        FORMAT_CALENDAR
       ]}
     />
   </div>
@@ -295,15 +295,7 @@ const RollupShow = ({ pageDispatchers, searchQuery }) => {
       renderer: renderReportMap
     }
   ]
-  const INITIAL_LAYOUT = {
-    direction: "row",
-    first: VISUALIZATIONS[0].id,
-    second: {
-      direction: "column",
-      first: VISUALIZATIONS[1].id,
-      second: VISUALIZATIONS[2].id
-    }
-  }
+  const INITIAL_LAYOUT = VISUALIZATIONS[1].id
   const DESCRIPTION = "Number of reports released per organization."
   const flexStyle = {
     display: "flex",


### PR DESCRIPTION
Only the reports summary section is displayed on the initial layout of the rollup page.

Closes [AB#342](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/342)

#### User changes
- Initial layout of rollup page is changed

#### Super User changes
- None

#### Admin changes
- None

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [ ] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
