### PR TITLE
Fix text field bug

### DIFF
--- a/client/src/components/RichTextEditor.js
+++ b/client/src/components/RichTextEditor.js
@@ -169,7 +169,7 @@ const deserialize = element => {
       return jsx("element", { type: "heading-three" }, children)
     case "P":
       return element.parentNode.nodeName === "LI"
-        ? jsx("text", {}, children)
+        ? jsx("fragment", {}, children)
         : jsx("element", { type: "paragraph" }, children)
     case "OL":
       return jsx("element", { type: "numbered-list" }, children)

--- a/insertBaseData-psql.sql
+++ b/insertBaseData-psql.sql
@@ -848,7 +848,7 @@ INSERT INTO "reportTasks" ("taskUuid", "reportUuid")
 SELECT ('''' || uuid_generate_v4() || '''') AS reportuuid \gset
 INSERT INTO reports (uuid, "createdAt", "updatedAt", "locationUuid", intent, text, "nextSteps", state, "engagementDate", atmosphere, "advisorOrganizationUuid", "principalOrganizationUuid")
 	VALUES (:reportuuid, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, (SELECT uuid from locations where name='General Hospital'), 'Test report with rich text',
-	'<h1>Heading 1</h1><h2>Heading 2</h2><h3>Heading 3</h3>Handle text without tags. <p>Handle the white space below</p> <p>'||chr(10)||'</p> <blockquote>Blockquote</blockquote><b>Bold</b> <i>Italic</i> <u>Underline</u> <strike>Strike</strike> <strike><b>BoldStrike</b></strike> <i><b>BoldItalic</b></i><ol><li>numbered list 1</li><li>numbered list 2</li></ol><ul><li>bulleted list 1</li><li>bulleted list 2</li></ul>',
+	'<h1>Heading 1</h1><h2>Heading 2</h2><h3>Heading 3</h3>Handle text without tags. <p>Handle the white space below</p> <p>'||chr(10)||'</p> <blockquote>Blockquote</blockquote><b>Bold</b> <i>Italic</i> <u>Underline</u> <strike>Strike</strike> <strike><b>BoldStrike</b></strike> <i><b>BoldItalic</b></i><ol><li>numbered list 1</li><li><p><b>numbered</b> list 2<p></li></ol><ul><li>bulleted list 1</li><li>bulleted list 2</li></ul>',
 	'Keep testing', 0, '2022-08-25', 0,
 	(SELECT uuid FROM organizations where "shortName" = 'EF 2.1'), (SELECT uuid FROM organizations WHERE "longName" LIKE 'Ministry of Defense'));
 INSERT INTO "reportPeople" ("personUuid", "reportUuid", "isPrimary", "isAuthor")


### PR DESCRIPTION
Error causing the edit report page to crash when the rich text contains styled (bold, italic etc.) list items is fixed.

Closes [AB#583](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/583)

#### User changes
- Rich text field bug is fixed

#### Super User changes
- None

#### Admin changes
- None

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [x] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
