### PR TITLE
Update scroll-link for report page

### DIFF
--- a/client/src/components/Fieldset.js
+++ b/client/src/components/Fieldset.js
@@ -33,7 +33,7 @@ const Fieldset = ({
       id={id}
       name={id}
       className="scroll-anchor-container"
-      style={style}
+      style={{ style }}
     >
       {(title || action) && (
         <h4 className="legend">


### PR DESCRIPTION
Scroll-link was not work properly for Cancelled Reports. Updated scroll-link component offset.

Closes [AB#721](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/721)

#### User changes
- none

#### Super User changes
- none

#### Admin changes
- none

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [ ] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
