### PR TITLE
Minor improvements related to demo database

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -389,7 +389,14 @@ task dbLoad(dependsOn: pushPsqlBaseData, type: DockerExecContainer) {
 
 dbLoad.mustRunAfter('dbMigrate')
 
-task dbDump(type: DockerExecContainer) {
+task deleteDbDump(type: DockerExecContainer) {
+	group = "database runtime"
+	description = "Deletes the database dump in the container"
+	containerId = dbContainerName
+	commands = [ ["rm", "-f", "${psqlPushDataPath}/anet-db-dump.sql"] as String[] ]
+}
+
+task dbDump(type: DockerExecContainer, dependsOn: deleteDbDump) {
 	group = "database runtime"
 	description = "Dumps the ANET database in the container"
 	containerId = dbContainerName
@@ -402,6 +409,21 @@ task extractDbDump(type: DockerCopyFileFromContainer, dependsOn: dbDump) {
 	containerId = dbContainerName
 	hostPath = "${buildDir}/db/anet-db-dump.sql"
 	remotePath = "${psqlPushDataPath}/anet-db-dump.sql"
+}
+
+task pushDbDump(type: DockerCopyFileToContainer) {
+	group = "database runtime"
+	description = "Copies the database dump to the container"
+	containerId = dbContainerName
+	hostPath = "${buildDir}/db/anet-db-dump.sql"
+	remotePath = psqlPushDataPath
+}
+
+task dbRestore(type: DockerExecContainer, dependsOn: pushDbDump) {
+	group = "database runtime"
+	description = "Restores the ANET database in the container"
+	containerId = dbContainerName
+	commands = [ ["psql", "-U", run.environment["ANET_DB_USERNAME"], "-d", run.environment["ANET_DB_NAME"], "-f", "${psqlPushDataPath}/anet-db-dump.sql"] as String[] ]
 }
 
 task dockerBuildImage(dependsOn: installDist, type: DockerBuildImage) {

--- a/client/src/components/Kanban.js
+++ b/client/src/components/Kanban.js
@@ -20,7 +20,9 @@ const Kanban = ({ columns, allTasks }) => (
   >
     {columns.map(column => {
       const name =
-        column.name || allTasks.find(task => task.uuid === column)?.shortName
+        column.name ||
+        allTasks.find(task => task.uuid === column)?.shortName ||
+        column
       const tasks =
         (column.tasks &&
           allTasks.filter(task => column.tasks.includes(task.uuid))) ||
@@ -56,7 +58,7 @@ const Column = ({ name, tasks }) => {
     <Card style={{ flex: "1 1 0%", margin: "4px" }}>
       <Card.Header>
         <strong>
-          <em>{name} </em>
+          <em>{name}</em>
         </strong>
       </Card.Header>
       <Card.Body>

--- a/client/src/components/Kanban.js
+++ b/client/src/components/Kanban.js
@@ -67,7 +67,7 @@ const Column = ({ name, tasks }) => {
           label={`${tasks.length}`}
           segmentFill={entity => {
             const matching = Object.entries(
-              Settings.fields.task.customFieldEnum1.enum
+              Settings.fields.task.customFieldEnum1?.enum || {}
             ).filter(([key, val]) => {
               return key === entity.data.key
             })
@@ -124,7 +124,7 @@ Column.propTypes = {
 const CardView = ({ task }) => {
   const [open, setOpen] = useState(false)
   const { customFieldEnum1 } = task
-  const enumSettings = Settings.fields.task.customFieldEnum1.enum
+  const enumSettings = Settings.fields.task.customFieldEnum1?.enum
   return (
     <Card
       onClick={() => setOpen(!open)}

--- a/client/src/components/previews/OrganizationPreview.js
+++ b/client/src/components/previews/OrganizationPreview.js
@@ -139,7 +139,7 @@ const OrganizationPreview = ({ className, uuid }) => {
         />
 
         <PreviewField
-          label={orgSettings.identificationCode.label}
+          label={orgSettings.identificationCode?.label}
           value={organization.identificationCode}
         />
 

--- a/client/src/models/Organization.js
+++ b/client/src/models/Organization.js
@@ -151,7 +151,7 @@ export default class Organization extends Model {
   static toIdentificationCodeString(organization) {
     return organization.type === Organization.TYPE.PRINCIPAL_ORG
       ? `${organization.shortName} \\ ${
-        Settings.fields.principal.org.identificationCode.label
+        Settings.fields.principal.org.identificationCode?.label
       }: ${organization.identificationCode || "Not specified"}`
       : `${organization.shortName} ${organization.longName} ${
         organization.identificationCode || ""

--- a/client/src/pages/dashboards/BoardDashboard.js
+++ b/client/src/pages/dashboards/BoardDashboard.js
@@ -173,17 +173,24 @@ const BoardDashboard = ({ pageDispatchers }) => {
   }, [model, edit])
 
   useEffect(() => {
-    async function fetchData() {
-      await fetch(dashboardSettings.data)
-        .then(response => response.json())
-        .then(data => {
-          const model = new DiagramModel()
-          model.deserializeModel(data, engineRef.current)
-          setModel(model)
-        })
-    }
-    fetchData()
-  }, [dashboardSettings.data])
+    fetch(dashboardSettings.data)
+      .then(response => response.json())
+      .then(data => {
+        const model = new DiagramModel()
+        model.deserializeModel(data, engineRef.current)
+        setModel(model)
+      })
+      .catch(error =>
+        console.error(
+          "Error fetching",
+          dashboardSettings.type,
+          "dashboard",
+          dashboardSettings.data,
+          ":",
+          error
+        )
+      )
+  }, [dashboardSettings.data, dashboardSettings.type])
 
   useEffect(() => {
     if (dropEvent) {

--- a/client/src/pages/dashboards/DecisivesDashboard.js
+++ b/client/src/pages/dashboards/DecisivesDashboard.js
@@ -102,13 +102,20 @@ const DecisivesDashboard = ({ pageDispatchers }) => {
   const [dashboardData, setDashboardData] = useState([])
   usePageTitle("Decisives")
   useEffect(() => {
-    async function fetchData() {
-      await fetch(dashboardSettings.data)
-        .then(response => response.json())
-        .then(setDashboardData)
-    }
-    fetchData()
-  }, [dashboardSettings.data])
+    fetch(dashboardSettings.data)
+      .then(response => response.json())
+      .then(setDashboardData)
+      .catch(error =>
+        console.error(
+          "Error fetching",
+          dashboardSettings.type,
+          "dashboard",
+          dashboardSettings.data,
+          ":",
+          error
+        )
+      )
+  }, [dashboardSettings.data, dashboardSettings.type])
 
   return (
     <DecisivesDashboardStatic

--- a/client/src/pages/dashboards/DiagramNode.js
+++ b/client/src/pages/dashboards/DiagramNode.js
@@ -87,6 +87,16 @@ export class DiagramNodeModel extends NodeModel {
     modelClass &&
       modelClass
         .fetchByUuid(event.data.anetObjectUuid, ENTITY_GQL_FIELDS)
+        .catch(error =>
+          console.error(
+            "Error fetching",
+            event.data.anetObjectType,
+            "with uuid",
+            event.data.anetObjectUuid,
+            ":",
+            error
+          )
+        )
         .then(function(entity) {
           options.anetObject = entity
           // TODO: fire an event instead

--- a/client/src/pages/dashboards/KanbanDashboard.js
+++ b/client/src/pages/dashboards/KanbanDashboard.js
@@ -62,13 +62,20 @@ const KanbanDashboard = ({ pageDispatchers }) => {
   const [dashboardData, setDashboardData] = useState({})
   usePageTitle("Dashboard")
   useEffect(() => {
-    async function fetchData() {
-      await fetch(dashboardSettings.data)
-        .then(response => response.json())
-        .then(setDashboardData)
-    }
-    fetchData()
-  }, [dashboardSettings.data])
+    fetch(dashboardSettings.data)
+      .then(response => response.json())
+      .then(setDashboardData)
+      .catch(error =>
+        console.error(
+          "Error fetching",
+          dashboardSettings.type,
+          "dashboard",
+          dashboardSettings.data,
+          ":",
+          error
+        )
+      )
+  }, [dashboardSettings.data, dashboardSettings.type])
 
   return (
     <KanbanDashboardImpl


### PR DESCRIPTION
Avoid some uncaught errors in the ANET UI (found when working on the demo database).
Also add a Gradle task to restore a demo database dump.

Closes [AB#653](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/653)

#### User changes
- ANET should no longer show an empty page in case of some rare errors related to the dictionary.

#### Super User changes
- none

#### Admin changes
- none

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here