### PR TITLE
Speed up slow queries

### DIFF
--- a/src/main/java/mil/dds/anet/database/ApprovalStepDao.java
+++ b/src/main/java/mil/dds/anet/database/ApprovalStepDao.java
@@ -60,7 +60,7 @@ public class ApprovalStepDao extends AnetBaseDao<ApprovalStep, AbstractSearchQue
   static class PositionsBatcher extends ForeignKeyBatcher<Position> {
     private static final String sql =
         "/* batch.getApproversForStep */ SELECT \"approvalStepUuid\", "
-            + PositionDao.POSITIONS_FIELDS + " FROM approvers "
+            + PositionDao.POSITION_FIELDS + " FROM approvers "
             + "LEFT JOIN positions ON \"positions\".\"uuid\" = approvers.\"positionUuid\" "
             + "WHERE \"approvalStepUuid\" IN ( <foreignKeys> )";
 

--- a/src/main/java/mil/dds/anet/database/AuthorizationGroupDao.java
+++ b/src/main/java/mil/dds/anet/database/AuthorizationGroupDao.java
@@ -22,7 +22,11 @@ import ru.vyarus.guicey.jdbi3.tx.InTransaction;
 public class AuthorizationGroupDao
     extends AnetBaseDao<AuthorizationGroup, AuthorizationGroupSearchQuery> {
 
+  private static final String[] fields =
+      {"uuid", "name", "description", "status", "createdAt", "updatedAt"};
   public static final String TABLE_NAME = "authorizationGroups";
+  public static final String AUTHORIZATION_GROUP_FIELDS =
+      DaoUtils.buildFieldAliases(TABLE_NAME, fields, true);
 
   @Override
   public AuthorizationGroup getByUuid(String uuid) {
@@ -30,8 +34,8 @@ public class AuthorizationGroupDao
   }
 
   static class SelfIdBatcher extends IdBatcher<AuthorizationGroup> {
-    private static final String sql =
-        "/* batch.getAuthorizationGroupsByUuids */ SELECT * from \"authorizationGroups\" where uuid IN ( <uuids> )";
+    private static final String sql = "/* batch.getAuthorizationGroupsByUuids */ SELECT "
+        + AUTHORIZATION_GROUP_FIELDS + " FROM \"authorizationGroups\" WHERE uuid IN ( <uuids> )";
 
     public SelfIdBatcher() {
       super(sql, "uuids", new AuthorizationGroupMapper());
@@ -48,7 +52,7 @@ public class AuthorizationGroupDao
   static class PositionsBatcher extends ForeignKeyBatcher<Position> {
     private static final String sql =
         "/* batch.getPositionsForAuthorizationGroup */ SELECT \"authorizationGroupUuid\", "
-            + PositionDao.POSITIONS_FIELDS + " FROM positions, \"authorizationGroupPositions\" "
+            + PositionDao.POSITION_FIELDS + " FROM positions, \"authorizationGroupPositions\" "
             + "WHERE \"authorizationGroupPositions\".\"authorizationGroupUuid\" IN ( <foreignKeys> ) "
             + "AND \"authorizationGroupPositions\".\"positionUuid\" = positions.uuid";
 
@@ -124,13 +128,14 @@ public class AuthorizationGroupDao
   }
 
   static class AuthorizationGroupsBatcher extends ForeignKeyBatcher<AuthorizationGroup> {
-    private static final String sql =
-        "/* batch.getAuthorizationGroupsByPosition */ SELECT * FROM \"authorizationGroupPositions\""
-            + " INNER JOIN \"authorizationGroups\" ON \"authorizationGroups\".uuid"
-            + " = \"authorizationGroupPositions\".\"authorizationGroupUuid\""
-            + " WHERE \"authorizationGroupPositions\".\"positionUuid\" IN ( <foreignKeys> )"
-            + " ORDER BY \"authorizationGroupPositions\".\"positionUuid\","
-            + " \"authorizationGroups\".name, \"authorizationGroups\".uuid";
+    private static final String sql = "/* batch.getAuthorizationGroupsByPosition */ SELECT "
+        + AUTHORIZATION_GROUP_FIELDS
+        + ", \"authorizationGroupPositions\".\"positionUuid\" FROM \"authorizationGroupPositions\""
+        + " INNER JOIN \"authorizationGroups\" ON \"authorizationGroups\".uuid"
+        + " = \"authorizationGroupPositions\".\"authorizationGroupUuid\""
+        + " WHERE \"authorizationGroupPositions\".\"positionUuid\" IN ( <foreignKeys> )"
+        + " ORDER BY \"authorizationGroupPositions\".\"positionUuid\","
+        + " \"authorizationGroups\".name, \"authorizationGroups\".uuid";
 
     public AuthorizationGroupsBatcher() {
       super(sql, "foreignKeys", new AuthorizationGroupMapper(), "positionUuid");

--- a/src/main/java/mil/dds/anet/database/LocationDao.java
+++ b/src/main/java/mil/dds/anet/database/LocationDao.java
@@ -12,7 +12,10 @@ import ru.vyarus.guicey.jdbi3.tx.InTransaction;
 
 public class LocationDao extends AnetSubscribableObjectDao<Location, LocationSearchQuery> {
 
+  private static final String[] fields =
+      {"uuid", "name", "status", "lat", "lng", "type", "createdAt", "updatedAt", "customFields"};
   public static final String TABLE_NAME = "locations";
+  public static final String LOCATION_FIELDS = DaoUtils.buildFieldAliases(TABLE_NAME, fields, true);
 
   @Override
   public Location getByUuid(String uuid) {
@@ -21,8 +24,8 @@ public class LocationDao extends AnetSubscribableObjectDao<Location, LocationSea
 
   static class SelfIdBatcher extends IdBatcher<Location> {
 
-    private static final String sql =
-        "/* batch.getLocationsByUuids */ SELECT * from locations where uuid IN ( <uuids> )";
+    private static final String sql = "/* batch.getLocationsByUuids */ SELECT " + LOCATION_FIELDS
+        + " FROM locations WHERE uuid IN ( <uuids> )";
 
     public SelfIdBatcher() {
       super(sql, "uuids", new LocationMapper());

--- a/src/main/java/mil/dds/anet/database/PersonDao.java
+++ b/src/main/java/mil/dds/anet/database/PersonDao.java
@@ -200,7 +200,7 @@ public class PersonDao extends AnetSubscribableObjectDao<Person, PersonSearchQue
     }
     return getDbHandle()
         .createQuery("/* findByDomainUsername */ SELECT " + PERSON_FIELDS + ","
-            + PositionDao.POSITIONS_FIELDS
+            + PositionDao.POSITION_FIELDS
             + "FROM people LEFT JOIN positions ON people.uuid = positions.\"currentPersonUuid\" "
             + "WHERE people.\"domainUsername\" = :domainUsername "
             + "AND people.status != :inactiveStatus")
@@ -217,7 +217,7 @@ public class PersonDao extends AnetSubscribableObjectDao<Person, PersonSearchQue
     }
     return getDbHandle()
         .createQuery("/* findByEmailAddress */ SELECT " + PERSON_FIELDS + ","
-            + PositionDao.POSITIONS_FIELDS
+            + PositionDao.POSITION_FIELDS
             + "FROM people LEFT JOIN positions ON people.uuid = positions.\"currentPersonUuid\" "
             + "WHERE people.\"emailAddress\" = :emailAddress "
             + "AND people.status != :inactiveStatus")
@@ -237,7 +237,7 @@ public class PersonDao extends AnetSubscribableObjectDao<Person, PersonSearchQue
     }
     final List<Person> people = getDbHandle()
         .createQuery("/* findByOpenIdSubject */ SELECT " + PERSON_FIELDS + ","
-            + PositionDao.POSITIONS_FIELDS
+            + PositionDao.POSITION_FIELDS
             + "FROM people LEFT JOIN positions ON people.uuid = positions.\"currentPersonUuid\" "
             + "WHERE people.\"openIdSubject\" = :openIdSubject "
             + "AND people.status != :inactiveStatus")

--- a/src/main/java/mil/dds/anet/database/PositionDao.java
+++ b/src/main/java/mil/dds/anet/database/PositionDao.java
@@ -36,8 +36,7 @@ public class PositionDao extends AnetSubscribableObjectDao<Position, PositionSea
   public static final String[] fields = {"uuid", "name", "code", "createdAt", "updatedAt",
       "organizationUuid", "currentPersonUuid", "type", "status", "locationUuid", "customFields"};
   public static final String TABLE_NAME = "positions";
-  public static final String POSITIONS_FIELDS =
-      DaoUtils.buildFieldAliases(TABLE_NAME, fields, true);
+  public static final String POSITION_FIELDS = DaoUtils.buildFieldAliases(TABLE_NAME, fields, true);
 
   @Override
   public Position insertInternal(Position p) {
@@ -84,7 +83,7 @@ public class PositionDao extends AnetSubscribableObjectDao<Position, PositionSea
   }
 
   static class SelfIdBatcher extends IdBatcher<Position> {
-    private static final String sql = "/* batch.getPositionsByUuids */ SELECT " + POSITIONS_FIELDS
+    private static final String sql = "/* batch.getPositionsByUuids */ SELECT " + POSITION_FIELDS
         + "FROM positions WHERE positions.uuid IN ( <uuids> )";
 
     public SelfIdBatcher() {
@@ -117,7 +116,7 @@ public class PositionDao extends AnetSubscribableObjectDao<Position, PositionSea
 
   static class PositionsBatcher extends ForeignKeyBatcher<Position> {
     private static final String sql =
-        "/* batch.getCurrentPositionForPerson */ SELECT " + POSITIONS_FIELDS + " FROM positions "
+        "/* batch.getCurrentPositionForPerson */ SELECT " + POSITION_FIELDS + " FROM positions "
             + "WHERE positions.\"currentPersonUuid\" IN ( <foreignKeys> )";
 
     public PositionsBatcher() {
@@ -189,7 +188,7 @@ public class PositionDao extends AnetSubscribableObjectDao<Position, PositionSea
     }
     // Find out if person already holds a position (we also need its type later on)
     final Position currPos = getDbHandle()
-        .createQuery("/* positionSetPerson.find */ SELECT " + POSITIONS_FIELDS
+        .createQuery("/* positionSetPerson.find */ SELECT " + POSITION_FIELDS
             + " FROM positions WHERE \"currentPersonUuid\" = :personUuid")
         .bind("personUuid", personUuid).map(new PositionMapper()).findFirst().orElse(null);
     if (currPos != null && currPos.getUuid().equals(positionUuid)) {
@@ -331,7 +330,7 @@ public class PositionDao extends AnetSubscribableObjectDao<Position, PositionSea
 
   static class AssociatedPositionsBatcher extends ForeignKeyBatcher<Position> {
     private static final String sql = "/* batch.getAssociatedPositionsForPosition */ SELECT "
-        + POSITIONS_FIELDS
+        + POSITION_FIELDS
         + ", CASE WHEN positions.uuid = \"positionRelationships\".\"positionUuid_a\""
         + " THEN \"positionRelationships\".\"positionUuid_b\""
         + " ELSE \"positionRelationships\".\"positionUuid_a\" END AS \"associatedPositionUuid\" "
@@ -391,7 +390,7 @@ public class PositionDao extends AnetSubscribableObjectDao<Position, PositionSea
   @InTransaction
   public List<Position> getEmptyPositions(PositionType type) {
     return getDbHandle()
-        .createQuery("SELECT " + POSITIONS_FIELDS + " FROM positions "
+        .createQuery("SELECT " + POSITION_FIELDS + " FROM positions "
             + "WHERE \"currentPersonUuid\" IS NULL AND positions.type = :type")
         .bind("type", DaoUtils.getEnumId(type)).map(new PositionMapper()).list();
   }
@@ -424,7 +423,7 @@ public class PositionDao extends AnetSubscribableObjectDao<Position, PositionSea
   @InTransaction
   public Position getCurrentPositionForPerson(String personUuid) {
     List<Position> positions = getDbHandle()
-        .createQuery("/* getCurrentPositionForPerson */ SELECT " + POSITIONS_FIELDS
+        .createQuery("/* getCurrentPositionForPerson */ SELECT " + POSITION_FIELDS
             + " FROM positions WHERE \"currentPersonUuid\" = :personUuid")
         .bind("personUuid", personUuid).map(new PositionMapper()).list();
     if (positions.size() == 0) {

--- a/src/main/java/mil/dds/anet/database/ReportDao.java
+++ b/src/main/java/mil/dds/anet/database/ReportDao.java
@@ -324,10 +324,11 @@ public class ReportDao extends AnetSubscribableObjectDao<Report, ReportSearchQue
 
   @InTransaction
   public List<AuthorizationGroup> getAuthorizationGroupsForReport(String reportUuid) {
-    return getDbHandle().createQuery(
-        "/* getAuthorizationGroupsForReport */ SELECT * FROM \"authorizationGroups\", \"reportAuthorizationGroups\" "
-            + "WHERE \"reportAuthorizationGroups\".\"reportUuid\" = :reportUuid "
-            + "AND \"reportAuthorizationGroups\".\"authorizationGroupUuid\" = \"authorizationGroups\".uuid")
+    return getDbHandle().createQuery("/* getAuthorizationGroupsForReport */ SELECT "
+        + AuthorizationGroupDao.AUTHORIZATION_GROUP_FIELDS
+        + " FROM \"authorizationGroups\", \"reportAuthorizationGroups\" "
+        + "WHERE \"reportAuthorizationGroups\".\"reportUuid\" = :reportUuid "
+        + "AND \"reportAuthorizationGroups\".\"authorizationGroupUuid\" = \"authorizationGroups\".uuid")
         .bind("reportUuid", reportUuid).map(new AuthorizationGroupMapper()).list();
   }
 
@@ -724,10 +725,10 @@ public class ReportDao extends AnetSubscribableObjectDao<Report, ReportSearchQue
   }
 
   static class TasksBatcher extends ForeignKeyBatcher<Task> {
-    private static final String sql =
-        "/* batch.getTasksForReport */ SELECT * FROM tasks, \"reportTasks\" "
-            + "WHERE \"reportTasks\".\"reportUuid\" IN ( <foreignKeys> ) "
-            + "AND \"reportTasks\".\"taskUuid\" = tasks.uuid ORDER BY uuid";
+    private static final String sql = "/* batch.getTasksForReport */ SELECT " + TaskDao.TASK_FIELDS
+        + ", \"reportTasks\".\"reportUuid\" FROM tasks, \"reportTasks\" "
+        + "WHERE \"reportTasks\".\"reportUuid\" IN ( <foreignKeys> ) "
+        + "AND \"reportTasks\".\"taskUuid\" = tasks.uuid ORDER BY uuid";
 
     public TasksBatcher() {
       super(sql, "foreignKeys", new TaskMapper(), "reportUuid");

--- a/src/main/java/mil/dds/anet/database/ReportSensitiveInformationDao.java
+++ b/src/main/java/mil/dds/anet/database/ReportSensitiveInformationDao.java
@@ -25,7 +25,7 @@ public class ReportSensitiveInformationDao
 
   private static final String[] fields = {"uuid", "text", "reportUuid", "createdAt", "updatedAt"};
   public static final String TABLE_NAME = "reportsSensitiveInformation";
-  public static final String REPORTS_SENSITIVE_INFORMATION_FIELDS =
+  public static final String REPORT_SENSITIVE_INFORMATION_FIELDS =
       DaoUtils.buildFieldAliases(TABLE_NAME, fields, true);
 
   @Override
@@ -42,7 +42,7 @@ public class ReportSensitiveInformationDao
       extends ForeignKeyBatcher<ReportSensitiveInformation> {
     private static final String sql =
         "/* batch.getReportSensitiveInformationsByReportUuids */ SELECT "
-            + REPORTS_SENSITIVE_INFORMATION_FIELDS + " FROM \"" + TABLE_NAME + "\""
+            + REPORT_SENSITIVE_INFORMATION_FIELDS + " FROM \"" + TABLE_NAME + "\""
             + " WHERE \"reportUuid\" IN ( <foreignKeys> )";
 
     public ReportsSensitiveInformationBatcher() {

--- a/src/main/java/mil/dds/anet/database/SubscriptionDao.java
+++ b/src/main/java/mil/dds/anet/database/SubscriptionDao.java
@@ -28,7 +28,11 @@ public class SubscriptionDao extends AnetBaseDao<Subscription, AbstractSearchQue
   private static final Logger logger =
       LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
+  private static final String[] fields = {"uuid", "subscriberUuid", "subscribedObjectType",
+      "subscribedObjectUuid", "createdAt", "updatedAt"};
   public static final String TABLE_NAME = "subscriptions";
+  public static final String SUBSCRIPTION_FIELDS =
+      DaoUtils.buildFieldAliases(TABLE_NAME, fields, true);
 
   @Override
   public Subscription getByUuid(String uuid) {
@@ -47,8 +51,8 @@ public class SubscriptionDao extends AnetBaseDao<Subscription, AbstractSearchQue
   }
 
   static class SelfIdBatcher extends IdBatcher<Subscription> {
-    private static final String sql =
-        "/* batch.getSubscriptionsByUuids */ SELECT * FROM subscriptions WHERE uuid IN ( <uuids> )";
+    private static final String sql = "/* batch.getSubscriptionsByUuids */ SELECT "
+        + SUBSCRIPTION_FIELDS + " FROM subscriptions WHERE uuid IN ( <uuids> )";
 
     public SelfIdBatcher() {
       super(sql, "uuids", new SubscriptionMapper());

--- a/src/main/java/mil/dds/anet/database/SubscriptionUpdateDao.java
+++ b/src/main/java/mil/dds/anet/database/SubscriptionUpdateDao.java
@@ -5,8 +5,15 @@ import mil.dds.anet.beans.Person;
 import mil.dds.anet.beans.SubscriptionUpdate;
 import mil.dds.anet.beans.lists.AnetBeanList;
 import mil.dds.anet.beans.search.SubscriptionUpdateSearchQuery;
+import mil.dds.anet.utils.DaoUtils;
 
 public class SubscriptionUpdateDao {
+
+  private static final String[] fields =
+      {"subscriptionUuid", "updatedObjectType", "updatedObjectUuid", "isNote", "createdAt"};
+  public static final String TABLE_NAME = "subscriptionUpdates";
+  public static final String SUBSCRIPTION_UPDATE_FIELDS =
+      DaoUtils.buildFieldAliases(TABLE_NAME, fields, true);
 
   public AnetBeanList<SubscriptionUpdate> search(Person user, SubscriptionUpdateSearchQuery query) {
     return AnetObjectEngine.getInstance().getSearcher().getSubscriptionUpdateSearcher()

--- a/src/main/java/mil/dds/anet/database/TaskDao.java
+++ b/src/main/java/mil/dds/anet/database/TaskDao.java
@@ -26,7 +26,11 @@ import ru.vyarus.guicey.jdbi3.tx.InTransaction;
 
 public class TaskDao extends AnetSubscribableObjectDao<Task, TaskSearchQuery> {
 
+  private static final String[] fields = {"uuid", "shortName", "longName", "status", "category",
+      "createdAt", "updatedAt", "projectedCompletion", "plannedCompletion", "customField",
+      "customFieldEnum1", "customFieldEnum2", "customFieldRef1Uuid", "customFields"};
   public static final String TABLE_NAME = "tasks";
+  public static final String TASK_FIELDS = DaoUtils.buildFieldAliases(TABLE_NAME, fields, true);
 
   @Override
   public Task getByUuid(String uuid) {
@@ -34,8 +38,8 @@ public class TaskDao extends AnetSubscribableObjectDao<Task, TaskSearchQuery> {
   }
 
   static class SelfIdBatcher extends IdBatcher<Task> {
-    private static final String sql =
-        "/* batch.getTasksByUuids */ SELECT * from tasks where uuid IN ( <uuids> )";
+    private static final String sql = "/* batch.getTasksByUuids */ SELECT " + TASK_FIELDS
+        + " FROM tasks WHERE uuid IN ( <uuids> )";
 
     public SelfIdBatcher() {
       super(sql, "uuids", new TaskMapper());
@@ -52,7 +56,7 @@ public class TaskDao extends AnetSubscribableObjectDao<Task, TaskSearchQuery> {
   static class ResponsiblePositionsBatcher extends ForeignKeyBatcher<Position> {
     private static final String sql =
         "/* batch.getResponsiblePositionsForTask */ SELECT \"taskUuid\", "
-            + PositionDao.POSITIONS_FIELDS + " FROM positions, \"taskResponsiblePositions\" "
+            + PositionDao.POSITION_FIELDS + " FROM positions, \"taskResponsiblePositions\" "
             + "WHERE \"taskResponsiblePositions\".\"taskUuid\" IN ( <foreignKeys> ) "
             + "AND \"taskResponsiblePositions\".\"positionUuid\" = positions.uuid";
 

--- a/src/main/java/mil/dds/anet/database/mappers/AuthorizationGroupMapper.java
+++ b/src/main/java/mil/dds/anet/database/mappers/AuthorizationGroupMapper.java
@@ -11,10 +11,11 @@ public class AuthorizationGroupMapper implements RowMapper<AuthorizationGroup> {
   @Override
   public AuthorizationGroup map(ResultSet rs, StatementContext ctx) throws SQLException {
     final AuthorizationGroup a = new AuthorizationGroup();
-    MapperUtils.setCommonBeanFields(a, rs, null);
-    a.setName(rs.getString("name"));
-    a.setDescription(rs.getString("description"));
-    a.setStatus(MapperUtils.getEnumIdx(rs, "status", AuthorizationGroup.Status.class));
+    MapperUtils.setCommonBeanFields(a, rs, "authorizationGroups");
+    a.setName(rs.getString("authorizationGroups_name"));
+    a.setDescription(rs.getString("authorizationGroups_description"));
+    a.setStatus(
+        MapperUtils.getEnumIdx(rs, "authorizationGroups_status", AuthorizationGroup.Status.class));
 
     if (MapperUtils.containsColumnNamed(rs, "totalCount")) {
       ctx.define("totalCount", rs.getInt("totalCount"));

--- a/src/main/java/mil/dds/anet/database/mappers/LocationMapper.java
+++ b/src/main/java/mil/dds/anet/database/mappers/LocationMapper.java
@@ -12,13 +12,13 @@ public class LocationMapper implements RowMapper<Location> {
   @Override
   public Location map(ResultSet rs, StatementContext ctx) throws SQLException {
     Location l = new Location();
-    MapperUtils.setCustomizableBeanFields(l, rs, null);
-    l.setName(rs.getString("name"));
-    l.setStatus(MapperUtils.getEnumIdx(rs, "status", Location.Status.class));
+    MapperUtils.setCustomizableBeanFields(l, rs, "locations");
+    l.setName(rs.getString("locations_name"));
+    l.setStatus(MapperUtils.getEnumIdx(rs, "locations_status", Location.Status.class));
     // preserve NULL values; when NULL there are no coordinates set:
-    l.setLat(MapperUtils.getOptionalDouble(rs, "lat"));
-    l.setLng(MapperUtils.getOptionalDouble(rs, "lng"));
-    l.setType(LocationType.valueOfCode(rs.getString("type")));
+    l.setLat(MapperUtils.getOptionalDouble(rs, "locations_lat"));
+    l.setLng(MapperUtils.getOptionalDouble(rs, "locations_lng"));
+    l.setType(LocationType.valueOfCode(rs.getString("locations_type")));
 
     if (MapperUtils.containsColumnNamed(rs, "totalCount")) {
       ctx.define("totalCount", rs.getInt("totalCount"));

--- a/src/main/java/mil/dds/anet/database/mappers/SubscriptionMapper.java
+++ b/src/main/java/mil/dds/anet/database/mappers/SubscriptionMapper.java
@@ -11,10 +11,10 @@ public class SubscriptionMapper implements RowMapper<Subscription> {
   @Override
   public Subscription map(ResultSet rs, StatementContext ctx) throws SQLException {
     final Subscription s = new Subscription();
-    MapperUtils.setCommonBeanFields(s, rs, null);
-    s.setSubscriberUuid(rs.getString("subscriberUuid"));
-    s.setSubscribedObjectType(rs.getString("subscribedObjectType"));
-    s.setSubscribedObjectUuid(rs.getString("subscribedObjectUuid"));
+    MapperUtils.setCommonBeanFields(s, rs, "subscriptions");
+    s.setSubscriberUuid(rs.getString("subscriptions_subscriberUuid"));
+    s.setSubscribedObjectType(rs.getString("subscriptions_subscribedObjectType"));
+    s.setSubscribedObjectUuid(rs.getString("subscriptions_subscribedObjectUuid"));
 
     if (MapperUtils.containsColumnNamed(rs, "totalCount")) {
       ctx.define("totalCount", rs.getInt("totalCount"));

--- a/src/main/java/mil/dds/anet/database/mappers/SubscriptionUpdateMapper.java
+++ b/src/main/java/mil/dds/anet/database/mappers/SubscriptionUpdateMapper.java
@@ -11,11 +11,11 @@ public class SubscriptionUpdateMapper implements RowMapper<SubscriptionUpdate> {
   @Override
   public SubscriptionUpdate map(ResultSet rs, StatementContext ctx) throws SQLException {
     final SubscriptionUpdate s = new SubscriptionUpdate();
-    s.setCreatedAt(MapperUtils.getInstantAsLocalDateTime(rs, "createdAt"));
-    s.setSubscriptionUuid(rs.getString("subscriptionUuid"));
-    s.setUpdatedObjectType(rs.getString("updatedObjectType"));
-    s.setUpdatedObjectUuid(rs.getString("updatedObjectUuid"));
-    s.setIsNote(rs.getBoolean("isNote"));
+    s.setCreatedAt(MapperUtils.getInstantAsLocalDateTime(rs, "subscriptionUpdates_createdAt"));
+    s.setSubscriptionUuid(rs.getString("subscriptionUpdates_subscriptionUuid"));
+    s.setUpdatedObjectType(rs.getString("subscriptionUpdates_updatedObjectType"));
+    s.setUpdatedObjectUuid(rs.getString("subscriptionUpdates_updatedObjectUuid"));
+    s.setIsNote(rs.getBoolean("subscriptionUpdates_isNote"));
 
     if (MapperUtils.containsColumnNamed(rs, "totalCount")) {
       ctx.define("totalCount", rs.getInt("totalCount"));

--- a/src/main/java/mil/dds/anet/database/mappers/TaskMapper.java
+++ b/src/main/java/mil/dds/anet/database/mappers/TaskMapper.java
@@ -11,17 +11,17 @@ public class TaskMapper implements RowMapper<Task> {
   @Override
   public Task map(ResultSet r, StatementContext ctx) throws SQLException {
     Task p = new Task();
-    MapperUtils.setCustomizableBeanFields(p, r, null);
-    p.setLongName(r.getString("longName"));
-    p.setShortName(r.getString("shortName"));
-    p.setCategory(r.getString("category"));
-    p.setCustomField(r.getString("customField"));
-    p.setCustomFieldEnum1(r.getString("customFieldEnum1"));
-    p.setCustomFieldEnum2(r.getString("customFieldEnum2"));
-    p.setPlannedCompletion(MapperUtils.getInstantAsLocalDateTime(r, "plannedCompletion"));
-    p.setProjectedCompletion(MapperUtils.getInstantAsLocalDateTime(r, "projectedCompletion"));
-    p.setStatus(MapperUtils.getEnumIdx(r, "status", Task.Status.class));
-    p.setCustomFieldRef1Uuid(r.getString("customFieldRef1Uuid"));
+    MapperUtils.setCustomizableBeanFields(p, r, "tasks");
+    p.setLongName(r.getString("tasks_longName"));
+    p.setShortName(r.getString("tasks_shortName"));
+    p.setCategory(r.getString("tasks_category"));
+    p.setCustomField(r.getString("tasks_customField"));
+    p.setCustomFieldEnum1(r.getString("tasks_customFieldEnum1"));
+    p.setCustomFieldEnum2(r.getString("tasks_customFieldEnum2"));
+    p.setPlannedCompletion(MapperUtils.getInstantAsLocalDateTime(r, "tasks_plannedCompletion"));
+    p.setProjectedCompletion(MapperUtils.getInstantAsLocalDateTime(r, "tasks_projectedCompletion"));
+    p.setStatus(MapperUtils.getEnumIdx(r, "tasks_status", Task.Status.class));
+    p.setCustomFieldRef1Uuid(r.getString("tasks_customFieldRef1Uuid"));
 
     if (MapperUtils.containsColumnNamed(r, "totalCount")) {
       ctx.define("totalCount", r.getInt("totalCount"));

--- a/src/main/java/mil/dds/anet/search/AbstractOrganizationSearcher.java
+++ b/src/main/java/mil/dds/anet/search/AbstractOrganizationSearcher.java
@@ -85,18 +85,18 @@ public abstract class AbstractOrganizationSearcher extends
       OrganizationSearchQuery query) {
     switch (query.getSortBy()) {
       case CREATED_AT:
-        qb.addAllOrderByClauses(getOrderBy(query.getSortOrder(), "organizations", "\"createdAt\""));
+        qb.addAllOrderByClauses(getOrderBy(query.getSortOrder(), "organizations_createdAt"));
         break;
       case TYPE:
-        qb.addAllOrderByClauses(getOrderBy(query.getSortOrder(), "organizations", "type"));
+        qb.addAllOrderByClauses(getOrderBy(query.getSortOrder(), "organizations_type"));
         break;
       case NAME:
       default:
-        qb.addAllOrderByClauses(getOrderBy(query.getSortOrder(), "organizations", "\"shortName\"",
-            "\"longName\"", "\"identificationCode\""));
+        qb.addAllOrderByClauses(getOrderBy(query.getSortOrder(), "organizations_shortName",
+            "organizations_longName", "organizations_identificationCode"));
         break;
     }
-    qb.addAllOrderByClauses(getOrderBy(SortOrder.ASC, "organizations", "uuid"));
+    qb.addAllOrderByClauses(getOrderBy(SortOrder.ASC, "organizations_uuid"));
   }
 
 }

--- a/src/main/java/mil/dds/anet/search/AbstractPersonSearcher.java
+++ b/src/main/java/mil/dds/anet/search/AbstractPersonSearcher.java
@@ -95,6 +95,7 @@ public abstract class AbstractPersonSearcher extends AbstractSearcher<Person, Pe
     }
 
     if (Boolean.TRUE.equals(query.isInMyReports())) {
+      qb.addSelectClause("\"inMyReports\".max AS \"inMyReports_max\"");
       qb.addFromClause("JOIN ("
           + "  SELECT \"reportPeople\".\"personUuid\" AS uuid, MAX(reports.\"createdAt\") AS max"
           + "  FROM reports"
@@ -114,23 +115,23 @@ public abstract class AbstractPersonSearcher extends AbstractSearcher<Person, Pe
   protected void addOrderByClauses(AbstractSearchQueryBuilder<?, ?> qb, PersonSearchQuery query) {
     switch (query.getSortBy()) {
       case CREATED_AT:
-        qb.addAllOrderByClauses(getOrderBy(query.getSortOrder(), "people", "\"createdAt\""));
+        qb.addAllOrderByClauses(getOrderBy(query.getSortOrder(), "people_createdAt"));
         break;
       case RANK:
-        qb.addAllOrderByClauses(getOrderBy(query.getSortOrder(), "people", "rank"));
+        qb.addAllOrderByClauses(getOrderBy(query.getSortOrder(), "people_rank"));
         break;
       case RECENT:
         if (Boolean.TRUE.equals(query.isInMyReports())) {
           // Otherwise the JOIN won't exist
-          qb.addAllOrderByClauses(getOrderBy(query.getSortOrder(), "\"inMyReports\"", "max"));
+          qb.addAllOrderByClauses(getOrderBy(query.getSortOrder(), "inMyReports_max"));
         }
         break;
       case NAME:
       default:
-        qb.addAllOrderByClauses(getOrderBy(query.getSortOrder(), "people", "name"));
+        qb.addAllOrderByClauses(getOrderBy(query.getSortOrder(), "people_name"));
         break;
     }
-    qb.addAllOrderByClauses(getOrderBy(SortOrder.ASC, "people", "uuid"));
+    qb.addAllOrderByClauses(getOrderBy(SortOrder.ASC, "people_uuid"));
   }
 
 }

--- a/src/main/java/mil/dds/anet/search/AbstractPositionSearcher.java
+++ b/src/main/java/mil/dds/anet/search/AbstractPositionSearcher.java
@@ -57,7 +57,7 @@ public abstract class AbstractPositionSearcher
 
   @Override
   protected void buildQuery(PositionSearchQuery query) {
-    qb.addSelectClause(PositionDao.POSITIONS_FIELDS);
+    qb.addSelectClause(PositionDao.POSITION_FIELDS);
     qb.addTotalCount();
     qb.addFromClause("positions");
 
@@ -131,17 +131,17 @@ public abstract class AbstractPositionSearcher
   protected void addOrderByClauses(AbstractSearchQueryBuilder<?, ?> qb, PositionSearchQuery query) {
     switch (query.getSortBy()) {
       case CREATED_AT:
-        qb.addAllOrderByClauses(getOrderBy(query.getSortOrder(), "positions", "\"createdAt\""));
+        qb.addAllOrderByClauses(getOrderBy(query.getSortOrder(), "positions_createdAt"));
         break;
       case CODE:
-        qb.addAllOrderByClauses(getOrderBy(query.getSortOrder(), "positions", "code"));
+        qb.addAllOrderByClauses(getOrderBy(query.getSortOrder(), "positions_code"));
         break;
       case NAME:
       default:
-        qb.addAllOrderByClauses(getOrderBy(query.getSortOrder(), "positions", "name"));
+        qb.addAllOrderByClauses(getOrderBy(query.getSortOrder(), "positions_name"));
         break;
     }
-    qb.addAllOrderByClauses(getOrderBy(SortOrder.ASC, "positions", "uuid"));
+    qb.addAllOrderByClauses(getOrderBy(SortOrder.ASC, "positions_uuid"));
   }
 
 }

--- a/src/main/java/mil/dds/anet/search/AbstractReportSearcher.java
+++ b/src/main/java/mil/dds/anet/search/AbstractReportSearcher.java
@@ -389,21 +389,20 @@ public abstract class AbstractReportSearcher extends AbstractSearcher<Report, Re
     // query!
     switch (query.getSortBy()) {
       case CREATED_AT:
-        qb.addAllOrderByClauses(getOrderBy(query.getSortOrder(), null, "\"reports_createdAt\""));
+        qb.addAllOrderByClauses(getOrderBy(query.getSortOrder(), "reports_createdAt"));
         break;
       case RELEASED_AT:
-        qb.addAllOrderByClauses(getOrderBy(query.getSortOrder(), null, "\"reports_releasedAt\""));
+        qb.addAllOrderByClauses(getOrderBy(query.getSortOrder(), "reports_releasedAt"));
         break;
       case UPDATED_AT:
-        qb.addAllOrderByClauses(getOrderBy(query.getSortOrder(), null, "\"reports_updatedAt\""));
+        qb.addAllOrderByClauses(getOrderBy(query.getSortOrder(), "reports_updatedAt"));
         break;
       case ENGAGEMENT_DATE:
       default:
-        qb.addAllOrderByClauses(
-            getOrderBy(query.getSortOrder(), null, "\"reports_engagementDate\""));
+        qb.addAllOrderByClauses(getOrderBy(query.getSortOrder(), "reports_engagementDate"));
         break;
     }
-    qb.addAllOrderByClauses(getOrderBy(SortOrder.ASC, null, "reports_uuid"));
+    qb.addAllOrderByClauses(getOrderBy(SortOrder.ASC, "reports_uuid"));
   }
 
 }

--- a/src/main/java/mil/dds/anet/search/AbstractSearchQueryBuilder.java
+++ b/src/main/java/mil/dds/anet/search/AbstractSearchQueryBuilder.java
@@ -350,7 +350,8 @@ public abstract class AbstractSearchQueryBuilder<B, T extends AbstractSearchQuer
 
   protected void addOrderByClauses() {
     if (!orderByClauses.isEmpty()) {
-      sql.append(" ORDER BY ");
+      sql.insert(0, "SELECT * FROM (");
+      sql.append(") AS results ORDER BY ");
       sql.append(Joiner.on(", ").join(orderByClauses));
     }
   }

--- a/src/main/java/mil/dds/anet/search/AbstractSearcher.java
+++ b/src/main/java/mil/dds/anet/search/AbstractSearcher.java
@@ -97,14 +97,10 @@ public abstract class AbstractSearcher<B, T extends AbstractSearchQuery<?>> {
     return String.format("(%1$s || %2$s)", tsQueryAnet, tsQuerySimple);
   }
 
-  protected List<String> getOrderBy(SortOrder sortOrder, String table, String... columns) {
+  protected List<String> getOrderBy(SortOrder sortOrder, String... columns) {
     final List<String> clauses = new ArrayList<>();
     for (final String column : columns) {
-      if (table == null) {
-        clauses.add(String.format("%1$s %2$s", column, sortOrder));
-      } else {
-        clauses.add(String.format("%1$s.%2$s %3$s", table, column, sortOrder));
-      }
+      clauses.add(String.format("\"%1$s\" %2$s", column, sortOrder));
     }
     return clauses;
   }

--- a/src/main/java/mil/dds/anet/search/AbstractSubscriptionSearcher.java
+++ b/src/main/java/mil/dds/anet/search/AbstractSubscriptionSearcher.java
@@ -6,6 +6,7 @@ import mil.dds.anet.beans.Subscription;
 import mil.dds.anet.beans.lists.AnetBeanList;
 import mil.dds.anet.beans.search.ISearchQuery.SortOrder;
 import mil.dds.anet.beans.search.SubscriptionSearchQuery;
+import mil.dds.anet.database.SubscriptionDao;
 import mil.dds.anet.database.mappers.SubscriptionMapper;
 import mil.dds.anet.utils.DaoUtils;
 import ru.vyarus.guicey.jdbi3.tx.InTransaction;
@@ -31,7 +32,7 @@ public abstract class AbstractSubscriptionSearcher extends
   }
 
   protected void buildQuery(SubscriptionSearchQuery query, Person user) {
-    qb.addSelectClause("subscriptions.*");
+    qb.addSelectClause(SubscriptionDao.SUBSCRIPTION_FIELDS);
     qb.addTotalCount();
     qb.addFromClause("subscriptions");
     final Position position = DaoUtils.getPosition(user);
@@ -50,11 +51,11 @@ public abstract class AbstractSubscriptionSearcher extends
     switch (query.getSortBy()) {
       case CREATED_AT:
       default:
-        qb.addAllOrderByClauses(getOrderBy(query.getSortOrder(), "subscriptions", "\"createdAt\""));
+        qb.addAllOrderByClauses(getOrderBy(query.getSortOrder(), "subscriptions_createdAt"));
         break;
     }
-    qb.addAllOrderByClauses(getOrderBy(SortOrder.ASC, "subscriptions", "\"subscribedObjectType\"",
-        "\"subscribedObjectUuid\""));
+    qb.addAllOrderByClauses(getOrderBy(SortOrder.ASC, "subscriptions_subscribedObjectType",
+        "subscriptions_subscribedObjectUuid"));
   }
 
 }

--- a/src/main/java/mil/dds/anet/search/AbstractSubscriptionUpdateSearcher.java
+++ b/src/main/java/mil/dds/anet/search/AbstractSubscriptionUpdateSearcher.java
@@ -6,6 +6,7 @@ import mil.dds.anet.beans.SubscriptionUpdate;
 import mil.dds.anet.beans.lists.AnetBeanList;
 import mil.dds.anet.beans.search.ISearchQuery.SortOrder;
 import mil.dds.anet.beans.search.SubscriptionUpdateSearchQuery;
+import mil.dds.anet.database.SubscriptionUpdateDao;
 import mil.dds.anet.database.mappers.SubscriptionUpdateMapper;
 import mil.dds.anet.utils.DaoUtils;
 import ru.vyarus.guicey.jdbi3.tx.InTransaction;
@@ -33,7 +34,7 @@ public abstract class AbstractSubscriptionUpdateSearcher
   }
 
   protected void buildQuery(SubscriptionUpdateSearchQuery query, Person user) {
-    qb.addSelectClause("\"subscriptionUpdates\".*");
+    qb.addSelectClause(SubscriptionUpdateDao.SUBSCRIPTION_UPDATE_FIELDS);
     qb.addTotalCount();
     qb.addFromClause("\"subscriptionUpdates\"");
     final Position position = DaoUtils.getPosition(user);
@@ -54,12 +55,11 @@ public abstract class AbstractSubscriptionUpdateSearcher
     switch (query.getSortBy()) {
       case CREATED_AT:
       default:
-        qb.addAllOrderByClauses(
-            getOrderBy(query.getSortOrder(), "\"subscriptionUpdates\"", "\"createdAt\""));
+        qb.addAllOrderByClauses(getOrderBy(query.getSortOrder(), "subscriptionUpdates_createdAt"));
         break;
     }
-    qb.addAllOrderByClauses(getOrderBy(SortOrder.ASC, "\"subscriptionUpdates\"",
-        "\"updatedObjectType\"", "\"updatedObjectUuid\""));
+    qb.addAllOrderByClauses(getOrderBy(SortOrder.ASC, "subscriptionUpdates_updatedObjectType",
+        "subscriptionUpdates_updatedObjectUuid"));
   }
 
 }

--- a/src/main/java/mil/dds/anet/search/pg/PostgresqlAuthorizationGroupSearcher.java
+++ b/src/main/java/mil/dds/anet/search/pg/PostgresqlAuthorizationGroupSearcher.java
@@ -24,7 +24,7 @@ public class PostgresqlAuthorizationGroupSearcher extends AbstractAuthorizationG
     if (hasTextQuery(query) && !query.isSortByPresent()) {
       // We're doing a full-text search without an explicit sort order,
       // so sort first on the search pseudo-rank.
-      qb.addAllOrderByClauses(getOrderBy(SortOrder.DESC, null, "search_rank"));
+      qb.addAllOrderByClauses(getOrderBy(SortOrder.DESC, "search_rank"));
     }
     super.addOrderByClauses(qb, query);
   }

--- a/src/main/java/mil/dds/anet/search/pg/PostgresqlLocationSearcher.java
+++ b/src/main/java/mil/dds/anet/search/pg/PostgresqlLocationSearcher.java
@@ -23,7 +23,7 @@ public class PostgresqlLocationSearcher extends AbstractLocationSearcher {
     if (hasTextQuery(query) && !query.isSortByPresent()) {
       // We're doing a full-text search without an explicit sort order,
       // so sort first on the search pseudo-rank.
-      qb.addAllOrderByClauses(getOrderBy(SortOrder.DESC, null, "search_rank"));
+      qb.addAllOrderByClauses(getOrderBy(SortOrder.DESC, "search_rank"));
     }
     super.addOrderByClauses(qb, query);
   }

--- a/src/main/java/mil/dds/anet/search/pg/PostgresqlOrganizationSearcher.java
+++ b/src/main/java/mil/dds/anet/search/pg/PostgresqlOrganizationSearcher.java
@@ -24,7 +24,7 @@ public class PostgresqlOrganizationSearcher extends AbstractOrganizationSearcher
     if (hasTextQuery(query) && !query.isSortByPresent()) {
       // We're doing a full-text search without an explicit sort order,
       // so sort first on the search pseudo-rank.
-      qb.addAllOrderByClauses(getOrderBy(SortOrder.DESC, null, "search_rank"));
+      qb.addAllOrderByClauses(getOrderBy(SortOrder.DESC, "search_rank"));
     }
     super.addOrderByClauses(qb, query);
   }

--- a/src/main/java/mil/dds/anet/search/pg/PostgresqlPersonSearcher.java
+++ b/src/main/java/mil/dds/anet/search/pg/PostgresqlPersonSearcher.java
@@ -22,7 +22,7 @@ public class PostgresqlPersonSearcher extends AbstractPersonSearcher {
     if (hasTextQuery(query) && !query.isSortByPresent()) {
       // We're doing a full-text search without an explicit sort order,
       // so sort first on the search pseudo-rank.
-      qb.addAllOrderByClauses(getOrderBy(SortOrder.DESC, null, "search_rank"));
+      qb.addAllOrderByClauses(getOrderBy(SortOrder.DESC, "search_rank"));
     }
     super.addOrderByClauses(qb, query);
   }

--- a/src/main/java/mil/dds/anet/search/pg/PostgresqlPositionSearcher.java
+++ b/src/main/java/mil/dds/anet/search/pg/PostgresqlPositionSearcher.java
@@ -23,7 +23,7 @@ public class PostgresqlPositionSearcher extends AbstractPositionSearcher {
     if (hasTextQuery(query) && !query.isSortByPresent()) {
       // We're doing a full-text search without an explicit sort order,
       // so sort first on the search pseudo-rank.
-      qb.addAllOrderByClauses(getOrderBy(SortOrder.DESC, null, "search_rank"));
+      qb.addAllOrderByClauses(getOrderBy(SortOrder.DESC, "search_rank"));
     }
     super.addOrderByClauses(qb, query);
   }

--- a/src/main/java/mil/dds/anet/search/pg/PostgresqlReportSearcher.java
+++ b/src/main/java/mil/dds/anet/search/pg/PostgresqlReportSearcher.java
@@ -82,7 +82,7 @@ public class PostgresqlReportSearcher extends AbstractReportSearcher {
     if (hasTextQuery(query) && !query.isSortByPresent()) {
       // We're doing a full-text search without an explicit sort order,
       // so sort first on the search pseudo-rank.
-      qb.addAllOrderByClauses(getOrderBy(SortOrder.DESC, null, "search_rank"));
+      qb.addAllOrderByClauses(getOrderBy(SortOrder.DESC, "search_rank"));
     }
 
     super.addOrderByClauses(qb, query);

--- a/src/main/java/mil/dds/anet/search/pg/PostgresqlTaskSearcher.java
+++ b/src/main/java/mil/dds/anet/search/pg/PostgresqlTaskSearcher.java
@@ -22,7 +22,7 @@ public class PostgresqlTaskSearcher extends AbstractTaskSearcher {
     if (hasTextQuery(query) && !query.isSortByPresent()) {
       // We're doing a full-text search without an explicit sort order,
       // so sort first on the search pseudo-rank.
-      qb.addAllOrderByClauses(getOrderBy(SortOrder.DESC, null, "search_rank"));
+      qb.addAllOrderByClauses(getOrderBy(SortOrder.DESC, "search_rank"));
     }
     super.addOrderByClauses(qb, query);
   }

--- a/src/main/java/mil/dds/anet/utils/AnetDbLogger.java
+++ b/src/main/java/mil/dds/anet/utils/AnetDbLogger.java
@@ -28,11 +28,11 @@ public class AnetDbLogger implements SqlLogger {
     if (logger.isDebugEnabled() && !renderedSql.startsWith("INSERT INTO \"userActivities\"")) {
       final String msg = renderedSql.replace(PersonDao.PERSON_FIELDS, " <PERSON_FIELDS> ")
           .replace(PersonDao.PERSON_FIELDS_NOAS, " <PERSON_FIELDS> ")
-          .replace(PositionDao.POSITIONS_FIELDS, " <POSITION_FIELDS> ")
+          .replace(PositionDao.POSITION_FIELDS, " <POSITION_FIELDS> ")
           .replace(OrganizationDao.ORGANIZATION_FIELDS, " <ORGANIZATION_FIELDS> ")
           .replace(ReportDao.REPORT_FIELDS, " <REPORT_FIELDS> ")
-          .replace(ReportSensitiveInformationDao.REPORTS_SENSITIVE_INFORMATION_FIELDS,
-              " <REPORTS_SENSITIVE_INFORMATION_FIELDS> ")
+          .replace(ReportSensitiveInformationDao.REPORT_SENSITIVE_INFORMATION_FIELDS,
+              " <REPORT_SENSITIVE_INFORMATION_FIELDS> ")
           .replace(CommentDao.COMMENT_FIELDS, " <COMMENT_FIELDS> ")
           .replaceAll("LEFT JOIN (CONTAINS|FREETEXT)TABLE[^=]*= (\\S+)\\.\\[Key\\]", "<$1_$2>")
           .replaceFirst("LEFT JOIN (mv_fts_\\S+) ON \\S+\\s*=\\s*\\S+", "<$1>")


### PR DESCRIPTION
Address slow PostgreSQL search queries by putting the ORDER BY, OFFSET and LIMIT clauses in an outer query.

Closes [AB#254](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/254)

#### User changes
- None

#### Super User changes
- None

#### Admin changes
- None

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
