### PR TITLE
Hide engagement information field if empty

### DIFF
--- a/client/src/components/CustomFields.js
+++ b/client/src/components/CustomFields.js
@@ -882,7 +882,8 @@ export const CustomFieldsContainer = props => {
   const {
     parentFieldName,
     formikProps: { values, setFieldValue },
-    fieldsConfig
+    fieldsConfig,
+    setShowCustomFields
   } = props
   const deprecatedFieldsFiltered = filterDeprecatedFields(
     fieldsConfig,
@@ -901,6 +902,12 @@ export const CustomFieldsContainer = props => {
     }
   }, [invisibleFields, values, invisibleFieldsFieldName, setFieldValue])
 
+  useEffect(() => {
+    if (setShowCustomFields) {
+      setShowCustomFields(!_isEmpty(deprecatedFieldsFiltered))
+    }
+  }, [setShowCustomFields, deprecatedFieldsFiltered])
+
   return (
     <>
       <CustomFields
@@ -915,6 +922,7 @@ CustomFieldsContainer.propTypes = {
   fieldsConfig: PropTypes.object,
   formikProps: PropTypes.object,
   parentFieldName: PropTypes.string.isRequired,
+  setShowCustomFields: PropTypes.func,
   vertical: PropTypes.bool
 }
 CustomFieldsContainer.defaultProps = {
@@ -1099,13 +1107,21 @@ export const ReadonlyCustomFields = ({
   vertical,
   isCompact,
   extraColElem,
-  labelColumnWidth
+  labelColumnWidth,
+  setShowCustomFields
 }) => {
   const deprecatedFieldsFiltered = filterDeprecatedFields(
     fieldsConfig,
     values,
     parentFieldName
   )
+
+  useEffect(() => {
+    if (setShowCustomFields) {
+      setShowCustomFields(!_isEmpty(deprecatedFieldsFiltered))
+    }
+  }, [setShowCustomFields, deprecatedFieldsFiltered])
+
   return (
     <>
       {Object.entries(deprecatedFieldsFiltered).map(([key, fieldConfig]) => {
@@ -1154,7 +1170,8 @@ ReadonlyCustomFields.propTypes = {
   vertical: PropTypes.bool,
   isCompact: PropTypes.bool,
   extraColElem: PropTypes.object,
-  labelColumnWidth: PropTypes.number
+  labelColumnWidth: PropTypes.number,
+  setShowCustomFields: PropTypes.func
 }
 ReadonlyCustomFields.defaultProps = {
   parentFieldName: DEFAULT_CUSTOM_FIELDS_PARENT,

--- a/client/src/pages/reports/Form.js
+++ b/client/src/pages/reports/Form.js
@@ -170,6 +170,9 @@ const ReportForm = ({
   // update the yup schema for the selected tasks/attendees instant assessments
   const [reportTasks, setReportTasks] = useState(initialValues.tasks)
   const [reportPeople, setReportPeople] = useState(initialValues.reportPeople)
+  const [showCustomFields, setShowCustomFields] = useState(
+    !!Settings.fields.report.customFields
+  )
   // some autosave settings
   const defaultTimeout = moment.duration(AUTOSAVE_TIMEOUT, "seconds")
   const autoSaveSettings = useRef({
@@ -808,7 +811,7 @@ const ReportForm = ({
                 </Fieldset>
               )}
 
-              {Settings.fields.report.customFields && (
+              {showCustomFields && (
                 <Fieldset title="Engagement information" id="custom-fields">
                   <CustomFieldsContainer
                     fieldsConfig={Settings.fields.report.customFields}
@@ -818,6 +821,7 @@ const ReportForm = ({
                       values,
                       validateForm
                     }}
+                    setShowCustomFields={setShowCustomFields}
                   />
                 </Fieldset>
               )}

--- a/client/src/pages/reports/Show.js
+++ b/client/src/pages/reports/Show.js
@@ -276,6 +276,9 @@ const ReportShow = ({ setSearchQuery, pageDispatchers }) => {
   const [saveSuccess, setSaveSuccess] = useState(null)
   const [saveError, setSaveError] = useState(null)
   const [showEmailModal, setShowEmailModal] = useState(false)
+  const [showCustomFields, setShowCustomFields] = useState(
+    !!Settings.fields.report.customFields
+  )
   const { uuid } = useParams()
   const { loading, error, data, refetch } = API.useApiQuery(GQL_GET_REPORT, {
     uuid
@@ -676,11 +679,12 @@ const ReportShow = ({ setSearchQuery, pageDispatchers }) => {
                   )) || <h5>No groups are authorized!</h5>}
                 </Fieldset>
               )}
-              {Settings.fields.report.customFields && (
+              {showCustomFields && (
                 <Fieldset title="Engagement information" id="custom-fields">
                   <ReadonlyCustomFields
                     fieldsConfig={Settings.fields.report.customFields}
                     values={values}
+                    setShowCustomFields={setShowCustomFields}
                   />
                 </Fieldset>
               )}


### PR DESCRIPTION
The engagement information field is not displayed if it only contains deprecated fields without values.

Closes [AB#345](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/345)

#### User changes
- Users won't see the engagement information field if all fields are deprecated and don't have a value

#### Super User changes
- None

#### Admin changes
- None

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
