### PR TITLE
Replace Yes/No SelectFilters with a new RadioButtonFilter

### DIFF
--- a/client/src/components/SearchFilters.js
+++ b/client/src/components/SearchFilters.js
@@ -11,6 +11,9 @@ import DateRangeFilter, {
 import OrganizationFilter, {
   deserialize as deserializeOrganizationFilter
 } from "components/advancedSearch/OrganizationFilter"
+import RadioButtonFilter, {
+  deserialize as deserializeRadioButtonFilter
+} from "components/advancedSearch/RadioButtonFilter"
 import ReportStateFilter, {
   deserialize as deserializeReportStateFilter
 } from "components/advancedSearch/ReportStateFilter"
@@ -418,22 +421,23 @@ export const searchFilters = function() {
         }
       },
       "Has Biography?": {
-        component: SelectFilter,
+        component: RadioButtonFilter,
         deserializer: deserializeSelectFilter,
         props: {
           queryKey: "hasBiography",
-          options: ["true", "false"],
+          options: [true, false],
           labels: ["Yes", "No"]
         }
       },
       "Pending Verification": {
-        component: SelectFilter,
+        component: RadioButtonFilter,
         deserializer: deserializeSelectFilter,
         isDefault: true,
         props: {
           queryKey: "pendingVerification",
-          options: ["false", "true"],
-          labels: ["No", "Yes"]
+          options: [true, false],
+          defaultOption: false,
+          labels: ["Yes", "No"]
         }
       }
     }
@@ -475,11 +479,11 @@ export const searchFilters = function() {
         })
       },
       [`Has ${Settings.fields.organization.profile}?`]: {
-        component: SelectFilter,
+        component: RadioButtonFilter,
         deserializer: deserializeSelectFilter,
         props: {
           queryKey: "hasProfile",
-          options: ["true", "false"],
+          options: [true, false],
           labels: ["Yes", "No"]
         }
       }
@@ -527,11 +531,11 @@ export const searchFilters = function() {
         })
       },
       "Is Filled?": {
-        component: SelectFilter,
-        deserializer: deserializeSelectFilter,
+        component: RadioButtonFilter,
+        deserializer: deserializeRadioButtonFilter,
         props: {
           queryKey: "isFilled",
-          options: ["true", "false"],
+          options: [true, false],
           labels: ["Yes", "No"]
         }
       },

--- a/client/src/components/advancedSearch/RadioButtonFilter.js
+++ b/client/src/components/advancedSearch/RadioButtonFilter.js
@@ -1,0 +1,74 @@
+import useSearchFilter from "components/advancedSearch/hooks"
+import PropTypes from "prop-types"
+import React from "react"
+import { FormCheck, FormGroup } from "react-bootstrap"
+import { deserializeSearchFilter } from "searchUtils"
+import utils from "utils"
+
+const RadioButtonFilter = ({
+  asFormField,
+  queryKey,
+  value: inputValue,
+  onChange,
+  options,
+  defaultOption,
+  labels
+}) => {
+  const defaultValue = {
+    value: inputValue.value ?? defaultOption ?? options[0]
+  }
+  const toQuery = val => {
+    return { [queryKey]: val.value }
+  }
+  const [value, setValue] = useSearchFilter(
+    asFormField,
+    onChange,
+    inputValue,
+    defaultValue,
+    toQuery
+  )
+
+  const optionsLabels = labels || options.map(v => utils.sentenceCase(v))
+  return !asFormField ? (
+    <>{optionsLabels[options.indexOf(value.value)]}</>
+  ) : (
+    <FormGroup>
+      {options.map((v, idx) => (
+        <FormCheck
+          key={idx}
+          type="radio"
+          inline
+          label={optionsLabels[idx]}
+          id={`${queryKey}.${v}`}
+          value={v}
+          checked={v === value.value}
+          onChange={() => setValue({ value: v })}
+        />
+      ))}
+    </FormGroup>
+  )
+}
+RadioButtonFilter.propTypes = {
+  queryKey: PropTypes.string.isRequired,
+  options: PropTypes.array.isRequired,
+  defaultOption: PropTypes.any,
+  labels: PropTypes.array,
+  value: PropTypes.oneOfType([
+    PropTypes.any,
+    PropTypes.shape({
+      value: PropTypes.any,
+      toQuery: PropTypes.oneOfType([PropTypes.func, PropTypes.object])
+    })
+  ]),
+  onChange: PropTypes.func, // eslint-disable-line react/no-unused-prop-types
+  asFormField: PropTypes.bool
+}
+RadioButtonFilter.defaultProps = {
+  asFormField: true
+}
+
+export const deserialize = ({ queryKey }, query, key) => {
+  return deserializeSearchFilter(queryKey, query, key)
+}
+
+export default RadioButtonFilter


### PR DESCRIPTION
GraphQL v20 is now stricter in adhering to the schema, and we really need to pass boolean values in some places and not strings like "true" or "false". So advanced search filters that presented simple Yes/No options as a select drop-down are now using radio buttons.

#### User changes
- Advanced search filters for Yes/No options are now shown as radio buttons.

#### Super User changes
- none

#### Admin changes
- none

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
