### PR TITLE
Add explicit dependency on graphql-java

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -58,6 +58,7 @@
       "matchPackageNames": [
         "autoprefixer",
         "react-router-dom",
+        "com.graphql-java:graphql-java",
         "com.graphql-java:graphql-java-extended-scalars",
         "io.leangen.graphql:spqr"
       ],

--- a/build.gradle
+++ b/build.gradle
@@ -107,8 +107,6 @@ dependencies {
 	implementation "ch.qos.logback:logback-classic:${logbackVersion}"
 	implementation "ch.qos.logback:logback-core:${logbackVersion}"
 	implementation "ch.qos.logback:logback-access:${logbackVersion}"
-	implementation 'com.graphql-java:java-dataloader:3.2.0'
-	implementation 'io.leangen.graphql:spqr:0.12.1'
 	implementation 'com.googlecode.owasp-java-html-sanitizer:owasp-java-html-sanitizer:20220608.1'
 	implementation 'com.mikesamuel:json-sanitizer:1.2.3'
 	// Authentication
@@ -136,6 +134,10 @@ dependencies {
 	// For fast and simple image scaling
 	implementation 'net.coobird:thumbnailator:0.4.19'
 
+	// GraphQL dependencies
+	implementation 'com.graphql-java:graphql-java:20.2'
+	implementation 'com.graphql-java:java-dataloader:3.2.0'
+	implementation 'io.leangen.graphql:spqr:0.12.1'
 	// The graphql-java-client-runtime module aggregates all dependencies for the generated code,
 	// including the plugin runtime
 	testImplementation('com.graphql-java-generator:graphql-java-client-runtime:1.18.10') {


### PR DESCRIPTION
So we have control over (minor) updates of it, and avoid automatic updates by Renovate. Also group our GraphQL dependencies together.

#### User changes
- none

#### Superuser changes
- none

#### Admin changes
- none

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here