### PR TITLE
Update most non-major Java dependencies

### DIFF
--- a/.github/actions/build-cache/action.yml
+++ b/.github/actions/build-cache/action.yml
@@ -30,7 +30,7 @@ runs:
     shell: bash
   - name: Get yarn cache directory path
     id: yarn-cache-dir-path
-    run: echo "::set-output name=dir::$(./gradlew -q yarn_cache_dir)"
+    run: echo "dir=$(./gradlew -q yarn_cache_dir)" >> $GITHUB_OUTPUT
     shell: bash
   - name: Cache yarn and node_modules
     uses: actions/cache@v3

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -103,8 +103,5 @@
     "labels": [
       "security"
     ]
-  },
-  "pipenv": {
-    "enabled": true
   }
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -31,6 +31,7 @@
     },
     {
       "matchPackagePrefixes": [
+        "ch.qos.logback",
         "com.graphql_java_generator"
       ],
       "enabled": false

--- a/.github/workflows/build-gradle.yml
+++ b/.github/workflows/build-gradle.yml
@@ -84,7 +84,7 @@ jobs:
       id: tagName
     - name: Set local identifier for BrowserStack
       id: browserstack-local
-      run: echo ::set-output name=identifier::github-${GITHUB_RUN_ID}-${DB_DRIVER}-${CLIENT_TESTS}
+      run: echo "identifier=github-${GITHUB_RUN_ID}-${DB_DRIVER}-${CLIENT_TESTS}" >> $GITHUB_OUTPUT
     - run: ./gradlew yarn_run_${CLIENT_TESTS}
       env:
         GIT_TAG_NAME: ${{ steps.tagName.outputs.tag }}

--- a/build.gradle
+++ b/build.gradle
@@ -5,8 +5,8 @@ plugins {
 	id "org.kordamp.gradle.markdown" version "2.2.0"
 	// https://github.com/bmuschko/gradle-docker-plugin
 	id "com.bmuschko.docker-remote-api" version "8.1.0"
-	id "com.github.node-gradle.node" version "3.4.0"
-	id "com.diffplug.spotless" version "6.8.0"
+	id "com.github.node-gradle.node" version "3.5.0"
+	id "com.diffplug.spotless" version "6.11.0"
 	id "com.graphql_java_generator.graphql-gradle-plugin" version "1.18"
 	id "org.beryx.runtime" version "1.12.7"
 	id "nebula.ospackage" version "9.1.1"
@@ -24,9 +24,9 @@ sourceCompatibility = 11
 targetCompatibility = 11
 
 boolean isTestEnv = project.hasProperty("testEnv")
-String dropwizardVersion = "2.1.1"
+String dropwizardVersion = "2.1.4"
 String logbackVersion = "1.2.11"
-String log4jVersion = "2.18.0"
+String log4jVersion = "2.19.0"
 String keycloakVersion = "19.0.3"
 String psqlPushDataPath = "/var/tmp"
 String keycloakContainerPath = "/opt/keycloak"
@@ -87,11 +87,11 @@ dependencies {
 	implementation 'commons-collections:commons-collections:3.2.2'
 
 	// Supported database is PostgreSQL:
-	implementation 'org.postgresql:postgresql:42.4.0'
-	implementation 'org.liquibase:liquibase-core:4.12.0'
+	implementation 'org.postgresql:postgresql:42.5.0'
+	implementation 'org.liquibase:liquibase-core:4.17.1'
 
 	// For caching domain users (used in every request in the AuthenticationFilter)
-	implementation('org.ehcache:ehcache:3.10.0') {
+	implementation('org.ehcache:ehcache:3.10.2') {
 		capabilities {
 			requireCapability('org.ehcache:ehcache-jakarta')
 		}
@@ -99,11 +99,11 @@ dependencies {
 	implementation 'javax.cache:cache-api:1.1.1'
 	implementation 'commons-beanutils:commons-beanutils:1.9.4'
 
-	implementation 'org.simplejavamail:simple-java-mail:7.1.1'
+	implementation 'org.simplejavamail:simple-java-mail:7.5.0'
 	implementation "ch.qos.logback:logback-classic:${logbackVersion}"
 	implementation "ch.qos.logback:logback-core:${logbackVersion}"
 	implementation "ch.qos.logback:logback-access:${logbackVersion}"
-	implementation 'com.graphql-java:java-dataloader:3.1.4'
+	implementation 'com.graphql-java:java-dataloader:3.2.0'
 	implementation 'io.leangen.graphql:spqr:0.11.2'
 	implementation 'com.googlecode.owasp-java-html-sanitizer:owasp-java-html-sanitizer:20220608.1'
 	implementation 'com.mikesamuel:json-sanitizer:1.2.3'
@@ -118,14 +118,14 @@ dependencies {
 	implementation 'com.qindesign:snowy-json:0.16.0'
 
 	// used for writing Excel documents
-	implementation 'org.apache.poi:poi:5.2.2'
-	implementation 'org.apache.poi:poi-ooxml:5.2.2'
+	implementation 'org.apache.poi:poi:5.2.3'
+	implementation 'org.apache.poi:poi-ooxml:5.2.3'
 
 	// For parsing HTML to check for 'empty' input
-	implementation 'org.jsoup:jsoup:1.15.2'
+	implementation 'org.jsoup:jsoup:1.15.3'
 
 	// For fast and simple image scaling
-	implementation 'net.coobird:thumbnailator:0.4.17'
+	implementation 'net.coobird:thumbnailator:0.4.18'
 
 	// The graphql-java-runtime module agregates all dependencies for the generated code,
 	// including the plugin runtime
@@ -143,8 +143,8 @@ dependencies {
 	testImplementation 'org.powermock:powermock-module-junit4:2.0.9'
 	testImplementation 'org.powermock:powermock-module-junit4-rule:2.0.9'
 
-	testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.2'
-	testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.2'
+	testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.1'
+	testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.1'
 
 	// Avoid "ERROR StatusLogger Log4j2 could not find a logging implementation.
 	// Please add log4j-core to the classpath. Using SimpleLogger to log to the console..."


### PR DESCRIPTION
Update most non-major Java dependencies, but ignore logback updates for now, as Dropwizard depends on logback 1.2.11.
Remove obsolete pipenv setting for Renovate.
Make some recommended changes by GitHub Actions.