### PR TITLE
Clear dictionary error after successful reload

### DIFF
--- a/client/src/pages/admin/Index.js
+++ b/client/src/pages/admin/Index.js
@@ -292,11 +292,13 @@ const AdminIndex = ({ pageDispatchers }) => {
   function reloadDictionary() {
     setActionLoading(true)
     return API.query(RELOAD_DICTIONARY, {})
-      .then(result =>
+      .then(result => {
         toast.success(result?.reloadDictionary, {
           toastId: "success-reload-dictionary"
         })
-      )
+        // Clear previous error message
+        handleError(null)
+      })
       .catch(handleError)
       .finally(() => setActionLoading(false))
   }


### PR DESCRIPTION
Dictionary error is cleared after a successful reload.

Closes [AB#643](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/643)

#### User changes
- None

#### Super User changes
- None

#### Admin changes
- Dictionary error is cleared after a successful reload.

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [ ] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
