### PR TITLE
Prevent rich-text editor to scroll up after inserting ANET object

### DIFF
--- a/client/src/components/editor/LinkSourceAnet.js
+++ b/client/src/components/editor/LinkSourceAnet.js
@@ -5,6 +5,7 @@ import PropTypes from "prop-types"
 import React, { useCallback } from "react"
 import { Button, Form as FormBS, Modal } from "react-bootstrap"
 import { Transforms } from "slate"
+import { ReactEditor } from "slate-react"
 import { ANET_LINK, EXTERNAL_LINK } from "utils_links"
 import * as yup from "yup"
 
@@ -17,6 +18,7 @@ const LinkSourceAnet = ({
 }) => {
   const insertAnetLink = useCallback(
     node => {
+      ReactEditor.focus(editor)
       if (selection) {
         Transforms.insertNodes(editor, node, {
           at: { path: selection.focus.path, offset: selection.focus.offset },
@@ -27,6 +29,7 @@ const LinkSourceAnet = ({
           select: true
         })
       }
+      Transforms.move(editor, { distance: 1 })
       setShowModal(false)
     },
     [editor, selection, setShowModal]


### PR DESCRIPTION
When inserting an ANET object or external link the rich text editor editing area was scrolling back to the top. As expected, the mouse cursor now remains positioned at the point after adding the ANET object or external link.

Closes AB#784

#### User changes
- Rich-text editor editing area will not scroll up after inserting ANET object or external link

#### Super User changes
-

#### Admin changes
-

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [ ] Described the user behavior in PR body
  - [ ] Referenced/updated all related issues
  - [ ] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [ ] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [ ] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
