### PR TITLE
Make rich-text buttons accessible

### DIFF
--- a/client/src/components/editor/RichTextEditor.css
+++ b/client/src/components/editor/RichTextEditor.css
@@ -11,7 +11,7 @@
 
 .editor-container .editable {
   min-height: 10rem;
-  max-height: 50rem;
+  max-height: 25rem;
   overflow: auto;
   padding: 1rem;
 }


### PR DESCRIPTION
If the text becomes longer, the rich text editor button becomes inaccessible. To avoid this, the `max-height` value for the editor has been reduced.

Closes [AB#783](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/783)

#### User changes
- The height of rich text editing area is now reduced

#### Super User changes
- None

#### Admin changes
- None

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [ ] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
