### PR TITLE
Add written document to linguist assessment

### DIFF
--- a/anet-dictionary.yml
+++ b/anet-dictionary.yml
@@ -855,6 +855,37 @@ fields:
             read: ['c21e7321-7ec5-4837-8805-a302f9575754']
             write: ['39a78d51-c351-452c-9206-4305ec8dd76d']
           questions:
+            preparedDocuments:
+              test: $.subject.position.organization[?(@property === "shortName" && @.match(/^LNG/i))]
+              type: enum
+              helpText: "Did the linguist prepare any written documents used for the engagement meeting?"
+              label: Prepared documents
+              choices:
+                yes:
+                  label: "Yes"
+                no:
+                  label: "No"
+            documentQuality:
+              test: $.relatedObject.attendeesAssessments[?(@property === @root.subject.uuid && @.advisorOnceReportLinguist && @.advisorOnceReportLinguist.preparedDocuments === "yes")]
+              type: enum
+              helpText: "What was the quality of the document the linuist prepared?"
+              label: Document quality
+              choices:
+                "EX":
+                  label: Excellent
+                  color: "#03f8fc"
+                "VG":
+                  label: Very Good
+                  color: "#00fc03"
+                "G":
+                  label: Good
+                  color: "#84fc03"
+                "S":
+                  label: Satisfactory
+                  color: "#e3fc03"
+                "B":
+                  label: Bad
+                  color: "#fc5a03"
             linguistRole:
               test: $.subject.position.organization[?(@property === "shortName" && @.match(/^LNG/i))]
               type: enum
@@ -1134,6 +1165,15 @@ fields:
                   widget: richTextEditor
                   style:
                     height: 100px
+        advisorPeriodic:
+          recurrence: "monthly"
+          questions:
+            question1:
+                type: special_field
+                label: General remarks
+                widget: richTextEditor
+                style:
+                  height: 70px
         advisorOndemand:
           recurrence: ondemand
           questions:

--- a/client/stories/1-user/LinguistAssessments.stories.js
+++ b/client/stories/1-user/LinguistAssessments.stories.js
@@ -46,6 +46,8 @@ const ASSESSMENT_RESULTS = [
           translatorSubjectVocabularyScore: "B",
           translatorSubjectComment:
             "Translator doesn't know the meanings of some <i>mission specific</i> words",
+          preparedDocuments: "yes",
+          documentQuality: "EX",
           translatorOverallScore: "VG"
         }
       }
@@ -61,6 +63,8 @@ const ASSESSMENT_RESULTS = [
           translatorGotAdequateTime: "no",
           translatorMetDeadline: "yes",
           translatorSubjectVocabularyScore: "EX",
+          preparedDocuments: "yes",
+          documentQuality: "B",
           translatorOverallScore: "EX"
         }
       }
@@ -76,6 +80,7 @@ const ASSESSMENT_RESULTS = [
           translatorGotAdequateTime: "yes",
           translatorMetDeadline: "no",
           translatorSubjectVocabularyScore: "S",
+          preparedDocuments: "no",
           translatorOverallScore: "B",
           translatorOverallComment:
             "He <b>couldn't</b> translate most of the sentences"
@@ -97,6 +102,8 @@ const ASSESSMENT_RESULTS = [
           interpreterWorkEthicScore: "EX",
           interpreterPostureScore: "G",
           interpreterRoleScore: "VG",
+          preparedDocuments: "yes",
+          documentQuality: "VG",
           interpreterInterpretationOverallScore: "VG"
         }
       }


### PR DESCRIPTION
Linguist assessments have a new question for written documents.

Closes [AB#503](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/503)

#### User changes
- Users can evaluate linguist's written documents

#### Super User changes
- None

#### Admin changes
- None

#### System admin changes
- [x] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [ ] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
