### PR TITLE
Center error modal when removing approval step

### DIFF
--- a/client/src/components/approvals/ApprovalsDefinition.js
+++ b/client/src/components/approvals/ApprovalsDefinition.js
@@ -106,6 +106,7 @@ const ApprovalsDefinition = ({
                 </Modal.Footer>
               </Modal>
               <Modal
+                centered
                 show={showRemoveApprovalStepAlert}
                 onHide={hideRemoveApprovalStepAlert}
               >


### PR DESCRIPTION
Modal displaying the error message when trying to remove an approval step is centered.

Closes [AB#604](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/604)

#### User changes
- None

#### Super User changes
- Error message is visible when removing an approval step used by a report

#### Admin changes
- None

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [ ] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
