### PR TITLE
Fix related object notes bug

### DIFF
--- a/client/src/components/RelatedObjectNotes.js
+++ b/client/src/components/RelatedObjectNotes.js
@@ -15,11 +15,10 @@ import Model, {
 import RelatedObjectNoteModal from "components/RelatedObjectNoteModal"
 import ResponsiveLayoutContext from "components/ResponsiveLayoutContext"
 import _isEmpty from "lodash/isEmpty"
-import _isEqualWith from "lodash/isEqualWith"
 import { Person } from "models"
 import moment from "moment"
 import PropTypes from "prop-types"
-import React, { useContext, useEffect, useRef, useState } from "react"
+import React, { useContext, useState } from "react"
 import { Button, Card, Col, Offcanvas, Row } from "react-bootstrap"
 import NotificationBadge from "react-notification-badge"
 import Settings from "settings"
@@ -50,33 +49,20 @@ const RelatedObjectNotes = ({
 }) => {
   const { currentUser } = useContext(AppContext)
   const { topbarOffset } = useContext(ResponsiveLayoutContext)
-  const notesFiltered = notesProp.filter(
-    note => !EXCLUDED_NOTE_TYPES.includes(note.type)
-  )
-  const latestNotesProp = useRef(notesFiltered)
-  const notesPropUnchanged = _isEqualWith(
-    latestNotesProp.current,
-    notesFiltered,
-    utils.treatFunctionsAsEqual
-  )
 
   const [error, setError] = useState(null)
   const [showRelatedObjectNoteModalKey, setShowRelatedObjectNoteModalKey] =
     useState(null)
   const [noteType, setNoteType] = useState(null)
-  const [notes, setNotes] = useState(notesFiltered)
+  const [notes, setNotes] = useState(notesProp)
   const [show, setShow] = useState(false)
 
-  useEffect(() => {
-    if (!notesPropUnchanged) {
-      latestNotesProp.current = notesFiltered
-      setError(null)
-      setNotes(notesFiltered)
-    }
-  }, [notesPropUnchanged, notesFiltered])
+  const notesFiltered = notes.filter(
+    note => !EXCLUDED_NOTE_TYPES.includes(note.type)
+  )
 
-  const noNotes = _isEmpty(notes)
-  const nrNotes = noNotes ? 0 : notes.length
+  const noNotes = _isEmpty(notesFiltered)
+  const nrNotes = noNotes ? 0 : notesFiltered.length
   const badgeLabel = nrNotes > 10 ? "10+" : null
 
   const handleClose = () => setShow(false)
@@ -149,7 +135,7 @@ const RelatedObjectNotes = ({
               flexDirection: "column"
             }}
           >
-            {notes.map(note => {
+            {notesFiltered.map(note => {
               const updatedAt = moment(note.updatedAt).format(
                 Settings.dateFormats.forms.displayShort.withTime
               )


### PR DESCRIPTION
Filtered notes are created from the state variable. Unnecessary update logic is removed as filtered notes can only be changed using the note modal.

Closes  [AB#602](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/602)

#### User changes
- Users can see the newly created object related notes without refreshing the page.

#### Super User changes
- None

#### Admin changes
- None

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [ ] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
