### PR TITLE
Use engagement date in report links in rich text editor

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -143,7 +143,6 @@
     "graphiql": "2.1.0",
     "graphql": "16.6.0",
     "hopscotch": "0.3.1",
-    "html-react-parser": "3.0.4",
     "jsonpath-plus": "7.2.0",
     "keycloak-js": "20.0.2",
     "leaflet": "1.9.3",

--- a/client/src/components/CustomFields.js
+++ b/client/src/components/CustomFields.js
@@ -3,7 +3,6 @@ import { IconNames } from "@blueprintjs/icons"
 import { Tooltip2 } from "@blueprintjs/popover2"
 import MultiTypeAdvancedSelectComponent from "components/advancedSelectWidget/MultiTypeAdvancedSelectComponent"
 import CustomDateInput from "components/CustomDateInput"
-import { parseHtmlWithLinkTo } from "components/editor/LinkAnet"
 import LinkAnetEntity from "components/editor/LinkAnetEntity"
 import * as FieldHelper from "components/FieldHelper"
 import Fieldset from "components/Fieldset"
@@ -89,8 +88,7 @@ const ReadonlySpecialField = ({
         name={name}
         isCompact={isCompact}
         component={FieldHelper.ReadonlyField}
-        className="rich-text-readonly"
-        humanValue={parseHtmlWithLinkTo(fieldValue)}
+        humanValue={<RichTextEditor readOnly value={fieldValue} />}
         {...Object.without(otherFieldProps, "style")}
       />
     )

--- a/client/src/components/LinkTo.js
+++ b/client/src/components/LinkTo.js
@@ -26,7 +26,7 @@ const LinkTo = ({
   modelType,
   model,
   style,
-  displayedFields,
+  displayCallback,
   ...componentProps
 }) => {
   const { level } = useContext(LinkToContext)
@@ -86,7 +86,7 @@ const LinkTo = ({
         >
           <span style={{ cursor: "help", ...style }}>
             {avatarComponent}
-            {modelInstance.toString(displayedFields?.[modelType])}
+            {modelInstance.toString(displayCallback)}
             {children}
           </span>
         </ModelTooltip>
@@ -111,7 +111,7 @@ const LinkTo = ({
       <>
         {iconComponent}
         {avatarComponent}
-        {children || modelInstance.toString(displayedFields?.[modelType])}
+        {children || modelInstance.toString(displayCallback)}
       </>
     </LinkToComponent>
   )
@@ -159,7 +159,7 @@ LinkTo.propTypes = {
   whenUnspecified: PropTypes.string,
   modelType: PropTypes.string.isRequired,
   model: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
-  displayedFields: PropTypes.object,
+  displayCallback: PropTypes.func,
   style: PropTypes.object
 }
 
@@ -172,7 +172,7 @@ LinkTo.defaultProps = {
   button: false,
   whenUnspecified: "Unspecified",
   modelType: null,
-  displayedFields: null,
+  displayCallback: null,
   model: null
 }
 

--- a/client/src/components/LinkTo.js
+++ b/client/src/components/LinkTo.js
@@ -26,6 +26,7 @@ const LinkTo = ({
   modelType,
   model,
   style,
+  displayedFields,
   ...componentProps
 }) => {
   const { level } = useContext(LinkToContext)
@@ -85,7 +86,7 @@ const LinkTo = ({
         >
           <span style={{ cursor: "help", ...style }}>
             {avatarComponent}
-            {modelInstance.toString()}
+            {modelInstance.toString(displayedFields?.[modelType])}
             {children}
           </span>
         </ModelTooltip>
@@ -110,7 +111,7 @@ const LinkTo = ({
       <>
         {iconComponent}
         {avatarComponent}
-        {children || modelInstance.toString()}
+        {children || modelInstance.toString(displayedFields?.[modelType])}
       </>
     </LinkToComponent>
   )
@@ -158,6 +159,7 @@ LinkTo.propTypes = {
   whenUnspecified: PropTypes.string,
   modelType: PropTypes.string.isRequired,
   model: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
+  displayedFields: PropTypes.object,
   style: PropTypes.object
 }
 
@@ -170,6 +172,7 @@ LinkTo.defaultProps = {
   button: false,
   whenUnspecified: "Unspecified",
   modelType: null,
+  displayedFields: null,
   model: null
 }
 

--- a/client/src/components/Model.js
+++ b/client/src/components/Model.js
@@ -84,7 +84,7 @@ export const GRAPHQL_NOTES_FIELDS = /* GraphQL */ `
 
 // Entity type --> GQL query
 export const GRAPHQL_ENTITY_FIELDS = {
-  Report: "uuid intent",
+  Report: "uuid intent engagementDate",
   Person: "uuid name role avatar(size: 32)",
   Organization: "uuid shortName",
   Position: "uuid name",

--- a/client/src/components/RelatedObjectNotes.js
+++ b/client/src/components/RelatedObjectNotes.js
@@ -5,7 +5,6 @@ import { IconNames } from "@blueprintjs/icons"
 import API from "api"
 import AppContext from "components/AppContext"
 import ConfirmDestructive from "components/ConfirmDestructive"
-import { parseHtmlWithLinkTo } from "components/editor/LinkAnet"
 import LinkTo from "components/LinkTo"
 import Messages from "components/Messages"
 import Model, {
@@ -14,6 +13,7 @@ import Model, {
 } from "components/Model"
 import RelatedObjectNoteModal from "components/RelatedObjectNoteModal"
 import ResponsiveLayoutContext from "components/ResponsiveLayoutContext"
+import RichTextEditor from "components/RichTextEditor"
 import _isEmpty from "lodash/isEmpty"
 import { Person } from "models"
 import moment from "moment"
@@ -147,9 +147,7 @@ const RelatedObjectNotes = ({
               const isJson = note.type !== NOTE_TYPE.FREE_TEXT
               const jsonFields =
                 isJson && note.text ? utils.parseJsonSafe(note.text) : {}
-              const noteText = isJson
-                ? jsonFields.text
-                : parseHtmlWithLinkTo(note.text)
+              const noteText = isJson ? jsonFields.text : note.text
               return (
                 <Card
                   key={note.uuid}
@@ -230,15 +228,7 @@ const RelatedObjectNotes = ({
                           </span>
                         ))}
                     </div>
-                    <div
-                      className="rich-text-readonly"
-                      style={{
-                        overflowWrap: "break-word",
-                        wordWrap: "break-word" // IE
-                      }}
-                    >
-                      {noteText}
-                    </div>
+                    <RichTextEditor readOnly value={noteText} />
                   </Card.Body>
                 </Card>
               )

--- a/client/src/components/RichTextEditor.js
+++ b/client/src/components/RichTextEditor.js
@@ -21,7 +21,13 @@ import {
 } from "slate-react"
 import { getUrlFromEntityInfo } from "utils_links"
 
-const RichTextEditor = ({ value, onChange, onHandleBlur, className }) => {
+const RichTextEditor = ({
+  value,
+  onChange,
+  onHandleBlur,
+  className,
+  readOnly
+}) => {
   const [showLinksModal, setShowLinksModal] = useState(false)
   const editor = useMemo(
     () => withHtml(withReact(withHistory(withAnetLink(createEditor())))),
@@ -47,16 +53,19 @@ const RichTextEditor = ({ value, onChange, onHandleBlur, className }) => {
         }}
       >
         <div className="editor-container">
-          <Toolbar
-            showLinksModal={showLinksModal}
-            setShowLinksModal={setShowLinksModal}
-          />
+          {!readOnly && (
+            <Toolbar
+              showLinksModal={showLinksModal}
+              setShowLinksModal={setShowLinksModal}
+            />
+          )}
           <Editable
             renderElement={renderElement}
             renderLeaf={renderLeaf}
             onBlur={onHandleBlur}
             onKeyDown={e => handleOnKeyDown(e, editor, setShowLinksModal)}
             className="editable"
+            readOnly={readOnly}
           />
         </div>
       </Slate>
@@ -68,7 +77,8 @@ RichTextEditor.propTypes = {
   value: PropTypes.string,
   onChange: PropTypes.func,
   onHandleBlur: PropTypes.func,
-  className: PropTypes.string
+  className: PropTypes.string,
+  readOnly: PropTypes.bool
 }
 
 const withHtml = editor => {

--- a/client/src/components/RichTextEditor.js
+++ b/client/src/components/RichTextEditor.js
@@ -1,4 +1,4 @@
-import LinkAnet from "components/editor/LinkAnet"
+import LinkAnet, { RICH_TEXT_FIELDS } from "components/editor/LinkAnet"
 import LinkAnetEntity from "components/editor/LinkAnetEntity"
 import "components/editor/RichTextEditor.css"
 import Toolbar, { handleOnKeyDown } from "components/editor/Toolbar"
@@ -236,11 +236,12 @@ const Element = ({ attributes, children, element }) => {
           }}
         >
           {element.href ? (
-            <LinkAnet url={element.href} />
+            <LinkAnet url={element.href} displayedFields={RICH_TEXT_FIELDS} />
           ) : (
             <LinkAnetEntity
               type={element.entityType}
               uuid={element.entityUuid}
+              displayedFields={RICH_TEXT_FIELDS}
             />
           )}
           {children}

--- a/client/src/components/RichTextEditor.js
+++ b/client/src/components/RichTextEditor.js
@@ -72,7 +72,7 @@ const RichTextEditor = ({
           serializeDebounced(editor, onChange)
         }}
       >
-        <div className="editor-container">
+        <div className={!readOnly ? "editor-container" : null}>
           {!readOnly && (
             <Toolbar
               showLinksModal={showLinksModal}

--- a/client/src/components/RichTextEditor.js
+++ b/client/src/components/RichTextEditor.js
@@ -51,13 +51,13 @@ const RichTextEditor = ({
   const previousValue = usePrevious(value)
 
   useEffect(() => {
-    if (previousValue !== undefined && previousValue !== value) {
+    if (readOnly && previousValue !== undefined && previousValue !== value) {
       // Only update editor when a new value comes in
       // (different from the one used for slateValue above)
       editor.children = createSlateValue(value)
       editor.onChange()
     }
-  }, [editor, previousValue, value])
+  }, [editor, previousValue, readOnly, value])
 
   const renderElement = useCallback(props => <Element {...props} />, [])
   const renderLeaf = useCallback(props => <Leaf {...props} />, [])

--- a/client/src/components/RichTextEditor.js
+++ b/client/src/components/RichTextEditor.js
@@ -1,10 +1,12 @@
-import LinkAnet, { RICH_TEXT_FIELDS } from "components/editor/LinkAnet"
+import LinkAnet from "components/editor/LinkAnet"
 import LinkAnetEntity from "components/editor/LinkAnetEntity"
 import "components/editor/RichTextEditor.css"
 import Toolbar, { handleOnKeyDown } from "components/editor/Toolbar"
 import escapeHtml from "escape-html"
 import { debounce } from "lodash"
 import _isEmpty from "lodash/isEmpty"
+import * as Models from "models"
+import moment from "moment/moment"
 import PropTypes from "prop-types"
 import React, { useCallback, useMemo, useState } from "react"
 import { createEditor, Text, Transforms } from "slate"
@@ -205,6 +207,18 @@ const deserialize = element => {
   }
 }
 
+const displayCallback = modelInstance => {
+  if (modelInstance instanceof Models.Report) {
+    return modelInstance.engagementDate
+      ? moment(modelInstance.engagementDate).format(
+        Models.Report.getEngagementDateFormat()
+      )
+      : "None"
+  } else {
+    return modelInstance.toString()
+  }
+}
+
 const Element = ({ attributes, children, element }) => {
   const selected = useSelected()
   const focused = useFocused()
@@ -236,12 +250,12 @@ const Element = ({ attributes, children, element }) => {
           }}
         >
           {element.href ? (
-            <LinkAnet url={element.href} displayedFields={RICH_TEXT_FIELDS} />
+            <LinkAnet url={element.href} displayCallback={displayCallback} />
           ) : (
             <LinkAnetEntity
               type={element.entityType}
               uuid={element.entityUuid}
-              displayedFields={RICH_TEXT_FIELDS}
+              displayCallback={displayCallback}
             />
           )}
           {children}

--- a/client/src/components/aggregations/utils.js
+++ b/client/src/components/aggregations/utils.js
@@ -1,4 +1,4 @@
-import { parseHtmlWithLinkTo } from "components/editor/LinkAnet"
+import RichTextEditor from "components/RichTextEditor"
 import _clone from "lodash/clone"
 import _cloneDeep from "lodash/cloneDeep"
 import _isEmpty from "lodash/isEmpty"
@@ -6,6 +6,7 @@ import { Person, Report } from "models"
 import moment from "moment"
 import { AssessmentPeriodPropType, PeriodPropType } from "periodUtils"
 import PropTypes from "prop-types"
+import React from "react"
 import Settings from "settings"
 
 export const aggregationWidgetPropTypes = {
@@ -198,7 +199,7 @@ export const richTextAggregation = (fieldName, fieldConfig, data) => {
   return {
     values: data
       .map(item => Object.get(item, fieldName))
-      .map(htmlString => parseHtmlWithLinkTo(htmlString))
+      .map(htmlString => <RichTextEditor readOnly value={htmlString} />)
   }
 }
 

--- a/client/src/components/editor/LinkAnet.js
+++ b/client/src/components/editor/LinkAnet.js
@@ -4,10 +4,6 @@ import PropTypes from "prop-types"
 import React from "react"
 import { getEntityInfoFromUrl } from "utils_links"
 
-export const RICH_TEXT_FIELDS = {
-  Report: "engagementDate"
-}
-
 // Enhanced HTML so that links will be converted to link components
 export function parseHtmlWithLinkTo(html) {
   if (!html) {
@@ -16,18 +12,13 @@ export function parseHtmlWithLinkTo(html) {
   return parse(html, {
     replace: domNode => {
       if (domNode.attribs && domNode.attribs.href) {
-        return (
-          <LinkAnet
-            url={domNode.attribs.href}
-            displayedFields={RICH_TEXT_FIELDS}
-          />
-        )
+        return <LinkAnet url={domNode.attribs.href} />
       }
     }
   })
 }
 
-const LinkAnet = ({ entityKey, contentState, url, displayedFields }) => {
+const LinkAnet = ({ entityKey, contentState, url, displayCallback }) => {
   const urlLink =
     url || (contentState && contentState.getEntity(entityKey).getData().url)
 
@@ -38,7 +29,7 @@ const LinkAnet = ({ entityKey, contentState, url, displayedFields }) => {
       <LinkAnetEntity
         type={isAnetEntityLink.type}
         uuid={isAnetEntityLink.uuid}
-        displayedFields={displayedFields}
+        displayCallback={displayCallback}
       />
     )
   } else {
@@ -51,7 +42,11 @@ LinkAnet.propTypes = {
   entityKey: PropTypes.string,
   contentState: PropTypes.object,
   url: PropTypes.string,
-  displayedFields: PropTypes.string
+  displayCallback: PropTypes.func
+}
+
+LinkAnet.defaultProps = {
+  displayCallback: null
 }
 
 export default LinkAnet

--- a/client/src/components/editor/LinkAnet.js
+++ b/client/src/components/editor/LinkAnet.js
@@ -4,6 +4,10 @@ import PropTypes from "prop-types"
 import React from "react"
 import { getEntityInfoFromUrl } from "utils_links"
 
+export const RICH_TEXT_FIELDS = {
+  Report: "engagementDate"
+}
+
 // Enhanced HTML so that links will be converted to link components
 export function parseHtmlWithLinkTo(html) {
   if (!html) {
@@ -12,13 +16,18 @@ export function parseHtmlWithLinkTo(html) {
   return parse(html, {
     replace: domNode => {
       if (domNode.attribs && domNode.attribs.href) {
-        return <LinkAnet url={domNode.attribs.href} />
+        return (
+          <LinkAnet
+            url={domNode.attribs.href}
+            displayedFields={RICH_TEXT_FIELDS}
+          />
+        )
       }
     }
   })
 }
 
-const LinkAnet = ({ entityKey, contentState, url }) => {
+const LinkAnet = ({ entityKey, contentState, url, displayedFields }) => {
   const urlLink =
     url || (contentState && contentState.getEntity(entityKey).getData().url)
 
@@ -29,6 +38,7 @@ const LinkAnet = ({ entityKey, contentState, url }) => {
       <LinkAnetEntity
         type={isAnetEntityLink.type}
         uuid={isAnetEntityLink.uuid}
+        displayedFields={displayedFields}
       />
     )
   } else {
@@ -40,7 +50,8 @@ const LinkAnet = ({ entityKey, contentState, url }) => {
 LinkAnet.propTypes = {
   entityKey: PropTypes.string,
   contentState: PropTypes.object,
-  url: PropTypes.string
+  url: PropTypes.string,
+  displayedFields: PropTypes.string
 }
 
 export default LinkAnet

--- a/client/src/components/editor/LinkAnet.js
+++ b/client/src/components/editor/LinkAnet.js
@@ -1,22 +1,7 @@
 import LinkAnetEntity from "components/editor/LinkAnetEntity"
-import parse from "html-react-parser"
 import PropTypes from "prop-types"
 import React from "react"
 import { getEntityInfoFromUrl } from "utils_links"
-
-// Enhanced HTML so that links will be converted to link components
-export function parseHtmlWithLinkTo(html) {
-  if (!html) {
-    return null
-  }
-  return parse(html, {
-    replace: domNode => {
-      if (domNode.attribs && domNode.attribs.href) {
-        return <LinkAnet url={domNode.attribs.href} />
-      }
-    }
-  })
-}
 
 const LinkAnet = ({ entityKey, contentState, url, displayCallback }) => {
   const urlLink =

--- a/client/src/components/editor/LinkAnetEntity.js
+++ b/client/src/components/editor/LinkAnetEntity.js
@@ -4,7 +4,7 @@ import * as Models from "models"
 import PropTypes from "prop-types"
 import React, { useEffect, useState } from "react"
 
-const LinkAnetEntity = ({ type, uuid, displayedFields, children }) => {
+const LinkAnetEntity = ({ type, uuid, displayCallback, children }) => {
   const [entity, setEntity] = useState()
 
   useEffect(() => {
@@ -20,7 +20,7 @@ const LinkAnetEntity = ({ type, uuid, displayedFields, children }) => {
   }, [type, uuid])
 
   return (
-    <LinkTo modelType={type} model={entity} displayedFields={displayedFields}>
+    <LinkTo modelType={type} model={entity} displayCallback={displayCallback}>
       {children}
     </LinkTo>
   )
@@ -29,8 +29,12 @@ const LinkAnetEntity = ({ type, uuid, displayedFields, children }) => {
 LinkAnetEntity.propTypes = {
   type: PropTypes.string.isRequired,
   uuid: PropTypes.string.isRequired,
-  displayedFields: PropTypes.object,
+  displayCallback: PropTypes.func,
   children: PropTypes.any
+}
+
+LinkAnetEntity.defaultProps = {
+  displayCallback: null
 }
 
 export default LinkAnetEntity

--- a/client/src/components/editor/LinkAnetEntity.js
+++ b/client/src/components/editor/LinkAnetEntity.js
@@ -4,7 +4,7 @@ import * as Models from "models"
 import PropTypes from "prop-types"
 import React, { useEffect, useState } from "react"
 
-const LinkAnetEntity = ({ type, uuid, children }) => {
+const LinkAnetEntity = ({ type, uuid, displayedFields, children }) => {
   const [entity, setEntity] = useState()
 
   useEffect(() => {
@@ -20,7 +20,7 @@ const LinkAnetEntity = ({ type, uuid, children }) => {
   }, [type, uuid])
 
   return (
-    <LinkTo modelType={type} model={entity}>
+    <LinkTo modelType={type} model={entity} displayedFields={displayedFields}>
       {children}
     </LinkTo>
   )
@@ -29,6 +29,7 @@ const LinkAnetEntity = ({ type, uuid, children }) => {
 LinkAnetEntity.propTypes = {
   type: PropTypes.string.isRequired,
   uuid: PropTypes.string.isRequired,
+  displayedFields: PropTypes.object,
   children: PropTypes.any
 }
 

--- a/client/src/components/editor/RichTextEditor.css
+++ b/client/src/components/editor/RichTextEditor.css
@@ -9,7 +9,7 @@
   flex-wrap: wrap;
 }
 
-.editable {
+.editor-container .editable {
   min-height: 10rem;
   max-height: 50rem;
   overflow: auto;

--- a/client/src/components/editor/RichTextEditor.css
+++ b/client/src/components/editor/RichTextEditor.css
@@ -48,7 +48,6 @@
 
 /* 
  * Rich text editor style overrides.
- * when making a change, change rich-text-readonly class accordingly.
 */
 
 .editable h1 {

--- a/client/src/components/previews/PersonPreview.js
+++ b/client/src/components/previews/PersonPreview.js
@@ -2,11 +2,11 @@ import { gql } from "@apollo/client"
 import API from "api"
 import AppContext from "components/AppContext"
 import AvatarDisplayComponent from "components/AvatarDisplayComponent"
-import { parseHtmlWithLinkTo } from "components/editor/LinkAnet"
 import { PreviewField } from "components/FieldHelper"
 import LinkTo from "components/LinkTo"
 import { DEFAULT_CUSTOM_FIELDS_PARENT } from "components/Model"
 import PreviousPositions from "components/PreviousPositions"
+import RichTextEditor from "components/RichTextEditor"
 import { Person, Position } from "models"
 import moment from "moment"
 import PropTypes from "prop-types"
@@ -180,8 +180,8 @@ const PersonPreview = ({ className, uuid }) => {
         </Row>
 
         <div className="preview-field-label">Biography</div>
-        <div className="preview-field-value rich-text-readonly">
-          {parseHtmlWithLinkTo(person.biography)}
+        <div className="preview-field-value">
+          <RichTextEditor readOnly value={person.biography} />
         </div>
       </div>
       <br />

--- a/client/src/components/previews/ReportPreview.js
+++ b/client/src/components/previews/ReportPreview.js
@@ -1,10 +1,10 @@
 import { gql } from "@apollo/client"
 import API from "api"
-import { parseHtmlWithLinkTo } from "components/editor/LinkAnet"
 import { PreviewField } from "components/FieldHelper"
 import LinkTo from "components/LinkTo"
 import NoPaginationTaskTable from "components/NoPaginationTaskTable"
 import PlanningConflictForReport from "components/PlanningConflictForReport"
+import RichTextEditor from "components/RichTextEditor"
 import { Person, Report, Task } from "models"
 import moment from "moment"
 import ReportPeople from "pages/reports/ReportPeople"
@@ -278,8 +278,8 @@ const ReportPreview = ({ className, uuid }) => {
       {report.reportText && (
         <React.Fragment>
           <h4>{Settings.fields.report.reportText}</h4>
-          <div className="preview-section rich-text-readonly">
-            {parseHtmlWithLinkTo(report.reportText)}
+          <div className="preview-section">
+            <RichTextEditor readOnly value={report.reportText} />
           </div>
         </React.Fragment>
       )}

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1308,15 +1308,3 @@ div[id*='fg-entityAssessment'] {
     text-align: left;
   }
 }
-
-.rich-text-readonly h1 {
-  font-size: 1.5rem;
-}
-
-.rich-text-readonly h2 {
-  font-size: 1.25rem;
-}
-
-.rich-text-readonly h3 {
-  font-size: 1.0rem;
-}

--- a/client/src/models/Report.js
+++ b/client/src/models/Report.js
@@ -412,11 +412,9 @@ export default class Report extends Model {
     return REPORTS_ICON
   }
 
-  toString(displayedField) {
-    if (displayedField === "engagementDate") {
-      return this.engagementDate
-        ? moment(this.engagementDate).format(Report.getEngagementDateFormat())
-        : "None"
+  toString(displayCallback) {
+    if (typeof displayCallback === "function") {
+      return displayCallback(this)
     }
     return this.intent || "None"
   }

--- a/client/src/models/Report.js
+++ b/client/src/models/Report.js
@@ -412,7 +412,12 @@ export default class Report extends Model {
     return REPORTS_ICON
   }
 
-  toString() {
+  toString(displayedField) {
+    if (displayedField === "engagementDate") {
+      return this.engagementDate
+        ? moment(this.engagementDate).format(Report.getEngagementDateFormat())
+        : "None"
+    }
     return this.intent || "None"
   }
 

--- a/client/src/pages/admin/merge/MergePeople.js
+++ b/client/src/pages/admin/merge/MergePeople.js
@@ -8,7 +8,6 @@ import AdvancedSingleSelect from "components/advancedSelectWidget/AdvancedSingle
 import AvatarDisplayComponent from "components/AvatarDisplayComponent"
 import { customFieldsJSONString } from "components/CustomFields"
 import EditHistory from "components/EditHistory"
-import { parseHtmlWithLinkTo } from "components/editor/LinkAnet"
 import LinkTo from "components/LinkTo"
 import PersonField from "components/MergeField"
 import Messages from "components/Messages"
@@ -25,6 +24,7 @@ import {
   usePageTitle
 } from "components/Page"
 import PreviousPositions from "components/PreviousPositions"
+import RichTextEditor from "components/RichTextEditor"
 import useMergeObjects, {
   ALIGN_OPTIONS,
   areAllSet,
@@ -423,8 +423,9 @@ const MergePeople = ({ pageDispatchers }) => {
               />
               <PersonField
                 label="Biography"
-                value={parseHtmlWithLinkTo(mergedPerson.biography)}
-                className="rich-text-readonly"
+                value={
+                  <RichTextEditor readOnly value={mergedPerson.biography} />
+                }
                 align={ALIGN_OPTIONS.CENTER}
                 action={
                   matchingRoles &&
@@ -939,8 +940,7 @@ const PersonColumn = ({
           <PersonField
             label="Biography"
             fieldName="biography"
-            className="rich-text-readonly"
-            value={parseHtmlWithLinkTo(person.biography)}
+            value={<RichTextEditor readOnly value={person.biography} />}
             align={align}
             action={
               actionButtons &&

--- a/client/src/pages/people/Compact.js
+++ b/client/src/pages/people/Compact.js
@@ -14,7 +14,6 @@ import CompactTable, {
   PAGE_SIZES
 } from "components/Compact"
 import { mapReadonlyCustomFieldsToComps } from "components/CustomFields"
-import { parseHtmlWithLinkTo } from "components/editor/LinkAnet"
 import * as FieldHelper from "components/FieldHelper"
 import LinkTo from "components/LinkTo"
 import {
@@ -29,6 +28,7 @@ import {
   usePageTitle
 } from "components/Page"
 import { GRAPHQL_NOTES_FIELDS } from "components/RelatedObjectNotes"
+import RichTextEditor from "components/RichTextEditor"
 import SimpleMultiCheckboxDropdown from "components/SimpleMultiCheckboxDropdown"
 import { Field, Formik } from "formik"
 import _isEmpty from "lodash/isEmpty"
@@ -387,15 +387,15 @@ const CompactPersonView = ({ pageDispatchers }) => {
 
   function mapNonCustomFields() {
     const classNameExceptions = {
-      biography: "biography rich-text-readonly"
+      biography: "biography"
     }
 
     const idExceptions = {
       position: "current-position"
     }
-    // map fields that have specific human person
+    // map fields that have specific human value
     const humanValuesExceptions = {
-      biography: parseHtmlWithLinkTo(person.biography),
+      biography: <RichTextEditor readOnly value={person.biography} />,
       emailAddress: emailHumanValue,
       endOfTourDate:
         person.endOfTourDate &&

--- a/client/src/pages/people/Show.js
+++ b/client/src/pages/people/Show.js
@@ -10,7 +10,6 @@ import AvatarDisplayComponent from "components/AvatarDisplayComponent"
 import { mapReadonlyCustomFieldsToComps } from "components/CustomFields"
 import EditAssociatedPositionsModal from "components/EditAssociatedPositionsModal"
 import EditHistory from "components/EditHistory"
-import { parseHtmlWithLinkTo } from "components/editor/LinkAnet"
 import * as FieldHelper from "components/FieldHelper"
 import Fieldset from "components/Fieldset"
 import GuidedTour from "components/GuidedTour"
@@ -34,6 +33,7 @@ import RelatedObjectNotes, {
   GRAPHQL_NOTES_FIELDS
 } from "components/RelatedObjectNotes"
 import ReportCollection from "components/ReportCollection"
+import RichTextEditor from "components/RichTextEditor"
 import { Field, Form, Formik } from "formik"
 import _isEmpty from "lodash/isEmpty"
 import { Person, Position } from "models"
@@ -480,12 +480,12 @@ const PersonShow = ({ pageDispatchers }) => {
 
   function mapNonCustomFields() {
     const classNameExceptions = {
-      biography: "biography rich-text-readonly"
+      biography: "biography"
     }
 
-    // map fields that have specific human person
+    // map fields that have specific human value
     const humanValuesExceptions = {
-      biography: parseHtmlWithLinkTo(person.biography),
+      biography: <RichTextEditor readOnly value={person.biography} />,
       emailAddress: emailHumanValue,
       endOfTourDate:
         person.endOfTourDate &&

--- a/client/src/pages/reports/Compact.js
+++ b/client/src/pages/reports/Compact.js
@@ -17,7 +17,6 @@ import CompactTable, {
   PAGE_SIZES
 } from "components/Compact"
 import { ReadonlyCustomFields } from "components/CustomFields"
-import { parseHtmlWithLinkTo } from "components/editor/LinkAnet"
 import Fieldset from "components/Fieldset"
 import LinkTo from "components/LinkTo"
 import { DEFAULT_CUSTOM_FIELDS_PARENT } from "components/Model"
@@ -29,6 +28,7 @@ import {
 } from "components/Page"
 import { GRAPHQL_NOTES_FIELDS } from "components/RelatedObjectNotes"
 import { ActionButton, ActionStatus } from "components/ReportWorkflow"
+import RichTextEditor from "components/RichTextEditor"
 import SimpleMultiCheckboxDropdown from "components/SimpleMultiCheckboxDropdown"
 import { Formik } from "formik"
 import _isEmpty from "lodash/isEmpty"
@@ -373,8 +373,10 @@ const CompactReportView = ({ pageDispatchers }) => {
                     {report.reportText ? (
                       <CompactRow
                         label={Settings.fields.report.reportText}
-                        content={parseHtmlWithLinkTo(report.reportText)}
-                        className="reportField rich-text-readonly"
+                        content={
+                          <RichTextEditor readOnly value={report.reportText} />
+                        }
+                        className="reportField"
                       />
                     ) : null}
                     {Settings.fields.report.customFields ? (

--- a/client/src/pages/reports/Show.js
+++ b/client/src/pages/reports/Show.js
@@ -10,7 +10,6 @@ import AppContext from "components/AppContext"
 import InstantAssessmentsContainerField from "components/assessments/instant/InstantAssessmentsContainerField"
 import ConfirmDestructive from "components/ConfirmDestructive"
 import { ReadonlyCustomFields } from "components/CustomFields"
-import { parseHtmlWithLinkTo } from "components/editor/LinkAnet"
 import * as FieldHelper from "components/FieldHelper"
 import Fieldset from "components/Fieldset"
 import LinkTo from "components/LinkTo"
@@ -31,6 +30,7 @@ import RelatedObjectNotes, {
   GRAPHQL_NOTES_FIELDS
 } from "components/RelatedObjectNotes"
 import { ReportFullWorkflow } from "components/ReportWorkflow"
+import RichTextEditor from "components/RichTextEditor"
 import { deserializeQueryParams } from "components/SearchFilters"
 import TriggerableConfirm from "components/TriggerableConfirm"
 import { Field, Form, Formik } from "formik"
@@ -674,17 +674,16 @@ const ReportShow = ({ setSearchQuery, pageDispatchers }) => {
                 <Fieldset
                   title={Settings.fields.report.reportText}
                   id="report-text"
-                  className="rich-text-readonly"
                 >
-                  {parseHtmlWithLinkTo(report.reportText)}
+                  <RichTextEditor readOnly value={report.reportText} />
                 </Fieldset>
               )}
               {report.reportSensitiveInformation?.text && (
-                <Fieldset
-                  title="Sensitive information"
-                  className="rich-text-readonly"
-                >
-                  {parseHtmlWithLinkTo(report.reportSensitiveInformation.text)}
+                <Fieldset title="Sensitive information">
+                  <RichTextEditor
+                    readOnly
+                    value={report.reportSensitiveInformation.text}
+                  />
                   {(hasAuthorizationGroups && (
                     <div>
                       <h5>Authorized groups:</h5>

--- a/client/tests/webdriver/baseSpecs/richTextField.spec.js
+++ b/client/tests/webdriver/baseSpecs/richTextField.spec.js
@@ -2,6 +2,7 @@ import { expect } from "chai"
 import MyReports, { REPORT_STATES } from "../pages/myReports.page"
 import EditReport from "../pages/report/editReport.page"
 import ShowReport from "../pages/report/showReport.page"
+import { getRichTextContent } from "./richTextUtils"
 
 const RICH_TEXT_CONTENT = [
   { selector: "h1", content: "Heading 1" },
@@ -49,7 +50,8 @@ describe("When reports have rich text content", () => {
     RICH_TEXT_CONTENT.forEach(
       ({ selector, multipleElements, index, content }) => {
         expect(
-          ShowReport.getReportTextContent(
+          getRichTextContent(
+            ShowReport.reportText,
             selector,
             multipleElements,
             index
@@ -63,7 +65,8 @@ describe("When reports have rich text content", () => {
     RICH_TEXT_CONTENT.forEach(
       ({ selector, multipleElements, index, content }) => {
         expect(
-          EditReport.getReportTextContent(
+          getRichTextContent(
+            EditReport.reportText,
             selector,
             multipleElements,
             index

--- a/client/tests/webdriver/baseSpecs/richTextUtils.js
+++ b/client/tests/webdriver/baseSpecs/richTextUtils.js
@@ -1,0 +1,39 @@
+export const getRichTextContent = (
+  richTextEditor,
+  selector,
+  multipleElements,
+  index
+) => {
+  const tags = selector.split(" ")
+  const convertedSelector = tags.map(tag => convertTagForEditor(tag)).join(" ")
+  if (multipleElements) {
+    return richTextEditor.$(convertedSelector).$$(multipleElements)[index]
+  }
+  return richTextEditor.$(convertedSelector)
+
+  function convertTagForEditor(tag) {
+    let convertedTag = tag
+    // Some tags are deserialized into different tags having the same appearance
+    switch (tag) {
+      // "b" and "strong" tags are deserialized into "strong" tag
+      case "b":
+        convertedTag = "strong"
+        break
+      // "i" and "em" tags are deserialized into "em" tag
+      case "i":
+        convertedTag = "em"
+        break
+      // "cite" and "blockquote" tags are deserialized into "blockquote" tag
+      case "cite":
+        convertedTag = "blockquote"
+        break
+      // Text content without a tag is wrapped inside a "p" tag
+      case "":
+        convertedTag = "p"
+        break
+      default:
+        return tag
+    }
+    return convertedTag
+  }
+}

--- a/client/tests/webdriver/pages/report/editReport.page.js
+++ b/client/tests/webdriver/pages/report/editReport.page.js
@@ -25,41 +25,6 @@ class EditReport extends Page {
     return browser.$(".reportTextField")
   }
 
-  getReportTextContent(selector, multipleElements, index) {
-    const tags = selector.split(" ")
-    selector = tags.map(tag => convertTagForEditor(tag)).join(" ")
-    if (multipleElements) {
-      return this.reportText.$(selector).$$(multipleElements)[index]
-    }
-    return this.reportText.$(selector)
-
-    function convertTagForEditor(tag) {
-      let convertedTag = tag
-      // Some tags are deserialized into different tags having the same appearance
-      switch (tag) {
-        // "b" and "strong" tags are deserialized into "strong" tag
-        case "b":
-          convertedTag = "strong"
-          break
-        // "i" and "em" tags are deserialized into "em" tag
-        case "i":
-          convertedTag = "em"
-          break
-        // "cite" and "blockquote" tags are deserialized into "blockquote" tag
-        case "cite":
-          convertedTag = "blockquote"
-          break
-        // Text content without a tag is wrapped inside a "p" tag
-        case "":
-          convertedTag = "p"
-          break
-        default:
-          return tag
-      }
-      return convertedTag
-    }
-  }
-
   confirmDeleteButton(uuid) {
     return browser.$('//button[text()="Yes, I am sure"]')
   }

--- a/client/tests/webdriver/pages/report/showReport.page.js
+++ b/client/tests/webdriver/pages/report/showReport.page.js
@@ -130,16 +130,6 @@ class ShowReport extends Page {
     return browser.$('//div[text()="Successfully approved report."]')
   }
 
-  getReportTextContent(selector, multipleElements, index) {
-    if (!selector) {
-      return this.reportText
-    }
-    if (multipleElements) {
-      return this.reportText.$(selector).$$(multipleElements)[index]
-    }
-    return this.reportText.$(selector)
-  }
-
   getAttendeeByName(name) {
     const td = browser
       .$("#reportPeopleContainer")

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -7844,15 +7844,6 @@ dom-serializer@^1.0.1:
     domhandler "^4.2.0"
     entities "^2.0.0"
 
-dom-serializer@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-2.0.0.tgz#e41b802e1eedf9f6cae183ce5e622d789d7d8e53"
-  integrity sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==
-  dependencies:
-    domelementtype "^2.3.0"
-    domhandler "^5.0.2"
-    entities "^4.2.0"
-
 dom-walk@^0.1.0:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/dom-walk/-/dom-walk-0.1.2.tgz#0c548bef048f4d1f2a97249002236060daa3fd84"
@@ -7863,7 +7854,7 @@ dom4@^2.1.5:
   resolved "https://registry.yarnpkg.com/dom4/-/dom4-2.1.6.tgz#c90df07134aa0dbd81ed4d6ba1237b36fc164770"
   integrity sha512-JkCVGnN4ofKGbjf5Uvc8mmxaATIErKQKSgACdBXpsQ3fY6DlIpAyWfiBSrGkttATssbDCp3psiAKWXk5gmjycA==
 
-domelementtype@^2.0.1, domelementtype@^2.2.0, domelementtype@^2.3.0:
+domelementtype@^2.0.1, domelementtype@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.3.0.tgz#5c45e8e869952626331d7aab326d01daf65d589d"
   integrity sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==
@@ -7874,13 +7865,6 @@ domexception@^4.0.0:
   integrity sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==
   dependencies:
     webidl-conversions "^7.0.0"
-
-domhandler@5.0.3, domhandler@^5.0.1, domhandler@^5.0.2:
-  version "5.0.3"
-  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-5.0.3.tgz#cc385f7f751f1d1fc650c21374804254538c7d31"
-  integrity sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==
-  dependencies:
-    domelementtype "^2.3.0"
 
 domhandler@^4.0.0, domhandler@^4.2.0, domhandler@^4.3.1:
   version "4.3.1"
@@ -7897,15 +7881,6 @@ domutils@^2.5.2, domutils@^2.8.0:
     dom-serializer "^1.0.1"
     domelementtype "^2.2.0"
     domhandler "^4.2.0"
-
-domutils@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/domutils/-/domutils-3.0.1.tgz#696b3875238338cb186b6c0612bd4901c89a4f1c"
-  integrity sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==
-  dependencies:
-    dom-serializer "^2.0.0"
-    domelementtype "^2.3.0"
-    domhandler "^5.0.1"
 
 dot-case@^3.0.4:
   version "3.0.4"
@@ -8089,7 +8064,7 @@ entities@^2.0.0:
   resolved "https://registry.yarnpkg.com/entities/-/entities-2.2.0.tgz#098dc90ebb83d8dffa089d55256b351d34c4da55"
   integrity sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==
 
-entities@^4.2.0, entities@^4.3.0, entities@^4.4.0:
+entities@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/entities/-/entities-4.4.0.tgz#97bdaba170339446495e653cfd2db78962900174"
   integrity sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==
@@ -9932,14 +9907,6 @@ hpack.js@^2.1.6:
     readable-stream "^2.0.1"
     wbuf "^1.1.0"
 
-html-dom-parser@3.1.2:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/html-dom-parser/-/html-dom-parser-3.1.2.tgz#c137c42df80e17d185ff35a806925d96cc73f408"
-  integrity sha512-mLTtl3pVn3HnqZSZzW3xVs/mJAKrG1yIw3wlp+9bdoZHHLaBRvELdpfShiPVLyjPypq1Fugv2KMDoGHW4lVXnw==
-  dependencies:
-    domhandler "5.0.3"
-    htmlparser2 "8.0.1"
-
 html-encoding-sniffer@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz#2cb1a8cf0db52414776e5b2a7a04d5dd98158de9"
@@ -9970,16 +9937,6 @@ html-minifier-terser@^6.0.2:
     relateurl "^0.2.7"
     terser "^5.10.0"
 
-html-react-parser@3.0.4:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/html-react-parser/-/html-react-parser-3.0.4.tgz#6a6a115a011dfdadd901ca9d2ed80fa5390647e5"
-  integrity sha512-va68PSmC7uA6PbOEc9yuw5Mu3OHPXmFKUpkLGvUPdTuNrZ0CJZk1s/8X/FaHjswK/6uZghu2U02tJjussT8+uw==
-  dependencies:
-    domhandler "5.0.3"
-    html-dom-parser "3.1.2"
-    react-property "2.0.0"
-    style-to-js "1.1.1"
-
 html-tags@^3.1.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/html-tags/-/html-tags-3.2.0.tgz#dbb3518d20b726524e4dd43de397eb0a95726961"
@@ -10000,16 +9957,6 @@ html-webpack-plugin@5.5.0, html-webpack-plugin@^5.0.0:
     lodash "^4.17.21"
     pretty-error "^4.0.0"
     tapable "^2.0.0"
-
-htmlparser2@8.0.1:
-  version "8.0.1"
-  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-8.0.1.tgz#abaa985474fcefe269bc761a779b544d7196d010"
-  integrity sha512-4lVbmc1diZC7GUJQtRQ5yBAeUCL1exyMwmForWkRLnwyzWBFxN633SALPMGYaWZvKe9j1pRZJpauvmxENSp/EA==
-  dependencies:
-    domelementtype "^2.3.0"
-    domhandler "^5.0.2"
-    domutils "^3.0.1"
-    entities "^4.3.0"
 
 htmlparser2@^6.1.0:
   version "6.1.0"
@@ -14263,11 +14210,6 @@ react-popper@^2.3.0:
     react-fast-compare "^3.0.1"
     warning "^4.0.2"
 
-react-property@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/react-property/-/react-property-2.0.0.tgz#2156ba9d85fa4741faf1918b38efc1eae3c6a136"
-  integrity sha512-kzmNjIgU32mO4mmH5+iUyrqlpFQhF8K2k7eZ4fdLSOPFrD1XgEuSBv9LDEgxRXTMBqMd8ppT0x6TIzqE5pdGdw==
-
 react-redux-loading-bar@5.0.4:
   version "5.0.4"
   resolved "https://registry.yarnpkg.com/react-redux-loading-bar/-/react-redux-loading-bar-5.0.4.tgz#06dffcc53a447828dec1a26903e6b22807dd4254"
@@ -15789,13 +15731,6 @@ style-loader@^2.0.0:
   dependencies:
     loader-utils "^2.0.0"
     schema-utils "^3.0.0"
-
-style-to-js@1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/style-to-js/-/style-to-js-1.1.1.tgz#417786986cda61d4525c80aed9d1123a6a7af9b8"
-  integrity sha512-RJ18Z9t2B02sYhZtfWKQq5uplVctgvjTfLWT7+Eb1zjUjIrWzX5SdlkwLGQozrqarTmEzJJ/YmdNJCUNI47elg==
-  dependencies:
-    style-to-object "0.3.0"
 
 style-to-object@0.3.0, style-to-object@^0.3.0:
   version "0.3.0"


### PR DESCRIPTION
Report links in the rich text editor display the _engagement date_ instead of the _intent_. This improves the readability of the fields as _intent_ can be lengthy and makes the links hard to use inline.

Closes [AB#635](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/635)

#### User changes
- Rich texts including report links are more readable.

#### Super User changes
- None

#### Admin changes
- None

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [x] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
