### PR TITLE
Hide parent task if no parent task, and show sub tasks

### DIFF
--- a/anet-dictionary.yml
+++ b/anet-dictionary.yml
@@ -199,6 +199,9 @@ fields:
     parentTask:
       label: Parent task
       placeholder: Start typing to search for a higher level task
+    childTask:
+      label: Child task
+      placeholder: Start typing to search for a lower level task
     taskedOrganizations:
       label: Tasked organizations
       placeholder: Search for an organization...

--- a/anet-dictionary.yml
+++ b/anet-dictionary.yml
@@ -197,11 +197,9 @@ fields:
               label: Instant assessment Question 3
 
     parentTask:
-      label: Parent task
+      label: Parent objective / effort
       placeholder: Start typing to search for a higher level task
-    childTask:
-      label: Child task
-      placeholder: Start typing to search for a lower level task
+    childrenTasks: Sub efforts
     taskedOrganizations:
       label: Tasked organizations
       placeholder: Search for an organization...

--- a/client/src/components/previews/TaskPreview.js
+++ b/client/src/components/previews/TaskPreview.js
@@ -10,6 +10,10 @@ import moment from "moment"
 import PropTypes from "prop-types"
 import React from "react"
 import Settings from "settings"
+import {
+  ListGroup,
+  ListGroupItem
+} from "react-bootstrap"
 
 const GQL_GET_TASK = gql`
   query ($uuid: String!) {
@@ -39,6 +43,10 @@ const GQL_GET_TASK = gql`
         parentTask {
           uuid
         }
+      }
+      childrenTasks {
+        uuid
+        shortName
       }
       responsiblePositions {
         uuid
@@ -117,7 +125,6 @@ const TaskPreview = ({ className, uuid }) => {
   const task = new Task(data.task ? data.task : {})
 
   const fieldSettings = task.fieldSettings()
-
   return (
     <div className={`${className} preview-content-scroll`}>
       <div className="preview-sticky-title">
@@ -153,7 +160,7 @@ const TaskPreview = ({ className, uuid }) => {
           }
         />
 
-        {Settings.fields.task.parentTask && (
+        {Settings.fields.task.parentTask && task.parentTask?.uuid && (
           <PreviewField
             label={Settings.fields.task.parentTask.label}
             value={
@@ -165,6 +172,26 @@ const TaskPreview = ({ className, uuid }) => {
                   parentField="parentTask"
                 />
               )
+            }
+          />
+        )}
+
+        {task.childrenTasks.length > 0 && (
+          <PreviewField
+            label={Settings.fields.task.childrenTasks}
+            name="subEfforts"
+            value={
+              <ListGroup>
+                {task.childrenTasks?.map(task => (
+                  <ListGroupItem key={task.uuid}>
+                    <LinkTo
+                      showIcon={false}
+                      modelType="Task"
+                      model={task}
+                    />
+                  </ListGroupItem>
+                ))}
+              </ListGroup>
             }
           />
         )}

--- a/client/src/components/previews/TaskPreview.js
+++ b/client/src/components/previews/TaskPreview.js
@@ -9,11 +9,8 @@ import { Task } from "models"
 import moment from "moment"
 import PropTypes from "prop-types"
 import React from "react"
+import { ListGroup, ListGroupItem } from "react-bootstrap"
 import Settings from "settings"
-import {
-  ListGroup,
-  ListGroupItem
-} from "react-bootstrap"
 
 const GQL_GET_TASK = gql`
   query ($uuid: String!) {
@@ -176,7 +173,7 @@ const TaskPreview = ({ className, uuid }) => {
           />
         )}
 
-        {task.childrenTasks.length > 0 && (
+        {Settings.fields.task.childrenTasks && task.childrenTasks?.length > 0 && (
           <PreviewField
             label={Settings.fields.task.childrenTasks}
             name="subEfforts"
@@ -184,11 +181,7 @@ const TaskPreview = ({ className, uuid }) => {
               <ListGroup>
                 {task.childrenTasks?.map(task => (
                   <ListGroupItem key={task.uuid}>
-                    <LinkTo
-                      showIcon={false}
-                      modelType="Task"
-                      model={task}
-                    />
+                    <LinkTo showIcon={false} modelType="Task" model={task} />
                   </ListGroupItem>
                 ))}
               </ListGroup>

--- a/client/src/pages/tasks/Show.js
+++ b/client/src/pages/tasks/Show.js
@@ -304,7 +304,7 @@ const TaskShow = ({ pageDispatchers }) => {
                       )
                     }
                   />
-                  {Settings.fields.task.parentTask && (
+                  {task.parentTask && task.parentTask.uuid && (
                     <TaskParentTask
                       dictProps={Settings.fields.task.parentTask}
                       name="parentTask"

--- a/client/src/pages/tasks/Show.js
+++ b/client/src/pages/tasks/Show.js
@@ -33,6 +33,10 @@ import React, { useContext, useState } from "react"
 import { connect } from "react-redux"
 import { useLocation, useParams } from "react-router-dom"
 import Settings from "settings"
+import {
+  ListGroup,
+  ListGroupItem
+} from "react-bootstrap"
 import DictionaryField from "../../HOC/DictionaryField"
 
 const GQL_GET_TASK = gql`
@@ -66,6 +70,10 @@ const GQL_GET_TASK = gql`
         parentTask {
           uuid
         }
+      }
+      childrenTasks {
+        uuid
+        shortName
       }
       descendantTasks(query: { pageNum: 0, pageSize: 0 }) {
         uuid
@@ -184,6 +192,7 @@ const TaskShow = ({ pageDispatchers }) => {
   const ShortNameField = DictionaryField(Field)
   const LongNameField = DictionaryField(Field)
   const TaskParentTask = DictionaryField(Field)
+  const TaskChildrenTasks = DictionaryField(Field)
   const PlannedCompletionField = DictionaryField(Field)
   const ProjectedCompletionField = DictionaryField(Field)
 
@@ -304,7 +313,7 @@ const TaskShow = ({ pageDispatchers }) => {
                       )
                     }
                   />
-                  {task.parentTask && task.parentTask.uuid && (
+                  {Settings.fields.task.parentTask && task.parentTask?.uuid && (
                     <TaskParentTask
                       dictProps={Settings.fields.task.parentTask}
                       name="parentTask"
@@ -318,6 +327,26 @@ const TaskShow = ({ pageDispatchers }) => {
                             parentField="parentTask"
                           />
                         )
+                      }
+                    />
+                  )}
+                  {Settings.fields.task.childrenTasks && task.childrenTasks.length > 0 && (
+                    <TaskChildrenTasks
+                      dictProps={Settings.fields.task.childrenTasks}
+                      name="subEfforts"
+                      component={FieldHelper.ReadonlyField}
+                      humanValue={
+                        <ListGroup>
+                          {task.childrenTasks?.map(task => (
+                            <ListGroupItem key={task.uuid}>
+                              <LinkTo
+                                showIcon={false}
+                                modelType="Task"
+                                model={task}
+                              />
+                            </ListGroupItem>
+                          ))}
+                        </ListGroup>
                       }
                     />
                   )}

--- a/client/src/pages/tasks/Show.js
+++ b/client/src/pages/tasks/Show.js
@@ -30,13 +30,10 @@ import _isEmpty from "lodash/isEmpty"
 import { Task } from "models"
 import moment from "moment"
 import React, { useContext, useState } from "react"
+import { ListGroup, ListGroupItem } from "react-bootstrap"
 import { connect } from "react-redux"
 import { useLocation, useParams } from "react-router-dom"
 import Settings from "settings"
-import {
-  ListGroup,
-  ListGroupItem
-} from "react-bootstrap"
 import DictionaryField from "../../HOC/DictionaryField"
 
 const GQL_GET_TASK = gql`
@@ -192,7 +189,6 @@ const TaskShow = ({ pageDispatchers }) => {
   const ShortNameField = DictionaryField(Field)
   const LongNameField = DictionaryField(Field)
   const TaskParentTask = DictionaryField(Field)
-  const TaskChildrenTasks = DictionaryField(Field)
   const PlannedCompletionField = DictionaryField(Field)
   const ProjectedCompletionField = DictionaryField(Field)
 
@@ -330,25 +326,26 @@ const TaskShow = ({ pageDispatchers }) => {
                       }
                     />
                   )}
-                  {Settings.fields.task.childrenTasks && task.childrenTasks.length > 0 && (
-                    <TaskChildrenTasks
-                      dictProps={Settings.fields.task.childrenTasks}
-                      name="subEfforts"
-                      component={FieldHelper.ReadonlyField}
-                      humanValue={
-                        <ListGroup>
-                          {task.childrenTasks?.map(task => (
-                            <ListGroupItem key={task.uuid}>
-                              <LinkTo
-                                showIcon={false}
-                                modelType="Task"
-                                model={task}
-                              />
-                            </ListGroupItem>
-                          ))}
-                        </ListGroup>
-                      }
-                    />
+                  {Settings.fields.task.childrenTasks &&
+                    task.childrenTasks?.length > 0 && (
+                      <Field
+                        label={Settings.fields.task.childrenTasks}
+                        name="subEfforts"
+                        component={FieldHelper.ReadonlyField}
+                        humanValue={
+                          <ListGroup>
+                            {task.childrenTasks?.map(task => (
+                              <ListGroupItem key={task.uuid}>
+                                <LinkTo
+                                  showIcon={false}
+                                  modelType="Task"
+                                  model={task}
+                                />
+                              </ListGroupItem>
+                            ))}
+                          </ListGroup>
+                        }
+                      />
                   )}
                   {Settings.fields.task.plannedCompletion && (
                     <PlannedCompletionField

--- a/client/tests/webdriver/customFieldsSpecs/showTask.spec.js
+++ b/client/tests/webdriver/customFieldsSpecs/showTask.spec.js
@@ -3,6 +3,7 @@ import MyReports, { REPORT_STATES } from "../pages/myReports.page"
 import ShowReport from "../pages/report/showReport.page"
 import ShowTask from "../pages/showTask.page"
 
+// Load a task "1.2.B" from "A test report from Arthur"
 describe("Show task page", () => {
   beforeEach("Open the show task page", async() => {
     await MyReports.open("arthur")
@@ -28,6 +29,55 @@ describe("Show task page", () => {
       ).$("[id*=question1-assessment]")
       // eslint-disable-next-line no-unused-expressions
       expect(await question1AssessmentWeekly.isExisting()).to.be.true
+    })
+  })
+
+  describe("When in the show page of a task with a parent task", () => {
+    it("We should see a parent task that related to the current task", async() => {
+      const parentTaskField = await await ShowTask.getParentTaskField()
+      await (await ShowTask.getParentTaskField()).waitForDisplayed()
+      // eslint-disable-next-line no-unused-expressions
+      expect(await parentTaskField.isExisting()).to.be.true
+      await expect(await (await ShowTask.getParentTask()).getText()).to.equal(
+        "EF 1 » EF 1.2"
+      )
+    })
+  })
+
+  describe("When in the show page of a task without a children tasks", () => {
+    it("We should not see list of children tasks", async() => {
+      const childrenTasksField = await await ShowTask.getChildrenTasksField()
+      // eslint-disable-next-line no-unused-expressions
+      expect(await childrenTasksField.isExisting()).to.be.false
+    })
+  })
+})
+
+// Load a task "EF 1"
+describe("Show task page", () => {
+  beforeEach("Open the show task page", async() => {
+    await ShowTask.openAsAdminUser(await ShowReport.getTaskEF1Url())
+  })
+
+  describe("When in the show page of a task without a parent task", () => {
+    it("We should not see a parent task", async() => {
+      const parentTaskField = await await ShowTask.getParentTaskField()
+      // eslint-disable-next-line no-unused-expressions
+      expect(await parentTaskField.isExisting()).to.be.false
+    })
+  })
+  describe("When in the show page of a task with a children tasks", () => {
+    it("We should see list of children tasks that related to the current task", async() => {
+      const childrenTasks = await await ShowTask.getChildrenTasks()
+      const childrenTasksField = await await ShowTask.getChildrenTasksField()
+      if (await childrenTasks.isExisting()) {
+        await (await ShowTask.getChildrenTasksField()).waitForDisplayed()
+        // eslint-disable-next-line no-unused-expressions
+        expect(await childrenTasksField.isExisting()).to.be.true
+        await expect(
+          await (await ShowTask.getFirstItemFromChildrenTasks()).getText()
+        ).to.equal("1.1")
+      }
     })
   })
 })

--- a/client/tests/webdriver/pages/report/showReport.page.js
+++ b/client/tests/webdriver/pages/report/showReport.page.js
@@ -15,6 +15,10 @@ class ShowReport extends Page {
     return (await browser.$("*=1.2.B")).getAttribute("href")
   }
 
+  async getTaskEF1Url() {
+    return (await browser.$("*=EF 1")).getAttribute("href")
+  }
+
   async getDefaultReportView() {
     return browser.$(".report-show")
   }

--- a/client/tests/webdriver/pages/showTask.page.js
+++ b/client/tests/webdriver/pages/showTask.page.js
@@ -1,20 +1,40 @@
 import Page from "./page"
 
 class ShowTask extends Page {
-  async getAssessmentResultsMonthly() {
-    return browser.$("#entity-assessments-results-monthly")
-  }
-
-  async getAssessmentResultsWeekly() {
-    return browser.$("#entity-assessments-results-weekly")
+  async getShortName() {
+    return browser.$('div[id="shortName"')
   }
 
   async getLongName() {
     return browser.$('div[id="longName"')
   }
 
-  async getShortName() {
-    return browser.$('div[id="shortName"')
+  async getParentTask() {
+    return browser.$('div[id="parentTask"')
+  }
+
+  async getParentTaskField() {
+    return browser.$("#fg-parentTask")
+  }
+
+  async getChildrenTasks() {
+    return browser.$('div[id="subEfforts"')
+  }
+
+  async getChildrenTasksField() {
+    return browser.$("#fg-subEfforts")
+  }
+
+  async getFirstItemFromChildrenTasks() {
+    return browser.$("#subEfforts > .list-group .list-group-item:first-child")
+  }
+
+  async getAssessmentResultsMonthly() {
+    return browser.$("#entity-assessments-results-monthly")
+  }
+
+  async getAssessmentResultsWeekly() {
+    return browser.$("#entity-assessments-results-weekly")
   }
 
   async getDescription() {

--- a/src/main/resources/anet-schema.yml
+++ b/src/main/resources/anet-schema.yml
@@ -510,8 +510,10 @@ properties:
             "$ref": "#/$defs/inputField"
           parentTask:
             "$ref": "#/$defs/inputField"
-          childTask:
-            "$ref": "#/$defs/inputField"
+          childrenTasks:
+            type: string
+            title: The sub tasks for this field
+            description: Used in the UI where sub tasks for task are shown.
           taskedOrganizations:
             "$ref": "#/$defs/inputField"
           responsiblePositions:

--- a/src/main/resources/anet-schema.yml
+++ b/src/main/resources/anet-schema.yml
@@ -510,6 +510,8 @@ properties:
             "$ref": "#/$defs/inputField"
           parentTask:
             "$ref": "#/$defs/inputField"
+          childTask:
+            "$ref": "#/$defs/inputField"
           taskedOrganizations:
             "$ref": "#/$defs/inputField"
           responsiblePositions:


### PR DESCRIPTION
Only show parent task for tasks with a parent, and show sub tasks if a task has any.

Closes [AB#777](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/777), [AB#778](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/778)

#### User changes
- Parent task is only shown if a task has one.
- A task's sub tasks are now also shown if there are any.
- Parent task is only shown if a task has one in task hover preview.
- A task's sub tasks are now also shown if there are any in task preview with hover.

#### Super User changes
- none

#### Admin changes
- none

#### System admin changes
- [x] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [x] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
