### PR TITLE
Run ShiftLeft on push only to main

### DIFF
--- a/.github/workflows/shiftleft-analysis.yml
+++ b/.github/workflows/shiftleft-analysis.yml
@@ -4,7 +4,13 @@
 name: ShiftLeft Scan
 
 # This section configures the trigger for the workflow. Feel free to customize depending on your convention
-on: push
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - '**'
 
 jobs:
   Scan-Build:


### PR DESCRIPTION
Avoid getting an error on Dependabot PR's, since they run with read-only access on push.