### PR TITLE
Fix problems with position history

### DIFF
--- a/client/src/components/AssignPersonModal.js
+++ b/client/src/components/AssignPersonModal.js
@@ -280,7 +280,7 @@ const AssignPersonModal = ({ position, showModal, onCancel, onSuccess }) => {
             if (removeUser || !person) {
               setPerson(null)
               setDoSave(true)
-            } else if (person.name !== latestPositionProp.current.person.name) {
+            } else if (person.uuid !== latestPositionProp.current.person.uuid) {
               setDoSave(true)
             } else {
               closeModal()

--- a/insertBaseData-psql.sql
+++ b/insertBaseData-psql.sql
@@ -194,30 +194,27 @@ INSERT INTO "peoplePositions" ("positionUuid", "personUuid", "createdAt")
 UPDATE positions SET "currentPersonUuid" = (SELECT uuid from people where "emailAddress" = 'hunter+henry@example.com') WHERE name = 'EF 2.1 SuperUser';
 
 -- Rotate an advisor through a billet ending up with Jack in the EF 2.1 Advisor B Billet
--- DECLARE :positionTimestamp DATETIME;
-SELECT ('''' || CURRENT_TIMESTAMP || '''') AS "positionTimestamp" \gset
 INSERT INTO "peoplePositions" ("positionUuid", "personUuid", "createdAt")
-	VALUES ((SELECT uuid from positions where name = 'EF 2.1 Advisor B'), (SELECT uuid from people where "emailAddress" = 'hunter+erin@example.com'), :positionTimestamp);
+	VALUES ((SELECT uuid from positions where name = 'EF 2.1 Advisor B'), (SELECT uuid from people where "emailAddress" = 'hunter+erin@example.com'), CURRENT_TIMESTAMP);
 UPDATE positions SET "currentPersonUuid" = (SELECT uuid from people where "emailAddress" = 'hunter+erin@example.com') WHERE name = 'EF 2.1 Advisor B';
-UPDATE "peoplePositions" SET "endedAt" = :positionTimestamp WHERE "positionUuid" = (SELECT uuid from positions where name = 'EF 2.1 Advisor B');
+UPDATE "peoplePositions" SET "endedAt" = CURRENT_TIMESTAMP + INTERVAL '1 millisecond' WHERE "positionUuid" = (SELECT uuid from positions where name = 'EF 2.1 Advisor B');
 INSERT INTO "peoplePositions" ("positionUuid", "personUuid", "createdAt")
-	VALUES ((SELECT uuid from positions where name = 'EF 2.1 Advisor B'), (SELECT uuid from people where "emailAddress" = 'hunter+jack@example.com'), :positionTimestamp);
+	VALUES ((SELECT uuid from positions where name = 'EF 2.1 Advisor B'), (SELECT uuid from people where "emailAddress" = 'hunter+jack@example.com'), CURRENT_TIMESTAMP + INTERVAL '1 millisecond');
 UPDATE positions SET "currentPersonUuid" = (SELECT uuid from people where "emailAddress" = 'hunter+jack@example.com') WHERE name = 'EF 2.1 Advisor B';
 
 -- Rotate advisors through billets ending up with Dvisor in the EF 2.2 Advisor Sewing Facilities Billet and Selena in the EF 1.2 Advisor Billet
-SELECT ('''' || CURRENT_TIMESTAMP || '''') AS "positionTimestamp" \gset
 INSERT INTO "peoplePositions" ("positionUuid", "personUuid", "createdAt")
-	VALUES ((SELECT uuid from positions where name = 'EF 2.2 Advisor Sewing Facilities'), (SELECT uuid from people where "emailAddress" = 'hunter+selena@example.com'), :positionTimestamp);
-UPDATE "peoplePositions" SET "endedAt" = :positionTimestamp WHERE "positionUuid" = (SELECT uuid from positions where name = 'EF 2.2 Advisor Sewing Facilities');
+	VALUES ((SELECT uuid from positions where name = 'EF 2.2 Advisor Sewing Facilities'), (SELECT uuid from people where "emailAddress" = 'hunter+selena@example.com'), CURRENT_TIMESTAMP);
+UPDATE "peoplePositions" SET "endedAt" = CURRENT_TIMESTAMP + INTERVAL '1 millisecond' WHERE "positionUuid" = (SELECT uuid from positions where name = 'EF 2.2 Advisor Sewing Facilities');
 INSERT INTO "peoplePositions" ("positionUuid", "personUuid", "createdAt")
-	VALUES ((SELECT uuid from positions where name = 'EF 2.2 Advisor Sewing Facilities'), (SELECT uuid from people where "emailAddress" = 'hunter+advisor@example.com'), :positionTimestamp);
+	VALUES ((SELECT uuid from positions where name = 'EF 2.2 Advisor Sewing Facilities'), (SELECT uuid from people where "emailAddress" = 'hunter+advisor@example.com'), CURRENT_TIMESTAMP + INTERVAL '1 millisecond');
 UPDATE positions SET "currentPersonUuid" = (SELECT uuid from people where "emailAddress" = 'hunter+advisor@example.com') WHERE name = 'EF 2.2 Advisor Sewing Facilities';
 
 INSERT INTO "peoplePositions" ("positionUuid", "personUuid", "createdAt")
-	VALUES ((SELECT uuid from positions where name = 'EF 1.2 Advisor'), (SELECT uuid from people where "emailAddress" = 'hunter+advisor@example.com'), :positionTimestamp);
-UPDATE "peoplePositions" SET "endedAt" = :positionTimestamp WHERE "positionUuid" = (SELECT uuid from positions where name = 'EF 1.2 Advisor');
+	VALUES ((SELECT uuid from positions where name = 'EF 1.2 Advisor'), (SELECT uuid from people where "emailAddress" = 'hunter+advisor@example.com'), CURRENT_TIMESTAMP);
+UPDATE "peoplePositions" SET "endedAt" = CURRENT_TIMESTAMP + INTERVAL '1 millisecond' WHERE "positionUuid" = (SELECT uuid from positions where name = 'EF 1.2 Advisor');
 INSERT INTO "peoplePositions" ("positionUuid", "personUuid", "createdAt")
-	VALUES ((SELECT uuid from positions where name = 'EF 1.2 Advisor'), (SELECT uuid from people where "emailAddress" = 'hunter+selena@example.com'), :positionTimestamp);
+	VALUES ((SELECT uuid from positions where name = 'EF 1.2 Advisor'), (SELECT uuid from people where "emailAddress" = 'hunter+selena@example.com'), CURRENT_TIMESTAMP + INTERVAL '1 millisecond');
 UPDATE positions SET "currentPersonUuid" = (SELECT uuid from people where "emailAddress" = 'hunter+selena@example.com') WHERE name = 'EF 1.2 Advisor';
 
 -- Put Elizabeth into the EF 1.1 Advisor A Billet

--- a/src/main/java/mil/dds/anet/beans/PersonPositionHistory.java
+++ b/src/main/java/mil/dds/anet/beans/PersonPositionHistory.java
@@ -6,10 +6,8 @@ import io.leangen.graphql.annotations.GraphQLInputField;
 import io.leangen.graphql.annotations.GraphQLQuery;
 import io.leangen.graphql.annotations.GraphQLRootContext;
 import java.time.Instant;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-import java.util.stream.Collectors;
 import javax.ws.rs.WebApplicationException;
 import mil.dds.anet.utils.IdDataLoaderKey;
 import mil.dds.anet.views.AbstractAnetBean;
@@ -122,13 +120,5 @@ public class PersonPositionHistory extends AbstractAnetBean {
 
   public void setEndTime(Instant endTime) {
     this.endTime = endTime;
-  }
-
-  public static List<PersonPositionHistory> getDerivedHistory(List<PersonPositionHistory> history) {
-    // Remove all null entries
-    return history.stream()
-        .filter(
-            pph -> (pph != null && pph.getPersonUuid() != null && pph.getPositionUuid() != null))
-        .collect(Collectors.toList());
   }
 }

--- a/src/main/java/mil/dds/anet/database/PersonDao.java
+++ b/src/main/java/mil/dds/anet/database/PersonDao.java
@@ -465,9 +465,8 @@ public class PersonDao extends AnetSubscribableObjectDao<Person, PersonSearchQue
 
   public CompletableFuture<List<PersonPositionHistory>> getPositionHistory(
       Map<String, Object> context, String personUuid) {
-    return new ForeignKeyFetcher<PersonPositionHistory>()
-        .load(context, FkDataLoaderKey.PERSON_PERSON_POSITION_HISTORY, personUuid)
-        .thenApply(l -> PersonPositionHistory.getDerivedHistory(l));
+    return new ForeignKeyFetcher<PersonPositionHistory>().load(context,
+        FkDataLoaderKey.PERSON_PERSON_POSITION_HISTORY, personUuid);
   }
 
   @InTransaction
@@ -566,12 +565,14 @@ public class PersonDao extends AnetSubscribableObjectDao<Person, PersonSearchQue
   @InTransaction
   protected void updatePeoplePositions(final String positionUuid, final String personUuid,
       final Instant startTime, final Instant endTime) {
-    getDbHandle()
-        .createUpdate("INSERT INTO \"peoplePositions\" "
-            + "(\"positionUuid\", \"personUuid\", \"createdAt\", \"endedAt\") "
-            + "VALUES (:positionUuid, :personUuid, :createdAt, :endedAt)")
-        .bind("positionUuid", positionUuid).bind("personUuid", personUuid)
-        .bind("createdAt", DaoUtils.asLocalDateTime(startTime))
-        .bind("endedAt", DaoUtils.asLocalDateTime(endTime)).execute();
+    if (positionUuid != null && personUuid != null) {
+      getDbHandle()
+          .createUpdate("INSERT INTO \"peoplePositions\" "
+              + "(\"positionUuid\", \"personUuid\", \"createdAt\", \"endedAt\") "
+              + "VALUES (:positionUuid, :personUuid, :createdAt, :endedAt)")
+          .bind("positionUuid", positionUuid).bind("personUuid", personUuid)
+          .bind("createdAt", DaoUtils.asLocalDateTime(startTime))
+          .bind("endedAt", DaoUtils.asLocalDateTime(endTime)).execute();
+    }
   }
 }

--- a/src/main/java/mil/dds/anet/resources/PersonResource.java
+++ b/src/main/java/mil/dds/anet/resources/PersonResource.java
@@ -143,7 +143,7 @@ public class PersonResource {
         AuthUtils.assertSuperUser(user);
         AnetObjectEngine.getInstance().getPositionDao()
             .removePersonFromPosition(existingPos.getUuid());
-        AnetAuditLogger.log("Person {} removed from position by {}", p, user);
+        AnetAuditLogger.log("Person {} removed from position {} by {}", p, existingPos, user);
       } else if (existingPos != null && !existingPos.getUuid().equals(positionUuid)) {
         // Update the position for this person.
         AuthUtils.assertSuperUser(user);

--- a/src/main/java/mil/dds/anet/resources/PositionResource.java
+++ b/src/main/java/mil/dds/anet/resources/PositionResource.java
@@ -172,9 +172,8 @@ public class PositionResource {
     final Position existing = dao.getByUuid(pos.getUuid());
     assertCanUpdatePosition(user, existing);
 
-    final String existingPersonUuid = DaoUtils.getUuid(existing.getPerson());
     ResourceUtils.validateHistoryInput(pos.getUuid(), pos.getPreviousPeople(), false,
-        existingPersonUuid);
+        existing.getPersonUuid());
 
     if (AnetObjectEngine.getInstance().getPersonDao().hasHistoryConflict(pos.getUuid(), null,
         pos.getPreviousPeople(), false)) {

--- a/src/main/java/mil/dds/anet/resources/PositionResource.java
+++ b/src/main/java/mil/dds/anet/resources/PositionResource.java
@@ -219,7 +219,7 @@ public class PositionResource {
       throw new WebApplicationException("Couldn't process delete person from position",
           Status.NOT_FOUND);
     }
-    AnetAuditLogger.log("Person removed from Position uuid#{} by {}", positionUuid, user);
+    AnetAuditLogger.log("Person removed from position {} by {}", pos, user);
     return numRows;
   }
 

--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -4140,4 +4140,16 @@
 			constraintName="uniqueUserActivities" />
 	</changeSet>
 
+	<changeSet id="delete-obsolete-peoplePositions" author="gjvoosten">
+		<!-- Rows with either a NULL positionUuid or a NULL personUuid are no longer needed -->
+		<sql>
+			DELETE FROM "peoplePositions"
+			WHERE "positionUuid" IS NULL
+			OR "personUuid" IS NULL;
+		</sql>
+		<!-- Make sure rows with a NULL positionUuid or a NULL personUuid are no longer allowed -->
+		<addNotNullConstraint tableName="peoplePositions" columnName="positionUuid" columnDataType="${uuid_type}" />
+		<addNotNullConstraint tableName="peoplePositions" columnName="personUuid" columnDataType="${uuid_type}" />
+	</changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
Editing a position's history of assigned people would always fail; this is corrected.

On a position with an assigned person, clicking the **Change assigned person** button, picking a person with the exact same name  and clicking **Save**, nothing happened; this is corrected.

Since we don't actually need or use peoplePositions rows with either positionUuid or personUuid equal to NULL, stop creating these, delete the existing ones, and add not-NULL constraints on these columns to prevent any new ones from being created.
Also update the audit logging a bit for consistency.

Closes [AB#606](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/606), [AB#609](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/609), [AB#611](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/611)

#### User changes
- No visible changes.

#### Super User changes
- Editing a position's history of assigned people works again.
- Assigning a position to a different person with the exact same name works again.

#### Admin changes
- None

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [x] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [x] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here