### PR TITLE
End time can be null when updating person history in position

### DIFF
--- a/src/main/java/mil/dds/anet/resources/PositionResource.java
+++ b/src/main/java/mil/dds/anet/resources/PositionResource.java
@@ -169,10 +169,8 @@ public class PositionResource {
   public int updatePositionHistory(@GraphQLRootContext Map<String, Object> context,
       @GraphQLArgument(name = "position") Position pos) {
     final Person user = DaoUtils.getUserFromContext(context);
-    final Position existing = dao.getByUuid(pos.getUuid());
-    assertCanUpdatePosition(user, existing);
 
-    final String existingPersonUuid = DaoUtils.getUuid(existing.getPerson());
+    final String existingPersonUuid = DaoUtils.getUuid(pos.getPerson());
     ResourceUtils.validateHistoryInput(pos.getUuid(), pos.getPreviousPeople(), false,
         existingPersonUuid);
 

--- a/src/test/java/mil/dds/anet/test/resources/PositionResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/PositionResourceTest.java
@@ -643,15 +643,6 @@ public class PositionResourceTest extends AbstractResourceTest {
       throws GraphQLRequestExecutionException, GraphQLRequestPreparationException {
     final Organization ao = adminMutationExecutor.createOrganization(ORGANIZATION_FIELDS,
         TestData.createAdvisorOrganizationInput(true));
-    final PositionInput testInput1 = PositionInput.builder()
-        .withName("A Test Position for edittting history").withType(PositionType.ADVISOR)
-        .withStatus(Status.ACTIVE).withOrganization(getOrganizationInput(ao))
-        .withLocation(getLocationInput(getGeneralHospital())).build();
-
-    final Position createdPos = adminMutationExecutor.createPosition(FIELDS, testInput1);
-    assertThat(createdPos).isNotNull();
-    assertThat(createdPos.getUuid()).isNotNull();
-    assertThat(createdPos.getName()).isEqualTo(testInput1.getName());
 
     final PersonInput persInput1 = PersonInput.builder().withRole(Role.ADVISOR)
         .withName("Test person for edit history").build();
@@ -672,12 +663,21 @@ public class PositionResourceTest extends AbstractResourceTest {
         .build();
     final PersonPositionHistoryInput histInput2 =
         PersonPositionHistoryInput.builder().withCreatedAt(Instant.now().minus(49, ChronoUnit.DAYS))
-            .withStartTime(Instant.now().minus(49, ChronoUnit.DAYS)).withEndTime(Instant.now())
+            .withStartTime(Instant.now().minus(49, ChronoUnit.DAYS)).withEndTime(null)
             .withPerson(getPersonInput(person2)).build();
     prevPersons.add(histInput1);
     prevPersons.add(histInput2);
-    final PositionInput inputForTest = PositionInput.builder().withUuid(createdPos.getUuid())
-        .withPreviousPeople(prevPersons).build();
+    final PositionInput testInput1 =
+        PositionInput.builder().withName("A Test Position for edittting history")
+            .withType(PositionType.ADVISOR).withStatus(Status.ACTIVE)
+            .withOrganization(getOrganizationInput(ao)).withPreviousPeople(prevPersons)
+            .withLocation(getLocationInput(getGeneralHospital())).build();
+    final Position createdPos = adminMutationExecutor.createPosition(FIELDS, testInput1);
+    assertThat(createdPos).isNotNull();
+    assertThat(createdPos.getUuid()).isNotNull();
+    assertThat(createdPos.getName()).isEqualTo(testInput1.getName());
+    final PositionInput inputForTest =
+        PositionInput.builder().withUuid(createdPos.getUuid()).build();
     adminMutationExecutor.updatePositionHistory("", inputForTest);
     final Position positionUpdated =
         adminQueryExecutor.position(FIELDS, getPositionInput(createdPos).getUuid());


### PR DESCRIPTION
Avoid the "End time cannot be null" problem when updating person position history.

Closes [AB#606](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/606)

#### User changes
- None

#### Super User changes
- None

#### Admin changes
- When updating person history in position, end time can be null if the position holder's end time is "present".

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [x] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [ ] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
