### PR TITLE
Replace JSON schema validator

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -114,7 +114,12 @@ dependencies {
 	// Used for converting GraphQL request output to XML:
 	implementation 'com.github.javadev:underscore-lodash:1.26'
 	// For JSON schema validation
-	implementation 'com.qindesign:snowy-json:0.16.0'
+	implementation('io.vertx:vertx-json-schema:4.3.8') {
+		// We don't actually need most of these (dragged in through vertx-core)
+		exclude group: 'io.netty'
+	}
+	// But we do need io.netty.buffer.ByteBufOutputStream, so explicitly include that here
+	implementation 'io.netty:netty-buffer:4.1.87.Final'
 
 	// used for writing Excel documents
 	implementation 'org.apache.poi:poi:5.2.3'
@@ -128,7 +133,10 @@ dependencies {
 
 	// The graphql-java-client-runtime module aggregates all dependencies for the generated code,
 	// including the plugin runtime
-	testImplementation 'com.graphql-java-generator:graphql-java-client-runtime:1.18.10'
+	testImplementation('com.graphql-java-generator:graphql-java-client-runtime:1.18.10') {
+		// We don't actually need any of these (dragged in through org.springframework.boot)
+		exclude group: 'io.netty'
+	}
 	// We use some extended scalars in `generateClientCodeConf` below
 	testImplementation 'com.graphql-java:graphql-java-extended-scalars:20.0'
 

--- a/src/main/resources/anet-schema.yml
+++ b/src/main/resources/anet-schema.yml
@@ -1,5 +1,5 @@
 "$schema": "https://json-schema.org/draft/2019-09/schema"
-"$id": https://raw.githubusercontent.com/NCI-Agency/anet/main/src/main/resources/anet-schema.json
+"$id": https://raw.githubusercontent.com/NCI-Agency/anet/main/src/main/resources/anet-schema.yml
 
 #########################################################
 ### $defs


### PR DESCRIPTION
Replace our schema validator with one that supports the same draft version, but is better maintained.

Closes [AB#726](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/726) 

#### User changes
- None

#### Super User changes
- None

#### Admin changes
- None

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
