### PR TITLE
Fix ie 11 tests

### DIFF
--- a/client/config/browserstack.config.js
+++ b/client/config/browserstack.config.js
@@ -30,7 +30,8 @@ const bstackOptions = {
   userName: user,
   accessKey: key,
   // This requires that BrowserStackLocal is running!
-  local: "true"
+  local: "true",
+  seleniumVersion: "4.1.2"
 }
 const capabilities = {
   maxInstances: 1,

--- a/client/tests/webdriver/pages/page.js
+++ b/client/tests/webdriver/pages/page.js
@@ -70,7 +70,10 @@ class Page {
     pathName = "/",
     credentials = Page.DEFAULT_CREDENTIALS.user
   ) {
-    browser.url(this._buildUrl(pathName, credentials))
+    browser.url(pathName)
+    if (this.loginForm.isExisting()) {
+      this.login(credentials)
+    }
   }
 
   open(pathName = "/", credentials = Page.DEFAULT_CREDENTIALS.user) {


### PR DESCRIPTION
Fix `this.buildUrl is not a function` error in IE 11 tests.

Closes [AB#397](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/397)

#### User changes
- None

#### Super User changes
- None

#### Admin changes
- None

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [ ] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [x] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
