### PR TITLE
Record user activity

### DIFF
--- a/src/main/java/mil/dds/anet/AnetApplication.java
+++ b/src/main/java/mil/dds/anet/AnetApplication.java
@@ -63,6 +63,7 @@ import mil.dds.anet.threads.ReportPublicationWorker;
 import mil.dds.anet.utils.DaoUtils;
 import mil.dds.anet.utils.HttpsRedirectFilter;
 import mil.dds.anet.utils.Utils;
+import mil.dds.anet.views.RequestLoggingFilter;
 import mil.dds.anet.views.ViewRequestFilter;
 import mil.dds.anet.views.ViewResponseFilter;
 import org.eclipse.jetty.server.session.SessionHandler;
@@ -398,6 +399,7 @@ public class AnetApplication extends Application<AnetConfiguration> {
     environment.jersey().register(adminResource);
     environment.jersey().register(homeResource);
     environment.jersey().register(graphQlResource);
+    environment.jersey().register(new RequestLoggingFilter(engine));
     environment.jersey().register(ViewRequestFilter.class);
     environment.jersey().register(ViewResponseFilter.class);
   }

--- a/src/main/java/mil/dds/anet/AnetObjectEngine.java
+++ b/src/main/java/mil/dds/anet/AnetObjectEngine.java
@@ -43,6 +43,7 @@ import mil.dds.anet.database.SavedSearchDao;
 import mil.dds.anet.database.SubscriptionDao;
 import mil.dds.anet.database.SubscriptionUpdateDao;
 import mil.dds.anet.database.TaskDao;
+import mil.dds.anet.database.UserActivityDao;
 import mil.dds.anet.search.ISearcher;
 import mil.dds.anet.search.Searcher;
 import mil.dds.anet.utils.AuthUtils;
@@ -74,6 +75,7 @@ public class AnetObjectEngine {
   private final JobHistoryDao jobHistoryDao;
   private final SubscriptionDao subscriptionDao;
   private final SubscriptionUpdateDao subscriptionUpdateDao;
+  private final UserActivityDao userActivityDao;
   private final MetricRegistry metricRegistry;
   private ThreadLocal<Map<String, Object>> context;
 
@@ -108,6 +110,7 @@ public class AnetObjectEngine {
     jobHistoryDao = injector.getInstance(JobHistoryDao.class);
     subscriptionDao = injector.getInstance(SubscriptionDao.class);
     subscriptionUpdateDao = injector.getInstance(SubscriptionUpdateDao.class);
+    userActivityDao = injector.getInstance(UserActivityDao.class);
     this.metricRegistry = metricRegistry;
     searcher = Searcher.getSearcher(DaoUtils.getDbType(dbUrl), injector);
     configuration = config;
@@ -192,6 +195,10 @@ public class AnetObjectEngine {
 
   public SubscriptionUpdateDao getSubscriptionUpdateDao() {
     return subscriptionUpdateDao;
+  }
+
+  public UserActivityDao getUserActivityDao() {
+    return userActivityDao;
   }
 
   public EmailDao getEmailDao() {

--- a/src/main/java/mil/dds/anet/database/UserActivityDao.java
+++ b/src/main/java/mil/dds/anet/database/UserActivityDao.java
@@ -1,0 +1,26 @@
+package mil.dds.anet.database;
+
+import java.time.Instant;
+import javax.inject.Inject;
+import javax.inject.Provider;
+import mil.dds.anet.utils.DaoUtils;
+import org.jdbi.v3.core.Handle;
+import ru.vyarus.guicey.jdbi3.tx.InTransaction;
+
+public class UserActivityDao {
+  @Inject
+  private Provider<Handle> handle;
+
+  protected Handle getDbHandle() {
+    return handle.get();
+  }
+
+  @InTransaction
+  public int insert(String personUuid, Instant visitedAt) {
+    return getDbHandle()
+        .createUpdate("INSERT INTO \"userActivities\" (\"personUuid\", \"visitedAt\") "
+            + "VALUES (:personUuid, :visitedAt) ON CONFLICT DO NOTHING")
+        .bind("personUuid", personUuid).bind("visitedAt", DaoUtils.asLocalDateTime(visitedAt))
+        .execute();
+  }
+}

--- a/src/main/java/mil/dds/anet/utils/AnetDbLogger.java
+++ b/src/main/java/mil/dds/anet/utils/AnetDbLogger.java
@@ -24,18 +24,20 @@ public class AnetDbLogger implements SqlLogger {
 
   @Override
   public void logAfterExecution(StatementContext context) {
-    final String msg =
-        context.getRenderedSql().replace(PersonDao.PERSON_FIELDS, " <PERSON_FIELDS> ")
-            .replace(PersonDao.PERSON_FIELDS_NOAS, " <PERSON_FIELDS> ")
-            .replace(PositionDao.POSITIONS_FIELDS, " <POSITION_FIELDS> ")
-            .replace(OrganizationDao.ORGANIZATION_FIELDS, " <ORGANIZATION_FIELDS> ")
-            .replace(ReportDao.REPORT_FIELDS, " <REPORT_FIELDS> ")
-            .replace(ReportSensitiveInformationDao.REPORTS_SENSITIVE_INFORMATION_FIELDS,
-                " <REPORTS_SENSITIVE_INFORMATION_FIELDS> ")
-            .replace(CommentDao.COMMENT_FIELDS, " <COMMENT_FIELDS> ")
-            .replaceAll("LEFT JOIN (CONTAINS|FREETEXT)TABLE[^=]*= (\\S+)\\.\\[Key\\]", "<$1_$2>")
-            .replaceFirst("LEFT JOIN (mv_fts_\\S+) ON \\S+\\s*=\\s*\\S+", "<$1>")
-            .replaceFirst("\\(?(EXP|ISNULL|CASE|ts_rank).* AS (search_rank)", "<$2>");
-    logger.debug("{}\t{}", context.getElapsedTime(ChronoUnit.MILLIS), msg);
+    final String renderedSql = context.getRenderedSql();
+    if (logger.isDebugEnabled() && !renderedSql.startsWith("INSERT INTO \"userActivities\"")) {
+      final String msg = renderedSql.replace(PersonDao.PERSON_FIELDS, " <PERSON_FIELDS> ")
+          .replace(PersonDao.PERSON_FIELDS_NOAS, " <PERSON_FIELDS> ")
+          .replace(PositionDao.POSITIONS_FIELDS, " <POSITION_FIELDS> ")
+          .replace(OrganizationDao.ORGANIZATION_FIELDS, " <ORGANIZATION_FIELDS> ")
+          .replace(ReportDao.REPORT_FIELDS, " <REPORT_FIELDS> ")
+          .replace(ReportSensitiveInformationDao.REPORTS_SENSITIVE_INFORMATION_FIELDS,
+              " <REPORTS_SENSITIVE_INFORMATION_FIELDS> ")
+          .replace(CommentDao.COMMENT_FIELDS, " <COMMENT_FIELDS> ")
+          .replaceAll("LEFT JOIN (CONTAINS|FREETEXT)TABLE[^=]*= (\\S+)\\.\\[Key\\]", "<$1_$2>")
+          .replaceFirst("LEFT JOIN (mv_fts_\\S+) ON \\S+\\s*=\\s*\\S+", "<$1>")
+          .replaceFirst("\\(?(EXP|ISNULL|CASE|ts_rank).* AS (search_rank)", "<$2>");
+      logger.debug("{}\t{}", context.getElapsedTime(ChronoUnit.MILLIS), msg);
+    }
   }
 }

--- a/src/main/java/mil/dds/anet/views/RequestLoggingFilter.java
+++ b/src/main/java/mil/dds/anet/views/RequestLoggingFilter.java
@@ -1,0 +1,33 @@
+package mil.dds.anet.views;
+
+import java.io.IOException;
+import java.security.Principal;
+import javax.ws.rs.HttpMethod;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import mil.dds.anet.AnetObjectEngine;
+import mil.dds.anet.beans.Person;
+import mil.dds.anet.database.UserActivityDao;
+import mil.dds.anet.utils.DaoUtils;
+import mil.dds.anet.utils.ResponseUtils;
+
+public class RequestLoggingFilter implements ContainerRequestFilter {
+  private final UserActivityDao dao;
+
+  public RequestLoggingFilter(final AnetObjectEngine engine) {
+    this.dao = engine.getUserActivityDao();
+  }
+
+  @Override
+  public void filter(ContainerRequestContext requestContext) throws IOException {
+    // Log only requests other than GET and if userPrincipal is a Person,
+    // and the activity should not be ignored
+    final boolean isGet = HttpMethod.GET.equals(requestContext.getMethod());
+    final Principal userPrincipal = requestContext.getSecurityContext().getUserPrincipal();
+    if (!isGet && userPrincipal instanceof Person
+        && !ResponseUtils.ignoreActivity(requestContext)) {
+      // Store this request in the database (only once per minute)
+      dao.insert(((Person) userPrincipal).getUuid(), DaoUtils.getCurrentMinute());
+    }
+  }
+}

--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -4121,4 +4121,16 @@
 		</addColumn>
 	</changeSet>
 
+	<changeSet id="add-userActivities-table" author="gjvoosten">
+		<createTable tableName="userActivities">
+			<!-- Note: personUuid is *not* a foreign key so the person can still be deleted without deleting the activities -->
+			<column name="personUuid" type="${uuid_type}">
+				<constraints primaryKey="true" nullable="false" />
+			</column>
+			<column name="visitedAt" type="datetime">
+				<constraints primaryKey="true" nullable="false" />
+			</column>
+		</createTable>
+	</changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
Add a new database table that records the active users (with a granularity of once per minute).

Closes NCI-Agency/anet#3880
Closes [AB#469](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/469)

#### User changes
- none

#### Super User changes
- none

#### Admin changes
- none

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [x] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [x] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here