### PR TITLE
Fix e2e test related to report validation

### DIFF
--- a/client/tests/e2e/report.js
+++ b/client/tests/e2e/report.js
@@ -503,6 +503,8 @@ test.serial("Verify that validations work", async t => {
     'Clicking the "today" button puts the current date in the engagement field'
   )
 
+  await $meetingGoalInput.click() // click intent to make sure the date picker is being closed
+
   const $locationInput = await $("#location")
   t.is(
     await $locationInput.getAttribute("value"),


### PR DESCRIPTION
In the report validation e2e test ("Verify that validations work") test, the "Recent Locations" value is tried to be obtained before the date-picker is closed and the date-picker may hide it.

Closes [AB#818](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/818)

#### User changes
- None

#### Superuser changes
- None

#### Admin changes
- None

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [x] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
