### PR TITLE
Use the Jakarta EE namespaced versions of the JAXB APIs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -88,7 +88,11 @@ dependencies {
 	implementation 'org.liquibase:liquibase-core:4.12.0'
 
 	// For caching domain users (used in every request in the AuthenticationFilter)
-	implementation 'org.ehcache:ehcache:3.10.0'
+	implementation('org.ehcache:ehcache:3.10.0') {
+		capabilities {
+			requireCapability('org.ehcache:ehcache-jakarta')
+		}
+	}
 	implementation 'javax.cache:cache-api:1.1.1'
 	implementation 'commons-beanutils:commons-beanutils:1.9.4'
 
@@ -113,10 +117,6 @@ dependencies {
 	// used for writing Excel documents
 	implementation 'org.apache.poi:poi:5.2.2'
 	implementation 'org.apache.poi:poi-ooxml:5.2.2'
-
-	// For Java 9+
-	runtimeOnly 'org.glassfish.jaxb:jaxb-runtime:2.3.6'
-	runtimeOnly 'javax.xml.bind:jaxb-api:2.3.1'
 
 	// For parsing HTML to check for 'empty' input
 	implementation 'org.jsoup:jsoup:1.15.2'


### PR DESCRIPTION
Simplify runtime dependencies by declaring the JAXB implementation on ehcache.

#### User changes
- None

#### Super User changes
- None

#### Admin changes
- None

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [ ] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here