### PR TITLE
Search behaviour changes

### DIFF
--- a/client/src/components/AdvancedSearch.js
+++ b/client/src/components/AdvancedSearch.js
@@ -238,7 +238,13 @@ const AdvancedSearch = ({
 
     setFilters(
       filters
-        .filter(value => commonFiltersForAllObjectTypes[value.key])
+        .filter(
+          value =>
+            // Keep the common filters for every object type
+            commonFiltersForAllObjectTypes[value.key] &&
+            // Discard the default filters as they will be concatenated later
+            !ALL_FILTERS[objectType].filters[value.key].isDefault
+        )
         // Add defaults as well
         .concat(defaultFiltersForObjectType)
     )

--- a/client/src/components/SearchFilters.js
+++ b/client/src/components/SearchFilters.js
@@ -71,6 +71,7 @@ export const getSearchQuery = searchQuery => {
 const StatusFilter = {
   component: SelectFilter,
   deserializer: deserializeSelectFilter,
+  isDefault: true,
   props: {
     queryKey: "status",
     options: [Model.STATUS.ACTIVE, Model.STATUS.INACTIVE]

--- a/client/src/pages/insights/Show.js
+++ b/client/src/pages/insights/Show.js
@@ -10,7 +10,6 @@ import AppContext from "components/AppContext"
 import CancelledEngagementReports from "components/CancelledEngagementReports"
 import Fieldset from "components/Fieldset"
 import FutureEngagementsByLocation from "components/FutureEngagementsByLocation"
-import Messages from "components/Messages"
 import {
   mapPageDispatchersToProps,
   PageDispatchersPropType,
@@ -25,7 +24,6 @@ import {
   getSearchQuery,
   SearchQueryPropType
 } from "components/SearchFilters"
-import _isEmpty from "lodash/isEmpty"
 import { Report } from "models"
 import moment from "moment"
 import PropTypes from "prop-types"
@@ -194,28 +192,16 @@ const InsightsShow = ({ pageDispatchers, searchQuery, setSearchQuery }) => {
     searchProps: insightConfig.searchProps,
     pageDispatchers
   })
-  const hasSearchCriteria =
-    _isEmpty(insightDefaultQueryParams[insight]) || !_isEmpty(queryParams)
 
   return (
     <div style={flexStyle}>
-      {hasSearchCriteria ? (
-        <Fieldset
-          id={insight}
-          title={insightConfig.title}
-          style={fieldsetStyle}
-        >
-          <InsightComponent
-            pageDispatchers={pageDispatchers}
-            style={mosaicLayoutStyle}
-            queryParams={queryParams}
-          />
-        </Fieldset>
-      ) : (
-        <Messages
-          error={{ message: "You did not enter any search criteria." }}
+      <Fieldset id={insight} title={insightConfig.title} style={fieldsetStyle}>
+        <InsightComponent
+          pageDispatchers={pageDispatchers}
+          style={mosaicLayoutStyle}
+          queryParams={queryParams}
         />
-      )}
+      </Fieldset>
     </div>
   )
 

--- a/client/src/pages/searches/Search.js
+++ b/client/src/pages/searches/Search.js
@@ -631,11 +631,9 @@ const Search = ({
       }),
     [searchQueryParams]
   )
-  const queryTypes = _isEmpty(searchQueryParams)
-    ? []
-    : searchQuery.objectType
-      ? [searchQuery.objectType]
-      : Object.keys(SEARCH_OBJECT_TYPES)
+  const queryTypes = searchQuery.objectType
+    ? [searchQuery.objectType]
+    : Object.keys(SEARCH_OBJECT_TYPES)
   const hasOrganizationsResults =
     queryTypes.includes(SEARCH_OBJECT_TYPES.ORGANIZATIONS) &&
     numOrganizations > 0

--- a/client/src/pages/searches/Search.js
+++ b/client/src/pages/searches/Search.js
@@ -39,7 +39,6 @@ import UltimatePaginationTopDown from "components/UltimatePaginationTopDown"
 import { exportResults } from "exportUtils"
 import { Field, Form, Formik } from "formik"
 import _get from "lodash/get"
-import _isEmpty from "lodash/isEmpty"
 import _isEqual from "lodash/isEqual"
 import { Organization } from "models"
 import pluralize from "pluralize"
@@ -773,7 +772,7 @@ const Search = ({
             </Dropdown.Menu>
           </Dropdown>
         )}
-        {!_isEmpty(searchQueryParams) && numResults >= 0 && (
+        {numResults >= 0 && (
           <Button
             onClick={openSaveModal}
             id="saveSearchButton"
@@ -785,19 +784,12 @@ const Search = ({
         )}
       </div>
       <Messages error={error} /> {/* success is shown through toast */}
-      {!_isEmpty(searchQueryParams) && (
-        <h4 className="d-none d-print-block">
-          Search query: {searchQuery.text}
-          <br />
-          Filters: <SearchDescription searchQuery={searchQuery} />
-        </h4>
-      )}
-      {_isEmpty(searchQueryParams) && (
-        <Alert variant="warning">
-          <b>You did not enter any search criteria.</b>
-        </Alert>
-      )}
-      {!_isEmpty(searchQueryParams) && numResults === 0 && (
+      <h4 className="d-none d-print-block">
+        Search query: {searchQuery.text}
+        <br />
+        Filters: <SearchDescription searchQuery={searchQuery} />
+      </h4>
+      {numResults === 0 && (
         <Alert variant="warning">
           <b>No search results found!</b>
         </Alert>


### PR DESCRIPTION
Search results are displayed even if no criteria are selected. The status filter behaves like a default filter and is refreshed on every object type change.

Closes [AB#391](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/391)

#### User changes
- Users can search ANET object without selecting a search criteria

#### Super User changes
- None

#### Admin changes
- None

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
