### PR TITLE
Remove task longname from the search results table

### DIFF
--- a/client/src/components/TaskTable.js
+++ b/client/src/components/TaskTable.js
@@ -103,7 +103,6 @@ const BaseTaskTable = ({
           <thead>
             <tr>
               <th>Name</th>
-              <th />
             </tr>
           </thead>
           <tbody>
@@ -112,7 +111,7 @@ const BaseTaskTable = ({
                 <tr key={task.uuid}>
                   <td>
                     <LinkTo modelType="Task" model={task}>
-                      {task.shortName} {task.longName}
+                      {task.shortName}
                     </LinkTo>
                   </td>
                 </tr>


### PR DESCRIPTION
Search results table for tasks displays only the short name rather than the combination of the short and long name.

Closes [AB#392](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/392)

#### User changes
- Search results for tasks are more readable

#### Super User changes
- None

#### Admin changes
- None

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
