### PR TITLE
Add breadcrumb trail for tasks

### DIFF
--- a/client/src/components/BreadcrumbTrail.js
+++ b/client/src/components/BreadcrumbTrail.js
@@ -2,12 +2,7 @@ import LinkTo from "components/LinkTo"
 import PropTypes from "prop-types"
 import React from "react"
 
-export const BreadcrumbTrail = ({
-  ascendantObjects,
-  leaf,
-  modelType,
-  parentField
-}) => {
+const getBreadcrumbTrail = (leaf, ascendantObjects, parentField) => {
   const parentMap =
     ascendantObjects?.reduce((acc, val) => {
       acc[val.uuid] = val
@@ -21,25 +16,54 @@ export const BreadcrumbTrail = ({
     if (!node) {
       break
     }
-    if (trail.length) {
-      trail.unshift(" » ")
-    }
-    trail.unshift(
-      <LinkTo
-        key={node.uuid}
-        modelType={modelType}
-        model={node}
-        showIcon={false}
-      />
-    )
+    trail.unshift(node)
     uuid = node[parentField]?.uuid
   }
   return trail
+}
+
+export const getBreadcrumbTrailAsText = (
+  leaf,
+  ascendantObjects,
+  parentField,
+  labelField
+) => {
+  const trail = getBreadcrumbTrail(leaf, ascendantObjects, parentField)
+  return trail.map(node => node[labelField]).join(" » ")
+}
+
+export const BreadcrumbTrail = ({
+  modelType,
+  leaf,
+  ascendantObjects,
+  parentField,
+  isLink,
+  style
+}) => {
+  const trail = getBreadcrumbTrail(leaf, ascendantObjects, parentField)
+  return (
+    <span>
+      {trail.map((node, i) => (
+        <React.Fragment key={node.uuid}>
+          {i > 0 && " » "}
+          <LinkTo
+            modelType={modelType}
+            model={node}
+            showIcon={false}
+            isLink={isLink}
+            style={style}
+          />
+        </React.Fragment>
+      ))}
+    </span>
+  )
 }
 
 BreadcrumbTrail.propTypes = {
   modelType: PropTypes.string.isRequired,
   leaf: PropTypes.object.isRequired,
   ascendantObjects: PropTypes.array,
-  parentField: PropTypes.string.isRequired
+  parentField: PropTypes.string.isRequired,
+  isLink: PropTypes.bool,
+  style: PropTypes.object
 }

--- a/client/src/components/BreadcrumbTrail.js
+++ b/client/src/components/BreadcrumbTrail.js
@@ -1,0 +1,45 @@
+import LinkTo from "components/LinkTo"
+import PropTypes from "prop-types"
+import React from "react"
+
+export const BreadcrumbTrail = ({
+  ascendantObjects,
+  leaf,
+  modelType,
+  parentField
+}) => {
+  const parentMap =
+    ascendantObjects?.reduce((acc, val) => {
+      acc[val.uuid] = val
+      return acc
+    }, {}) || {}
+  parentMap[leaf.uuid] = leaf
+  let uuid = leaf.uuid
+  const trail = []
+  while (uuid) {
+    const node = parentMap[uuid]
+    if (!node) {
+      break
+    }
+    if (trail.length) {
+      trail.unshift(" » ")
+    }
+    trail.unshift(
+      <LinkTo
+        key={node.uuid}
+        modelType={modelType}
+        model={node}
+        showIcon={false}
+      />
+    )
+    uuid = node[parentField]?.uuid
+  }
+  return trail
+}
+
+BreadcrumbTrail.propTypes = {
+  modelType: PropTypes.string.isRequired,
+  leaf: PropTypes.object.isRequired,
+  ascendantObjects: PropTypes.array,
+  parentField: PropTypes.string.isRequired
+}

--- a/client/src/components/FieldHelper.js
+++ b/client/src/components/FieldHelper.js
@@ -1,12 +1,14 @@
 import { Icon } from "@blueprintjs/core"
 import { IconNames } from "@blueprintjs/icons"
 import classNames from "classnames"
+import { BreadcrumbTrail } from "components/BreadcrumbTrail"
 import { CompactRow } from "components/Compact"
 import LinkTo from "components/LinkTo"
 import RemoveButton from "components/RemoveButton"
 import _cloneDeep from "lodash/cloneDeep"
 import _get from "lodash/get"
 import _isEmpty from "lodash/isEmpty"
+import { Task } from "models"
 import PropTypes from "prop-types"
 import React, { useCallback, useMemo } from "react"
 import {
@@ -608,32 +610,41 @@ export const FieldShortcuts = ({
   onChange,
   handleAddItem,
   title
-}) =>
-  shortcuts &&
-  shortcuts.length > 0 && (
-    <div id={`${fieldName}-shortcut-list`} className="shortcut-list">
-      <h5>{title}</h5>
-      <ListGroup>
-        {objectType.map(shortcuts, (shortcut, idx) => (
-          <ListGroup.Item key={shortcut.uuid}>
-            <Button
-              onClick={() => handleAddItem(shortcut, onChange, curValue)}
-              variant="secondary"
-              size="sm"
-            >
-              <Icon icon={IconNames.DOUBLE_CHEVRON_LEFT} />
-            </Button>
-            <LinkTo
-              modelType={objectType.resourceName}
-              model={shortcut}
-              isLink={false}
-              forShortcut
-            />
-          </ListGroup.Item>
-        ))}
-      </ListGroup>
-    </div>
+}) => {
+  const modelType = objectType.resourceName
+  return (
+    shortcuts &&
+    shortcuts.length > 0 && (
+      <div id={`${fieldName}-shortcut-list`} className="shortcut-list">
+        <h5>{title}</h5>
+        <ListGroup>
+          {objectType.map(shortcuts, (shortcut, idx) => (
+            <ListGroup.Item key={shortcut.uuid}>
+              <Button
+                onClick={() => handleAddItem(shortcut, onChange, curValue)}
+                variant="secondary"
+                size="sm"
+              >
+                <Icon icon={IconNames.DOUBLE_CHEVRON_LEFT} />
+              </Button>
+              {modelType === Task.resourceName ? (
+                <BreadcrumbTrail
+                  modelType={modelType}
+                  leaf={shortcut}
+                  ascendantObjects={shortcut.ascendantTasks}
+                  parentField="parentTask"
+                  isLink={false}
+                />
+              ) : (
+                <LinkTo modelType={modelType} model={shortcut} isLink={false} />
+              )}
+            </ListGroup.Item>
+          ))}
+        </ListGroup>
+      </div>
+    )
   )
+}
 
 FieldShortcuts.propTypes = {
   shortcuts: PropTypes.arrayOf(PropTypes.shape({ uuid: PropTypes.string })),

--- a/client/src/components/Kanban.js
+++ b/client/src/components/Kanban.js
@@ -1,5 +1,6 @@
 import { Icon } from "@blueprintjs/core"
 import { IconNames } from "@blueprintjs/icons"
+import { BreadcrumbTrail } from "components/BreadcrumbTrail"
 import Pie from "components/graphs/Pie"
 import LinkTo from "components/LinkTo"
 import { EngagementTrends } from "components/Trends"
@@ -141,9 +142,12 @@ const CardView = ({ task }) => {
       }}
     >
       <div>
-        <LinkTo modelType="Task" model={task}>
-          <strong>{task.shortName}</strong>
-        </LinkTo>
+        <BreadcrumbTrail
+          modelType="Task"
+          leaf={task}
+          ascendantObjects={task.ascendantTasks}
+          parentField="parentTask"
+        />
         <br />
         <EngagementTrends
           newValue={task.lastMonthReports.length}

--- a/client/src/components/NoPaginationTaskTable.js
+++ b/client/src/components/NoPaginationTaskTable.js
@@ -1,3 +1,4 @@
+import { BreadcrumbTrail } from "components/BreadcrumbTrail"
 import LinkTo from "components/LinkTo"
 import RemoveButton from "components/RemoveButton"
 import _get from "lodash/get"
@@ -10,7 +11,6 @@ import Settings from "settings"
 const NoPaginationTaskTable = ({
   id,
   tasks,
-  showParent,
   showOrganization,
   showDelete,
   showDescription,
@@ -26,9 +26,6 @@ const NoPaginationTaskTable = ({
           <thead>
             <tr>
               <th>Name</th>
-              {showParent && (
-                <th>{Settings.fields.task.topLevel.shortLabel}</th>
-              )}
               {showOrganization && <th>Tasked organizations</th>}
               {showDescription && <th>Description</th>}
               <th />
@@ -40,19 +37,13 @@ const NoPaginationTaskTable = ({
               return (
                 <tr key={task.uuid}>
                   <td className="taskName">
-                    <LinkTo modelType="Task" model={task}>
-                      {task.shortName}
-                    </LinkTo>
+                    <BreadcrumbTrail
+                      modelType="Task"
+                      leaf={task}
+                      ascendantObjects={task.ascendantTasks}
+                      parentField="parentTask"
+                    />
                   </td>
-                  {showParent && (
-                    <td className="parentTaskName">
-                      {task.parentTask && (
-                        <LinkTo modelType="Task" model={task.parentTask}>
-                          {task.parentTask.shortName}
-                        </LinkTo>
-                      )}
-                    </td>
-                  )}
                   {showOrganization && (
                     <td className="taskOrg">
                       {task.taskedOrganizations.map(org => (
@@ -92,7 +83,6 @@ const NoPaginationTaskTable = ({
 NoPaginationTaskTable.propTypes = {
   id: PropTypes.string,
   tasks: PropTypes.array,
-  showParent: PropTypes.bool,
   showDelete: PropTypes.bool,
   onDelete: PropTypes.func,
   showOrganization: PropTypes.bool,

--- a/client/src/components/PendingAssessmentsByPosition.js
+++ b/client/src/components/PendingAssessmentsByPosition.js
@@ -1,5 +1,6 @@
 import { gql } from "@apollo/client"
 import API from "api"
+import { BreadcrumbTrail } from "components/BreadcrumbTrail"
 import Fieldset from "components/Fieldset"
 import LinkTo from "components/LinkTo"
 import {
@@ -78,6 +79,14 @@ const GQL_GET_POSITION_LIST = gql`
           longName
           parentTask {
             uuid
+            shortName
+          }
+          ascendantTasks(query: { pageNum: 0, pageSize: 0 }) {
+            uuid
+            shortName
+            parentTask {
+              uuid
+            }
           }
           ${GRAPHQL_NOTIFICATIONS_NOTE_FIELDS}
         }
@@ -285,9 +294,12 @@ const TaskList = ({ tasks }) => {
           return (
             <tr key={task.uuid}>
               <td>
-                <LinkTo modelType="Task" model={task}>
-                  {task.shortName} {task.longName}
-                </LinkTo>
+                <BreadcrumbTrail
+                  modelType="Task"
+                  leaf={task}
+                  ascendantObjects={task.ascendantTasks}
+                  parentField="parentTask"
+                />
               </td>
             </tr>
           )

--- a/client/src/components/ReportSummary.js
+++ b/client/src/components/ReportSummary.js
@@ -1,5 +1,6 @@
 import { gql } from "@apollo/client"
 import API from "api"
+import { BreadcrumbTrail } from "components/BreadcrumbTrail"
 import LinkTo from "components/LinkTo"
 import { PageDispatchersPropType, useBoilerplate } from "components/Page"
 import { ReportCompactWorkflow } from "components/ReportWorkflow"
@@ -13,6 +14,7 @@ import pluralize from "pluralize"
 import PropTypes from "prop-types"
 import React, { useEffect, useRef, useState } from "react"
 import { Badge, Col, Container, Row } from "react-bootstrap"
+import TASKS_ICON from "resources/tasks.png"
 import Settings from "settings"
 import utils from "utils"
 
@@ -63,6 +65,17 @@ const GQL_GET_REPORT_LIST = gql`
         tasks {
           uuid
           shortName
+          parentTask {
+            uuid
+            shortName
+          }
+          ascendantTasks(query: { pageNum: 0, pageSize: 0 }) {
+            uuid
+            shortName
+            parentTask {
+              uuid
+            }
+          }
         }
         workflow {
           type
@@ -327,10 +340,19 @@ const ReportSummaryRow = ({ report }) => {
               <strong>
                 {pluralize(Settings.fields.task.subLevel.shortLabel)}:
               </strong>{" "}
-              {report.tasks.map(
-                (task, i) =>
-                  task.shortName + (i < report.tasks.length - 1 ? ", " : "")
-              )}
+              {report.tasks.map((task, i) => (
+                <React.Fragment key={task.uuid}>
+                  {i > 0 && (
+                    <img src={TASKS_ICON} alt="★" className="ms-1 me-1" />
+                  )}
+                  <BreadcrumbTrail
+                    modelType="Task"
+                    leaf={task}
+                    ascendantObjects={task.ascendantTasks}
+                    parentField="parentTask"
+                  />
+                </React.Fragment>
+              ))}
             </span>
           )}
         </Col>

--- a/client/src/components/SearchFilters.js
+++ b/client/src/components/SearchFilters.js
@@ -27,8 +27,9 @@ import {
   LocationOverlayRow,
   PersonDetailedOverlayRow,
   PositionOverlayRow,
-  TaskSimpleOverlayRow
+  TaskOverlayRow
 } from "components/advancedSelectWidget/AdvancedSelectOverlayRow"
+import { getBreadcrumbTrailAsText } from "components/BreadcrumbTrail"
 import Model from "components/Model"
 import _isEmpty from "lodash/isEmpty"
 import _pickBy from "lodash/pickBy"
@@ -168,9 +169,11 @@ const advancedSelectFilterLocationProps = {
 }
 const advancedSelectFilterTaskProps = {
   overlayColumns: ["Name"],
-  overlayRenderRow: TaskSimpleOverlayRow,
+  overlayRenderRow: TaskOverlayRow,
   objectType: Task,
   valueKey: "shortName",
+  valueFunc: (v, k) =>
+    getBreadcrumbTrailAsText(v, v?.ascendantTasks, "parentTask", k),
   fields: Task.autocompleteQuery,
   addon: TASKS_ICON
 }

--- a/client/src/components/TaskTable.js
+++ b/client/src/components/TaskTable.js
@@ -1,6 +1,6 @@
 import { gql } from "@apollo/client"
 import API from "api"
-import LinkTo from "components/LinkTo"
+import { BreadcrumbTrail } from "components/BreadcrumbTrail"
 import {
   mapPageDispatchersToProps,
   PageDispatchersPropType,
@@ -24,6 +24,17 @@ const GQL_GET_TASK_LIST = gql`
         uuid
         shortName
         longName
+        parentTask {
+          uuid
+          shortName
+        }
+        ascendantTasks(query: { pageNum: 0, pageSize: 0 }) {
+          uuid
+          shortName
+          parentTask {
+            uuid
+          }
+        }
       }
     }
   }
@@ -106,17 +117,18 @@ const BaseTaskTable = ({
             </tr>
           </thead>
           <tbody>
-            {Task.map(tasks, task => {
-              return (
-                <tr key={task.uuid}>
-                  <td>
-                    <LinkTo modelType="Task" model={task}>
-                      {task.shortName}
-                    </LinkTo>
-                  </td>
-                </tr>
-              )
-            })}
+            {Task.map(tasks, task => (
+              <tr key={task.uuid}>
+                <td>
+                  <BreadcrumbTrail
+                    modelType="Task"
+                    leaf={task}
+                    ascendantObjects={task.ascendantTasks}
+                    parentField="parentTask"
+                  />
+                </td>
+              </tr>
+            ))}
           </tbody>
         </Table>
       </UltimatePaginationTopDown>

--- a/client/src/components/advancedSearch/AdvancedSelectFilter.js
+++ b/client/src/components/advancedSearch/AdvancedSelectFilter.js
@@ -11,6 +11,7 @@ const AdvancedSelectFilter = ({
   value: inputValue,
   onChange,
   valueKey,
+  valueFunc,
   ...advancedSelectProps
 }) => {
   const defaultValue = inputValue || {}
@@ -26,7 +27,7 @@ const AdvancedSelectFilter = ({
   )
 
   return !asFormField ? (
-    <>{value[valueKey]}</>
+    <>{valueFunc(value, valueKey)}</>
   ) : (
     <AdvancedSingleSelect
       {...advancedSelectProps}
@@ -37,6 +38,7 @@ const AdvancedSelectFilter = ({
       onChange={handleChange}
       value={value}
       valueKey={valueKey}
+      valueFunc={valueFunc}
       smallOverlay
     />
   )
@@ -57,10 +59,12 @@ AdvancedSelectFilter.propTypes = {
   value: PropTypes.any,
   onChange: PropTypes.func, // eslint-disable-line react/no-unused-prop-types
   valueKey: PropTypes.string.isRequired,
+  valueFunc: PropTypes.func,
   fields: PropTypes.string,
   asFormField: PropTypes.bool
 }
 AdvancedSelectFilter.defaultProps = {
+  valueFunc: (v, k) => v?.[k],
   fields: "",
   asFormField: true
 }

--- a/client/src/components/advancedSearch/TaskFilter.js
+++ b/client/src/components/advancedSearch/TaskFilter.js
@@ -1,8 +1,9 @@
 import { gql } from "@apollo/client"
 import API from "api"
 import useSearchFilter from "components/advancedSearch/hooks"
-import { TaskSimpleOverlayRow } from "components/advancedSelectWidget/AdvancedSelectOverlayRow"
+import { TaskOverlayRow } from "components/advancedSelectWidget/AdvancedSelectOverlayRow"
 import AdvancedSingleSelect from "components/advancedSelectWidget/AdvancedSingleSelect"
+import { getBreadcrumbTrailAsText } from "components/BreadcrumbTrail"
 import { Task } from "models"
 import PropTypes from "prop-types"
 import React from "react"
@@ -51,8 +52,17 @@ const TaskFilter = ({
     }
   }
 
+  const parentKey = "parentTask"
+  const valueKey = "shortName"
   return !asFormField ? (
-    <>{value.value?.shortName}</>
+    <>
+      {getBreadcrumbTrailAsText(
+        value.value,
+        value.value?.ascendantTasks,
+        parentKey,
+        valueKey
+      )}
+    </>
   ) : (
     <AdvancedSingleSelect
       {...advancedSelectProps}
@@ -62,9 +72,12 @@ const TaskFilter = ({
       showRemoveButton={false}
       filterDefs={advancedSelectFilters}
       overlayColumns={["Name"]}
-      overlayRenderRow={TaskSimpleOverlayRow}
+      overlayRenderRow={TaskOverlayRow}
       objectType={Task}
-      valueKey="shortName"
+      valueKey={valueKey}
+      valueFunc={(v, k) =>
+        getBreadcrumbTrailAsText(v, v?.ascendantTasks, parentKey, k)
+      }
       fields={Task.autocompleteQuery}
       placeholder="Filter by task..."
       addon={TASKS_ICON}

--- a/client/src/components/advancedSelectWidget/AdvancedSelectOverlayRow.js
+++ b/client/src/components/advancedSelectWidget/AdvancedSelectOverlayRow.js
@@ -1,5 +1,6 @@
+import { BreadcrumbTrail } from "components/BreadcrumbTrail"
 import LinkTo from "components/LinkTo"
-import { Location } from "models"
+import { Location, Task } from "models"
 import moment from "moment"
 import PropTypes from "prop-types"
 import React from "react"
@@ -10,17 +11,27 @@ const cursorStyle = {
   cursor: "pointer"
 }
 
-const AsLink = ({ modelType, model, whenUnspecified, children }) => (
-  <LinkTo
-    modelType={modelType}
-    model={model}
-    whenUnspecified={whenUnspecified}
-    isLink={false}
-    style={cursorStyle}
-  >
-    {children}
-  </LinkTo>
-)
+const AsLink = ({ modelType, model, whenUnspecified, children }) =>
+  modelType === Task.resourceName ? (
+    <BreadcrumbTrail
+      modelType={modelType}
+      leaf={model}
+      ascendantObjects={model.ascendantTasks}
+      parentField="parentTask"
+      isLink={false}
+      style={cursorStyle}
+    />
+  ) : (
+    <LinkTo
+      modelType={modelType}
+      model={model}
+      whenUnspecified={whenUnspecified}
+      isLink={false}
+      style={cursorStyle}
+    >
+      {children}
+    </LinkTo>
+  )
 AsLink.propTypes = {
   modelType: PropTypes.string.isRequired,
   model: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
@@ -62,25 +73,12 @@ export const OrganizationOverlayRow = item => (
   </React.Fragment>
 )
 
-export const TaskSimpleOverlayRow = item => (
+export const TaskOverlayRow = item => (
   <React.Fragment key={item.uuid}>
     <td className="taskName">
       <span>
-        <AsLink modelType="Task" model={item}>
-          {` - ${item.longName}`}
-        </AsLink>
+        <AsLink modelType="Task" model={item} />
       </span>
-    </td>
-  </React.Fragment>
-)
-
-export const TaskDetailedOverlayRow = item => (
-  <React.Fragment key={item.uuid}>
-    <td className="taskName">
-      <AsLink modelType="Task" model={item} />
-    </td>
-    <td className="parentTaskName">
-      {item.parentTask && <AsLink modelType="Task" model={item.parentTask} />}
     </td>
   </React.Fragment>
 )

--- a/client/src/components/advancedSelectWidget/AdvancedSelectOverlayTable.js
+++ b/client/src/components/advancedSelectWidget/AdvancedSelectOverlayTable.js
@@ -22,8 +22,10 @@ const AdvancedSelectOverlayTable = ({
     <Table responsive hover striped>
       <thead>
         <tr>
-          {columns.map(col => (
-            <th key={col}>{col}</th>
+          {columns.map((col, idx) => (
+            <th className={idx === 0 ? "col-1" : undefined} key={col}>
+              {col}
+            </th>
           ))}
         </tr>
       </thead>

--- a/client/src/components/advancedSelectWidget/AdvancedSingleSelect.js
+++ b/client/src/components/advancedSelectWidget/AdvancedSingleSelect.js
@@ -16,7 +16,9 @@ const AdvancedSingleSelect = props => {
       handleRemoveItem={handleRemoveItem}
       closeOverlayOnAdd
       selectedValueAsString={
-        !_isEmpty(props.value) ? props.value[props.valueKey] : ""
+        _isEmpty(props.value)
+          ? ""
+          : props.valueFunc(props.value, props.valueKey)
       }
       extraAddon={
         props.showRemoveButton && !_isEmpty(props.value) ? (
@@ -37,10 +39,12 @@ const AdvancedSingleSelect = props => {
 AdvancedSingleSelect.propTypes = {
   ...advancedSelectPropTypes,
   value: PropTypes.object,
-  valueKey: PropTypes.string
+  valueKey: PropTypes.string,
+  valueFunc: PropTypes.func
 }
 AdvancedSingleSelect.defaultProps = {
   value: {},
+  valueFunc: (v, k) => v?.[k],
   overlayTable: AdvancedSingleSelectOverlayTable,
   showRemoveButton: true // whether to display a remove button in the input field to allow removing the selected value
 }

--- a/client/src/components/advancedSelectWidget/MultiTypeAdvancedSelectComponent.js
+++ b/client/src/components/advancedSelectWidget/MultiTypeAdvancedSelectComponent.js
@@ -6,7 +6,7 @@ import {
   PersonDetailedOverlayRow,
   PositionOverlayRow,
   ReportDetailedOverlayRow,
-  TaskSimpleOverlayRow
+  TaskOverlayRow
 } from "components/advancedSelectWidget/AdvancedSelectOverlayRow"
 import AdvancedSingleSelect from "components/advancedSelectWidget/AdvancedSingleSelect"
 import ButtonToggleGroup from "components/ButtonToggleGroup"
@@ -117,7 +117,7 @@ const widgetPropsLocation = {
 
 const widgetPropsTask = {
   objectType: Models.Task,
-  overlayRenderRow: TaskSimpleOverlayRow,
+  overlayRenderRow: TaskOverlayRow,
   overlayColumns: ["Name"],
   filterDefs: entityFilters,
   queryParams: { status: Model.STATUS.ACTIVE },

--- a/client/src/components/assessments/instant/InstantAssessmentsContainerField.js
+++ b/client/src/components/assessments/instant/InstantAssessmentsContainerField.js
@@ -1,4 +1,5 @@
 import AppContext from "components/AppContext"
+import { BreadcrumbTrail } from "components/BreadcrumbTrail"
 import {
   CustomFieldsContainer,
   ReadonlyCustomFields
@@ -6,6 +7,7 @@ import {
 import LinkTo from "components/LinkTo"
 import Model from "components/Model"
 import _isEmpty from "lodash/isEmpty"
+import { Task } from "models"
 import PropTypes from "prop-types"
 import React, { useContext, useMemo } from "react"
 import { Table } from "react-bootstrap"
@@ -145,12 +147,22 @@ const InstantAssessmentsContainerField = ({
       <tbody>
         {filteredEntities.map(entity => {
           const entityInstantAssessments = entity.getInstantAssessments()
+          const modelType = entityType.resourceName
 
           return (
             <React.Fragment key={`assessment-${values.uuid}-${entity.uuid}`}>
               <tr>
                 <td>
-                  <LinkTo modelType={entityType.resourceName} model={entity} />
+                  {modelType === Task.resourceName ? (
+                    <BreadcrumbTrail
+                      modelType={modelType}
+                      leaf={entity}
+                      ascendantObjects={entity.ascendantTasks}
+                      parentField="parentTask"
+                    />
+                  ) : (
+                    <LinkTo modelType={modelType} model={entity} />
+                  )}
                 </td>
               </tr>
               {entityInstantAssessments.map(([ak, ac]) => (

--- a/client/src/components/assessments/periodic/PeriodicAssessmentResultsTable.js
+++ b/client/src/components/assessments/periodic/PeriodicAssessmentResultsTable.js
@@ -1,8 +1,10 @@
+import { BreadcrumbTrail } from "components/BreadcrumbTrail"
 import Fieldset from "components/Fieldset"
 import LinkTo from "components/LinkTo"
 import Model from "components/Model"
 import PeriodsNavigation from "components/PeriodsNavigation"
 import _isEmpty from "lodash/isEmpty"
+import { Task } from "models"
 import {
   AssessmentPeriodsConfigPropType,
   getPeriodsConfig,
@@ -43,12 +45,22 @@ const EntityPeriodicAssessmentResults = ({
     return null
   }
   const instantAssessments = entity.getInstantAssessments()
+  const modelType = entityType.resourceName
   const { periods } = periodsConfig
   return (
     <>
       <tr>
         <td colSpan={periods.length} className="entity-title-row">
-          <LinkTo modelType={entityType.resourceName} model={entity} />
+          {modelType === Task.resourceName ? (
+            <BreadcrumbTrail
+              modelType={modelType}
+              leaf={entity}
+              ascendantObjects={entity.ascendantTasks}
+              parentField="parentTask"
+            />
+          ) : (
+            <LinkTo modelType={modelType} model={entity} />
+          )}
         </td>
       </tr>
       {instantAssessments.map(([ak, ac]) => {

--- a/client/src/components/previews/ReportPreview.js
+++ b/client/src/components/previews/ReportPreview.js
@@ -66,6 +66,13 @@ const GQL_GET_REPORT = gql`
           uuid
           shortName
         }
+        ascendantTasks(query: { pageNum: 0, pageSize: 0 }) {
+          uuid
+          shortName
+          parentTask {
+            uuid
+          }
+        }
         taskedOrganizations {
           uuid
           shortName
@@ -287,7 +294,6 @@ const ReportPreview = ({ className, uuid }) => {
       <div className="preview-section">
         <NoPaginationTaskTable
           tasks={report.tasks}
-          showParent
           noTasksMessage={`No ${tasksLabel} selected`}
         />
       </div>

--- a/client/src/components/previews/TaskPreview.js
+++ b/client/src/components/previews/TaskPreview.js
@@ -1,5 +1,6 @@
 import { gql } from "@apollo/client"
 import API from "api"
+import { BreadcrumbTrail } from "components/BreadcrumbTrail"
 import { PreviewField } from "components/FieldHelper"
 import LinkTo from "components/LinkTo"
 import Model from "components/Model"
@@ -28,7 +29,16 @@ const GQL_GET_TASK = gql`
       parentTask {
         uuid
         shortName
-        longName
+        parentTask {
+          uuid
+        }
+      }
+      ascendantTasks(query: { pageNum: 0, pageSize: 0 }) {
+        uuid
+        shortName
+        parentTask {
+          uuid
+        }
       }
       responsiblePositions {
         uuid
@@ -148,9 +158,12 @@ const TaskPreview = ({ className, uuid }) => {
             label={Settings.fields.task.parentTask.label}
             value={
               task.parentTask && (
-                <LinkTo modelType="Task" model={task.parentTask}>
-                  {task.parentTask.shortName} {task.parentTask.longName}
-                </LinkTo>
+                <BreadcrumbTrail
+                  modelType="Task"
+                  leaf={task.parentTask}
+                  ascendantObjects={task.ascendantTasks}
+                  parentField="parentTask"
+                />
               )
             }
           />

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -968,7 +968,7 @@ header.searchPagination {
   width: 100% !important;
 }
 
-.advanced-select-popover span.bp4-popover2-target {
+.advanced-select-popover .input-group > span.bp4-popover2-target {
   display: block;
   width: 100%;
 }

--- a/client/src/models/Task.js
+++ b/client/src/models/Task.js
@@ -133,7 +133,9 @@ export default class Task extends Model {
     .concat(Model.yupSchema)
 
   static autocompleteQuery =
-    "uuid, shortName, longName, parentTask { uuid, shortName } taskedOrganizations { uuid, shortName }, customFields"
+    "uuid shortName longName parentTask { uuid shortName }" +
+    " ascendantTasks(query: { pageNum: 0, pageSize: 0 }) { uuid shortName parentTask { uuid } }" +
+    " taskedOrganizations { uuid shortName } customFields"
 
   static autocompleteQueryWithNotes = `${this.autocompleteQuery} ${GRAPHQL_NOTES_FIELDS}`
 
@@ -173,9 +175,7 @@ export default class Task extends Model {
     return this.fieldSettings().assessments || {}
   }
 
-  static FILTERED_CLIENT_SIDE_FIELDS = [
-    // Fill if necessary
-  ]
+  static FILTERED_CLIENT_SIDE_FIELDS = ["ascendantTasks"]
 
   static filterClientSideFields(obj, ...additionalFields) {
     return Model.filterClientSideFields(

--- a/client/src/pages/App.js
+++ b/client/src/pages/App.js
@@ -104,6 +104,14 @@ const GQL_GET_APP_DATA = gql`
           longName
           parentTask {
             uuid
+            shortName
+          }
+          ascendantTasks(query: { pageNum: 0, pageSize: 0 }) {
+            uuid
+            shortName
+            parentTask {
+              uuid
+            }
           }
           ${GRAPHQL_NOTIFICATIONS_NOTE_FIELDS}
         }

--- a/client/src/pages/dashboards/KanbanDashboard.js
+++ b/client/src/pages/dashboards/KanbanDashboard.js
@@ -32,6 +32,14 @@ const GQL_GET_TASK_LIST = gql`
         }
         parentTask {
           uuid
+          shortName
+        }
+        ascendantTasks(query: { pageNum: 0, pageSize: 0 }) {
+          uuid
+          shortName
+          parentTask {
+            uuid
+          }
         }
         allReports: reports {
           uuid

--- a/client/src/pages/organizations/Form.js
+++ b/client/src/pages/organizations/Form.js
@@ -4,7 +4,7 @@ import AdvancedMultiSelect from "components/advancedSelectWidget/AdvancedMultiSe
 import {
   LocationOverlayRow,
   OrganizationOverlayRow,
-  TaskSimpleOverlayRow
+  TaskOverlayRow
 } from "components/advancedSelectWidget/AdvancedSelectOverlayRow"
 import AdvancedSingleSelect from "components/advancedSelectWidget/AdvancedSingleSelect"
 import AppContext from "components/AppContext"
@@ -429,7 +429,7 @@ const OrganizationForm = ({ edit, title, initialValues, notesComponent }) => {
                                 />
                               }
                               overlayColumns={["Name"]}
-                              overlayRenderRow={TaskSimpleOverlayRow}
+                              overlayRenderRow={TaskOverlayRow}
                               filterDefs={tasksFilters}
                               objectType={Task}
                               queryParams={{ status: Model.STATUS.ACTIVE }}

--- a/client/src/pages/organizations/OrganizationTasks.js
+++ b/client/src/pages/organizations/OrganizationTasks.js
@@ -1,6 +1,7 @@
 import { gql } from "@apollo/client"
 import API from "api"
 import AppContext from "components/AppContext"
+import { BreadcrumbTrail } from "components/BreadcrumbTrail"
 import Fieldset from "components/Fieldset"
 import LinkTo from "components/LinkTo"
 import {
@@ -102,9 +103,12 @@ const OrganizationTasks = ({ pageDispatchers, queryParams, organization }) => {
             {Task.map(tasks, (task, idx) => (
               <tr key={task.uuid} id={`task_${idx}`}>
                 <td>
-                  <LinkTo modelType="Task" model={task}>
-                    {task.shortName}
-                  </LinkTo>
+                  <BreadcrumbTrail
+                    modelType="Task"
+                    leaf={task}
+                    ascendantObjects={task.ascendantTasks}
+                    parentField="parentTask"
+                  />
                 </td>
                 <td>{task.longName}</td>
               </tr>

--- a/client/src/pages/reports/Compact.js
+++ b/client/src/pages/reports/Compact.js
@@ -4,6 +4,7 @@ import { DEFAULT_PAGE_PROPS, DEFAULT_SEARCH_PROPS } from "actions"
 import API from "api"
 import AppContext from "components/AppContext"
 import InstantAssessmentsContainerField from "components/assessments/instant/InstantAssessmentsContainerField"
+import { BreadcrumbTrail } from "components/BreadcrumbTrail"
 import CompactTable, {
   CompactFooterContent,
   CompactHeaderContent,
@@ -39,6 +40,7 @@ import React, { useContext, useState } from "react"
 import { Button, Dropdown, DropdownButton } from "react-bootstrap"
 import { connect } from "react-redux"
 import { useNavigate, useParams } from "react-router-dom"
+import TASKS_ICON from "resources/tasks.png"
 import Settings from "settings"
 import utils from "utils"
 
@@ -140,6 +142,13 @@ const GQL_GET_REPORT = gql`
         parentTask {
           uuid
           shortName
+        }
+        ascendantTasks(query: { pageNum: 0, pageSize: 0 }) {
+          uuid
+          shortName
+          parentTask {
+            uuid
+          }
         }
         taskedOrganizations {
           uuid
@@ -354,6 +363,7 @@ const CompactReportView = ({ pageDispatchers }) => {
                       className="reportField"
                     />
                     <CompactRow
+                      id="tasks"
                       label={Settings.fields.task.subLevel.longLabel}
                       content={getTasksAndAssessments()}
                       className="reportField"
@@ -466,8 +476,16 @@ const CompactReportView = ({ pageDispatchers }) => {
           readonly
         />
       ) : (
-        report.tasks.map(task => (
-          <LinkTo key={task.uuid} modelType="Task" model={task} />
+        report.tasks.map((task, i) => (
+          <React.Fragment key={task.uuid}>
+            {i > 0 && <img src={TASKS_ICON} alt="★" className="ms-1 me-1" />}
+            <BreadcrumbTrail
+              modelType="Task"
+              leaf={task}
+              ascendantObjects={task.ascendantTasks}
+              parentField="parentTask"
+            />
+          </React.Fragment>
         ))
       )
     )

--- a/client/src/pages/reports/Edit.js
+++ b/client/src/pages/reports/Edit.js
@@ -81,6 +81,13 @@ const GQL_GET_REPORT = gql`
           uuid
           shortName
         }
+        ascendantTasks(query: { pageNum: 0, pageSize: 0 }) {
+          uuid
+          shortName
+          parentTask {
+            uuid
+          }
+        }
         taskedOrganizations {
           uuid
           shortName

--- a/client/src/pages/reports/Form.js
+++ b/client/src/pages/reports/Form.js
@@ -7,7 +7,7 @@ import {
   AuthorizationGroupOverlayRow,
   LocationOverlayRow,
   PersonDetailedOverlayRow,
-  TaskDetailedOverlayRow
+  TaskOverlayRow
 } from "components/advancedSelectWidget/AdvancedSelectOverlayRow"
 import AdvancedSingleSelect from "components/advancedSelectWidget/AdvancedSingleSelect"
 import AppContext from "components/AppContext"
@@ -766,17 +766,15 @@ const ReportForm = ({
                           <NoPaginationTaskTable
                             id="tasks-tasks"
                             tasks={values.tasks}
-                            showParent
                             showDelete
                             showDescription
                             noTasksMessage={`No ${tasksLabel} selected; click in the efforts box to view your organization's efforts`}
                           />
                         }
                         overlayColumns={[
-                          Settings.fields.task.subLevel.shortLabel,
-                          Settings.fields.task.topLevel.shortLabel
+                          Settings.fields.task.subLevel.shortLabel
                         ]}
-                        overlayRenderRow={TaskDetailedOverlayRow}
+                        overlayRenderRow={TaskOverlayRow}
                         filterDefs={tasksFilters}
                         objectType={Task}
                         queryParams={{ status: Model.STATUS.ACTIVE }}

--- a/client/src/pages/reports/Show.js
+++ b/client/src/pages/reports/Show.js
@@ -147,6 +147,13 @@ const GQL_GET_REPORT = gql`
           uuid
           shortName
         }
+        ascendantTasks(query: { pageNum: 0, pageSize: 0 }) {
+          uuid
+          shortName
+          parentTask {
+            uuid
+          }
+        }
         taskedOrganizations {
           uuid
           shortName
@@ -666,7 +673,6 @@ const ReportShow = ({ setSearchQuery, pageDispatchers }) => {
               <Fieldset title={Settings.fields.task.subLevel.longLabel}>
                 <NoPaginationTaskTable
                   tasks={report.tasks}
-                  showParent
                   noTasksMessage={`No ${tasksLabel} selected`}
                 />
               </Fieldset>

--- a/client/src/pages/searches/Search.js
+++ b/client/src/pages/searches/Search.js
@@ -163,6 +163,17 @@ const GQL_GET_TASK_LIST = gql`
         uuid
         shortName
         longName
+        parentTask {
+          uuid
+          shortName
+        }
+        ascendantTasks(query: { pageNum: 0, pageSize: 0 }) {
+          uuid
+          shortName
+          parentTask {
+            uuid
+          }
+        }
       }
     }
   }

--- a/client/src/pages/tasks/Edit.js
+++ b/client/src/pages/tasks/Edit.js
@@ -38,7 +38,13 @@ const GQL_GET_TASK = gql`
       parentTask {
         uuid
         shortName
-        longName
+      }
+      ascendantTasks(query: { pageNum: 0, pageSize: 0 }) {
+        uuid
+        shortName
+        parentTask {
+          uuid
+        }
       }
       responsiblePositions {
         uuid

--- a/client/src/pages/tasks/Form.js
+++ b/client/src/pages/tasks/Form.js
@@ -4,7 +4,7 @@ import AdvancedMultiSelect from "components/advancedSelectWidget/AdvancedMultiSe
 import {
   OrganizationOverlayRow,
   PositionOverlayRow,
-  TaskSimpleOverlayRow
+  TaskOverlayRow
 } from "components/advancedSelectWidget/AdvancedSelectOverlayRow"
 import AdvancedSingleSelect from "components/advancedSelectWidget/AdvancedSingleSelect"
 import AppContext from "components/AppContext"
@@ -279,7 +279,7 @@ const TaskForm = ({ edit, title, initialValues, notesComponent }) => {
                         }
                         value={values.parentTask}
                         overlayColumns={["Name"]}
-                        overlayRenderRow={TaskSimpleOverlayRow}
+                        overlayRenderRow={TaskOverlayRow}
                         filterDefs={tasksFilters}
                         objectType={Task}
                         fields={Task.autocompleteQuery}

--- a/client/src/pages/tasks/Show.js
+++ b/client/src/pages/tasks/Show.js
@@ -4,6 +4,7 @@ import API from "api"
 import AppContext from "components/AppContext"
 import Approvals from "components/approvals/Approvals"
 import AssessmentResultsContainer from "components/assessments/AssessmentResultsContainer"
+import { BreadcrumbTrail } from "components/BreadcrumbTrail"
 import { ReadonlyCustomFields } from "components/CustomFields"
 import * as FieldHelper from "components/FieldHelper"
 import Fieldset from "components/Fieldset"
@@ -53,15 +54,30 @@ const GQL_GET_TASK = gql`
       parentTask {
         uuid
         shortName
-        longName
+        parentTask {
+          uuid
+        }
+      }
+      ascendantTasks(query: { pageNum: 0, pageSize: 0 }) {
+        uuid
+        shortName
+        parentTask {
+          uuid
+        }
       }
       descendantTasks(query: { pageNum: 0, pageSize: 0 }) {
         uuid
         shortName
-        longName
         parentTask {
           uuid
           shortName
+        }
+        ascendantTasks(query: { pageNum: 0, pageSize: 0 }) {
+          uuid
+          shortName
+          parentTask {
+            uuid
+          }
         }
         customFields
         ${GRAPHQL_NOTES_FIELDS}
@@ -285,10 +301,12 @@ const TaskShow = ({ pageDispatchers }) => {
                       component={FieldHelper.ReadonlyField}
                       humanValue={
                         task.parentTask && (
-                          <LinkTo modelType="Task" model={task.parentTask}>
-                            {task.parentTask.shortName}{" "}
-                            {task.parentTask.longName}
-                          </LinkTo>
+                          <BreadcrumbTrail
+                            modelType="Task"
+                            leaf={task.parentTask}
+                            ascendantObjects={task.ascendantTasks}
+                            parentField="parentTask"
+                          />
                         )
                       }
                     />

--- a/client/tests/e2e/report.js
+++ b/client/tests/e2e/report.js
@@ -150,7 +150,7 @@ test.serial("Draft and submit a report", async t => {
   )
 
   const $newTaskRow = await $("#tasks-tasks table tbody tr td")
-  await assertElementText(t, $newTaskRow, "2.A")
+  await assertElementText(t, $newTaskRow, "EF 2 » 2.A")
 
   await pageHelpers.writeInForm("#keyOutcomes", "key outcomes")
   await pageHelpers.writeInForm("#nextSteps", "next steps")

--- a/client/tests/webdriver/baseSpecs/printReport.spec.js
+++ b/client/tests/webdriver/baseSpecs/printReport.spec.js
@@ -11,6 +11,8 @@ const PRINCIPALS = [
 
 const ADVISORS = ["CIV DMIN, Arthur", "CIV GUIST, Lin"]
 
+const TASKS = ["EF 1 » EF 1.2 » 1.2.A", "EF 1 » EF 1.2 » 1.2.B"]
+
 describe("Show print report page", () => {
   beforeEach("Open the show report page", async() => {
     await MyReports.open("arthur")
@@ -78,10 +80,10 @@ describe("Show print report page", () => {
       await expect(compactBannerText).to.equal(bannerSecurityText)
     })
     it("Should display all attendees", async() => {
-      const displayedPrincipals = await ShowReport.getCompactViewAttendees(
+      const displayedPrincipals = await ShowReport.getCompactViewElements(
         "principals"
       )
-      const displayedAdvisors = await ShowReport.getCompactViewAttendees(
+      const displayedAdvisors = await ShowReport.getCompactViewElements(
         "advisors"
       )
       for (const principal of PRINCIPALS) {
@@ -93,19 +95,35 @@ describe("Show print report page", () => {
     })
     it("Should display all attendees when assessments are shown", async() => {
       await ShowReport.selectOptionalField("assessments")
-      const displayedPrincipals = await ShowReport.getCompactViewAttendees(
+      const displayedPrincipals = await ShowReport.getCompactViewElements(
         "principals",
         true
       )
       for (const principal of PRINCIPALS) {
         await expect(displayedPrincipals).to.contain(principal)
       }
-      const displayedAdvisors = await ShowReport.getCompactViewAttendees(
+      const displayedAdvisors = await ShowReport.getCompactViewElements(
         "advisors",
         true
       )
       for (const advisor of ADVISORS) {
         await expect(displayedAdvisors).to.contain(advisor)
+      }
+    })
+    it("Should display all tasks", async() => {
+      const displayedTasks = await ShowReport.getCompactViewElements("tasks")
+      for (const task of TASKS) {
+        await expect(displayedTasks).to.contain(task)
+      }
+    })
+    it("Should display all tasks when assessments are shown", async() => {
+      await ShowReport.selectOptionalField("assessments")
+      const displayedTasks = await ShowReport.getCompactViewElements(
+        "tasks",
+        true
+      )
+      for (const task of TASKS) {
+        await expect(displayedTasks).to.contain(task)
       }
     })
   })

--- a/client/tests/webdriver/customFieldsSpecs/createFutureReport.spec.js
+++ b/client/tests/webdriver/customFieldsSpecs/createFutureReport.spec.js
@@ -6,7 +6,7 @@ const PRINCIPAL = "Christopf"
 const PRINCIPAL_VALUE = `CIV TOPFERNESS, ${PRINCIPAL}`
 
 const TASK = "1.2.A"
-const TASK_VALUE = `${TASK}`
+const TASK_VALUE = "EF 1 » EF 1.2 » 1.2.A"
 
 const ENGAGEMENT_DATE_FORMAT = "DD-MM-YYYY HH:mm"
 const SHORT_WAIT_MS = 1000
@@ -147,9 +147,7 @@ describe("Create report form page", () => {
         await (await CreateFutureReport.getTasksAssessments()).isExisting()
       ).to.be.true
       expect(
-        await (
-          await CreateFutureReport.getTaskAssessment(TASK_VALUE)
-        ).isExisting()
+        await (await CreateFutureReport.getTaskAssessment(TASK)).isExisting()
       ).to.be.true
       /* eslint-enable no-unused-expressions */
 
@@ -175,9 +173,7 @@ describe("Create report form page", () => {
         await (await CreateFutureReport.getTasksAssessments()).isExisting()
       ).to.be.true
       expect(
-        await (
-          await CreateFutureReport.getTaskAssessment(TASK_VALUE)
-        ).isExisting()
+        await (await CreateFutureReport.getTaskAssessment(TASK)).isExisting()
       ).to.be.true
       /* eslint-enable no-unused-expressions */
     })

--- a/client/tests/webdriver/customFieldsSpecs/pendingAssessments.spec.js
+++ b/client/tests/webdriver/customFieldsSpecs/pendingAssessments.spec.js
@@ -260,7 +260,7 @@ describe("In new report page", () => {
         const assessment = taskAssessmentRows[i + 1]
         const questions = await assessment.$$("td > div")
         switch (await task.getText()) {
-          case "1.2.A":
+          case "EF 1 » EF 1.2 » 1.2.A":
             expect(questions).to.have.length(3)
             expect(await questions[0].getAttribute("id")).to.match(
               /\.question1$/

--- a/client/tests/webdriver/pages/report/showReport.page.js
+++ b/client/tests/webdriver/pages/report/showReport.page.js
@@ -166,16 +166,13 @@ class ShowReport extends Page {
     await (await this.getReportStatus()).waitForDisplayed()
   }
 
-  async getCompactViewAttendees(type, withAssessments) {
-    const attendees = withAssessments
-      ? browser.$$(`#${type} > td > table > tbody > tr > td`)
-      : browser.$$(`#${type} > td > span > a`)
-    return withAssessments
-      ? attendees
-      // Filter out the assessment rows to get the attendees
-        .filter(row => row.$("span > a").isExisting())
-        .map(row => row.$("span > a").getText())
-      : attendees.map(attendeeLink => attendeeLink.getText())
+  async getCompactViewElements(type, withAssessments) {
+    const elements = await (withAssessments
+      ? browser.$$(`#${type} > td > table > tbody > tr > td > span`)
+      : browser.$$(`#${type} > td > span`))
+    return await Promise.all(
+      elements.map(async element => (await element).getText())
+    )
   }
 
   async selectOptionalField(field) {

--- a/src/test/resources/graphQLTests/appQuery.gql
+++ b/src/test/resources/graphQLTests/appQuery.gql
@@ -82,6 +82,14 @@ me {
       longName
       parentTask {
         uuid
+        shortName
+      }
+      ascendantTasks(query: { pageNum: 0, pageSize: 0 }) {
+        uuid
+        shortName
+        parentTask {
+          uuid
+        }
       }
       customFields
       notes {

--- a/src/test/resources/graphQLTests/taskShow.gql
+++ b/src/test/resources/graphQLTests/taskShow.gql
@@ -14,7 +14,16 @@ task(uuid: "${taskUuid}") {
   parentTask {
     uuid
     shortName
-    longName
+    parentTask {
+      uuid
+    }
+  }
+  ascendantTasks(query: { pageNum: 0, pageSize: 0 }) {
+    uuid
+    shortName
+    parentTask {
+      uuid
+    }
   }
   descendantTasks(query: { pageNum: 0, pageSize: 0 }) {
     uuid


### PR DESCRIPTION
Tasks are now shown using a breadcrumb trail, showing a task all the way to its top-level parent.

Closes [AB#758](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/758), [AB#776](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/776)

#### User changes
- Tasks are now shown with their context: a breadcrumb trail up to the top-level parent task.

#### Super User changes
- none

#### Admin changes
- none

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [x] Added and/or updated unit tests
  - [x] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here