### PR TITLE
Fix rich text errors with empty html tags

### DIFF
--- a/client/src/components/RichTextEditor.js
+++ b/client/src/components/RichTextEditor.js
@@ -5,7 +5,6 @@ import Toolbar, { handleOnKeyDown } from "components/editor/Toolbar"
 import escapeHtml from "escape-html"
 import { debounce } from "lodash"
 import _isEmpty from "lodash/isEmpty"
-import _trim from "lodash/trim"
 import PropTypes from "prop-types"
 import React, { useCallback, useMemo, useState } from "react"
 import { createEditor, Text, Transforms } from "slate"
@@ -149,13 +148,6 @@ const serializeDebounced = debounce((node, onChange) => {
 }, 100)
 
 const deserialize = element => {
-  if (
-    element.nodeName === "#text" &&
-    _isEmpty(_trim(element.textContent, "\n"))
-  ) {
-    // Skip empty elements
-    return null
-  }
   let children = Array.from(element.childNodes).map(deserialize)
   // Body must have at least one children node for user to be able to edit the text in it
   // Every other node must have a non-empty array of children


### PR DESCRIPTION
Rich text field bug with empty html tags is fixed.

Closes [AB#482](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/482)

#### User changes
- None

#### Super User changes
- None

#### Admin changes
- None

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [ ] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
