### PR TITLE
Be able to search super-user and administrator positions

### DIFF
--- a/anet-dictionary.yml
+++ b/anet-dictionary.yml
@@ -1391,11 +1391,13 @@ fields:
   superUser:
 
     position:
+      name: Super User
       type: ANET Super User
 
   administrator:
 
     position:
+      name: Administrator
       type: ANET Administrator
 
 pinned_ORGs: [Key Leader Engagement]

--- a/client/src/components/SearchFilters.js
+++ b/client/src/components/SearchFilters.js
@@ -472,10 +472,17 @@ export const searchFilters = function() {
         deserializer: deserializeSelectFilter,
         props: {
           queryKey: "type",
-          options: [Position.TYPE.ADVISOR, Position.TYPE.PRINCIPAL],
+          options: [
+            Position.TYPE.PRINCIPAL,
+            Position.TYPE.ADVISOR,
+            Position.TYPE.SUPER_USER,
+            Position.TYPE.ADMINISTRATOR
+          ],
           labels: [
+            Settings.fields.principal.position.name,
             Settings.fields.advisor.position.name,
-            Settings.fields.principal.position.name
+            Settings.fields.superUser.position.name,
+            Settings.fields.administrator.position.name
           ],
           isPositionTypeFilter: true
         }

--- a/src/main/resources/anet-schema.yml
+++ b/src/main/resources/anet-schema.yml
@@ -914,8 +914,8 @@ properties:
             properties:
               name:
                 type: string
-                title: The permision name of this field
-                description: Used in the UI for the type filter of position,
+                title: The permission name of this field
+                description: Used in the UI for the type filter of position.
               type:
                 type: string
                 title: The permissions type of this field
@@ -934,8 +934,8 @@ properties:
             properties:
               name:
                   type: string
-                  title: The permision name of this field
-                  description: Used in the UI for the type filter of position,
+                  title: The permission name of this field
+                  description: Used in the UI for the type filter of position.
               type:
                 type: string
                 title: The permissions type of this field

--- a/src/main/resources/anet-schema.yml
+++ b/src/main/resources/anet-schema.yml
@@ -912,6 +912,10 @@ properties:
             additionalProperties: false
             required: [type]
             properties:
+              name:
+                type: string
+                title: The permision name of this field
+                description: Used in the UI for the type filter of position,
               type:
                 type: string
                 title: The permissions type of this field
@@ -928,6 +932,10 @@ properties:
             additionalProperties: false
             required: [type]
             properties:
+              name:
+                  type: string
+                  title: The permision name of this field
+                  description: Used in the UI for the type filter of position,
               type:
                 type: string
                 title: The permissions type of this field


### PR DESCRIPTION
Super user and administrator options are added to the position type filter in advanced search

Closes [AB#502](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/502)

#### User changes
- Users can search super user and administrator type positions.

#### Super User changes
- None

#### Admin changes
- None

#### System admin changes
- [x] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [ ] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
