### PR TITLE
Split up dependencies and debt label

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -11,10 +11,10 @@ categories:
     label: improvement
   - title: '🐛 Bug Fixes'
     label: bug
+  - title: '⬆️ Dependency Updates'
+    label: dependencies
   - title: '🔧 Under the hood'
-    labels:
-      - debt
-      - dependencies
+    label: debt
 change-template: "* $TITLE (#$NUMBER)"
 exclude-labels:
   - devDependencies


### PR DESCRIPTION
Dependencies and debt label are separated, PRs for these two will be displayed under different categories in release

Closes [AB#772](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/772)

#### User changes
- None

#### Super User changes
- None

#### Admin changes
- None

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
