### PR TITLE
Allow to write an engagement report without a principal participating in the meeting

### DIFF
--- a/client/src/components/ReportSummary.js
+++ b/client/src/components/ReportSummary.js
@@ -254,12 +254,16 @@ const ReportSummaryRow = ({ report }) => {
             {" "}
             (<LinkTo modelType="Organization" model={report.advisorOrg} />)
           </span>
-          <span className="people-separator">&#x25B6;</span>
-          <LinkTo modelType="Person" model={report.primaryPrincipal} />
-          <span>
-            {" "}
-            (<LinkTo modelType="Organization" model={report.principalOrg} />)
-          </span>
+          {report.primaryPrincipal && (
+            <>
+              <span className="people-separator">&#x25B6;</span>
+              <LinkTo modelType="Person" model={report.primaryPrincipal} />
+              <span>
+                {" "}
+                <LinkTo modelType="Organization" model={report.principalOrg} />
+              </span>
+            </>
+          )}
         </Col>
       </Row>
       {!_isEmpty(report.location) && (

--- a/client/src/pages/reports/Compact.js
+++ b/client/src/pages/reports/Compact.js
@@ -123,9 +123,15 @@ const GQL_GET_REPORT = gql`
       }
       primaryAdvisor {
         uuid
+        name
+        rank
+        role
       }
       primaryPrincipal {
         uuid
+        name
+        rank
+        role
       }
       tasks {
         uuid
@@ -406,22 +412,14 @@ const CompactReportView = ({ pageDispatchers }) => {
   function getReportTitle() {
     return (
       <>
-        Engagement of{" "}
-        <LinkTo
-          modelType="Person"
-          model={Report.getPrimaryAttendee(
-            report.attendees,
-            Person.ROLE.PRINCIPAL
-          )}
-        />{" "}
-        by{" "}
-        <LinkTo
-          modelType="Person"
-          model={Report.getPrimaryAttendee(
-            report.attendees,
-            Person.ROLE.ADVISOR
-          )}
-        />
+        Engagement
+        {report.primaryPrincipal && (
+          <>
+            {" of "}
+            <LinkTo modelType="Person" model={report.primaryPrincipal} />
+          </>
+        )}{" "}
+        by <LinkTo modelType="Person" model={report.primaryAdvisor} />
         <br />
         on{" "}
         {moment(report.engagementDate).format(

--- a/client/tests/webdriver/baseSpecs/createReportWithoutPrincipal.spec.js
+++ b/client/tests/webdriver/baseSpecs/createReportWithoutPrincipal.spec.js
@@ -1,0 +1,88 @@
+import { expect } from "chai"
+import moment from "moment"
+import Home from "../pages/home.page"
+import MyReports, { REPORT_STATES } from "../pages/myReports.page"
+import CreateReport from "../pages/report/createReport.page"
+import ShowReport from "../pages/report/showReport.page"
+import Search from "../pages/search.page"
+
+const REPORT_FIELDS = {
+  intent: "An engagement report without primary principal",
+  engagementDate: moment().subtract(1, "day"),
+  duration: "60",
+  location: "Cabot Tower",
+  atmosphere: "Positive",
+  advisors: ["CIV REPORTGUY, Ima"],
+  tasks: ["2.A"],
+  keyOutcomes: "Primary principal attendee is not required",
+  nextSteps: "Test steps",
+  reportText: "Test text"
+}
+
+const NO_PRINCIPAL_WARNING =
+  "You didn't provide the primary Afghan Partner for the Engagement"
+const REPORT_SUBMITTED_STATUS = "This report is PENDING approvals."
+const REPORT_APPROVED_STATUS = "This report is APPROVED."
+
+describe("When creating a report without a principal", () => {
+  it("Should save draft report without primary principal attendee", () => {
+    CreateReport.open()
+    browser.pause(500) // wait for the page transition and rendering of custom fields
+    CreateReport.fillForm(REPORT_FIELDS)
+    browser.pause(500)
+    CreateReport.submitForm()
+    expect(CreateReport.alert.getText()).to.include(NO_PRINCIPAL_WARNING)
+  })
+  it("Should warn user about missing primary principal", () => {
+    ShowReport.submitButton.click()
+    ShowReport.reportModal.waitForDisplayed()
+    expect(ShowReport.modalWarning.getText()).to.include(NO_PRINCIPAL_WARNING)
+  })
+  it("Should submit report without primary principal attendee", () => {
+    ShowReport.confirmSubmitButton.click()
+    browser.pause(1000) // Wait for status text to be updated
+    expect(ShowReport.reportStatusText).to.equal(REPORT_SUBMITTED_STATUS)
+  })
+  it("Should show missing principal warning to initial approver", () => {
+    MyReports.open("erin")
+    MyReports.selectReport(REPORT_FIELDS.intent, REPORT_STATES.PENDING_APPROVAL)
+    ShowReport.approveButton.waitForDisplayed()
+    ShowReport.approveButton.click()
+    ShowReport.reportModal.waitForDisplayed()
+    expect(ShowReport.modalWarning.getText()).to.include(NO_PRINCIPAL_WARNING)
+    ShowReport.confirmApproveButton.click()
+    ShowReport.successfullApprovalToast.waitForDisplayed()
+    ShowReport.logout()
+  })
+  it("Should show missing principal warning to secondary reviewer", () => {
+    Home.open("/", "rebecca")
+    Home.reportsPendingMyApproval.waitForDisplayed()
+    Home.reportsPendingMyApproval.click()
+    Search.selectReport(REPORT_FIELDS.intent)
+    ShowReport.approveButton.waitForDisplayed()
+    ShowReport.approveButton.click()
+    ShowReport.reportModal.waitForDisplayed()
+    expect(ShowReport.modalWarning.getText()).to.include(NO_PRINCIPAL_WARNING)
+    ShowReport.confirmApproveButton.click()
+    ShowReport.successfullApprovalToast.waitForDisplayed()
+    ShowReport.logout()
+  })
+  it("Should show missing principal warning to task owner", () => {
+    Home.open("/", "henry")
+    Home.reportsPendingMyApproval.waitForDisplayed()
+    Home.reportsPendingMyApproval.click()
+    Search.selectReport(REPORT_FIELDS.intent)
+    ShowReport.approveButton.waitForDisplayed()
+    ShowReport.approveButton.click()
+    ShowReport.reportModal.waitForDisplayed()
+    expect(ShowReport.modalWarning.getText()).to.include(NO_PRINCIPAL_WARNING)
+    ShowReport.confirmApproveButton.click()
+    ShowReport.successfullApprovalToast.waitForDisplayed()
+    ShowReport.logout(true)
+  })
+  it("Should complete the approval chain", () => {
+    MyReports.open("erin")
+    MyReports.selectReport(REPORT_FIELDS.intent, REPORT_STATES.APPROVED)
+    expect(ShowReport.reportStatusText).to.equal(REPORT_APPROVED_STATUS)
+  })
+})

--- a/client/tests/webdriver/baseSpecs/printReport.spec.js
+++ b/client/tests/webdriver/baseSpecs/printReport.spec.js
@@ -5,7 +5,7 @@ import ShowReport from "../pages/report/showReport.page"
 
 describe("Show print report page", () => {
   beforeEach("Open the show report page", () => {
-    MyReports.open()
+    MyReports.open("arthur")
     MyReports.selectReport("A test report from Arthur", REPORT_STATES.PUBLISHED)
     ShowReport.compactViewButton.click()
     ShowReport.compactView.waitForExist()

--- a/client/tests/webdriver/baseSpecs/richTextField.spec.js
+++ b/client/tests/webdriver/baseSpecs/richTextField.spec.js
@@ -43,7 +43,7 @@ const RICH_TEXT_CONTENT = [
 
 describe("When reports have rich text content", () => {
   it("Show report page should display content with correct tags", () => {
-    MyReports.open()
+    MyReports.open("arthur")
     MyReports.selectReport("Test report with rich text", REPORT_STATES.DRAFT)
     ShowReport.reportText.waitForDisplayed()
     RICH_TEXT_CONTENT.forEach(

--- a/client/tests/webdriver/baseSpecs/showReport.spec.js
+++ b/client/tests/webdriver/baseSpecs/showReport.spec.js
@@ -4,7 +4,7 @@ import ShowReport from "../pages/report/showReport.page"
 
 describe("Show report page", () => {
   beforeEach("Open the show report page", () => {
-    MyReports.open()
+    MyReports.open("arthur")
     MyReports.selectReport("A test report from Arthur", REPORT_STATES.PUBLISHED)
   })
   describe("When on the show page of a report with assessments", () => {

--- a/client/tests/webdriver/baseSpecs/unpublishReport.spec.js
+++ b/client/tests/webdriver/baseSpecs/unpublishReport.spec.js
@@ -5,7 +5,7 @@ import ShowReport from "../pages/report/showReport.page"
 
 describe("When unpublishing a report", () => {
   beforeEach("Open the show report page", () => {
-    MyReports.open()
+    MyReports.open("arthur")
     MyReports.selectReport(
       "A test report to be unpublished from Arthur",
       REPORT_STATES.PUBLISHED

--- a/client/tests/webdriver/customFieldsSpecs/showTask.spec.js
+++ b/client/tests/webdriver/customFieldsSpecs/showTask.spec.js
@@ -5,7 +5,7 @@ import ShowTask from "../pages/showTask.page"
 
 describe("Show task page", () => {
   beforeEach("Open the show task page", () => {
-    MyReports.open()
+    MyReports.open("arthur")
     MyReports.selectReport("A test report from Arthur", REPORT_STATES.PUBLISHED)
     ShowTask.openAsAdminUser(ShowReport.task12BUrl)
   })

--- a/client/tests/webdriver/pages/home.page.js
+++ b/client/tests/webdriver/pages/home.page.js
@@ -78,6 +78,10 @@ class Home extends Page {
     return this.myTasksLink.$("span.badge")
   }
 
+  get reportsPendingMyApproval() {
+    return browser.$('//button[text()="Reports pending my approval"]')
+  }
+
   waitForSecurityBannerValue(value) {
     this.securityBanner.waitForExist()
     this.securityBanner.waitForDisplayed()

--- a/client/tests/webdriver/pages/myReports.page.js
+++ b/client/tests/webdriver/pages/myReports.page.js
@@ -24,8 +24,8 @@ export const REPORT_STATES = {
 }
 
 class MyReports extends Page {
-  open() {
-    super.openAsAdminUser(PAGE_URL)
+  open(credentials) {
+    super.open(PAGE_URL, credentials)
   }
 
   selectReport(linkText, reportState) {

--- a/client/tests/webdriver/pages/page.js
+++ b/client/tests/webdriver/pages/page.js
@@ -23,6 +23,10 @@ class Page {
     return browser.$("#kc-login")
   }
 
+  get logo() {
+    return browser.$("#topbar .logo")
+  }
+
   loginFormSubmit() {
     this.loginFormSubmitButton.click()
   }
@@ -39,7 +43,12 @@ class Page {
     this.loginFormSubmit()
   }
 
-  logout() {
+  logout(resetRedux = false) {
+    // Reset redux state before logout
+    if (resetRedux) {
+      this.logo.click()
+      browser.pause(1000)
+    }
     browser.url("/api/logout")
   }
 

--- a/client/tests/webdriver/pages/report/createReport.page.js
+++ b/client/tests/webdriver/pages/report/createReport.page.js
@@ -31,6 +31,42 @@ class CreateReport extends cr.CreateReport {
     return browser.$("#reportPeople-popover .table-responsive table")
   }
 
+  get location() {
+    return browser.$('#fg-location input[id="location"]')
+  }
+
+  get locationTable() {
+    return browser.$("#location-popover .table-responsive table")
+  }
+
+  get atmosphere() {
+    return browser.$("#fg-atmosphere")
+  }
+
+  get atmospherePositive() {
+    return this.atmosphere.$('label[for="atmosphere_POSITIVE"]')
+  }
+
+  get atmosphereNeutral() {
+    return this.atmosphere.$('label[for="atmosphere_NEUTRAL"]')
+  }
+
+  get atmosphereNegative() {
+    return this.atmosphere.$('label[for="atmosphere_NEGATIVE"]')
+  }
+
+  get keyOutcomes() {
+    return browser.$('#fg-keyOutcomes textarea[id="keyOutcomes"]')
+  }
+
+  get nextSteps() {
+    return browser.$('#fg-nextSteps textarea[id="nextSteps"]')
+  }
+
+  get reportText() {
+    return browser.$("#fg-reportText .editable")
+  }
+
   getPersonByName(name) {
     const personRow = browser.$$(
       `//div[@id="reportPeopleContainer"]//tr[td[@class="reportPeopleName" and .//a[text()="${name}"]]]/td[@class="conflictButton" or @class="reportPeopleName"]`
@@ -91,6 +127,37 @@ class CreateReport extends cr.CreateReport {
     this.tasksTable.waitForExist({ reverse: true, timeout: 3000 })
   }
 
+  selectLocation(location) {
+    this.location.click()
+    browser.keys(location)
+    this.locationTable.waitForDisplayed()
+    const checkBox = this.locationTable.$(
+      "tbody tr:first-child td:first-child input.form-check-input"
+    )
+    if (!checkBox.isSelected()) {
+      checkBox.click()
+    }
+  }
+
+  selectAthosphere(option) {
+    switch (option) {
+      case "Positive":
+        this.atmospherePositive.click()
+        break
+
+      case "Neutral":
+        this.atmospherePositive.click()
+        break
+
+      case "Negative":
+        this.atmospherePositive.click()
+        break
+
+      default:
+        break
+    }
+  }
+
   fillForm(fields) {
     this.form.waitForClickable()
 
@@ -113,6 +180,14 @@ class CreateReport extends cr.CreateReport {
       this.duration.setValue(fields.duration)
     }
 
+    if (fields.location) {
+      this.selectLocation(fields.location)
+    }
+
+    if (fields.atmosphere) {
+      this.selectAthosphere(fields.atmosphere)
+    }
+
     if (Array.isArray(fields.advisors) && fields.advisors.length) {
       fields.advisors.forEach(at => this.selectAttendeeByName(at))
     }
@@ -123,6 +198,19 @@ class CreateReport extends cr.CreateReport {
 
     if (Array.isArray(fields.tasks) && fields.tasks.length) {
       fields.tasks.forEach(t => this.selectTaskByName(t))
+    }
+
+    if (fields.keyOutcomes) {
+      this.keyOutcomes.setValue(fields.keyOutcomes)
+    }
+
+    if (fields.nextSteps) {
+      this.nextSteps.setValue(fields.nextSteps)
+    }
+
+    if (fields.reportText) {
+      this.reportText.click()
+      browser.keys(fields.reportText)
     }
   }
 }

--- a/client/tests/webdriver/pages/report/showReport.page.js
+++ b/client/tests/webdriver/pages/report/showReport.page.js
@@ -102,6 +102,34 @@ class ShowReport extends Page {
     return browser.$("div[name='authors']").getText()
   }
 
+  get submitButton() {
+    return browser.$('//button[text()="Submit report"]')
+  }
+
+  get reportModal() {
+    return browser.$(".modal-dialog")
+  }
+
+  get confirmSubmitButton() {
+    return this.reportModal.$('//button[text()="Submit anyway"]')
+  }
+
+  get modalWarning() {
+    return this.reportModal.$(".alert")
+  }
+
+  get approveButton() {
+    return browser.$('//button[text()="Approve"]')
+  }
+
+  get confirmApproveButton() {
+    return this.reportModal.$('//button[text()="Approve anyway"]')
+  }
+
+  get successfullApprovalToast() {
+    return browser.$('//div[text()="Successfully approved report."]')
+  }
+
   getReportTextContent(selector, multipleElements, index) {
     if (!selector) {
       return this.reportText

--- a/client/tests/webdriver/pages/search.page.js
+++ b/client/tests/webdriver/pages/search.page.js
@@ -16,6 +16,20 @@ class Search extends Page {
   linkOfTaskFound(name) {
     return this.foundTaskTable.$(`//tbody/tr//a[contains(text(), "${name}")]`)
   }
+
+  selectReport(linkText) {
+    const tableTab = browser.$(
+      ".report-collection div header div button[value='table']"
+    )
+    tableTab.waitForExist()
+    tableTab.waitForDisplayed()
+    tableTab.click()
+    const reportLink = browser.$(`*=${linkText}`)
+    reportLink.waitForExist()
+    reportLink.waitForDisplayed()
+    reportLink.click()
+    super.waitUntilLoaded()
+  }
 }
 
 export default new Search()

--- a/src/main/java/mil/dds/anet/resources/ReportResource.java
+++ b/src/main/java/mil/dds/anet/resources/ReportResource.java
@@ -384,11 +384,10 @@ public class ReportResource {
     }
     if (r.getPrincipalOrgUuid() == null) {
       final ReportPerson principal = r.loadPrimaryPrincipal(engine.getContext()).join();
-      if (principal == null) {
-        throw new WebApplicationException("Report missing primary principal", Status.BAD_REQUEST);
+      if (principal != null) {
+        r.setPrincipalOrg(
+            engine.getOrganizationForPerson(engine.getContext(), principal.getUuid()).join());
       }
-      r.setPrincipalOrg(
-          engine.getOrganizationForPerson(engine.getContext(), principal.getUuid()).join());
     }
 
     if (r.getEngagementDate() == null) {


### PR DESCRIPTION
Engagement reports can be submitted without including a primary principal.

Closes [AB#613](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/613)

#### User changes
- Users can submit reports without a primary principal attendee

#### Super User changes
- None

#### Admin changes
- None

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [ ] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
