### PR TITLE
Utilize the HTML page title

### DIFF
--- a/client/src/components/AdvisorReports/FilterableAdvisorReportsTable.js
+++ b/client/src/components/AdvisorReports/FilterableAdvisorReportsTable.js
@@ -2,10 +2,15 @@ import { gql } from "@apollo/client"
 import API from "api"
 import OrganizationAdvisorsTable from "components/AdvisorReports/OrganizationAdvisorsTable"
 import Toolbar from "components/AdvisorReports/Toolbar"
-import { PageDispatchersPropType, useBoilerplate } from "components/Page"
+import {
+  PageDispatchersPropType,
+  useBoilerplate,
+  usePageTitle
+} from "components/Page"
 import _debounce from "lodash/debounce"
 import moment from "moment"
 import React, { useState } from "react"
+import Settings from "settings"
 
 const GQL_GET_ADVISOR_REPORTS_INSIGHT = gql`
   query ($weeksAgo: Int) {
@@ -33,6 +38,7 @@ const FilterableAdvisorReportsTable = ({ pageDispatchers }) => {
       weeksAgo
     }
   )
+  usePageTitle(`${Settings.fields.advisor.person.name} Reports`)
   const { done, result } = useBoilerplate({
     loading,
     error,

--- a/client/src/components/CancelledEngagementReports.js
+++ b/client/src/components/CancelledEngagementReports.js
@@ -3,7 +3,11 @@ import { IconNames } from "@blueprintjs/icons"
 import API from "api"
 import BarChart from "components/BarChart"
 import MosaicLayout from "components/MosaicLayout"
-import { PageDispatchersPropType, useBoilerplate } from "components/Page"
+import {
+  PageDispatchersPropType,
+  useBoilerplate,
+  usePageTitle
+} from "components/Page"
 import ReportCollection, {
   FORMAT_CALENDAR,
   FORMAT_MAP,
@@ -309,6 +313,7 @@ const CancelledEngagementReports = ({
   style
 }) => {
   const [focusedSelection, setFocusedSelection] = useState(null)
+  usePageTitle("Cancelled Engagement Reports")
 
   const advisorOrgLabel = Settings.fields.advisor.org.name
   const chartIdByOrg = "cancelled_reports_by_org"

--- a/client/src/components/FutureEngagementsByLocation.js
+++ b/client/src/components/FutureEngagementsByLocation.js
@@ -3,7 +3,11 @@ import { IconNames } from "@blueprintjs/icons"
 import API from "api"
 import HorizontalBarChart from "components/HorizontalBarChart"
 import MosaicLayout from "components/MosaicLayout"
-import { PageDispatchersPropType, useBoilerplate } from "components/Page"
+import {
+  PageDispatchersPropType,
+  useBoilerplate,
+  usePageTitle
+} from "components/Page"
 import ReportCollection, {
   FORMAT_CALENDAR,
   FORMAT_MAP,
@@ -222,6 +226,7 @@ const FutureEngagementsByLocation = ({
   style
 }) => {
   const [focusedSelection, setFocusedSelection] = useState(null)
+  usePageTitle("Future Engagements by Location")
 
   const chartId = "future_engagements_by_location"
   const selectedBarClass = "selected-bar"

--- a/client/src/components/MySubscriptions.js
+++ b/client/src/components/MySubscriptions.js
@@ -7,7 +7,8 @@ import {
   mapPageDispatchersToProps,
   PageDispatchersPropType,
   SubscriptionIcon,
-  useBoilerplate
+  useBoilerplate,
+  usePageTitle
 } from "components/Page"
 import UltimatePagination from "components/UltimatePagination"
 import _get from "lodash/get"
@@ -89,6 +90,7 @@ const MySubscriptions = ({
     error,
     pageDispatchers
   })
+  usePageTitle("My Subscriptions")
   if (done) {
     return result
   }

--- a/client/src/components/Page.js
+++ b/client/src/components/Page.js
@@ -211,7 +211,7 @@ const toggleSubscription = (
 
 export const usePageTitle = title => {
   useEffect(() => {
-    document.title = title || "ANET"
+    document.title = title ? `${title} - ANET` : "ANET"
     return () => {
       document.title = "ANET"
     }

--- a/client/src/components/Page.js
+++ b/client/src/components/Page.js
@@ -208,3 +208,12 @@ const toggleSubscription = (
     .then(data => refetch())
     .catch(setError)
 }
+
+export const usePageTitle = title => {
+  useEffect(() => {
+    document.title = title || "ANET"
+    return () => {
+      document.title = "ANET"
+    }
+  }, [title])
+}

--- a/client/src/components/PendingApprovalReports.js
+++ b/client/src/components/PendingApprovalReports.js
@@ -3,7 +3,11 @@ import { IconNames } from "@blueprintjs/icons"
 import API from "api"
 import BarChart from "components/BarChart"
 import MosaicLayout from "components/MosaicLayout"
-import { PageDispatchersPropType, useBoilerplate } from "components/Page"
+import {
+  PageDispatchersPropType,
+  useBoilerplate,
+  usePageTitle
+} from "components/Page"
 import ReportCollection, {
   FORMAT_CALENDAR,
   FORMAT_MAP,
@@ -183,6 +187,7 @@ Map.propTypes = {
  */
 const PendingApprovalReports = ({ pageDispatchers, queryParams, style }) => {
   const [focusedSelection, setFocusedSelection] = useState(null)
+  usePageTitle("Pendig Approval Reports")
 
   const advisorOrgLabel = Settings.fields.advisor.org.name
   const chartId = "not_approved_reports_chart"

--- a/client/src/components/PendingAssessmentsByPosition.js
+++ b/client/src/components/PendingAssessmentsByPosition.js
@@ -2,7 +2,11 @@ import { gql } from "@apollo/client"
 import API from "api"
 import Fieldset from "components/Fieldset"
 import LinkTo from "components/LinkTo"
-import { PageDispatchersPropType, useBoilerplate } from "components/Page"
+import {
+  PageDispatchersPropType,
+  useBoilerplate,
+  usePageTitle
+} from "components/Page"
 import UltimatePaginationTopDown from "components/UltimatePaginationTopDown"
 import _isEmpty from "lodash/isEmpty"
 import { Position, Task } from "models"
@@ -95,6 +99,7 @@ const PendingAssessmentsByPosition = ({
   const { loading, error, data } = API.useApiQuery(GQL_GET_POSITION_LIST, {
     positionQuery
   })
+  usePageTitle("Pending Assessments by Position")
   const { done, result } = useBoilerplate({
     loading,
     error,

--- a/client/src/components/ReportsByDayOfWeek.js
+++ b/client/src/components/ReportsByDayOfWeek.js
@@ -3,7 +3,11 @@ import { IconNames } from "@blueprintjs/icons"
 import API from "api"
 import BarChart from "components/BarChart"
 import MosaicLayout from "components/MosaicLayout"
-import { PageDispatchersPropType, useBoilerplate } from "components/Page"
+import {
+  PageDispatchersPropType,
+  useBoilerplate,
+  usePageTitle
+} from "components/Page"
 import ReportCollection, {
   FORMAT_CALENDAR,
   FORMAT_MAP,
@@ -177,6 +181,7 @@ Map.propTypes = {
  */
 const ReportsByDayOfWeek = ({ pageDispatchers, queryParams, style }) => {
   const [focusedSelection, setFocusedSelection] = useState(null)
+  usePageTitle("Reports by Day of the Week")
 
   const chartId = "reports_by_day_of_week"
   const selectedBarClass = "selected-bar"

--- a/client/src/components/ReportsByTask.js
+++ b/client/src/components/ReportsByTask.js
@@ -4,7 +4,11 @@ import API from "api"
 import { getReportsByTasks } from "components/aggregations/utils"
 import BarChart from "components/BarChart"
 import MosaicLayout from "components/MosaicLayout"
-import { PageDispatchersPropType, useBoilerplate } from "components/Page"
+import {
+  PageDispatchersPropType,
+  useBoilerplate,
+  usePageTitle
+} from "components/Page"
 import ReportCollection, {
   FORMAT_CALENDAR,
   FORMAT_MAP,
@@ -143,6 +147,7 @@ Map.propTypes = {
  */
 const ReportsByTask = ({ pageDispatchers, queryParams, style }) => {
   const [focusedSelection, setFocusedSelection] = useState(null)
+  usePageTitle(`Reports by ${Settings.fields.task.subLevel.shortLabel}`)
 
   const taskShortLabel = Settings.fields.task.subLevel.shortLabel
   const chartId = "reports_by_task"

--- a/client/src/pages/GraphiQL.js
+++ b/client/src/pages/GraphiQL.js
@@ -4,7 +4,8 @@ import API from "api"
 import {
   mapPageDispatchersToProps,
   PageDispatchersPropType,
-  useBoilerplate
+  useBoilerplate,
+  usePageTitle
 } from "components/Page"
 import GraphiQL from "graphiql"
 import "graphiql/graphiql.css"
@@ -17,7 +18,7 @@ const GraphiQLContainer = ({ pageDispatchers }) => {
     searchProps: DEFAULT_SEARCH_PROPS,
     pageDispatchers
   })
-
+  usePageTitle("GraphQL")
   // TODO: fix the below hack with inlined height after layout refactoring in NCI-Agency/anet#551
   return (
     <div style={{ height: "600px" }}>

--- a/client/src/pages/Help.js
+++ b/client/src/pages/Help.js
@@ -7,7 +7,8 @@ import Model from "components/Model"
 import {
   mapPageDispatchersToProps,
   PageDispatchersPropType,
-  useBoilerplate
+  useBoilerplate,
+  usePageTitle
 } from "components/Page"
 import { Person, Position } from "models"
 import PropTypes from "prop-types"
@@ -40,6 +41,7 @@ const screenshotCss = {
 
 const Help = ({ pageDispatchers }) => {
   const { appSettings, currentUser } = useContext(AppContext)
+  usePageTitle("Help")
   if (
     currentUser.uuid &&
     currentUser.position &&

--- a/client/src/pages/Home.js
+++ b/client/src/pages/Home.js
@@ -285,7 +285,7 @@ const Home = ({ setSearchQuery, pageDispatchers }) => {
     searchProps: DEFAULT_SEARCH_PROPS,
     pageDispatchers
   })
-  usePageTitle("ANET")
+  usePageTitle("Home")
   return (
     <div>
       <div style={{ width: "inherit" }} className="float-end">

--- a/client/src/pages/Home.js
+++ b/client/src/pages/Home.js
@@ -27,6 +27,7 @@ import { connect } from "react-redux"
 import { useLocation, useNavigate } from "react-router-dom"
 import { RECURSE_STRATEGY } from "searchUtils"
 import Settings from "settings"
+import { usePageTitle } from "../components/Page"
 
 const GQL_GET_REPORT_COUNT = gql`
   query ($reportQuery: ReportSearchQueryInput) {
@@ -284,7 +285,7 @@ const Home = ({ setSearchQuery, pageDispatchers }) => {
     searchProps: DEFAULT_SEARCH_PROPS,
     pageDispatchers
   })
-
+  usePageTitle("ANET")
   return (
     <div>
       <div style={{ width: "inherit" }} className="float-end">

--- a/client/src/pages/PageMissing.js
+++ b/client/src/pages/PageMissing.js
@@ -3,7 +3,8 @@ import NotFound from "components/NotFound"
 import {
   mapPageDispatchersToProps,
   PageDispatchersPropType,
-  useBoilerplate
+  useBoilerplate,
+  usePageTitle
 } from "components/Page"
 import React from "react"
 import { connect } from "react-redux"
@@ -16,6 +17,7 @@ const PageMissing = ({ pageDispatchers }) => {
     searchProps: DEFAULT_SEARCH_PROPS,
     pageDispatchers
   })
+  usePageTitle("Page not found")
 
   return <NotFound text={`Page ${params[0]} not found.`} />
 }

--- a/client/src/pages/admin/AuthorizationGroups.js
+++ b/client/src/pages/admin/AuthorizationGroups.js
@@ -5,7 +5,8 @@ import Fieldset from "components/Fieldset"
 import {
   mapPageDispatchersToProps,
   PageDispatchersPropType,
-  useBoilerplate
+  useBoilerplate,
+  usePageTitle
 } from "components/Page"
 import React from "react"
 import { connect } from "react-redux"
@@ -46,6 +47,7 @@ const AuthorizationGroups = ({ pageDispatchers }) => {
     searchProps: DEFAULT_SEARCH_PROPS,
     pageDispatchers
   })
+  usePageTitle("Authorization Groups")
   if (done) {
     return result
   }

--- a/client/src/pages/admin/Index.js
+++ b/client/src/pages/admin/Index.js
@@ -15,7 +15,8 @@ import {
   jumpToTop,
   mapPageDispatchersToProps,
   PageDispatchersPropType,
-  useBoilerplate
+  useBoilerplate,
+  usePageTitle
 } from "components/Page"
 import { Field, Form, Formik } from "formik"
 import moment from "moment"
@@ -105,6 +106,7 @@ const AdminIndex = ({ pageDispatchers }) => {
     searchProps: DEFAULT_SEARCH_PROPS,
     pageDispatchers
   })
+  usePageTitle("Admin")
   if (done) {
     return result
   }

--- a/client/src/pages/admin/authorizationgroup/Edit.js
+++ b/client/src/pages/admin/authorizationgroup/Edit.js
@@ -4,7 +4,8 @@ import API from "api"
 import {
   mapPageDispatchersToProps,
   PageDispatchersPropType,
-  useBoilerplate
+  useBoilerplate,
+  usePageTitle
 } from "components/Page"
 import { AuthorizationGroup } from "models"
 import React from "react"
@@ -56,6 +57,9 @@ const AuthorizationGroupEdit = ({ pageDispatchers }) => {
     searchProps: DEFAULT_SEARCH_PROPS,
     pageDispatchers
   })
+  usePageTitle(
+    data?.authorizationGroup?.name && `Edit | ${data.authorizationGroup.name}`
+  )
   if (done) {
     return result
   }

--- a/client/src/pages/admin/authorizationgroup/New.js
+++ b/client/src/pages/admin/authorizationgroup/New.js
@@ -2,7 +2,8 @@ import { DEFAULT_SEARCH_PROPS, PAGE_PROPS_NO_NAV } from "actions"
 import {
   mapPageDispatchersToProps,
   PageDispatchersPropType,
-  useBoilerplate
+  useBoilerplate,
+  usePageTitle
 } from "components/Page"
 import { AuthorizationGroup } from "models"
 import React from "react"
@@ -15,6 +16,7 @@ const AuthorizationGroupNew = ({ pageDispatchers }) => {
     searchProps: DEFAULT_SEARCH_PROPS,
     pageDispatchers
   })
+  usePageTitle("New Authorization Group")
 
   const authorizationGroup = new AuthorizationGroup()
 

--- a/client/src/pages/admin/authorizationgroup/Show.js
+++ b/client/src/pages/admin/authorizationgroup/Show.js
@@ -9,7 +9,8 @@ import Messages from "components/Messages"
 import {
   mapPageDispatchersToProps,
   PageDispatchersPropType,
-  useBoilerplate
+  useBoilerplate,
+  usePageTitle
 } from "components/Page"
 import PositionTable from "components/PositionTable"
 import ReportCollection, {
@@ -71,6 +72,7 @@ const AuthorizationGroupShow = ({ pageDispatchers }) => {
     searchProps: DEFAULT_SEARCH_PROPS,
     pageDispatchers
   })
+  usePageTitle(data?.authorizationGroup?.name)
   if (done) {
     return result
   }

--- a/client/src/pages/admin/merge/MergeLocations.js
+++ b/client/src/pages/admin/merge/MergeLocations.js
@@ -19,7 +19,8 @@ import {
   jumpToTop,
   mapPageDispatchersToProps,
   PageDispatchersPropType,
-  useBoilerplate
+  useBoilerplate,
+  usePageTitle
 } from "components/Page"
 import { convertLatLngToMGRS } from "geoUtils"
 import useMergeObjects, {
@@ -68,6 +69,7 @@ const MergeLocations = ({ pageDispatchers }) => {
     searchProps: DEFAULT_SEARCH_PROPS,
     pageDispatchers
   })
+  usePageTitle("Merge Locations")
 
   const location1 = mergeState[MERGE_SIDES.LEFT]
   const location2 = mergeState[MERGE_SIDES.RIGHT]

--- a/client/src/pages/admin/merge/MergePeople.js
+++ b/client/src/pages/admin/merge/MergePeople.js
@@ -21,7 +21,8 @@ import {
   jumpToTop,
   mapPageDispatchersToProps,
   PageDispatchersPropType,
-  useBoilerplate
+  useBoilerplate,
+  usePageTitle
 } from "components/Page"
 import PreviousPositions from "components/PreviousPositions"
 import useMergeObjects, {
@@ -68,6 +69,7 @@ const MergePeople = ({ pageDispatchers }) => {
     searchProps: DEFAULT_SEARCH_PROPS,
     pageDispatchers
   })
+  usePageTitle("Merge People")
 
   const person1 = mergeState[MERGE_SIDES.LEFT]
   const person2 = mergeState[MERGE_SIDES.RIGHT]

--- a/client/src/pages/admin/merge/MergePositions.js
+++ b/client/src/pages/admin/merge/MergePositions.js
@@ -21,7 +21,8 @@ import {
   jumpToTop,
   mapPageDispatchersToProps,
   PageDispatchersPropType,
-  useBoilerplate
+  useBoilerplate,
+  usePageTitle
 } from "components/Page"
 import useMergeObjects, {
   ALIGN_OPTIONS,
@@ -70,6 +71,7 @@ const MergePositions = ({ pageDispatchers }) => {
     searchProps: DEFAULT_SEARCH_PROPS,
     pageDispatchers
   })
+  usePageTitle("Merge Positions")
 
   const position1 = mergeState[MERGE_SIDES.LEFT]
   const position2 = mergeState[MERGE_SIDES.RIGHT]

--- a/client/src/pages/admin/useractivities/UserActivitiesOverTime.js
+++ b/client/src/pages/admin/useractivities/UserActivitiesOverTime.js
@@ -16,7 +16,8 @@ import MosaicLayout from "components/MosaicLayout"
 import {
   mapPageDispatchersToProps,
   PageDispatchersPropType,
-  useBoilerplate
+  useBoilerplate,
+  usePageTitle
 } from "components/Page"
 import _escape from "lodash/escape"
 import moment from "moment"
@@ -100,6 +101,7 @@ const UserActivitiesOverTime = ({
     searchProps: DEFAULT_SEARCH_PROPS,
     pageDispatchers
   })
+  usePageTitle("User activities over time")
   const { loading, error, data } = API.useApiQuery(
     GQL_GET_USER_ACTIVITY_COUNT,
     {

--- a/client/src/pages/admin/useractivities/UserActivitiesPerPeriod.js
+++ b/client/src/pages/admin/useractivities/UserActivitiesPerPeriod.js
@@ -17,7 +17,8 @@ import MosaicLayout from "components/MosaicLayout"
 import {
   mapPageDispatchersToProps,
   PageDispatchersPropType,
-  useBoilerplate
+  useBoilerplate,
+  usePageTitle
 } from "components/Page"
 import UltimatePagination from "components/UltimatePagination"
 import _escape from "lodash/escape"
@@ -137,6 +138,7 @@ const UserActivitiesPerPeriod = ({
     searchProps: DEFAULT_SEARCH_PROPS,
     pageDispatchers
   })
+  usePageTitle("User activities per period")
   const { loading, error, data } = API.useApiQuery(GQL_QUERIES[searchType], {
     userActivityQuery
   })

--- a/client/src/pages/dashboards/BoardDashboard.js
+++ b/client/src/pages/dashboards/BoardDashboard.js
@@ -23,7 +23,8 @@ import LinkTo from "components/LinkTo"
 import {
   mapPageDispatchersToProps,
   PageDispatchersPropType,
-  useBoilerplate
+  useBoilerplate,
+  usePageTitle
 } from "components/Page"
 import FileSaver from "file-saver"
 import * as Models from "models"
@@ -107,6 +108,7 @@ const BoardDashboard = ({ pageDispatchers }) => {
     pageProps: DEFAULT_PAGE_PROPS,
     pageDispatchers
   })
+  usePageTitle("Process Board")
   const { dashboard } = useParams()
   const dashboardSettings = Settings.dashboards.find(o => o.label === dashboard)
   const [dropEvent, setDropEvent] = useState(null)

--- a/client/src/pages/dashboards/DecisivesDashboard.js
+++ b/client/src/pages/dashboards/DecisivesDashboard.js
@@ -12,7 +12,8 @@ import Model from "components/Model"
 import {
   mapPageDispatchersToProps,
   PageDispatchersPropType,
-  useBoilerplate
+  useBoilerplate,
+  usePageTitle
 } from "components/Page"
 import {
   deserializeQueryParams,
@@ -99,6 +100,7 @@ const DecisivesDashboard = ({ pageDispatchers }) => {
   const { dashboard } = useParams()
   const dashboardSettings = Settings.dashboards.find(o => o.label === dashboard)
   const [dashboardData, setDashboardData] = useState([])
+  usePageTitle("Decisives")
   useEffect(() => {
     async function fetchData() {
       await fetch(dashboardSettings.data)

--- a/client/src/pages/dashboards/KanbanDashboard.js
+++ b/client/src/pages/dashboards/KanbanDashboard.js
@@ -6,7 +6,8 @@ import Model from "components/Model"
 import {
   mapPageDispatchersToProps,
   PageDispatchersPropType,
-  useBoilerplate
+  useBoilerplate,
+  usePageTitle
 } from "components/Page"
 import { LAST_MONTH } from "dateUtils"
 import PropTypes from "prop-types"
@@ -59,6 +60,7 @@ const KanbanDashboard = ({ pageDispatchers }) => {
   const { dashboard } = useParams()
   const dashboardSettings = Settings.dashboards.find(o => o.label === dashboard)
   const [dashboardData, setDashboardData] = useState({})
+  usePageTitle("Dashboard")
   useEffect(() => {
     async function fetchData() {
       await fetch(dashboardSettings.data)

--- a/client/src/pages/locations/Edit.js
+++ b/client/src/pages/locations/Edit.js
@@ -6,7 +6,8 @@ import { DEFAULT_CUSTOM_FIELDS_PARENT } from "components/Model"
 import {
   mapPageDispatchersToProps,
   PageDispatchersPropType,
-  useBoilerplate
+  useBoilerplate,
+  usePageTitle
 } from "components/Page"
 import RelatedObjectNotes, {
   GRAPHQL_NOTES_FIELDS
@@ -78,6 +79,7 @@ const LocationEdit = ({ pageDispatchers }) => {
     searchProps: DEFAULT_SEARCH_PROPS,
     pageDispatchers
   })
+  usePageTitle(data?.location?.name && `Edit | ${data.location.name}`)
   if (done) {
     return result
   }

--- a/client/src/pages/locations/New.js
+++ b/client/src/pages/locations/New.js
@@ -3,7 +3,8 @@ import { initInvisibleFields } from "components/CustomFields"
 import {
   mapPageDispatchersToProps,
   PageDispatchersPropType,
-  useBoilerplate
+  useBoilerplate,
+  usePageTitle
 } from "components/Page"
 import { Location } from "models"
 import React from "react"
@@ -17,6 +18,7 @@ const LocationNew = ({ pageDispatchers }) => {
     searchProps: DEFAULT_SEARCH_PROPS,
     pageDispatchers
   })
+  usePageTitle("New Location")
 
   const location = new Location()
   // mutates the object

--- a/client/src/pages/locations/Show.js
+++ b/client/src/pages/locations/Show.js
@@ -16,7 +16,8 @@ import {
   mapPageDispatchersToProps,
   PageDispatchersPropType,
   SubscriptionIcon,
-  useBoilerplate
+  useBoilerplate,
+  usePageTitle
 } from "components/Page"
 import RelatedObjectNotes from "components/RelatedObjectNotes"
 import ReportCollection from "components/ReportCollection"
@@ -58,6 +59,7 @@ const LocationShow = ({ pageDispatchers }) => {
     searchProps: DEFAULT_SEARCH_PROPS,
     pageDispatchers
   })
+  usePageTitle(data?.location?.name)
   if (done) {
     return result
   }

--- a/client/src/pages/onboarding/Edit.js
+++ b/client/src/pages/onboarding/Edit.js
@@ -5,7 +5,8 @@ import AppContext from "components/AppContext"
 import {
   mapPageDispatchersToProps,
   PageDispatchersPropType,
-  useBoilerplate
+  useBoilerplate,
+  usePageTitle
 } from "components/Page"
 import { Person } from "models"
 import moment from "moment"
@@ -57,6 +58,7 @@ const OnboardingEdit = ({ pageDispatchers }) => {
     searchProps: DEFAULT_SEARCH_PROPS,
     pageDispatchers
   })
+  usePageTitle("Create your account")
   if (done) {
     return result
   }

--- a/client/src/pages/onboarding/Show.js
+++ b/client/src/pages/onboarding/Show.js
@@ -2,7 +2,8 @@ import { DEFAULT_SEARCH_PROPS, PAGE_PROPS_MIN_HEAD } from "actions"
 import {
   mapPageDispatchersToProps,
   PageDispatchersPropType,
-  useBoilerplate
+  useBoilerplate,
+  usePageTitle
 } from "components/Page"
 import React from "react"
 import { Button } from "react-bootstrap"
@@ -15,6 +16,7 @@ const OnboardingShow = ({ pageDispatchers }) => {
     searchProps: DEFAULT_SEARCH_PROPS,
     pageDispatchers
   })
+  usePageTitle("Welcome to ANET")
   const navigate = useNavigate()
 
   return (

--- a/client/src/pages/organizations/Edit.js
+++ b/client/src/pages/organizations/Edit.js
@@ -6,7 +6,8 @@ import { DEFAULT_CUSTOM_FIELDS_PARENT } from "components/Model"
 import {
   mapPageDispatchersToProps,
   PageDispatchersPropType,
-  useBoilerplate
+  useBoilerplate,
+  usePageTitle
 } from "components/Page"
 import RelatedObjectNotes, {
   GRAPHQL_NOTES_FIELDS
@@ -89,6 +90,9 @@ const OrganizationEdit = ({ pageDispatchers }) => {
     searchProps: DEFAULT_SEARCH_PROPS,
     pageDispatchers
   })
+  usePageTitle(
+    data?.organization?.shortName && `Edit | ${data.organization.shortName}`
+  )
   if (done) {
     return result
   }

--- a/client/src/pages/organizations/New.js
+++ b/client/src/pages/organizations/New.js
@@ -5,7 +5,8 @@ import { initInvisibleFields } from "components/CustomFields"
 import {
   mapPageDispatchersToProps,
   PageDispatchersPropType,
-  useBoilerplate
+  useBoilerplate,
+  usePageTitle
 } from "components/Page"
 import { Organization } from "models"
 import PropTypes from "prop-types"
@@ -30,6 +31,7 @@ const GQL_GET_ORGANIZATION = gql`
 
 const OrganizationNew = ({ pageDispatchers }) => {
   const routerLocation = useLocation()
+  usePageTitle("New Organization")
   const qs = utils.parseQueryString(routerLocation.search)
   if (qs.parentOrgUuid) {
     return (

--- a/client/src/pages/organizations/Show.js
+++ b/client/src/pages/organizations/Show.js
@@ -16,7 +16,8 @@ import {
   mapPageDispatchersToProps,
   PageDispatchersPropType,
   SubscriptionIcon,
-  useBoilerplate
+  useBoilerplate,
+  usePageTitle
 } from "components/Page"
 import RelatedObjectNotes, {
   GRAPHQL_NOTES_FIELDS
@@ -160,6 +161,7 @@ const OrganizationShow = ({ pageDispatchers }) => {
     searchProps: DEFAULT_SEARCH_PROPS,
     pageDispatchers
   })
+  usePageTitle(data?.organization?.shortName)
   if (done) {
     return result
   }

--- a/client/src/pages/people/Compact.js
+++ b/client/src/pages/people/Compact.js
@@ -25,7 +25,8 @@ import {
 import {
   mapPageDispatchersToProps,
   PageDispatchersPropType,
-  useBoilerplate
+  useBoilerplate,
+  usePageTitle
 } from "components/Page"
 import { GRAPHQL_NOTES_FIELDS } from "components/RelatedObjectNotes"
 import SimpleMultiCheckboxDropdown from "components/SimpleMultiCheckboxDropdown"
@@ -198,6 +199,9 @@ const CompactPersonView = ({ pageDispatchers }) => {
     searchProps: DEFAULT_SEARCH_PROPS,
     pageDispatchers
   })
+  usePageTitle(
+    data?.person && `Print | ${data.person.rank} ${data.person.name}`
+  )
   if (done) {
     return result
   }

--- a/client/src/pages/people/Edit.js
+++ b/client/src/pages/people/Edit.js
@@ -10,7 +10,8 @@ import {
 import {
   mapPageDispatchersToProps,
   PageDispatchersPropType,
-  useBoilerplate
+  useBoilerplate,
+  usePageTitle
 } from "components/Page"
 import RelatedObjectNotes, {
   GRAPHQL_NOTES_FIELDS
@@ -74,6 +75,7 @@ const PersonEdit = ({ pageDispatchers }) => {
     searchProps: DEFAULT_SEARCH_PROPS,
     pageDispatchers
   })
+  usePageTitle(data?.person && `Edit | ${data.person.rank} ${data.person.name}`)
   if (done) {
     return result
   }

--- a/client/src/pages/people/New.js
+++ b/client/src/pages/people/New.js
@@ -3,7 +3,8 @@ import { initInvisibleFields } from "components/CustomFields"
 import {
   mapPageDispatchersToProps,
   PageDispatchersPropType,
-  useBoilerplate
+  useBoilerplate,
+  usePageTitle
 } from "components/Page"
 import { Person } from "models"
 import React from "react"
@@ -17,6 +18,7 @@ const PersonNew = ({ pageDispatchers }) => {
     searchProps: DEFAULT_SEARCH_PROPS,
     pageDispatchers
   })
+  usePageTitle("New Person")
 
   const person = new Person()
 

--- a/client/src/pages/people/Show.js
+++ b/client/src/pages/people/Show.js
@@ -26,7 +26,8 @@ import {
   mapPageDispatchersToProps,
   PageDispatchersPropType,
   SubscriptionIcon,
-  useBoilerplate
+  useBoilerplate,
+  usePageTitle
 } from "components/Page"
 import PreviousPositions from "components/PreviousPositions"
 import RelatedObjectNotes, {
@@ -148,6 +149,7 @@ const PersonShow = ({ pageDispatchers }) => {
     searchProps: DEFAULT_SEARCH_PROPS,
     pageDispatchers
   })
+  usePageTitle(data?.person && `${data.person.rank} ${data?.person.name}`)
   if (done) {
     return result
   }

--- a/client/src/pages/positions/Edit.js
+++ b/client/src/pages/positions/Edit.js
@@ -6,7 +6,8 @@ import { DEFAULT_CUSTOM_FIELDS_PARENT } from "components/Model"
 import {
   mapPageDispatchersToProps,
   PageDispatchersPropType,
-  useBoilerplate
+  useBoilerplate,
+  usePageTitle
 } from "components/Page"
 import RelatedObjectNotes, {
   GRAPHQL_NOTES_FIELDS
@@ -77,6 +78,7 @@ const PositionEdit = ({ pageDispatchers }) => {
     searchProps: DEFAULT_SEARCH_PROPS,
     pageDispatchers
   })
+  usePageTitle(data?.position?.name && `Edit | ${data.position.name}`)
   if (done) {
     return result
   }

--- a/client/src/pages/positions/MyCounterparts.js
+++ b/client/src/pages/positions/MyCounterparts.js
@@ -4,7 +4,8 @@ import Fieldset from "components/Fieldset"
 import {
   mapPageDispatchersToProps,
   PageDispatchersPropType,
-  useBoilerplate
+  useBoilerplate,
+  usePageTitle
 } from "components/Page"
 import PositionTable from "components/PositionTable"
 import React, { useContext } from "react"
@@ -16,6 +17,7 @@ const MyCounterparts = ({ pageDispatchers }) => {
     pageProps: DEFAULT_PAGE_PROPS,
     pageDispatchers
   })
+  usePageTitle("My Counterparts")
   const {
     currentUser,
     notifications: { counterpartsWithPendingAssessments }

--- a/client/src/pages/positions/New.js
+++ b/client/src/pages/positions/New.js
@@ -5,7 +5,8 @@ import { initInvisibleFields } from "components/CustomFields"
 import {
   mapPageDispatchersToProps,
   PageDispatchersPropType,
-  useBoilerplate
+  useBoilerplate,
+  usePageTitle
 } from "components/Page"
 import { Organization, Position } from "models"
 import PropTypes from "prop-types"
@@ -30,6 +31,7 @@ const GQL_GET_ORGANIZATION = gql`
 
 const PositionNew = ({ pageDispatchers }) => {
   const routerLocation = useLocation()
+  usePageTitle("New Position")
   const qs = utils.parseQueryString(routerLocation.search)
   if (qs.organizationUuid) {
     return (

--- a/client/src/pages/positions/Show.js
+++ b/client/src/pages/positions/Show.js
@@ -19,7 +19,8 @@ import {
   mapPageDispatchersToProps,
   PageDispatchersPropType,
   SubscriptionIcon,
-  useBoilerplate
+  useBoilerplate,
+  usePageTitle
 } from "components/Page"
 import RelatedObjectNotes from "components/RelatedObjectNotes"
 import { Field, Form, Formik } from "formik"
@@ -78,6 +79,7 @@ const PositionShow = ({ pageDispatchers }) => {
     searchProps: DEFAULT_SEARCH_PROPS,
     pageDispatchers
   })
+  usePageTitle(data?.position?.name)
   if (done) {
     return result
   }

--- a/client/src/pages/reports/Compact.js
+++ b/client/src/pages/reports/Compact.js
@@ -24,7 +24,8 @@ import { DEFAULT_CUSTOM_FIELDS_PARENT } from "components/Model"
 import {
   mapPageDispatchersToProps,
   PageDispatchersPropType,
-  useBoilerplate
+  useBoilerplate,
+  usePageTitle
 } from "components/Page"
 import { GRAPHQL_NOTES_FIELDS } from "components/RelatedObjectNotes"
 import { ActionButton, ActionStatus } from "components/ReportWorkflow"
@@ -235,6 +236,9 @@ const CompactReportView = ({ pageDispatchers }) => {
     searchProps: DEFAULT_SEARCH_PROPS,
     pageDispatchers
   })
+  usePageTitle(
+    data?.report && `Print | ${data.report.intent || data.report.uuid}`
+  )
   if (done) {
     return result
   }

--- a/client/src/pages/reports/Edit.js
+++ b/client/src/pages/reports/Edit.js
@@ -6,7 +6,8 @@ import { DEFAULT_CUSTOM_FIELDS_PARENT } from "components/Model"
 import {
   mapPageDispatchersToProps,
   PageDispatchersPropType,
-  useBoilerplate
+  useBoilerplate,
+  usePageTitle
 } from "components/Page"
 import RelatedObjectNotes, {
   GRAPHQL_NOTES_FIELDS
@@ -123,6 +124,9 @@ const ReportEdit = ({ pageDispatchers }) => {
     searchProps: DEFAULT_SEARCH_PROPS,
     pageDispatchers
   })
+  usePageTitle(
+    data?.report && `Edit | ${data.report.intent || data.report.uuid}`
+  )
   if (done) {
     return result
   }

--- a/client/src/pages/reports/MyReports.js
+++ b/client/src/pages/reports/MyReports.js
@@ -5,7 +5,8 @@ import { AnchorNavItem } from "components/Nav"
 import {
   mapPageDispatchersToProps,
   PageDispatchersPropType,
-  useBoilerplate
+  useBoilerplate,
+  usePageTitle
 } from "components/Page"
 import ReportCollection, {
   FORMAT_CALENDAR,
@@ -27,6 +28,7 @@ const MyReports = ({ pageDispatchers, searchQuery }) => {
     pageProps: DEFAULT_PAGE_PROPS,
     pageDispatchers
   })
+  usePageTitle("My Reports")
   const {
     currentUser: { uuid }
   } = useContext(AppContext)

--- a/client/src/pages/reports/New.js
+++ b/client/src/pages/reports/New.js
@@ -5,7 +5,8 @@ import GuidedTour from "components/GuidedTour"
 import {
   mapPageDispatchersToProps,
   PageDispatchersPropType,
-  useBoilerplate
+  useBoilerplate,
+  usePageTitle
 } from "components/Page"
 import { Person, Report } from "models"
 import { reportTour } from "pages/HopscotchTour"
@@ -21,6 +22,7 @@ const ReportNew = ({ pageDispatchers }) => {
     searchProps: DEFAULT_SEARCH_PROPS,
     pageDispatchers
   })
+  usePageTitle("New Report")
 
   const report = new Report()
 

--- a/client/src/pages/reports/Show.js
+++ b/client/src/pages/reports/Show.js
@@ -23,7 +23,8 @@ import {
   mapPageDispatchersToProps,
   PageDispatchersPropType,
   SubscriptionIcon,
-  useBoilerplate
+  useBoilerplate,
+  usePageTitle
 } from "components/Page"
 import PlanningConflictForReport from "components/PlanningConflictForReport"
 import RelatedObjectNotes, {
@@ -292,6 +293,7 @@ const ReportShow = ({ setSearchQuery, pageDispatchers }) => {
     searchProps: DEFAULT_SEARCH_PROPS,
     pageDispatchers
   })
+  usePageTitle(data?.report?.intent || data?.report?.uuid)
   if (done) {
     return result
   }

--- a/client/src/pages/rollup/Show.js
+++ b/client/src/pages/rollup/Show.js
@@ -21,7 +21,8 @@ import MosaicLayout from "components/MosaicLayout"
 import {
   mapPageDispatchersToProps,
   PageDispatchersPropType,
-  useBoilerplate
+  useBoilerplate,
+  usePageTitle
 } from "components/Page"
 import ReportCollection, {
   FORMAT_CALENDAR,
@@ -339,7 +340,7 @@ const RollupShow = ({ pageDispatchers, searchQuery, setSearchQuery }) => {
     searchProps: REPORT_SEARCH_PROPS,
     pageDispatchers
   })
-
+  usePageTitle("Daily Rollup")
   const VISUALIZATIONS = [
     {
       id: "rbdow-collection",

--- a/client/src/pages/searches/MySavedSearches.js
+++ b/client/src/pages/searches/MySavedSearches.js
@@ -8,7 +8,8 @@ import {
   jumpToTop,
   mapPageDispatchersToProps,
   PageDispatchersPropType,
-  useBoilerplate
+  useBoilerplate,
+  usePageTitle
 } from "components/Page"
 import SavedSearchTable from "components/SavedSearchTable"
 import { deserializeQueryParams } from "components/SearchFilters"
@@ -49,6 +50,7 @@ const MySavedSearches = ({ setSearchQuery, pageDispatchers }) => {
     error,
     pageDispatchers
   })
+  usePageTitle("My Saved Searches")
   if (done) {
     return result
   }

--- a/client/src/pages/searches/Search.js
+++ b/client/src/pages/searches/Search.js
@@ -17,7 +17,8 @@ import {
   jumpToTop,
   mapPageDispatchersToProps,
   PageDispatchersPropType,
-  useBoilerplate
+  useBoilerplate,
+  usePageTitle
 } from "components/Page"
 import PersonTable from "components/PersonTable"
 import PositionTable from "components/PositionTable"
@@ -601,6 +602,7 @@ const Search = ({
   const [numTasks, setNumTasks] = useState(null)
   const [numLocations, setNumLocations] = useState(null)
   const [numReports, setNumReports] = useState(null)
+  usePageTitle("Search")
   const numResults = sum(
     numOrganizations,
     numPeople,

--- a/client/src/pages/tasks/Edit.js
+++ b/client/src/pages/tasks/Edit.js
@@ -6,7 +6,8 @@ import { DEFAULT_CUSTOM_FIELDS_PARENT } from "components/Model"
 import {
   mapPageDispatchersToProps,
   PageDispatchersPropType,
-  useBoilerplate
+  useBoilerplate,
+  usePageTitle
 } from "components/Page"
 import RelatedObjectNotes, {
   GRAPHQL_NOTES_FIELDS
@@ -112,6 +113,7 @@ const TaskEdit = ({ pageDispatchers }) => {
     searchProps: DEFAULT_SEARCH_PROPS,
     pageDispatchers
   })
+  usePageTitle(data?.task?.shortName && `Edit | ${data.task.shortName}`)
   if (done) {
     return result
   }

--- a/client/src/pages/tasks/MyTasks.js
+++ b/client/src/pages/tasks/MyTasks.js
@@ -6,7 +6,8 @@ import Model from "components/Model"
 import {
   mapPageDispatchersToProps,
   PageDispatchersPropType,
-  useBoilerplate
+  useBoilerplate,
+  usePageTitle
 } from "components/Page"
 import { getSearchQuery, SearchQueryPropType } from "components/SearchFilters"
 import TaskTable from "components/TaskTable"
@@ -24,6 +25,7 @@ const MyTasks = ({ pageDispatchers, searchQuery }) => {
   })
   const { currentUser, notifications } = useContext(AppContext)
   const taskShortLabel = Settings.fields.task.shortLabel
+  usePageTitle(`My ${pluralize(taskShortLabel)}`)
   // Memo'ize the search query parameters we use to prevent unnecessary re-renders
   const searchQueryParams = useMemo(
     () => getSearchQuery(searchQuery),

--- a/client/src/pages/tasks/New.js
+++ b/client/src/pages/tasks/New.js
@@ -5,7 +5,8 @@ import { initInvisibleFields } from "components/CustomFields"
 import {
   mapPageDispatchersToProps,
   PageDispatchersPropType,
-  useBoilerplate
+  useBoilerplate,
+  usePageTitle
 } from "components/Page"
 import { Organization, Task } from "models"
 import PropTypes from "prop-types"
@@ -30,6 +31,8 @@ const GQL_GET_ORGANIZATION = gql`
 
 const TaskNew = ({ pageDispatchers }) => {
   const routerLocation = useLocation()
+  const taskShortLabel = Settings.fields.task.shortLabel
+  usePageTitle(`New ${taskShortLabel}`)
   const qs = utils.parseQueryString(routerLocation.search)
   if (qs.taskedOrgUuid) {
     return (

--- a/client/src/pages/tasks/Show.js
+++ b/client/src/pages/tasks/Show.js
@@ -14,7 +14,8 @@ import {
   mapPageDispatchersToProps,
   PageDispatchersPropType,
   SubscriptionIcon,
-  useBoilerplate
+  useBoilerplate,
+  usePageTitle
 } from "components/Page"
 import PositionTable from "components/PositionTable"
 import RelatedObjectNotes, {
@@ -154,6 +155,7 @@ const TaskShow = ({ pageDispatchers }) => {
     searchProps: DEFAULT_SEARCH_PROPS,
     pageDispatchers
   })
+  usePageTitle(data?.task?.shortName)
 
   if (done) {
     return result


### PR DESCRIPTION
Set the document title dynamically according to the route.

Closes [AB#585](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/585)

#### User changes
- Document title in the browser tab changes according to the route.

#### Super User changes
- None

#### Admin changes
- None

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
