### PR TITLE
Ignore background polling activity

### DIFF
--- a/client/src/connectionUtils.js
+++ b/client/src/connectionUtils.js
@@ -16,7 +16,14 @@ export const useConnectionInfo = () => {
   const { error, data, stopPolling } = API.useApiQuery(
     GQL_GET_VERSION_INFO,
     {},
-    { pollInterval: POLL_INTERVAL_IN_MS }
+    {
+      pollInterval: POLL_INTERVAL_IN_MS,
+      context: {
+        headers: {
+          "x-activity": "ignore"
+        }
+      }
+    }
   )
 
   const { pathname } = useLocation()

--- a/src/main/java/mil/dds/anet/AnetApplication.java
+++ b/src/main/java/mil/dds/anet/AnetApplication.java
@@ -63,6 +63,7 @@ import mil.dds.anet.threads.ReportPublicationWorker;
 import mil.dds.anet.utils.DaoUtils;
 import mil.dds.anet.utils.HttpsRedirectFilter;
 import mil.dds.anet.utils.Utils;
+import mil.dds.anet.views.ViewRequestFilter;
 import mil.dds.anet.views.ViewResponseFilter;
 import org.eclipse.jetty.server.session.SessionHandler;
 import org.eclipse.jetty.servlet.FilterHolder;
@@ -396,8 +397,9 @@ public class AnetApplication extends Application<AnetConfiguration> {
     environment.jersey().register(loggingResource);
     environment.jersey().register(adminResource);
     environment.jersey().register(homeResource);
-    environment.jersey().register(new ViewResponseFilter(configuration));
     environment.jersey().register(graphQlResource);
+    environment.jersey().register(ViewRequestFilter.class);
+    environment.jersey().register(ViewResponseFilter.class);
   }
 
   private void runAccountDeactivationWorker(final AnetConfiguration configuration,

--- a/src/main/java/mil/dds/anet/utils/DaoUtils.java
+++ b/src/main/java/mil/dds/anet/utils/DaoUtils.java
@@ -6,6 +6,8 @@ import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
@@ -239,5 +241,11 @@ public class DaoUtils {
       return Instant.ofEpochMilli(now + input.toEpochMilli());
     }
     return input;
+  }
+
+  public static Instant getCurrentMinute() {
+    final ZonedDateTime now = Instant.now().atZone(getServerNativeZoneId());
+    final ZonedDateTime bom = now.truncatedTo(ChronoUnit.MINUTES);
+    return bom.toInstant();
   }
 }

--- a/src/main/java/mil/dds/anet/utils/ResponseUtils.java
+++ b/src/main/java/mil/dds/anet/utils/ResponseUtils.java
@@ -1,6 +1,7 @@
 package mil.dds.anet.utils;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.net.HttpHeaders;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.StringWriter;
@@ -9,6 +10,7 @@ import java.util.HashMap;
 import java.util.Map;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import javax.xml.XMLConstants;
@@ -210,5 +212,20 @@ public class ResponseUtils {
     }
     logger.error("Unexpected SQL exception raised", e);
     return new WebApplicationException(Status.INTERNAL_SERVER_ERROR);
+  }
+
+  public static String getRemoteAddr(final HttpServletRequest request) {
+    final String remoteAddr = request.getRemoteAddr();
+    return remoteAddr == null ? "-" : remoteAddr;
+  }
+
+  public static String getReferer(final ContainerRequestContext requestContext) {
+    final String referer = requestContext.getHeaderString(HttpHeaders.REFERER);
+    return referer == null ? "-" : referer;
+  }
+
+  public static boolean ignoreActivity(final ContainerRequestContext requestContext) {
+    final String activityHeader = requestContext.getHeaderString("x-activity");
+    return "ignore".equals(activityHeader);
   }
 }

--- a/src/main/java/mil/dds/anet/views/ViewRequestFilter.java
+++ b/src/main/java/mil/dds/anet/views/ViewRequestFilter.java
@@ -1,0 +1,35 @@
+package mil.dds.anet.views;
+
+import java.security.Principal;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.HttpMethod;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.core.Context;
+import mil.dds.anet.AnetObjectEngine;
+import mil.dds.anet.beans.Person;
+import mil.dds.anet.beans.userActivity.Activity;
+import mil.dds.anet.utils.DaoUtils;
+import mil.dds.anet.utils.ResponseUtils;
+
+public class ViewRequestFilter implements ContainerRequestFilter {
+  @Context
+  HttpServletRequest request;
+
+  @Override
+  public void filter(ContainerRequestContext requestContext) {
+    // Log only requests other than GET and if userPrincipal is a Person,
+    // and the activity should not be ignored
+    final boolean isGet = HttpMethod.GET.equals(requestContext.getMethod());
+    final Principal userPrincipal = requestContext.getSecurityContext().getUserPrincipal();
+    if (!isGet && userPrincipal instanceof Person
+        && !ResponseUtils.ignoreActivity(requestContext)) {
+      final Person person = (Person) userPrincipal;
+      final Activity activity = new Activity(ResponseUtils.getRemoteAddr(request),
+          ResponseUtils.getReferer(requestContext), DaoUtils.getCurrentMinute());
+      // Store user activities in Person bean
+      AnetObjectEngine.getInstance().getPersonDao()
+          .logActivitiesByOpenIdSubject(person.getOpenIdSubject(), activity);
+    }
+  }
+}

--- a/src/main/java/mil/dds/anet/views/ViewResponseFilter.java
+++ b/src/main/java/mil/dds/anet/views/ViewResponseFilter.java
@@ -1,95 +1,33 @@
 package mil.dds.anet.views;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.net.HttpHeaders;
-import java.security.Principal;
-import java.time.Instant;
-import java.time.ZonedDateTime;
-import java.time.temporal.ChronoUnit;
+import java.util.List;
 import java.util.Set;
-import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.HttpMethod;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerResponseContext;
 import javax.ws.rs.container.ContainerResponseFilter;
-import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.SecurityContext;
-import mil.dds.anet.AnetObjectEngine;
-import mil.dds.anet.beans.Person;
-import mil.dds.anet.beans.userActivity.Activity;
-import mil.dds.anet.config.AnetConfiguration;
-import mil.dds.anet.utils.DaoUtils;
-import org.eclipse.jetty.security.DefaultUserIdentity;
-import org.eclipse.jetty.security.UserAuthentication;
-import org.eclipse.jetty.server.Request;
-import org.eclipse.jetty.server.UserIdentity;
+import javax.ws.rs.core.MultivaluedMap;
 
 public class ViewResponseFilter implements ContainerResponseFilter {
-
-  @Context
-  HttpServletRequest request;
-
-  AnetConfiguration config;
   private static final Set<MediaType> uncachedMediaTypes =
-      ImmutableSet.of(MediaType.APPLICATION_JSON_TYPE, MediaType.TEXT_HTML_TYPE);
-
-  public ViewResponseFilter(AnetConfiguration config) {
-    this.config = config;
-  }
+      Set.of(MediaType.APPLICATION_JSON_TYPE, MediaType.TEXT_HTML_TYPE);
 
   @Override
   public void filter(ContainerRequestContext requestContext,
       ContainerResponseContext responseContext) {
     // Don't cache requests other than GET, and don't cache selected media types
     final MediaType mediaType = responseContext.getMediaType();
-    if (!HttpMethod.GET.equals(requestContext.getMethod()) || mediaType == null
+    final MultivaluedMap<String, Object> headers = responseContext.getHeaders();
+    final boolean isGet = HttpMethod.GET.equals(requestContext.getMethod());
+    if (!isGet || mediaType == null
         || uncachedMediaTypes.stream().anyMatch(mt -> mt.equals(mediaType))) {
-      responseContext.getHeaders().put(HttpHeaders.CACHE_CONTROL,
-          ImmutableList.of("no-store, no-cache, must-revalidate, post-check=0, pre-check=0"));
-      responseContext.getHeaders().put(HttpHeaders.PRAGMA, ImmutableList.of("no-cache"));
-      // Log only requests other than GET and if userPrincipal exists
-      if (!HttpMethod.GET.equals(requestContext.getMethod())
-          && requestContext.getSecurityContext().getUserPrincipal() != null) {
-        // This code snippet resolves the situation that caused empty user information to be
-        // written to the access.log file
-        // Start
-        Principal userPrincipal = new Principal() {
-          @Override
-          public String getName() {
-            final SecurityContext secContext = requestContext.getSecurityContext();
-            Principal p = secContext.getUserPrincipal();
-            return p.getName();
-          }
-        };
-        UserIdentity userId = new DefaultUserIdentity(null, userPrincipal, null);
-        Request baseRequest = Request.getBaseRequest(request);
-        baseRequest.setAuthentication(new UserAuthentication(null, userId));
-        // End
-
-        // Store user activities in Person bean
-        if (requestContext.getSecurityContext().getUserPrincipal() instanceof Person) {
-          final Person person = (Person) requestContext.getSecurityContext().getUserPrincipal();
-          final Activity activity =
-              new Activity(request.getRemoteAddr() == null ? "-" : request.getRemoteAddr(),
-                  requestContext.getHeaderString("referer") != null
-                      ? requestContext.getHeaderString("referer")
-                      : "-",
-                  getCurrentMinute());
-          AnetObjectEngine.getInstance().getPersonDao()
-              .logActivitiesByOpenIdSubject(person.getOpenIdSubject(), activity);
-        }
-      }
+      headers.put(HttpHeaders.CACHE_CONTROL,
+          List.of("no-store, no-cache, must-revalidate, post-check=0, pre-check=0"));
+      headers.put(HttpHeaders.PRAGMA, List.of("no-cache"));
     } else {
-      responseContext.getHeaders().put(HttpHeaders.CACHE_CONTROL,
-          ImmutableList.of("max-age=259200, public"));
+      headers.put(HttpHeaders.CACHE_CONTROL, List.of("max-age=259200, public"));
     }
-  }
-
-  private Instant getCurrentMinute() {
-    final ZonedDateTime now = Instant.now().atZone(DaoUtils.getServerNativeZoneId());
-    final ZonedDateTime bom = now.truncatedTo(ChronoUnit.MINUTES);
-    return bom.toInstant();
   }
 }


### PR DESCRIPTION
Prevent background polling activity from updating the list of active users.

Closes NCI-Agency/anet#3462
Closes [AB#470](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/470)

#### User changes
- None

#### Super User changes
- None

#### Admin changes
- Idle users (who still have ANET open) no longer show up as being recently active; their background polling requests are now filtered from the list.

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here