### PR TITLE
Prevent accidental delete of avatar

### DIFF
--- a/src/main/java/mil/dds/anet/AnetApplication.java
+++ b/src/main/java/mil/dds/anet/AnetApplication.java
@@ -206,7 +206,7 @@ public class AnetApplication extends Application<AnetConfiguration> {
                   "found existing user={} by domainUsername={}; setting openIdSubject={} (was {})",
                   existingPerson, username, openIdSubject, existingPerson.getOpenIdSubject());
               existingPerson.setOpenIdSubject(openIdSubject);
-              dao.update(existingPerson);
+              dao.updateAuthenticationDetails(existingPerson);
               return existingPerson;
             }
 
@@ -219,7 +219,7 @@ public class AnetApplication extends Application<AnetConfiguration> {
                   "found existing user={} by emailAddress={}; setting openIdSubject={} (was {})",
                   existingPerson, email, openIdSubject, existingPerson.getOpenIdSubject());
               existingPerson.setOpenIdSubject(openIdSubject);
-              dao.update(existingPerson);
+              dao.updateAuthenticationDetails(existingPerson);
               return existingPerson;
             }
 


### PR DESCRIPTION
When the `openIdSubject` of a person has been reset in the database, the avatar could get cleared when this person re-authenticated. Fix this by only updating the fields relevant for the authentication layer (so not the avatar).

Closes [AB#816](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/816)

#### User changes
- none

#### Superuser changes
- none

#### Admin changes
- none

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here