### PR TITLE
Allow picking people with different roles when merging

### DIFF
--- a/client/src/components/EditHistory.js
+++ b/client/src/components/EditHistory.js
@@ -71,7 +71,7 @@ function EditHistory({
   parentEntityUuid1,
   parentEntityUuid2,
   historyComp: HistoryComp,
-  externalButton,
+  showEditButton,
   showModal,
   setShowModal,
   // currentlyOccupyingEntity used to assert the last item in the history and end time
@@ -101,7 +101,7 @@ function EditHistory({
       className="edit-history"
       style={{ display: "flex", flexDirection: "column" }}
     >
-      {!externalButton && (
+      {showEditButton && (
         <Button
           variant="outline-secondary"
           disabled={_isEmpty(history1) && _isEmpty(history2) && !!history2}
@@ -420,7 +420,7 @@ EditHistory.propTypes = {
   parentEntityUuid1: PropTypes.string.isRequired,
   parentEntityUuid2: PropTypes.string,
   historyComp: PropTypes.func,
-  externalButton: PropTypes.bool,
+  showEditButton: PropTypes.bool,
   showModal: PropTypes.bool.isRequired,
   setShowModal: PropTypes.func.isRequired,
   currentlyOccupyingEntity: PropTypes.oneOfType([

--- a/client/src/components/RemoveButton.js
+++ b/client/src/components/RemoveButton.js
@@ -12,7 +12,7 @@ const RemoveButton = ({
   disabled = false
 }) => (
   <Button
-    className="float-end"
+    className="float-end remove-button"
     variant={buttonStyle}
     title={title}
     onClick={onClick}

--- a/client/src/mergeUtils.js
+++ b/client/src/mergeUtils.js
@@ -335,6 +335,7 @@ export function getActivationButton(isActive, onClickAction, instanceName) {
       <Button
         variant={isActive ? "outline-danger" : "outline-success"}
         onClick={onClickAction}
+        className="activate-field-button"
       >
         <Icon icon={isActive ? IconNames.STOP : IconNames.PLAY} />
       </Button>

--- a/client/src/models/Report.js
+++ b/client/src/models/Report.js
@@ -422,7 +422,7 @@ export default class Report extends Model {
     if (!primaryAttendee && role === Person.ROLE.ADVISOR) {
       return `You must provide the primary ${roleName} for the Engagement`
     } else if (!primaryAttendee && role === Person.ROLE.PRINCIPAL) {
-      return `You didn't provide the primary ${roleName} for the Engagement`
+      return `No primary ${roleName} has been provided for the Engagement`
     } else if (primaryAttendee.status !== Model.STATUS.ACTIVE) {
       return `The primary ${roleName} - ${primaryAttendee.name} - needs to have an active profile`
     } else if (

--- a/client/src/pages/admin/merge/MergePeople.js
+++ b/client/src/pages/admin/merge/MergePeople.js
@@ -32,7 +32,6 @@ import useMergeObjects, {
   getActivationButton,
   getClearButton,
   getInfoButton,
-  getOtherSide,
   MERGE_SIDES,
   mergedPersonIsValid,
   selectAllFields,
@@ -56,6 +55,8 @@ const GQL_MERGE_PERSON = gql`
   }
 `
 
+const NONMATCHING_ROLE_WARNING = "People on each side has different roles."
+
 const MergePeople = ({ pageDispatchers }) => {
   const navigate = useNavigate()
   const [saveError, setSaveError] = useState(null)
@@ -75,10 +76,17 @@ const MergePeople = ({ pageDispatchers }) => {
   const person2 = mergeState[MERGE_SIDES.RIGHT]
   const mergedPerson = mergeState.merged
 
+  const matchingRoles = person1?.role === person2?.role
+
   return (
     <Container fluid>
       <Row>
-        <Messages error={saveError} />
+        <Messages
+          error={saveError}
+          warning={
+            person1 && person2 && !matchingRoles ? NONMATCHING_ROLE_WARNING : ""
+          }
+        />
         <h4>Merge People Tool</h4>
       </Row>
       <Row>
@@ -88,6 +96,7 @@ const MergePeople = ({ pageDispatchers }) => {
             dispatchMergeActions={dispatchMergeActions}
             align={ALIGN_OPTIONS.LEFT}
             label="Person 1"
+            actionButtons={matchingRoles}
           />
         </Col>
         <Col md={4} id="mid-merge-per-col">
@@ -126,21 +135,8 @@ const MergePeople = ({ pageDispatchers }) => {
           {areAllSet(person1, person2, !mergedPerson) && (
             <div style={{ padding: "16px 5%" }}>
               <Callout intent="primary">
-                - You must choose a <strong>name</strong> field.
-                <br />- Required fields for{" "}
-                {Person.humanNameOfRole(person1.role)} are
-                {person1.role === Person.ROLE.ADVISOR ? (
-                  <ul>
-                    <li>Name</li>
-                    <li>Role</li>
-                    <li>Status</li>
-                    <li>{Settings.fields.person.emailAddress.label}</li>
-                    <li>{Settings.fields.person.rank}</li>
-                    <li>{Settings.fields.person.gender}</li>
-                    <li>{Settings.fields.person.country}</li>
-                    <li>{Settings.fields.person.endOfTourDate}</li>
-                  </ul>
-                ) : (
+                <br />- Required fields are:{" "}
+                {
                   <ul>
                     <li>Name</li>
                     <li>Role</li>
@@ -149,7 +145,13 @@ const MergePeople = ({ pageDispatchers }) => {
                     <li>{Settings.fields.person.gender}</li>
                     <li>{Settings.fields.person.country}</li>
                   </ul>
-                )}
+                }
+                If the Merged Person will be an {Person.ROLE.ADVISOR}:
+                <ul>
+                  <li>{Settings.fields.person.emailAddress.label}</li>
+                  <li>{Settings.fields.person.endOfTourDate}</li>
+                </ul>
+                are also required.
               </Callout>
             </div>
           )}
@@ -170,9 +172,12 @@ const MergePeople = ({ pageDispatchers }) => {
                   />
                 }
                 align={ALIGN_OPTIONS.CENTER}
-                action={getClearButton(() =>
-                  dispatchMergeActions(setAMergedField("avatar", null, null))
-                )}
+                action={
+                  matchingRoles &&
+                  getClearButton(() =>
+                    dispatchMergeActions(setAMergedField("avatar", null, null))
+                  )
+                }
                 fieldName="avatar"
                 mergeState={mergeState}
                 dispatchMergeActions={dispatchMergeActions}
@@ -190,11 +195,14 @@ const MergePeople = ({ pageDispatchers }) => {
                 label="Domain username"
                 value={mergedPerson.domainUsername}
                 align={ALIGN_OPTIONS.CENTER}
-                action={getClearButton(() =>
-                  dispatchMergeActions(
-                    setAMergedField("domainUsername", "", null)
+                action={
+                  matchingRoles &&
+                  getClearButton(() =>
+                    dispatchMergeActions(
+                      setAMergedField("domainUsername", "", null)
+                    )
                   )
-                )}
+                }
                 fieldName="domainUsername"
                 mergeState={mergeState}
                 dispatchMergeActions={dispatchMergeActions}
@@ -203,11 +211,14 @@ const MergePeople = ({ pageDispatchers }) => {
                 label="OpenID subject"
                 value={mergedPerson.openIdSubject}
                 align={ALIGN_OPTIONS.CENTER}
-                action={getClearButton(() =>
-                  dispatchMergeActions(
-                    setAMergedField("openIdSubject", "", null)
+                action={
+                  matchingRoles &&
+                  getClearButton(() =>
+                    dispatchMergeActions(
+                      setAMergedField("openIdSubject", "", null)
+                    )
                   )
-                )}
+                }
                 fieldName="openIdSubject"
                 mergeState={mergeState}
                 dispatchMergeActions={dispatchMergeActions}
@@ -227,9 +238,12 @@ const MergePeople = ({ pageDispatchers }) => {
                   <LinkTo modelType="Position" model={mergedPerson.position} />
                 }
                 align={ALIGN_OPTIONS.CENTER}
-                action={getClearButton(() =>
-                  dispatchMergeActions(setAMergedField("position", {}, null))
-                )}
+                action={
+                  matchingRoles &&
+                  getClearButton(() =>
+                    dispatchMergeActions(setAMergedField("position", {}, null))
+                  )
+                }
                 fieldName="position"
                 mergeState={mergeState}
                 dispatchMergeActions={dispatchMergeActions}
@@ -264,11 +278,14 @@ const MergePeople = ({ pageDispatchers }) => {
                   </>
                 }
                 align={ALIGN_OPTIONS.CENTER}
-                action={getClearButton(() =>
-                  dispatchMergeActions(
-                    setAMergedField("previousPositions", [], null)
+                action={
+                  matchingRoles &&
+                  getClearButton(() =>
+                    dispatchMergeActions(
+                      setAMergedField("previousPositions", [], null)
+                    )
                   )
-                )}
+                }
                 fieldName="previousPositions"
                 mergeState={mergeState}
                 dispatchMergeActions={dispatchMergeActions}
@@ -277,20 +294,23 @@ const MergePeople = ({ pageDispatchers }) => {
                 label="Status"
                 value={mergedPerson.status}
                 align={ALIGN_OPTIONS.CENTER}
-                action={getActivationButton(
-                  mergedPerson.status === Person.STATUS.ACTIVE,
-                  () =>
-                    dispatchMergeActions(
-                      setAMergedField(
-                        "status",
-                        mergedPerson.status === Person.STATUS.ACTIVE
-                          ? Person.STATUS.INACTIVE
-                          : Person.STATUS.ACTIVE,
-                        null
-                      )
-                    ),
-                  Person.getInstanceName
-                )}
+                action={
+                  matchingRoles &&
+                  getActivationButton(
+                    mergedPerson.status === Person.STATUS.ACTIVE,
+                    () =>
+                      dispatchMergeActions(
+                        setAMergedField(
+                          "status",
+                          mergedPerson.status === Person.STATUS.ACTIVE
+                            ? Person.STATUS.INACTIVE
+                            : Person.STATUS.ACTIVE,
+                          null
+                        )
+                      ),
+                    Person.getInstanceName
+                  )
+                }
                 fieldName="status"
                 mergeState={mergeState}
                 dispatchMergeActions={dispatchMergeActions}
@@ -304,11 +324,12 @@ const MergePeople = ({ pageDispatchers }) => {
                     ? getInfoButton(
                       `${Settings.fields.person.emailAddress.label} is required.`
                     )
-                    : getClearButton(() =>
-                      dispatchMergeActions(
-                        setAMergedField("emailAddress", "", null)
+                    : matchingRoles &&
+                      getClearButton(() =>
+                        dispatchMergeActions(
+                          setAMergedField("emailAddress", "", null)
+                        )
                       )
-                    )
                 }
                 fieldName="emailAddress"
                 mergeState={mergeState}
@@ -318,9 +339,14 @@ const MergePeople = ({ pageDispatchers }) => {
                 label={Settings.fields.person.phoneNumber}
                 value={mergedPerson.phoneNumber}
                 align={ALIGN_OPTIONS.CENTER}
-                action={getClearButton(() =>
-                  dispatchMergeActions(setAMergedField("phoneNumber", "", null))
-                )}
+                action={
+                  matchingRoles &&
+                  getClearButton(() =>
+                    dispatchMergeActions(
+                      setAMergedField("phoneNumber", "", null)
+                    )
+                  )
+                }
                 fieldName="phoneNumber"
                 mergeState={mergeState}
                 dispatchMergeActions={dispatchMergeActions}
@@ -362,9 +388,12 @@ const MergePeople = ({ pageDispatchers }) => {
                 label={Settings.fields.person.code}
                 value={mergedPerson.code}
                 align={ALIGN_OPTIONS.CENTER}
-                action={getClearButton(() =>
-                  dispatchMergeActions(setAMergedField("code", "", null))
-                )}
+                action={
+                  matchingRoles &&
+                  getClearButton(() =>
+                    dispatchMergeActions(setAMergedField("code", "", null))
+                  )
+                }
                 fieldName="code"
                 mergeState={mergeState}
                 dispatchMergeActions={dispatchMergeActions}
@@ -380,11 +409,12 @@ const MergePeople = ({ pageDispatchers }) => {
                     ? getInfoButton(
                       `${Settings.fields.person.endOfTourDate} is required`
                     )
-                    : getClearButton(() =>
-                      dispatchMergeActions(
-                        setAMergedField("endOfTourDate", null, null)
+                    : matchingRoles &&
+                      getClearButton(() =>
+                        dispatchMergeActions(
+                          setAMergedField("endOfTourDate", null, null)
+                        )
                       )
-                    )
                 }
                 fieldName="endOfTourDate"
                 mergeState={mergeState}
@@ -395,9 +425,12 @@ const MergePeople = ({ pageDispatchers }) => {
                 value={parseHtmlWithLinkTo(mergedPerson.biography)}
                 className="rich-text-readonly"
                 align={ALIGN_OPTIONS.CENTER}
-                action={getClearButton(() =>
-                  dispatchMergeActions(setAMergedField("biography", "", null))
-                )}
+                action={
+                  matchingRoles &&
+                  getClearButton(() =>
+                    dispatchMergeActions(setAMergedField("biography", "", null))
+                  )
+                }
                 fieldName="biography"
                 mergeState={mergeState}
                 dispatchMergeActions={dispatchMergeActions}
@@ -413,15 +446,18 @@ const MergePeople = ({ pageDispatchers }) => {
                         label={fieldConfig.label || fieldName}
                         value={JSON.stringify(fieldValue)}
                         align={ALIGN_OPTIONS.CENTER}
-                        action={getClearButton(() =>
-                          dispatchMergeActions(
-                            setAMergedField(
-                              `${DEFAULT_CUSTOM_FIELDS_PARENT}.${fieldName}`,
-                              CUSTOM_FIELD_TYPE_DEFAULTS[fieldConfig.type],
-                              null
+                        action={
+                          matchingRoles &&
+                          getClearButton(() =>
+                            dispatchMergeActions(
+                              setAMergedField(
+                                `${DEFAULT_CUSTOM_FIELDS_PARENT}.${fieldName}`,
+                                CUSTOM_FIELD_TYPE_DEFAULTS[fieldConfig.type],
+                                null
+                              )
                             )
                           )
-                        )}
+                        }
                         fieldName={`${DEFAULT_CUSTOM_FIELDS_PARENT}.${fieldName}`}
                         mergeState={mergeState}
                         dispatchMergeActions={dispatchMergeActions}
@@ -438,6 +474,7 @@ const MergePeople = ({ pageDispatchers }) => {
             dispatchMergeActions={dispatchMergeActions}
             align={ALIGN_OPTIONS.RIGHT}
             label="Person 2"
+            actionButtons={matchingRoles}
           />
         </Col>
       </Row>
@@ -493,20 +530,22 @@ const MidColTitle = styled.div`
   align-items: center;
 `
 
-function getPersonFilters(mergeState, align) {
-  const peopleFilters = {
-    allPersons: {
-      label: "All",
-      queryVars: {
-        role: mergeState[getOtherSide(align)]?.role,
-        pendingVerification: false
-      }
+const peopleFilters = {
+  allPersons: {
+    label: "All",
+    queryVars: {
+      pendingVerification: false
     }
   }
-  return peopleFilters
 }
 
-const PersonColumn = ({ align, label, mergeState, dispatchMergeActions }) => {
+const PersonColumn = ({
+  align,
+  label,
+  mergeState,
+  dispatchMergeActions,
+  actionButtons
+}) => {
   const person = mergeState[align]
   const idForPerson = label.replace(/\s+/g, "")
 
@@ -523,7 +562,7 @@ const PersonColumn = ({ align, label, mergeState, dispatchMergeActions }) => {
           value={person}
           overlayColumns={["name"]}
           overlayRenderRow={PersonSimpleOverlayRow}
-          filterDefs={getPersonFilters(mergeState, align)}
+          filterDefs={peopleFilters}
           onChange={value => {
             const newValue = value
             if (newValue?.customFields) {
@@ -558,16 +597,19 @@ const PersonColumn = ({ align, label, mergeState, dispatchMergeActions }) => {
               />
             }
             align={align}
-            action={getActionButton(
-              () => {
-                dispatchMergeActions(
-                  setAMergedField("avatar", person.avatar, align)
-                )
-              },
-              align,
-              mergeState,
-              "avatar"
-            )}
+            action={
+              actionButtons &&
+              getActionButton(
+                () => {
+                  dispatchMergeActions(
+                    setAMergedField("avatar", person.avatar, align)
+                  )
+                },
+                align,
+                mergeState,
+                "avatar"
+              )
+            }
             mergeState={mergeState}
             dispatchMergeActions={dispatchMergeActions}
           />
@@ -576,26 +618,29 @@ const PersonColumn = ({ align, label, mergeState, dispatchMergeActions }) => {
             fieldName="name"
             value={person.name}
             align={align}
-            action={getActionButton(
-              () => {
-                dispatchMergeActions(
-                  setAMergedField("name", person.name, align)
-                )
-                dispatchMergeActions(
-                  setAMergedField("uuid", person.uuid, align)
-                )
-                dispatchMergeActions(
-                  setAMergedField(
-                    "pendingVerification",
-                    person.pendingVerification,
-                    align
+            action={
+              actionButtons &&
+              getActionButton(
+                () => {
+                  dispatchMergeActions(
+                    setAMergedField("name", person.name, align)
                   )
-                )
-              },
-              align,
-              mergeState,
-              "name"
-            )}
+                  dispatchMergeActions(
+                    setAMergedField("uuid", person.uuid, align)
+                  )
+                  dispatchMergeActions(
+                    setAMergedField(
+                      "pendingVerification",
+                      person.pendingVerification,
+                      align
+                    )
+                  )
+                },
+                align,
+                mergeState,
+                "name"
+              )
+            }
             mergeState={mergeState}
             dispatchMergeActions={dispatchMergeActions}
           />
@@ -604,20 +649,23 @@ const PersonColumn = ({ align, label, mergeState, dispatchMergeActions }) => {
             fieldName="domainUsername"
             value={person.domainUsername}
             align={align}
-            action={getActionButton(
-              () => {
-                dispatchMergeActions(
-                  setAMergedField(
-                    "domainUsername",
-                    person.domainUsername,
-                    align
+            action={
+              actionButtons &&
+              getActionButton(
+                () => {
+                  dispatchMergeActions(
+                    setAMergedField(
+                      "domainUsername",
+                      person.domainUsername,
+                      align
+                    )
                   )
-                )
-              },
-              align,
-              mergeState,
-              "domainUsername"
-            )}
+                },
+                align,
+                mergeState,
+                "domainUsername"
+              )
+            }
             mergeState={mergeState}
             dispatchMergeActions={dispatchMergeActions}
           />
@@ -626,16 +674,23 @@ const PersonColumn = ({ align, label, mergeState, dispatchMergeActions }) => {
             fieldName="openIdSubject"
             value={person.openIdSubject}
             align={align}
-            action={getActionButton(
-              () => {
-                dispatchMergeActions(
-                  setAMergedField("openIdSubject", person.openIdSubject, align)
-                )
-              },
-              align,
-              mergeState,
-              "openIdSubject"
-            )}
+            action={
+              actionButtons &&
+              getActionButton(
+                () => {
+                  dispatchMergeActions(
+                    setAMergedField(
+                      "openIdSubject",
+                      person.openIdSubject,
+                      align
+                    )
+                  )
+                },
+                align,
+                mergeState,
+                "openIdSubject"
+              )
+            }
             mergeState={mergeState}
             dispatchMergeActions={dispatchMergeActions}
           />
@@ -644,16 +699,19 @@ const PersonColumn = ({ align, label, mergeState, dispatchMergeActions }) => {
             fieldName="role"
             value={person.role}
             align={align}
-            action={getActionButton(
-              () => {
-                dispatchMergeActions(
-                  setAMergedField("role", person.role, align)
-                )
-              },
-              align,
-              mergeState,
-              "role"
-            )}
+            action={
+              actionButtons &&
+              getActionButton(
+                () => {
+                  dispatchMergeActions(
+                    setAMergedField("role", person.role, align)
+                  )
+                },
+                align,
+                mergeState,
+                "role"
+              )
+            }
             mergeState={mergeState}
             dispatchMergeActions={dispatchMergeActions}
           />
@@ -662,16 +720,19 @@ const PersonColumn = ({ align, label, mergeState, dispatchMergeActions }) => {
             fieldName="position"
             value={<LinkTo modelType="Position" model={person.position} />}
             align={align}
-            action={getActionButton(
-              () => {
-                dispatchMergeActions(
-                  setAMergedField("position", person.position, align)
-                )
-              },
-              align,
-              mergeState,
-              "position"
-            )}
+            action={
+              actionButtons &&
+              getActionButton(
+                () => {
+                  dispatchMergeActions(
+                    setAMergedField("position", person.position, align)
+                  )
+                },
+                align,
+                mergeState,
+                "position"
+              )
+            }
             mergeState={mergeState}
             dispatchMergeActions={dispatchMergeActions}
           />
@@ -680,20 +741,23 @@ const PersonColumn = ({ align, label, mergeState, dispatchMergeActions }) => {
             fieldName="previousPositions"
             value={<PreviousPositions history={person.previousPositions} />}
             align={align}
-            action={getActionButton(
-              () => {
-                dispatchMergeActions(
-                  setAMergedField(
-                    "previousPositions",
-                    person.previousPositions,
-                    align
+            action={
+              actionButtons &&
+              getActionButton(
+                () => {
+                  dispatchMergeActions(
+                    setAMergedField(
+                      "previousPositions",
+                      person.previousPositions,
+                      align
+                    )
                   )
-                )
-              },
-              align,
-              mergeState,
-              "previousPositions"
-            )}
+                },
+                align,
+                mergeState,
+                "previousPositions"
+              )
+            }
             mergeState={mergeState}
             dispatchMergeActions={dispatchMergeActions}
           />
@@ -702,16 +766,19 @@ const PersonColumn = ({ align, label, mergeState, dispatchMergeActions }) => {
             fieldName="status"
             value={person.status}
             align={align}
-            action={getActionButton(
-              () => {
-                dispatchMergeActions(
-                  setAMergedField("status", person.status, align)
-                )
-              },
-              align,
-              mergeState,
-              "status"
-            )}
+            action={
+              actionButtons &&
+              getActionButton(
+                () => {
+                  dispatchMergeActions(
+                    setAMergedField("status", person.status, align)
+                  )
+                },
+                align,
+                mergeState,
+                "status"
+              )
+            }
             mergeState={mergeState}
             dispatchMergeActions={dispatchMergeActions}
           />
@@ -720,16 +787,19 @@ const PersonColumn = ({ align, label, mergeState, dispatchMergeActions }) => {
             fieldName="emailAddress"
             value={person.emailAddress}
             align={align}
-            action={getActionButton(
-              () => {
-                dispatchMergeActions(
-                  setAMergedField("emailAddress", person.emailAddress, align)
-                )
-              },
-              align,
-              mergeState,
-              "emailAddress"
-            )}
+            action={
+              actionButtons &&
+              getActionButton(
+                () => {
+                  dispatchMergeActions(
+                    setAMergedField("emailAddress", person.emailAddress, align)
+                  )
+                },
+                align,
+                mergeState,
+                "emailAddress"
+              )
+            }
             mergeState={mergeState}
             dispatchMergeActions={dispatchMergeActions}
           />
@@ -738,16 +808,19 @@ const PersonColumn = ({ align, label, mergeState, dispatchMergeActions }) => {
             fieldName="phoneNumber"
             value={person.phoneNumber}
             align={align}
-            action={getActionButton(
-              () => {
-                dispatchMergeActions(
-                  setAMergedField("phoneNumber", person.phoneNumber, align)
-                )
-              },
-              align,
-              mergeState,
-              "phoneNumber"
-            )}
+            action={
+              actionButtons &&
+              getActionButton(
+                () => {
+                  dispatchMergeActions(
+                    setAMergedField("phoneNumber", person.phoneNumber, align)
+                  )
+                },
+                align,
+                mergeState,
+                "phoneNumber"
+              )
+            }
             mergeState={mergeState}
             dispatchMergeActions={dispatchMergeActions}
           />
@@ -756,16 +829,19 @@ const PersonColumn = ({ align, label, mergeState, dispatchMergeActions }) => {
             fieldName="rank"
             value={person.rank}
             align={align}
-            action={getActionButton(
-              () => {
-                dispatchMergeActions(
-                  setAMergedField("rank", person.rank, align)
-                )
-              },
-              align,
-              mergeState,
-              "rank"
-            )}
+            action={
+              actionButtons &&
+              getActionButton(
+                () => {
+                  dispatchMergeActions(
+                    setAMergedField("rank", person.rank, align)
+                  )
+                },
+                align,
+                mergeState,
+                "rank"
+              )
+            }
             mergeState={mergeState}
             dispatchMergeActions={dispatchMergeActions}
           />
@@ -774,16 +850,19 @@ const PersonColumn = ({ align, label, mergeState, dispatchMergeActions }) => {
             fieldName="gender"
             value={person.gender}
             align={align}
-            action={getActionButton(
-              () => {
-                dispatchMergeActions(
-                  setAMergedField("gender", person.gender, align)
-                )
-              },
-              align,
-              mergeState,
-              "gender"
-            )}
+            action={
+              actionButtons &&
+              getActionButton(
+                () => {
+                  dispatchMergeActions(
+                    setAMergedField("gender", person.gender, align)
+                  )
+                },
+                align,
+                mergeState,
+                "gender"
+              )
+            }
             mergeState={mergeState}
             dispatchMergeActions={dispatchMergeActions}
           />
@@ -792,16 +871,19 @@ const PersonColumn = ({ align, label, mergeState, dispatchMergeActions }) => {
             fieldName="country"
             value={person.country}
             align={align}
-            action={getActionButton(
-              () => {
-                dispatchMergeActions(
-                  setAMergedField("country", person.country, align)
-                )
-              },
-              align,
-              mergeState,
-              "country"
-            )}
+            action={
+              actionButtons &&
+              getActionButton(
+                () => {
+                  dispatchMergeActions(
+                    setAMergedField("country", person.country, align)
+                  )
+                },
+                align,
+                mergeState,
+                "country"
+              )
+            }
             mergeState={mergeState}
             dispatchMergeActions={dispatchMergeActions}
           />
@@ -810,16 +892,19 @@ const PersonColumn = ({ align, label, mergeState, dispatchMergeActions }) => {
             fieldName="code"
             value={person.code}
             align={align}
-            action={getActionButton(
-              () => {
-                dispatchMergeActions(
-                  setAMergedField("code", person.code, align)
-                )
-              },
-              align,
-              mergeState,
-              "code"
-            )}
+            action={
+              actionButtons &&
+              getActionButton(
+                () => {
+                  dispatchMergeActions(
+                    setAMergedField("code", person.code, align)
+                  )
+                },
+                align,
+                mergeState,
+                "code"
+              )
+            }
             mergeState={mergeState}
             dispatchMergeActions={dispatchMergeActions}
           />
@@ -830,16 +915,23 @@ const PersonColumn = ({ align, label, mergeState, dispatchMergeActions }) => {
               Settings.dateFormats.forms.displayShort.date
             )}
             align={align}
-            action={getActionButton(
-              () => {
-                dispatchMergeActions(
-                  setAMergedField("endOfTourDate", person.endOfTourDate, align)
-                )
-              },
-              align,
-              mergeState,
-              "endOfTourDate"
-            )}
+            action={
+              actionButtons &&
+              getActionButton(
+                () => {
+                  dispatchMergeActions(
+                    setAMergedField(
+                      "endOfTourDate",
+                      person.endOfTourDate,
+                      align
+                    )
+                  )
+                },
+                align,
+                mergeState,
+                "endOfTourDate"
+              )
+            }
             mergeState={mergeState}
             dispatchMergeActions={dispatchMergeActions}
           />
@@ -849,16 +941,19 @@ const PersonColumn = ({ align, label, mergeState, dispatchMergeActions }) => {
             className="rich-text-readonly"
             value={parseHtmlWithLinkTo(person.biography)}
             align={align}
-            action={getActionButton(
-              () => {
-                dispatchMergeActions(
-                  setAMergedField("biography", person.biography, align)
-                )
-              },
-              align,
-              mergeState,
-              "biography"
-            )}
+            action={
+              actionButtons &&
+              getActionButton(
+                () => {
+                  dispatchMergeActions(
+                    setAMergedField("biography", person.biography, align)
+                  )
+                },
+                align,
+                mergeState,
+                "biography"
+              )
+            }
             mergeState={mergeState}
             dispatchMergeActions={dispatchMergeActions}
           />
@@ -876,19 +971,22 @@ const PersonColumn = ({ align, label, mergeState, dispatchMergeActions }) => {
                     // To be able to see arrays and ojects
                     value={JSON.stringify(fieldValue)}
                     align={align}
-                    action={getActionButton(
-                      () =>
-                        dispatchMergeActions(
-                          setAMergedField(
-                            `${DEFAULT_CUSTOM_FIELDS_PARENT}.${fieldName}`,
-                            fieldValue,
-                            align
-                          )
-                        ),
-                      align,
-                      mergeState,
-                      `${DEFAULT_CUSTOM_FIELDS_PARENT}.${fieldName}`
-                    )}
+                    action={
+                      actionButtons &&
+                      getActionButton(
+                        () =>
+                          dispatchMergeActions(
+                            setAMergedField(
+                              `${DEFAULT_CUSTOM_FIELDS_PARENT}.${fieldName}`,
+                              fieldValue,
+                              align
+                            )
+                          ),
+                        align,
+                        mergeState,
+                        `${DEFAULT_CUSTOM_FIELDS_PARENT}.${fieldName}`
+                      )
+                    }
                     mergeState={mergeState}
                     dispatchMergeActions={dispatchMergeActions}
                   />
@@ -912,7 +1010,8 @@ PersonColumn.propTypes = {
   align: PropTypes.oneOf(["left", "right"]).isRequired,
   label: PropTypes.string.isRequired,
   mergeState: PropTypes.object,
-  dispatchMergeActions: PropTypes.func
+  dispatchMergeActions: PropTypes.func,
+  actionButtons: PropTypes.bool
 }
 
 export default connect(null, mapPageDispatchersToProps)(MergePeople)

--- a/client/src/pages/admin/merge/MergePeople.js
+++ b/client/src/pages/admin/merge/MergePeople.js
@@ -265,6 +265,7 @@ const MergePeople = ({ pageDispatchers }) => {
                       currentlyOccupyingEntity={mergedPerson.position}
                       parentEntityUuid1={person1.uuid}
                       parentEntityUuid2={person2.uuid}
+                      showEditButton={matchingRoles}
                       historyEntityType="position"
                       parentEntityType="person"
                       midColTitle="Merged Person History"

--- a/client/src/pages/admin/merge/MergePositions.js
+++ b/client/src/pages/admin/merge/MergePositions.js
@@ -251,6 +251,7 @@ const MergePositions = ({ pageDispatchers }) => {
                       showModal={showHistoryModal}
                       setShowModal={setShowHistoryModal}
                       currentlyOccupyingEntity={mergedPosition.person}
+                      showEditButton
                       parentEntityUuid1={position1.uuid}
                       parentEntityUuid2={position2.uuid}
                       midColTitle="Merged Position History"

--- a/client/src/pages/people/Show.js
+++ b/client/src/pages/people/Show.js
@@ -365,7 +365,6 @@ const PersonShow = ({ pageDispatchers }) => {
                   history1={person.previousPositions}
                   initialHistory={person.previousPositions}
                   currentlyOccupyingEntity={person.position}
-                  externalButton
                   historyEntityType="position"
                   parentEntityType={person.role}
                   parentEntityUuid1={person.uuid}

--- a/client/src/pages/reports/Show.js
+++ b/client/src/pages/reports/Show.js
@@ -1345,7 +1345,7 @@ const ReportShow = ({ setSearchQuery, pageDispatchers }) => {
     }
     return (
       <Alert variant="warning">
-        The following warnings should be addressed before {submitType} this{" "}
+        You may want to review the following warnings before {submitType} this{" "}
         {reportType}:
         <ul>
           {validationWarnings.map((warning, idx) => (

--- a/client/tests/webdriver/baseSpecs/createReportWithoutPrincipal.spec.js
+++ b/client/tests/webdriver/baseSpecs/createReportWithoutPrincipal.spec.js
@@ -20,7 +20,7 @@ const REPORT_FIELDS = {
 }
 
 const NO_PRINCIPAL_WARNING =
-  "You didn't provide the primary Afghan Partner for the Engagement"
+  "No primary Afghan Partner has been provided for the Engagement"
 const REPORT_SUBMITTED_STATUS = "This report is PENDING approvals."
 const REPORT_APPROVED_STATUS = "This report is APPROVED."
 

--- a/client/tests/webdriver/baseSpecs/mergePeople.spec.js
+++ b/client/tests/webdriver/baseSpecs/mergePeople.spec.js
@@ -48,10 +48,31 @@ const EXAMPLE_PEOPLE = {
     notes: ["Merge two person note"],
     perUuid: "c725aef3-cdd1-4baf-ac72-f28219b234e9",
     posUuid: "4dc40a27-19ae-4e03-a4f3-55b2c768725f"
+  },
+  advisorRight: {
+    search: "andrew",
+    fullName: "CIV ANDERSON, Andrew",
+    name: "ANDERSON, Andrew",
+    role: "ADVISOR",
+    position: "EF 1 Manager",
+    status: "ACTIVE",
+    email: "hunter+andrew@example.com",
+    phone: "+1-412-7324",
+    rank: "CIV",
+    gender: "MALE",
+    nationality: "United States of America",
+    previousPositions: [
+      {
+        name: "EF 1 Manager",
+        date: `${moment().format("D MMMM YYYY")} -  `
+      }
+    ],
+    biography: "Andrew is the EF 1 Manager",
+    notes: ["A really nice person to work with"]
   }
 }
 
-describe("Merge people page", () => {
+describe("Merge people of the same role", () => {
   it("Should display fields values of the left person", () => {
     // Open merge people page.
     MergePeople.open()
@@ -386,6 +407,163 @@ describe("Merge people page", () => {
     MergePeople.openPage(`/positions/${EXAMPLE_PEOPLE.validRight.posUuid}`)
     expect(MergePeople.unoccupiedPositionPersonMessage.getText()).to.equal(
       "Chief of Merge People Test 2 is currently empty."
+    )
+  })
+})
+
+describe("Merge people of different roles", () => {
+  it("Should select a principal for the left side", () => {
+    // Open merge people page.
+    MergePeople.open()
+    MergePeople.title.waitForExist()
+    MergePeople.title.waitForDisplayed()
+    // Search and select a person from left person field.
+    MergePeople.leftPersonField.setValue(EXAMPLE_PEOPLE.validLeft.search)
+    MergePeople.waitForAdvancedSelectLoading(EXAMPLE_PEOPLE.validLeft.fullName)
+    MergePeople.firstItemFromAdvancedSelect.click()
+    // Check if the fields displayed properly after selecting a person from left side.
+    MergePeople.waitForColumnToChange(
+      EXAMPLE_PEOPLE.validLeft.name,
+      "left",
+      "Name"
+    )
+  })
+  it("Sould select an advisor for the right side", () => {
+    MergePeople.rightPersonField.setValue(EXAMPLE_PEOPLE.advisorRight.search)
+    MergePeople.waitForAdvancedSelectLoading(
+      EXAMPLE_PEOPLE.advisorRight.fullName
+    )
+    MergePeople.firstItemFromAdvancedSelect.click()
+    // Check if the fields displayed properly after selecting a person from left side.
+    MergePeople.waitForColumnToChange(
+      EXAMPLE_PEOPLE.advisorRight.name,
+      "right",
+      "Name"
+    )
+  })
+  it("Should display the different roles warning", () => {
+    MergePeople.waitForDifferentRolesAlert()
+  })
+  it("Should not display the select buttons on each side", () => {
+    MergePeople.getSelectButton("left", "Name").waitForDisplayed({
+      reverse: true
+    })
+    MergePeople.getSelectButton("right", "Name").waitForDisplayed({
+      reverse: true
+    })
+  })
+  it("Should be able to select all fields from left person", () => {
+    MergePeople.getUseAllButton("left").click()
+    browser.pause(500) // wait for the rendering of custom fields
+    MergePeople.waitForColumnToChange(
+      EXAMPLE_PEOPLE.validLeft.name,
+      "mid",
+      "Name"
+    )
+    expect(MergePeople.getColumnContent("mid", "Name").getText()).to.eq(
+      EXAMPLE_PEOPLE.validLeft.name
+    )
+    expect(MergePeople.getColumnContent("mid", "Role").getText()).to.eq(
+      EXAMPLE_PEOPLE.validLeft.role
+    )
+    expect(MergePeople.getColumnContent("mid", "Position").getText()).to.eq(
+      EXAMPLE_PEOPLE.validLeft.position
+    )
+    expect(MergePeople.getPreviousPositions("mid")).to.eql(
+      EXAMPLE_PEOPLE.validLeft.previousPositions
+    )
+    expect(MergePeople.getColumnContent("mid", "Status").getText()).to.eq(
+      EXAMPLE_PEOPLE.validLeft.status
+    )
+    expect(MergePeople.getColumnContent("mid", "Email").getText()).to.eq(
+      EXAMPLE_PEOPLE.validLeft.email
+    )
+    expect(MergePeople.getColumnContent("mid", "Phone").getText()).to.eq(
+      EXAMPLE_PEOPLE.validLeft.phone
+    )
+    expect(MergePeople.getColumnContent("mid", "Rank").getText()).to.eq(
+      EXAMPLE_PEOPLE.validLeft.rank
+    )
+    expect(MergePeople.getColumnContent("mid", "Gender").getText()).to.eq(
+      EXAMPLE_PEOPLE.validLeft.gender
+    )
+    expect(MergePeople.getColumnContent("mid", "Nationality").getText()).to.eq(
+      EXAMPLE_PEOPLE.validLeft.nationality
+    )
+    expect(MergePeople.getColumnContent("mid", "Biography").getText()).to.eq(
+      EXAMPLE_PEOPLE.validLeft.biography
+    )
+  })
+  it("Should be able to select all fields from right person", () => {
+    MergePeople.getUseAllButton("right").click()
+    browser.pause(500) // wait for the rendering of custom fields
+    MergePeople.waitForColumnToChange(
+      EXAMPLE_PEOPLE.advisorRight.name,
+      "mid",
+      "Name"
+    )
+    expect(MergePeople.getColumnContent("mid", "Name").getText()).to.eq(
+      EXAMPLE_PEOPLE.advisorRight.name
+    )
+    expect(MergePeople.getColumnContent("mid", "Role").getText()).to.eq(
+      EXAMPLE_PEOPLE.advisorRight.role
+    )
+    expect(MergePeople.getColumnContent("mid", "Position").getText()).to.eq(
+      EXAMPLE_PEOPLE.advisorRight.position
+    )
+    expect(MergePeople.getPreviousPositions("mid")).to.eql(
+      EXAMPLE_PEOPLE.advisorRight.previousPositions
+    )
+    expect(MergePeople.getColumnContent("mid", "Status").getText()).to.eq(
+      EXAMPLE_PEOPLE.advisorRight.status
+    )
+    expect(MergePeople.getColumnContent("mid", "Email").getText()).to.eq(
+      EXAMPLE_PEOPLE.advisorRight.email
+    )
+    expect(MergePeople.getColumnContent("mid", "Phone").getText()).to.eq(
+      EXAMPLE_PEOPLE.advisorRight.phone
+    )
+    expect(MergePeople.getColumnContent("mid", "Rank").getText()).to.eq(
+      EXAMPLE_PEOPLE.advisorRight.rank
+    )
+    expect(MergePeople.getColumnContent("mid", "Gender").getText()).to.eq(
+      EXAMPLE_PEOPLE.advisorRight.gender
+    )
+    expect(MergePeople.getColumnContent("mid", "Nationality").getText()).to.eq(
+      EXAMPLE_PEOPLE.advisorRight.nationality
+    )
+    expect(MergePeople.getColumnContent("mid", "Biography").getText()).to.eq(
+      EXAMPLE_PEOPLE.advisorRight.biography
+    )
+  })
+  it("Should not display clear field buttons on the middle column", () => {
+    expect(MergePeople.clearValueButtons.length).to.eq(0)
+  })
+  it("Should not display edit history button on the middle column", () => {
+    MergePeople.editHistoryButton.waitForDisplayed({ reverse: true })
+  })
+  it("Should be able to merge both people when winner is right person", () => {
+    MergePeople.mergePeopleButton.click()
+    MergePeople.waitForSuccessAlert()
+  })
+  it("Should merge notes of the both people", () => {
+    MergePeople.showNotesButton.click()
+    // Wait for offcanvas to open
+    browser.pause(100)
+    // As validRight and validLeft merged before, notes should include notes from three people
+    expect(
+      MergePeople.areNotesExist([
+        ...EXAMPLE_PEOPLE.validLeft.notes,
+        ...EXAMPLE_PEOPLE.validRight.notes,
+        ...EXAMPLE_PEOPLE.advisorRight.notes
+      ])
+    ).to.eq(true)
+  })
+  it("Should be able to delete the loser person", () => {
+    MergePeople.openPage(`/people/${EXAMPLE_PEOPLE.validLeft.perUuid}`)
+    MergePeople.errorTitle.waitForExist()
+    expect(MergePeople.errorTitle.getText()).to.equal(
+      `User #${EXAMPLE_PEOPLE.validLeft.perUuid} not found.`
     )
   })
 })

--- a/client/tests/webdriver/baseSpecs/userLogin.spec.js
+++ b/client/tests/webdriver/baseSpecs/userLogin.spec.js
@@ -11,8 +11,9 @@ describe("Anet home page", function() {
   })
   it("should have the right title", function() {
     Home.open()
+    browser.pause(5000) // Wait until the title is set
     const title = browser.getTitle()
-    expect(title).to.equal("ANET")
+    expect(title).to.equal("Home - ANET")
     Home.logout()
   })
   it("should have the right security marking", () => {

--- a/client/tests/webdriver/pages/mergePeople.page.js
+++ b/client/tests/webdriver/pages/mergePeople.page.js
@@ -59,6 +59,16 @@ class MergePeople extends Page {
     return browser.$$(".offcanvas .card")
   }
 
+  get clearValueButtons() {
+    return browser.$$(
+      "//div[@id=\"mid-merge-per-col\"]//button[contains(@class, 'remove-button')]"
+    )
+  }
+
+  get editHistoryButton() {
+    return browser.$('//button[text()="Edit History Manually"]')
+  }
+
   getUseAllButton(side) {
     const button = side === "left" ? "small:first-child" : "small:last-child"
     return browser.$(`#mid-merge-per-col ${button} > button`)
@@ -148,6 +158,21 @@ class MergePeople extends Page {
       }
     })
     return areExist
+  }
+
+  waitForDifferentRolesAlert() {
+    browser.waitUntil(
+      () => {
+        return (
+          browser.$(".alert-warning").getText() ===
+          "People on each side has different roles."
+        )
+      },
+      {
+        timeout: 5000,
+        timeoutMsg: "Couldn't see the success alert in time"
+      }
+    )
   }
 }
 


### PR DESCRIPTION
Merging people with different roles is enabled. Admins can only select all fields from either side when merging people with different roles and fine-grained control is not possible in that case.

Closes [AB#614](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/614)

#### User changes
- None

#### Super User changes
- None

#### Admin changes
- Admins can merge two people with different roles

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [x] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
