### PR TITLE
Add top-level test condition to assessments

### DIFF
--- a/anet-dictionary.yml
+++ b/anet-dictionary.yml
@@ -95,6 +95,7 @@ fields:
               label: Instant assessment Question 3
         topTaskSemiannually:
           recurrence: semiannually
+          test: $.subject[?(@property === "shortName" && @.match(/^EF/i))]
           authorizationGroupUuids:
             read: ['c21e7321-7ec5-4837-8805-a302f9575754']
             write: ['39a78d51-c351-452c-9206-4305ec8dd76d']
@@ -852,12 +853,12 @@ fields:
         advisorOnceReportLinguist:
           recurrence: once
           relatedObjectType: report
+          test: $.subject.position.organization[?(@property === "shortName" && @.match(/^LNG/i))]
           authorizationGroupUuids:
             read: ['c21e7321-7ec5-4837-8805-a302f9575754']
             write: ['39a78d51-c351-452c-9206-4305ec8dd76d']
           questions:
             preparedDocuments:
-              test: $.subject.position.organization[?(@property === "shortName" && @.match(/^LNG/i))]
               type: enum
               helpText: "Did the linguist prepare any written documents used for the engagement meeting?"
               label: Prepared documents
@@ -888,7 +889,6 @@ fields:
                   label: Bad
                   color: "#fc5a03"
             linguistRole:
-              test: $.subject.position.organization[?(@property === "shortName" && @.match(/^LNG/i))]
               type: enum
               helpText: "What was the linguist's role?"
               label: "Linguist Role"
@@ -1344,6 +1344,7 @@ fields:
                   color: '#0000ff'
         principalOndemandScreeningAndVetting:
           recurrence: ondemand
+          test: $.subject.position.organization[?(@property === "shortName" && @.match(/^MoD/i))]
           onDemandAssessmentExpirationDays: 108
           label: "Screening & Vetting"
           authorizationGroupUuids:

--- a/client/src/components/Model.js
+++ b/client/src/components/Model.js
@@ -782,6 +782,13 @@ export default class Model {
       questions: {},
       questionSets: {}
     }
+    if (
+      assessmentConfig?.test &&
+      _isEmpty(JSONPath({ path: assessmentConfig.test, json: testValue }))
+    ) {
+      // Assessment config does not apply
+      return null
+    }
     if (!_isEmpty(assessmentConfig?.questions)) {
       Object.entries(assessmentConfig.questions)
         .filter(
@@ -850,7 +857,7 @@ export default class Model {
       // Clear invalid questions on the current level
       currentLevelQuestions.forEach(
         question =>
-          !filtered.questions[question] &&
+          !filtered?.questions?.[question] &&
           delete currentLevelAssessment.questions[question]
       )
     }

--- a/client/src/components/assessments/instant/InstantAssessmentsContainerField.js
+++ b/client/src/components/assessments/instant/InstantAssessmentsContainerField.js
@@ -43,8 +43,8 @@ const InstantAssessmentRow = ({
   const readOnlyAccess = readonly || !hasWriteAccess
   const { values } = formikProps
   if (
-    _isEmpty(entityInstantAssessmentConfig.questions) &&
-    _isEmpty(entityInstantAssessmentConfig.questionSets)
+    _isEmpty(entityInstantAssessmentConfig?.questions) &&
+    _isEmpty(entityInstantAssessmentConfig?.questionSets)
   ) {
     return null
   }
@@ -52,7 +52,7 @@ const InstantAssessmentRow = ({
   return (
     <tr>
       <td>
-        {!_isEmpty(entityInstantAssessmentConfig.questions) &&
+        {!_isEmpty(entityInstantAssessmentConfig?.questions) &&
           (readOnlyAccess ? (
             <ReadonlyCustomFields
               parentFieldName={parentFieldName}
@@ -66,7 +66,7 @@ const InstantAssessmentRow = ({
               formikProps={formikProps}
             />
           ))}
-        {!_isEmpty(entityInstantAssessmentConfig.questionSets) && (
+        {!_isEmpty(entityInstantAssessmentConfig?.questionSets) && (
           <QuestionSet
             entity={entity}
             relatedObject={relatedObject}
@@ -117,8 +117,8 @@ const InstantAssessmentsContainerField = ({
       relatedObject
     )
     return (
-      !_isEmpty(filteredAssessment.questions) ||
-      !_isEmpty(filteredAssessment.questionSets)
+      !_isEmpty(filteredAssessment?.questions) ||
+      !_isEmpty(filteredAssessment?.questionSets)
     )
   }
   // Sort entities to display the ones without any assessment at the beginning,

--- a/client/src/components/assessments/ondemand/OndemandAssessment.js
+++ b/client/src/components/assessments/ondemand/OndemandAssessment.js
@@ -77,8 +77,8 @@ const OnDemandAssessment = ({
   )
 
   if (
-    filteredAssessmentConfig.questions[ENTITY_ON_DEMAND_EXPIRATION_DATE] &&
-    filteredAssessmentConfig.onDemandAssessmentExpirationDays
+    filteredAssessmentConfig?.questions[ENTITY_ON_DEMAND_EXPIRATION_DATE] &&
+    filteredAssessmentConfig?.onDemandAssessmentExpirationDays
   ) {
     filteredAssessmentConfig.questions[
       ENTITY_ON_DEMAND_EXPIRATION_DATE
@@ -118,7 +118,7 @@ const OnDemandAssessment = ({
         <React.Fragment>
           <ValidationBar
             assessmentExpirationDays={
-              filteredAssessmentConfig.onDemandAssessmentExpirationDays
+              filteredAssessmentConfig?.onDemandAssessmentExpirationDays
             }
             index={index}
             assessmentFieldsObject={assessmentFieldsObject}
@@ -191,7 +191,7 @@ const OnDemandAssessment = ({
                   {() => {
                     return (
                       <>
-                        {!_isEmpty(filteredAssessmentConfig.questions) && (
+                        {!_isEmpty(filteredAssessmentConfig?.questions) && (
                           <ReadonlyCustomFields
                             parentFieldName={parentFieldName}
                             fieldsConfig={filteredAssessmentConfig.questions}
@@ -201,12 +201,10 @@ const OnDemandAssessment = ({
                             vertical
                           />
                         )}
-                        {!_isEmpty(filteredAssessmentConfig.questionSets) && (
+                        {!_isEmpty(filteredAssessmentConfig?.questionSets) && (
                           <QuestionSet
                             parentFieldName={`${parentFieldName}.questionSets`}
-                            questionSets={
-                              filteredAssessmentConfig?.questionSets
-                            }
+                            questionSets={filteredAssessmentConfig.questionSets}
                             formikProps={{
                               values: {
                                 [parentFieldName]: assessmentFieldsObject
@@ -287,6 +285,9 @@ const OnDemandAssessment = ({
     console.error(
       `Recurrence type is not ${RECURRENCE_TYPE.ON_DEMAND}. Component will not be rendered!`
     )
+    return null
+  } else if (!filteredAssessmentConfig) {
+    return null
   } else {
     return (
       <div style={{ ...style }}>

--- a/client/src/components/assessments/periodic/PeriodicAssessmentResultsTable.js
+++ b/client/src/components/assessments/periodic/PeriodicAssessmentResultsTable.js
@@ -139,57 +139,56 @@ const PeriodicAssessmentResultsTable = ({
     assessmentConfig,
     entity
   )
-  const showAssessmentResults =
-    !_isEmpty(entityInstantAssessmentConfig) ||
-    !_isEmpty(subEntitiesInstantAssessmentConfig) ||
-    !_isEmpty(filteredAssessmentConfig)
+  if (
+    _isEmpty(entityInstantAssessmentConfig) &&
+    _isEmpty(subEntitiesInstantAssessmentConfig) &&
+    _isEmpty(filteredAssessmentConfig)
+  ) {
+    return null
+  }
   return (
     <>
-      {showAssessmentResults && (
-        <div style={{ ...style }}>
-          <Fieldset
-            title={`Assessment results - ${
-              assessmentConfig.label || recurrence
-            }`}
-            id={`entity-assessments-results-${recurrence}`}
+      <div style={{ ...style }}>
+        <Fieldset
+          title={`Assessment results - ${assessmentConfig.label || recurrence}`}
+          id={`entity-assessments-results-${recurrence}`}
+        >
+          <PeriodsNavigation offset={offset} onChange={setOffset} />
+          <Table
+            borderless
+            responsive
+            className="assessments-table"
+            style={{ tableLayout: "fixed" }}
           >
-            <PeriodsNavigation offset={offset} onChange={setOffset} />
-            <Table
-              borderless
-              responsive
-              className="assessments-table"
-              style={{ tableLayout: "fixed" }}
-            >
-              <PeriodsTableHeader periodsConfig={periodsConfig} />
-              <tbody>
-                <>
-                  {subEntities?.map(subEntity => (
-                    <EntityPeriodicAssessmentResults
-                      key={`subassessment-${subEntity.uuid}`}
-                      assessmentKey={assessmentKey}
-                      idSuffix={`subassessment-${subEntity.uuid}`}
-                      entity={subEntity}
-                      entityType={entityType}
-                      periodsConfig={periodsConfig}
-                      canAddAssessment={false}
-                      onUpdateAssessment={onUpdateAssessment}
-                    />
-                  ))}
-                </>
-                <EntityPeriodicAssessmentResults
-                  assessmentKey={assessmentKey}
-                  idSuffix={`assessment-${entity.uuid}`}
-                  entity={entity}
-                  entityType={entityType}
-                  periodsConfig={periodsConfig}
-                  canAddAssessment={canAddAssessment}
-                  onUpdateAssessment={onUpdateAssessment}
-                />
-              </tbody>
-            </Table>
-          </Fieldset>
-        </div>
-      )}
+            <PeriodsTableHeader periodsConfig={periodsConfig} />
+            <tbody>
+              <>
+                {subEntities?.map(subEntity => (
+                  <EntityPeriodicAssessmentResults
+                    key={`subassessment-${subEntity.uuid}`}
+                    assessmentKey={assessmentKey}
+                    idSuffix={`subassessment-${subEntity.uuid}`}
+                    entity={subEntity}
+                    entityType={entityType}
+                    periodsConfig={periodsConfig}
+                    canAddAssessment={false}
+                    onUpdateAssessment={onUpdateAssessment}
+                  />
+                ))}
+              </>
+              <EntityPeriodicAssessmentResults
+                assessmentKey={assessmentKey}
+                idSuffix={`assessment-${entity.uuid}`}
+                entity={entity}
+                entityType={entityType}
+                periodsConfig={periodsConfig}
+                canAddAssessment={canAddAssessment}
+                onUpdateAssessment={onUpdateAssessment}
+              />
+            </tbody>
+          </Table>
+        </Fieldset>
+      </div>
     </>
   )
 }

--- a/client/tests/webdriver/baseSpecs/assessmentsForPeople.spec.js
+++ b/client/tests/webdriver/baseSpecs/assessmentsForPeople.spec.js
@@ -112,7 +112,7 @@ describe("For the periodic person assessments", () => {
       )
     })
 
-    it("Should allow admins to successfully edit existing assesment", () => {
+    it("Should allow admins to successfully edit existing assessment", () => {
       ShowPerson.editAssessmentButton.waitForExist()
       ShowPerson.editAssessmentButton.waitForDisplayed()
 

--- a/client/tests/webdriver/baseSpecs/assessmentsForTasks.spec.js
+++ b/client/tests/webdriver/baseSpecs/assessmentsForTasks.spec.js
@@ -95,7 +95,7 @@ describe("For the periodic task assessments", () => {
       expect(ShowTask.addMonthlyAssessmentButton.isExisting()).to.equal(false)
     })
 
-    it("Should allow admins to successfully edit existing assesment", () => {
+    it("Should allow admins to successfully edit existing assessment", () => {
       ShowTask.monthlyAssessmentsTable.waitForExist()
       ShowTask.monthlyAssessmentsTable.waitForDisplayed()
       ShowTask.editMonthlyAssessmentButton.click()
@@ -136,7 +136,7 @@ describe("For the periodic task assessments", () => {
       expect(ShowTask.addMonthlyAssessmentButton.isExisting()).to.equal(false)
     })
 
-    it("Should allow the other advisor to successfully edit existing assesment", () => {
+    it("Should allow the other advisor to successfully edit existing assessment", () => {
       ShowTask.monthlyAssessmentsTable.waitForExist()
       ShowTask.monthlyAssessmentsTable.waitForDisplayed()
       ShowTask.editMonthlyAssessmentButton.click()

--- a/src/main/resources/anet-schema.yml
+++ b/src/main/resources/anet-schema.yml
@@ -241,6 +241,9 @@ $defs:
         title: object type context in which the assessment will be made
         type: string
         enum: [report]
+      test:
+        type: string
+        title: optional test condition for showing this assessment
       onDemandAssessmentExpirationDays:
         type: integer
         minimum: 1

--- a/testDictionaries/no-custom-fields.yml
+++ b/testDictionaries/no-custom-fields.yml
@@ -381,6 +381,37 @@ fields:
             read: ['c21e7321-7ec5-4837-8805-a302f9575754']
             write: ['39a78d51-c351-452c-9206-4305ec8dd76d']
           questions:
+            preparedDocuments:
+              test: $.subject.position.organization[?(@property === "shortName" && @.match(/^LNG/i))]
+              type: enum
+              helpText: "Did the linguist prepare any written documents used for the engagement meeting?"
+              label: Prepared documents
+              choices:
+                yes:
+                  label: "Yes"
+                no:
+                  label: "No"
+            documentQuality:
+              test: $.relatedObject.attendeesAssessments[?(@property === @root.subject.uuid && @.advisorOnceReportLinguist && @.advisorOnceReportLinguist.preparedDocuments === "yes")]
+              type: enum
+              helpText: "What was the quality of the document the linuist prepared?"
+              label: Document quality
+              choices:
+                "EX":
+                  label: Excellent
+                  color: "#03f8fc"
+                "VG":
+                  label: Very Good
+                  color: "#00fc03"
+                "G":
+                  label: Good
+                  color: "#84fc03"
+                "S":
+                  label: Satisfactory
+                  color: "#e3fc03"
+                "B":
+                  label: Bad
+                  color: "#fc5a03"
             linguistRole:
               test: $.subject.position.organization[?(@property === "shortName" && @.match(/^LNG/i))]
               type: enum
@@ -660,6 +691,15 @@ fields:
                   widget: richTextEditor
                   style:
                     height: 100px
+        advisorPeriodic:
+          recurrence: "monthly"
+          questions:
+            question1:
+                type: special_field
+                label: General remarks
+                widget: richTextEditor
+                style:
+                  height: 70px
         advisorOndemand:
           recurrence: ondemand
           questions:
@@ -681,7 +721,7 @@ fields:
       location:
         filter: [POINT_LOCATION]
       organizationsAdministrated:
-        label: Responsible organizations
+        label: Organizations administrated
         placeholder: Search for an organization...
 
     org:
@@ -830,6 +870,7 @@ fields:
         principalOndemandScreeningAndVetting:
           recurrence: ondemand
           onDemandAssessmentExpirationDays: 108
+          label: "Screening & Vetting"
           authorizationGroupUuids:
             read: ['c21e7321-7ec5-4837-8805-a302f9575754']
             write: ['39a78d51-c351-452c-9206-4305ec8dd76d']
@@ -919,16 +960,18 @@ fields:
   superUser:
 
     position:
+      name: Super User
       type: ANET Super User
 
   administrator:
 
     position:
+      name: Administrator
       type: ANET Administrator
 
 pinned_ORGs: [Key Leader Engagement]
 non_reporting_ORGs: [ANET Administrators]
-tasking_ORGs: [EF 2.2]
+tasking_ORGs: [EF 2.2, EF 9]
 domainNames: [example.com, cmil.mil, mission.ita, nato.int, "*.isaf.nato.int"]
 activeDomainNames: [example.com, cmil.mil, mission.ita, nato.int, "*.isaf.nato.int"]
 imagery:

--- a/testDictionaries/no-custom-fields.yml
+++ b/testDictionaries/no-custom-fields.yml
@@ -94,6 +94,7 @@ fields:
               label: Instant assessment Question 3
         topTaskSemiannually:
           recurrence: semiannually
+          test: $.subject[?(@property === "shortName" && @.match(/^EF/i))]
           authorizationGroupUuids:
             read: ['c21e7321-7ec5-4837-8805-a302f9575754']
             write: ['39a78d51-c351-452c-9206-4305ec8dd76d']
@@ -377,12 +378,12 @@ fields:
         advisorOnceReportLinguist:
           recurrence: once
           relatedObjectType: report
+          test: $.subject.position.organization[?(@property === "shortName" && @.match(/^LNG/i))]
           authorizationGroupUuids:
             read: ['c21e7321-7ec5-4837-8805-a302f9575754']
             write: ['39a78d51-c351-452c-9206-4305ec8dd76d']
           questions:
             preparedDocuments:
-              test: $.subject.position.organization[?(@property === "shortName" && @.match(/^LNG/i))]
               type: enum
               helpText: "Did the linguist prepare any written documents used for the engagement meeting?"
               label: Prepared documents
@@ -413,7 +414,6 @@ fields:
                   label: Bad
                   color: "#fc5a03"
             linguistRole:
-              test: $.subject.position.organization[?(@property === "shortName" && @.match(/^LNG/i))]
               type: enum
               helpText: "What was the linguist's role?"
               label: "Linguist Role"
@@ -869,6 +869,7 @@ fields:
                   color: '#0000ff'
         principalOndemandScreeningAndVetting:
           recurrence: ondemand
+          test: $.subject.position.organization[?(@property === "shortName" && @.match(/^MoD/i))]
           onDemandAssessmentExpirationDays: 108
           label: "Screening & Vetting"
           authorizationGroupUuids:


### PR DESCRIPTION
Assessment definitions in the dictionary can now have a top-level `test:` condition; if that top-level test condition is false, the assessment will not be shown at all.

Closes [AB#308](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/308)

#### User changes
- None

#### Super User changes
- None

#### Admin changes
- Assessment definitions in the dictionary can now have a top-level `test:` condition; e.g. if you have a (repeated) test condition in your questions or questionSets, that condition could be moved to the top of the assessment definition, without having to repeat it every time.

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [x] Opened debt issues for anything not resolved here
