### PR TITLE
Open external links in the rich-text editor in a new tab

### DIFF
--- a/client/src/components/editor/LinkExternalHref.js
+++ b/client/src/components/editor/LinkExternalHref.js
@@ -5,7 +5,7 @@ import React from "react"
 
 const LinkExternalHref = ({ url, children }) => {
   return (
-    <a href={url}>
+    <a href={url} target="_blank" rel="noreferrer">
       {children}{" "}
       <Icon
         icon={IconNames.SHARE}


### PR DESCRIPTION
When in the rich-text editor, open external hrefs in a new tab, since especially when editing, opening them in the current page is annoying, as you may lose edits.

Closes [AB#812](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/812)

#### User changes
- External links in the rich-text editor are now opened in a new tab instead (to prevent e.g. edits getting lost).

#### Superuser changes
- none

#### Admin changes
- none

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here