### PR TITLE
Refactor OrganizationFilter to always search in children

### DIFF
--- a/client/src/components/SearchFilters.js
+++ b/client/src/components/SearchFilters.js
@@ -93,12 +93,13 @@ const SubscriptionFilter = {
 const taskFilters = () => {
   const taskShortLabel = Settings.fields.task.shortLabel
   const taskFiltersObj = {
-    Organization: {
+    "Within Organization": {
       component: OrganizationFilter,
       deserializer: deserializeOrganizationFilter,
       props: {
         queryKey: "taskedOrgUuid",
-        queryRecurseStrategyKey: "orgRecurseStrategy"
+        queryRecurseStrategyKey: "orgRecurseStrategy",
+        fixedRecurseStrategy: RECURSE_STRATEGY.CHILDREN
       }
     },
     [`Within ${taskShortLabel}`]: {
@@ -267,12 +268,13 @@ export const searchFilters = function() {
           queryKey: "attendeePositionUuid"
         })
       },
-      Organization: {
+      "Within Organization": {
         component: OrganizationFilter,
         deserializer: deserializeOrganizationFilter,
         props: {
           queryKey: "orgUuid",
-          queryRecurseStrategyKey: "orgRecurseStrategy"
+          queryRecurseStrategyKey: "orgRecurseStrategy",
+          fixedRecurseStrategy: RECURSE_STRATEGY.CHILDREN
         }
       },
       "Engagement Date": {
@@ -367,12 +369,13 @@ export const searchFilters = function() {
 
   filters[SEARCH_OBJECT_TYPES.PEOPLE] = {
     filters: {
-      Organization: {
+      "Within Organization": {
         component: OrganizationFilter,
         deserializer: deserializeOrganizationFilter,
         props: {
           queryKey: "orgUuid",
-          queryRecurseStrategyKey: "orgRecurseStrategy"
+          queryRecurseStrategyKey: "orgRecurseStrategy",
+          fixedRecurseStrategy: RECURSE_STRATEGY.CHILDREN
         }
       },
       Role: {
@@ -505,12 +508,13 @@ export const searchFilters = function() {
           isPositionTypeFilter: true
         }
       },
-      Organization: {
+      "Within Organization": {
         component: OrganizationFilter,
         deserializer: deserializeOrganizationFilter,
         props: {
           queryKey: "organizationUuid",
-          queryRecurseStrategyKey: "orgRecurseStrategy"
+          queryRecurseStrategyKey: "orgRecurseStrategy",
+          fixedRecurseStrategy: RECURSE_STRATEGY.CHILDREN
         }
       },
       Location: {


### PR DESCRIPTION
The advanced search filter for organizations now always searches within that organization and its children. The filter label has been updated to reflect that: **Within Organization**

Closes [AB#781](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/781) 

#### User changes
- The search filter for organizations no longer has any options to change where it searches.

#### Super User changes
- none

#### Admin changes
- none

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here