### PR TITLE
Fix organization diagram file name

### DIFF
--- a/client/src/components/graphs/OrganizationalChart.js
+++ b/client/src/components/graphs/OrganizationalChart.js
@@ -387,7 +387,7 @@ const OrganizationalChart = ({
     <SVGCanvas
       width={width}
       height={height}
-      exportTitle={`${data.shortName} organization chart`}
+      exportTitle={`${data.organization.shortName} organization chart`}
       zoomFn={increment =>
         setPersonnelDepth(Math.max(0, personnelDepth + increment))
       }


### PR DESCRIPTION
When downloading organization diagram, file name reflects the organization name

Closes [AB#644](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/644)

#### User changes
- File name of organization diagram matches the organization name

#### Super User changes
- None

#### Admin changes
- None

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [ ] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
