### PR TITLE
Fix test report including two primary attendees

### DIFF
--- a/insertBaseData-psql.sql
+++ b/insertBaseData-psql.sql
@@ -854,7 +854,7 @@ INSERT INTO reports (uuid, "createdAt", "updatedAt", "locationUuid", intent, tex
 INSERT INTO "reportPeople" ("personUuid", "reportUuid", "isPrimary", "isAuthor")
 	VALUES ((SELECT uuid FROM people where "emailAddress"='hunter+arthur@example.com'), :reportuuid, TRUE, TRUE);
 INSERT INTO "reportPeople" ("personUuid", "reportUuid", "isPrimary", "isAuthor")
-	VALUES ((SELECT uuid FROM people where "emailAddress"='hunter+jack@example.com'), :reportuuid, TRUE, TRUE);
+	VALUES ((SELECT uuid FROM people where "emailAddress"='hunter+jack@example.com'), :reportuuid, FALSE, FALSE);
 
 -- Release all of the reports right now, so they show up in the rollup.
 UPDATE reports SET "releasedAt" = reports."createdAt" WHERE state = 2 OR state = 4;


### PR DESCRIPTION
Test report data is fixed. Now it has a single primary attendee.

Closes [AB#619](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/619)

#### User changes
- None

#### Super User changes
- None

#### Admin changes
- None

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [ ] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
