### PR TITLE
Replace arrow from Glyphicons Halflings with regular Unicode arrow

### DIFF
--- a/client/src/components/ReportWorkflow.css
+++ b/client/src/components/ReportWorkflow.css
@@ -51,17 +51,13 @@
 
 .workflow-fieldset .workflow-action button::after {
   position: relative;
-  font-family: 'Glyphicons Halflings';
   font-style: normal;
   font-weight: 400;
   line-height: 1;
   -webkit-font-smoothing: antialiased;
-  content: "\e092";
-  color: #777;
-  width: 18px;
-  height: 18px;
-  top: 3px;
-  right: -26px;
+  content: "➡";
+  color: #000;
+  right: -25px;
 }
 
 .workflow-fieldset :last-child button::after {


### PR DESCRIPTION
In the report workflow, replace the arrow we used from Glyphicons Halflings, which is no longer included in Bootstrap 5, with a regular Unicode arrow.

Closes [AB#633](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/633)

#### User changes
- Report workflow no longer contains an undefined symbol between the workflow steps, but instead shows an arrow.

#### Super User changes
- none

#### Admin changes
- none

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here