### PR TITLE
Initialize ANET database with command-line options

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -280,14 +280,29 @@ task dbWait(dependsOn: 'compileJava', type: JavaExec) {
 }
 dbWait.mustRunAfter('dockerStartDB')
 
+// Create the task that runs the initialization command. Run with:
+//   ./gradlew dbInit -Pargs="--adminOrgName <adminOrgName> --adminPosName <adminPosName>
+//                            --adminFullName <LASTNAME, Firstname> --adminDomainName <adminDomainName>"
+// e.g. (take care to escape spaces in argument values with a backslash):
+//   ./gradlew dbInit -Pargs="--adminOrgName ANET\ Administrators --adminPosName ANET\ Administrator
+//                            --adminFullName DMIN,\ Arthur --adminDomainName arthur"
+// To see all options, run just:
+//   ./gradlew dbInit
+// which will print the help.
 task dbInit(dependsOn: 'compileJava', type: JavaExec) {
 	group = "database runtime"
 	description = "Runs the ANET database initialization command."
 	classpath = sourceSets.main.runtimeClasspath
 	environment(run.environment)
 	mainClass = mainClassName
-	args = ["init", anetConfig]
-	standardInput = System.in
+	def cmdline = ["init"]
+	if (project.hasProperty("args")) {
+		cmdline.addAll(project.args.split("(?<!\\\\)\\s+").collect { a -> a.replace("\\ ", " ")})
+	} else {
+		cmdline << "--help"
+	}
+	cmdline << anetConfig
+	args cmdline
 }
 
 task dbStatus(dependsOn: 'compileJava', type: JavaExec) {

--- a/src/main/java/mil/dds/anet/InitializationCommand.java
+++ b/src/main/java/mil/dds/anet/InitializationCommand.java
@@ -1,11 +1,9 @@
 package mil.dds.anet;
 
-import com.google.common.collect.ImmutableList;
 import io.dropwizard.Application;
 import io.dropwizard.cli.EnvironmentCommand;
 import io.dropwizard.setup.Environment;
 import java.util.List;
-import java.util.Scanner;
 import mil.dds.anet.beans.AdminSetting;
 import mil.dds.anet.beans.ApprovalStep;
 import mil.dds.anet.beans.ApprovalStep.ApprovalStepType;
@@ -18,7 +16,9 @@ import mil.dds.anet.beans.Position.PositionType;
 import mil.dds.anet.beans.search.PersonSearchQuery;
 import mil.dds.anet.config.AnetConfiguration;
 import mil.dds.anet.database.AdminDao.AdminSettingKeys;
+import net.sourceforge.argparse4j.impl.Arguments;
 import net.sourceforge.argparse4j.inf.Namespace;
+import net.sourceforge.argparse4j.inf.Subparser;
 
 public class InitializationCommand extends EnvironmentCommand<AnetConfiguration> {
 
@@ -27,119 +27,113 @@ public class InitializationCommand extends EnvironmentCommand<AnetConfiguration>
   }
 
   @Override
+  public void configure(Subparser subparser) {
+    subparser.addArgument("--adminOrgName").action(Arguments.store()).required(true)
+        .help("set administrative organization name");
+    subparser.addArgument("--adminPosName").action(Arguments.store()).required(true)
+        .help("set administrative position name");
+    subparser.addArgument("--adminFullName").action(Arguments.store()).required(true)
+        .help("set administrator's full name; use format: LASTNAME, Firstname");
+    subparser.addArgument("--adminDomainName").action(Arguments.store()).required(true)
+        .help("set administrator's domain user name");
+
+    super.configure(subparser);
+  }
+
+  @Override
   protected void run(Environment environment, Namespace namespace, AnetConfiguration configuration)
       throws Exception {
     final AnetObjectEngine engine = AnetObjectEngine.getInstance();
 
-    System.out.println("-------- WELCOME TO ANET! --------");
-    System.out.println("We're going to ask you a few questions to get ANET set up.");
-    System.out.println();
-    System.out.println("Detecting state of database...");
-
     final PersonSearchQuery psq = new PersonSearchQuery();
     final List<Person> currPeople = engine.getPersonDao().search(psq).getList();
     if (currPeople.isEmpty()) {
-      System.out.println("ERROR: ANET Importer missing from database");
-      System.out.println("\tYou should run all migrations first");
+      System.err.println("ERROR: ANET Importer missing from database");
+      System.err.println("\tYou should run all migrations first");
       System.exit(1);
       return;
     }
     // Only person should be "ANET Importer"
     if (currPeople.size() != 1 || !"ANET Importer".equals(currPeople.get(0).getName())) {
-      System.out.println("ERROR: Other people besides ANET Importer detected in database");
-      System.out.println("\tThis task can only be run on an otherwise empty database");
+      System.err.println("ERROR: Other people besides ANET Importer detected in database");
+      System.err.println("\tThis task can only be run on an otherwise empty database");
       System.exit(1);
       return;
     }
-    System.out.println("OK!");
-    System.out.println();
-    System.out.println("Please provide the following information:");
-    Scanner scanner = new Scanner(System.in);
 
-    // Set Classification String
-    System.out.print("Classification String >>");
-    AdminSetting classifString = new AdminSetting();
-    classifString.setKey(AdminSettingKeys.SECURITY_BANNER_CLASSIFICATION.name());
-    classifString.setValue(scanner.nextLine());
-    engine.getAdminDao().saveSetting(classifString);
-    System.out.println("... Saved!");
+    // Set Classification String as default
+    saveAdminSetting(engine, AdminSettingKeys.SECURITY_BANNER_CLASSIFICATION, "NATO_UNCLASSIFIED");
 
-    // Set Releasablility String
-    System.out.print("Releasability String >>");
-    AdminSetting releasabilityString = new AdminSetting();
-    releasabilityString.setKey(AdminSettingKeys.SECURITY_BANNER_RELEASABILITY.name());
-    releasabilityString.setValue(scanner.nextLine());
-    engine.getAdminDao().saveSetting(releasabilityString);
-    System.out.println("... Saved!");
+    // Set Releasablility String as default
+    saveAdminSetting(engine, AdminSettingKeys.SECURITY_BANNER_RELEASABILITY,
+        "releasable to NATO_UNCLASSIFIED");
 
-    // Set Classification Color
-    System.out.print("Classification Color >>");
-    AdminSetting classifColor = new AdminSetting();
-    classifColor.setKey(AdminSettingKeys.SECURITY_BANNER_COLOR.name());
-    classifColor.setValue(scanner.nextLine());
-    engine.getAdminDao().saveSetting(classifColor);
-    System.out.println("... Saved!");
+    // Set Classification Color as default
+    saveAdminSetting(engine, AdminSettingKeys.SECURITY_BANNER_COLOR, "GREEN");
 
-    // Create First Organization
-    System.out.print("Name of Administrator Organization >>");
+    // Set contact email as default
+    saveAdminSetting(engine, AdminSettingKeys.CONTACT_EMAIL, "team-anet@example.com");
+
+    // Set help link url as default
+    saveAdminSetting(engine, AdminSettingKeys.HELP_LINK_URL, "http://google.com");
+
+    // Set empty external documentation link text
+    saveAdminSetting(engine, AdminSettingKeys.EXTERNAL_DOCUMENTATION_LINK_TEXT, "");
+
+    // Set general banner level as default
+    saveAdminSetting(engine, AdminSettingKeys.GENERAL_BANNER_LEVEL, "notice");
+
+    // Set empty general banner text
+    saveAdminSetting(engine, AdminSettingKeys.GENERAL_BANNER_TEXT, "");
+
+    // Set general banner visibility as default
+    saveAdminSetting(engine, AdminSettingKeys.GENERAL_BANNER_VISIBILITY, "1");
+
+    // Set daily rollup max report age days as default
+    saveAdminSetting(engine, AdminSettingKeys.DAILY_ROLLUP_MAX_REPORT_AGE_DAYS, "14");
+
+    // Create admin organization
     Organization adminOrg = new Organization();
     adminOrg.setType(OrganizationType.ADVISOR_ORG);
-    adminOrg.setShortName(scanner.nextLine());
+    adminOrg.setShortName(namespace.getString("adminOrgName"));
     adminOrg.setStatus(Organization.Status.ACTIVE);
     adminOrg = engine.getOrganizationDao().insert(adminOrg);
-    System.out.println("... Organization " + adminOrg.getUuid() + " Saved!");
 
-    // Create First Position
-    System.out.print("Name of Administrator Position >>");
+    // Create admin position
     Position adminPos = new Position();
     adminPos.setType(PositionType.ADMINISTRATOR);
     adminPos.setOrganizationUuid(adminOrg.getUuid());
-    adminPos.setName(scanner.nextLine());
+    adminPos.setName(namespace.getString("adminPosName"));
     adminPos.setStatus(Position.Status.ACTIVE);
     adminPos = engine.getPositionDao().insert(adminPos);
-    System.out.println("... Position " + adminPos.getUuid() + " Saved!");
 
-    // Create First User
-    System.out.print("Your Name [LAST NAME, First name(s)] >>");
+    // Create admin user
     Person admin = new Person();
-    admin.setName(scanner.nextLine());
-    System.out.print("Your Domain Username >>");
-    admin.setDomainUsername(scanner.nextLine());
+    admin.setName(namespace.getString("adminFullName"));
+    admin.setDomainUsername(namespace.getString("adminDomainName"));
     admin.setRole(Role.ADVISOR);
     admin = engine.getPersonDao().insert(admin);
     engine.getPositionDao().setPersonInPosition(admin.getUuid(), adminPos.getUuid());
-    System.out.println("... Person " + admin + " Saved!");
 
     // Set Default Approval Chain.
-    System.out.println("Setting you as the default approver...");
-    AdminSetting defaultOrg = new AdminSetting();
-    defaultOrg.setKey(AdminSettingKeys.DEFAULT_APPROVAL_ORGANIZATION.name());
-    defaultOrg.setValue(adminOrg.getUuid());
-    engine.getAdminDao().saveSetting(defaultOrg);
+    saveAdminSetting(engine, AdminSettingKeys.DEFAULT_APPROVAL_ORGANIZATION, adminOrg.getUuid());
 
-    ApprovalStep defaultStep = new ApprovalStep();
+    final ApprovalStep defaultStep = new ApprovalStep();
     defaultStep.setName("Default Approver");
     defaultStep.setType(ApprovalStepType.REPORT_APPROVAL);
     defaultStep.setRelatedObjectUuid(adminOrg.getUuid());
-    defaultStep.setApprovers(ImmutableList.of(adminPos));
+    defaultStep.setApprovers(List.of(adminPos));
     engine.getApprovalStepDao().insert(defaultStep);
-    System.out.println("DONE!");
 
-    AdminSetting contactEmail = new AdminSetting();
-    contactEmail.setKey(AdminSettingKeys.CONTACT_EMAIL.name());
-    contactEmail.setValue("");
-    engine.getAdminDao().saveSetting(contactEmail);
-
-    AdminSetting helpUrl = new AdminSetting();
-    helpUrl.setKey(AdminSettingKeys.HELP_LINK_URL.name());
-    helpUrl.setValue("");
-    engine.getAdminDao().saveSetting(helpUrl);
-
-    System.out.println();
-    System.out.println("All Done! You should be able to start the server now and log in");
-
-    scanner.close();
     System.exit(0);
+  }
+
+  private static void saveAdminSetting(final AnetObjectEngine engine, final AdminSettingKeys key,
+      final String value) {
+    final AdminSetting adminSetting = new AdminSetting();
+    adminSetting.setKey(key.name());
+    adminSetting.setValue(value);
+    engine.getAdminDao().saveSetting(adminSetting);
   }
 
 }


### PR DESCRIPTION
Command line arguments are required for Initialization command instead of command prompt.

Closes [AB#666](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/666)

#### User changes
- none

#### Super User changes
- none

#### Admin changes
- none

#### System admin changes
When setting up a fresh installation of ANET, the `anet init` command is no longer interactive but takes its settings with command-line options (run `anet init` without options to see how to use it).
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
