### PR TITLE
CI: Ability to manually start the Release-Drafter workflow

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
+    inputs:
+      tags:
+        description: 'Update release notes'
 
 jobs:
   update_release_draft:


### PR DESCRIPTION
Allows to run the [Release-Drafter](https://github.com/marketplace/actions/release-drafter) workflow manually.
Could be convenient, for example after changing the configuration directly on the default branch, or updating the title, description or labels of some already merged PR's.