### PR TITLE
Fix storybook scripts

### DIFF
--- a/client/.storybook/main.js
+++ b/client/.storybook/main.js
@@ -9,15 +9,13 @@ module.exports = {
     "../stories/**/*.stories.mdx",
     "../stories/**/*.stories.@(js|jsx|ts|tsx)"
   ],
-  staticDirs: [
-    "../.."
-  ],
+  staticDirs: ["../stories/dictionaryForStories"],
   addons: [
     "@storybook/addon-essentials",
     "@storybook/addon-links",
     "@storybook/addon-postcss"
   ],
-  webpackFinal: async (config, { configType }) => {
+  webpackFinal: async(config, { configType }) => {
     // `configType` has a value of 'DEVELOPMENT' or 'PRODUCTION'
     // You can change the configuration based on that.
     // 'PRODUCTION' is used when building the static version of storybook.

--- a/client/package.json
+++ b/client/package.json
@@ -210,8 +210,8 @@
     "test-wdio-noCF": "env TEST_WDIO_SUITE=noCustomFields yarn run test-wdio",
     "generate-graphql-schema": "graphql-codegen -p anet",
     "storybook": "export STORYBOOK_ANET_DICTIONARY=/${ANET_DICTIONARY_NAME:-anet-dictionary.yml} ; start-storybook -p 6006",
-    "build-storybook": "export STORYBOOK_ANET_DICTIONARY=/${ANET_DICTIONARY_NAME:-anet-dictionary-storybook.yml} ; build-storybook -s ./stories/dictionaryForStories",
-    "build-storybook-docs": "export STORYBOOK_ANET_DICTIONARY=/${ANET_DICTIONARY_NAME:-anet-dictionary-storybook.yml} ; build-storybook -s ./stories/dictionaryForStories --docs",
+    "build-storybook": "export STORYBOOK_ANET_DICTIONARY=/${ANET_DICTIONARY_NAME:-anet-dictionary-storybook.yml} ; build-storybook",
+    "build-storybook-docs": "export STORYBOOK_ANET_DICTIONARY=/${ANET_DICTIONARY_NAME:-anet-dictionary-storybook.yml} ; build-storybook --docs",
     "chromatic": "chromatic --project-token ${CHROMATIC_PROJECT_TOKEN}",
     "sim": "export ANET_CONFIG=../anet.yml ANET_DICTIONARY=../${ANET_DICTIONARY_NAME:-anet-dictionary.yml} SERVER_URL=${SERVER_URL:-'http://localhost:8080'} ; NODE_ENV=development webpack --config config/webpack.sim.dev.js && node build/anet.sim.dev.js"
   },


### PR DESCRIPTION
Storybook scripts are fixed

Closes [AB#561](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/561)

#### User changes
- None

#### Super User changes
- None

#### Admin changes
- None

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [ ] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
