### PR TITLE
Add missing entities to report summary

### DIFF
--- a/client/src/components/Compact.js
+++ b/client/src/components/Compact.js
@@ -350,7 +350,7 @@ const EmptySpaceTdS = styled.td`
 `
 
 export const CompactRow = ({ label, content, ...otherProps }) => {
-  const { style, className } = otherProps
+  const { id, style, className } = otherProps
   // merge custom style
   const CustomStyled = styled(CompactRowS)`
     ${style};
@@ -360,7 +360,7 @@ export const CompactRow = ({ label, content, ...otherProps }) => {
   const isHeaderRow = className === "reportField"
 
   return (
-    <CustomStyled className={className || null}>
+    <CustomStyled id={id} className={className}>
       {label && <RowLabelS isHeaderRow={isHeaderRow}>{label}</RowLabelS>}
       <CompactRowContentS colSpan={label ? 1 : 2}>{content}</CompactRowContentS>
     </CustomStyled>

--- a/client/src/components/SimpleMultiCheckboxDropdown.js
+++ b/client/src/components/SimpleMultiCheckboxDropdown.js
@@ -9,7 +9,7 @@ import { useOutsideClick } from "utils"
  *  @param {object} options {key1: { text: string, active: boolean}, ...}
  *  @param {function} setOptions
  */
-const SimpleMultiCheckboxDropdown = ({ label, options, setOptions }) => {
+const SimpleMultiCheckboxDropdown = ({ id, label, options, setOptions }) => {
   const [active, setActive] = useState(false)
   const dropDownRef = useRef(null)
   useOutsideClick(dropDownRef, () => setActive(false))
@@ -23,7 +23,7 @@ const SimpleMultiCheckboxDropdown = ({ label, options, setOptions }) => {
         {label}
       </Button>
       <div>
-        <div>
+        <div id={id}>
           {Object.entries(options).map(([optionKey, option]) => (
             <label htmlFor={optionKey} key={optionKey}>
               {option.text}
@@ -134,6 +134,7 @@ const DropdownButton = styled.span`
 `
 
 SimpleMultiCheckboxDropdown.propTypes = {
+  id: PropTypes.string,
   label: PropTypes.string,
   options: PropTypes.objectOf(
     PropTypes.shape({

--- a/client/src/components/assessments/instant/InstantAssessmentsContainerField.js
+++ b/client/src/components/assessments/instant/InstantAssessmentsContainerField.js
@@ -105,31 +105,49 @@ const InstantAssessmentsContainerField = ({
   formikProps,
   canRead,
   canWrite,
-  readonly
+  readonly,
+  showEntitiesWithoutAssessments
 }) => {
   const { values } = formikProps
+  function sortEntries(e1, e2) {
+    const e1entityInstantAssessments = e1.getInstantAssessments()
+    return e1entityInstantAssessments.some(([ak, ac]) => {
+      const filteredAssessment = Model.filterAssessmentConfig(
+        ac,
+        e1,
+        relatedObject
+      )
+      return (
+        !_isEmpty(filteredAssessment.questions) ||
+        !_isEmpty(filteredAssessment.questionSets)
+      )
+    })
+      ? 1
+      : -1
+  }
+  function getEntitiesWithAssessments(entity) {
+    const entityInstantAssessments = entity.getInstantAssessments()
+    return entityInstantAssessments.some(([ak, ac]) => {
+      const filteredAssessment = Model.filterAssessmentConfig(
+        ac,
+        entity,
+        relatedObject
+      )
+      return (
+        !_isEmpty(filteredAssessment.questions) ||
+        !_isEmpty(filteredAssessment.questionSets)
+      )
+    })
+  }
+  // Sort entities to display the ones without any assessment at the beginning
+  const filteredEntities = showEntitiesWithoutAssessments
+    ? entities.sort(sortEntries)
+    : entities.filter(getEntitiesWithAssessments)
   return (
     <Table>
       <tbody>
-        {entities.map(entity => {
+        {filteredEntities.map(entity => {
           const entityInstantAssessments = entity.getInstantAssessments()
-          let hasAssessments = false
-          entityInstantAssessments.forEach(([ak, ac]) => {
-            const filteredAssessment = Model.filterAssessmentConfig(
-              ac,
-              entity,
-              relatedObject
-            )
-            if (
-              !_isEmpty(filteredAssessment.questions) ||
-              !_isEmpty(filteredAssessment.questionSets)
-            ) {
-              hasAssessments = true
-            }
-          })
-          if (!hasAssessments) {
-            return null
-          }
 
           return (
             <React.Fragment key={`assessment-${values.uuid}-${entity.uuid}`}>
@@ -172,7 +190,8 @@ InstantAssessmentsContainerField.propTypes = {
   }),
   canRead: PropTypes.bool,
   canWrite: PropTypes.bool,
-  readonly: PropTypes.bool
+  readonly: PropTypes.bool,
+  showEntitiesWithoutAssessments: PropTypes.bool
 }
 InstantAssessmentsContainerField.defaultProps = {
   entities: [],

--- a/client/src/components/assessments/instant/InstantAssessmentsContainerField.js
+++ b/client/src/components/assessments/instant/InstantAssessmentsContainerField.js
@@ -109,37 +109,34 @@ const InstantAssessmentsContainerField = ({
   showEntitiesWithoutAssessments
 }) => {
   const { values } = formikProps
+
+  function hasFilteredAssessments(ac, e) {
+    const filteredAssessment = Model.filterAssessmentConfig(
+      ac,
+      e,
+      relatedObject
+    )
+    return (
+      !_isEmpty(filteredAssessment.questions) ||
+      !_isEmpty(filteredAssessment.questionSets)
+    )
+  }
+  // Sort entities to display the ones without any assessment at the beginning,
+  // then the ones with assessments. Keep the original sort order within each section.
   function sortEntries(e1, e2) {
-    const e1entityInstantAssessments = e1.getInstantAssessments()
-    return e1entityInstantAssessments.some(([ak, ac]) => {
-      const filteredAssessment = Model.filterAssessmentConfig(
-        ac,
-        e1,
-        relatedObject
-      )
-      return (
-        !_isEmpty(filteredAssessment.questions) ||
-        !_isEmpty(filteredAssessment.questionSets)
-      )
-    })
-      ? 1
-      : -1
+    const e1hasAssessments = e1
+      .getInstantAssessments()
+      .some(([, ac]) => hasFilteredAssessments(ac, e1))
+    const e2hasAssessments = e2
+      .getInstantAssessments()
+      .some(([, ac]) => hasFilteredAssessments(ac, e2))
+    return Number(e1hasAssessments) - Number(e2hasAssessments)
   }
   function getEntitiesWithAssessments(entity) {
-    const entityInstantAssessments = entity.getInstantAssessments()
-    return entityInstantAssessments.some(([ak, ac]) => {
-      const filteredAssessment = Model.filterAssessmentConfig(
-        ac,
-        entity,
-        relatedObject
-      )
-      return (
-        !_isEmpty(filteredAssessment.questions) ||
-        !_isEmpty(filteredAssessment.questionSets)
-      )
-    })
+    return entity
+      .getInstantAssessments()
+      .some(([, ac]) => hasFilteredAssessments(ac, entity))
   }
-  // Sort entities to display the ones without any assessment at the beginning
   const filteredEntities = showEntitiesWithoutAssessments
     ? entities.sort(sortEntries)
     : entities.filter(getEntitiesWithAssessments)

--- a/client/src/pages/reports/Compact.js
+++ b/client/src/pages/reports/Compact.js
@@ -484,6 +484,7 @@ const CompactReportView = ({ pageDispatchers }) => {
         }}
         canRead={canReadAssessments}
         readonly
+        showEntitiesWithoutAssessments
       />
     ) : (
       attendees.map(attendee => (

--- a/client/src/pages/reports/Compact.js
+++ b/client/src/pages/reports/Compact.js
@@ -340,6 +340,7 @@ const CompactReportView = ({ pageDispatchers }) => {
                       className="reportField"
                     />
                     <CompactRow
+                      id="principals"
                       label="principals"
                       content={getAttendeesAndAssessments(
                         Person.ROLE.PRINCIPAL
@@ -347,6 +348,7 @@ const CompactReportView = ({ pageDispatchers }) => {
                       className="reportField"
                     />
                     <CompactRow
+                      id="advisors"
                       label="advisors"
                       content={getAttendeesAndAssessments(Person.ROLE.ADVISOR)}
                       className="reportField"
@@ -535,6 +537,7 @@ const CompactReportViewHeader = ({
       ))}
     </DropdownButton>
     <SimpleMultiCheckboxDropdown
+      id="optionalFields"
       label="Optional Fields ⇓"
       options={optionalFields}
       setOptions={setOptionalFields}

--- a/client/tests/webdriver/baseSpecs/printReport.spec.js
+++ b/client/tests/webdriver/baseSpecs/printReport.spec.js
@@ -3,6 +3,14 @@ import Home from "../pages/home.page"
 import MyReports, { REPORT_STATES } from "../pages/myReports.page"
 import ShowReport from "../pages/report/showReport.page"
 
+const PRINCIPALS = [
+  "Maj CHRISVILLE, Chris",
+  "CIV KYLESON, Kyle",
+  "CIV SHARTON, Shardul"
+]
+
+const ADVISORS = ["CIV DMIN, Arthur", "CIV GUIST, Lin"]
+
 describe("Show print report page", () => {
   beforeEach("Open the show report page", () => {
     MyReports.open("arthur")
@@ -51,6 +59,34 @@ describe("Show print report page", () => {
       Home.openAsAdminUser()
       const bannerSecurityText = Home.bannerSecurityText.getText()
       expect(compactBannerText).to.equal(bannerSecurityText)
+    })
+    it("Should display all attendees", () => {
+      const displayedPrincipals =
+        ShowReport.getCompactViewAttendees("principals")
+      const displayedAdvisors = ShowReport.getCompactViewAttendees("advisors")
+      PRINCIPALS.forEach(principal => {
+        expect(displayedPrincipals).to.contain(principal)
+      })
+      ADVISORS.forEach(advisor => {
+        expect(displayedAdvisors).to.contain(advisor)
+      })
+    })
+    it("Should display all attendees when assessments are shown", () => {
+      ShowReport.selectOptionalField("assessments")
+      const displayedPrincipals = ShowReport.getCompactViewAttendees(
+        "principals",
+        true
+      )
+      PRINCIPALS.forEach(principal => {
+        expect(displayedPrincipals).to.contain(principal)
+      })
+      const displayedAdvisors = ShowReport.getCompactViewAttendees(
+        "advisors",
+        true
+      )
+      ADVISORS.forEach(advisor => {
+        expect(displayedAdvisors).to.contain(advisor)
+      })
     })
   })
 })

--- a/client/tests/webdriver/pages/report/showReport.page.js
+++ b/client/tests/webdriver/pages/report/showReport.page.js
@@ -160,6 +160,35 @@ class ShowReport extends Page {
     this.reportStatus.waitForExist()
     this.reportStatus.waitForDisplayed()
   }
+
+  getCompactViewAttendees(type, withAssessments) {
+    return withAssessments
+      ? browser
+        .$$(`#${type} > td > table > tbody > tr > td`)
+      // Filter out the assessment rows to get the attendees
+        .filter(row => {
+          return row.$("span > a").isExisting()
+        })
+        .map(row => {
+          return row.$("span > a").getText()
+        })
+      : browser
+        .$$(`#${type} > td > span > a`)
+        .map(attendeeLink => attendeeLink.getText())
+  }
+
+  selectOptionalField(field) {
+    const optionalFieldsButton = browser.$(
+      '//button[text()="Optional Fields ⇓"]'
+    )
+    const optionalFields = browser.$("#optionalFields")
+    const fieldCheckbox = browser.$(`input[id="${field}"]`)
+    optionalFieldsButton.click()
+    optionalFields.waitForDisplayed()
+    if (!fieldCheckbox.isSelected()) {
+      fieldCheckbox.click()
+    }
+  }
 }
 
 export default new ShowReport()

--- a/insertBaseData-psql.sql
+++ b/insertBaseData-psql.sql
@@ -830,6 +830,12 @@ INSERT INTO "reportPeople" ("personUuid", "reportUuid", "isPrimary", "isAuthor")
 	VALUES ((SELECT uuid FROM people where "emailAddress"='hunter+arthur@example.com'), :reportuuid, TRUE, TRUE);
 INSERT INTO "reportPeople" ("personUuid", "reportUuid", "isPrimary")
 	VALUES ((SELECT uuid FROM people where "emailAddress"='hunter+shardul@example.com'), :reportuuid, TRUE);
+INSERT INTO "reportPeople" ("personUuid", "reportUuid", "isPrimary")
+	VALUES ((SELECT uuid FROM people where "emailAddress"='lin+guist@example.com'), :reportuuid, FALSE);
+INSERT INTO "reportPeople" ("personUuid", "reportUuid", "isPrimary")
+	VALUES ((SELECT uuid FROM people where "emailAddress"='kyleson+kyle@example.com'), :reportuuid, FALSE);
+INSERT INTO "reportPeople" ("personUuid", "reportUuid", "isPrimary")
+	VALUES ((SELECT uuid FROM people where "emailAddress"='chrisville+chris@example.com'), :reportuuid, FALSE);
 INSERT INTO "reportTasks" ("taskUuid", "reportUuid")
 	VALUES ((SELECT uuid from tasks where "shortName" = '1.2.A'), :reportuuid);
 INSERT INTO "reportTasks" ("taskUuid", "reportUuid")


### PR DESCRIPTION
In the report summary view, all entities (attendees and tasks) are displayed when assessments are activated in the optional fields.

Closes [AB#670](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/670)

#### User changes
- Report summary view displays the tasks and attendees correctly

#### Super User changes
- None

#### Admin changes
- None

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [x] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
