### PR TITLE
Change person.avatar GraphQL to byte[]

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 	id "com.bmuschko.docker-remote-api" version "9.3.1"
 	id "com.github.node-gradle.node" version "3.5.1"
 	id "com.diffplug.spotless" version "6.18.0"
-	id "com.graphql_java_generator.graphql-gradle-plugin" version "1.18.10"
+	id "com.graphql_java_generator.graphql-gradle-plugin" version "1.18.11"
 	id "org.beryx.runtime" version "1.13.0"
 	id "com.netflix.nebula.ospackage" version "11.2.0"
 }
@@ -140,7 +140,7 @@ dependencies {
 	implementation 'io.leangen.graphql:spqr:0.12.1'
 	// The graphql-java-client-runtime module aggregates all dependencies for the generated code,
 	// including the plugin runtime
-	testImplementation('com.graphql-java-generator:graphql-java-client-runtime:1.18.10') {
+	testImplementation('com.graphql-java-generator:graphql-java-client-runtime:1.18.11') {
 		// We don't actually need any of these (dragged in through org.springframework.boot)
 		exclude group: 'io.netty'
 	}
@@ -685,6 +685,11 @@ generateClientCodeConf {
 			graphQLTypeName: "Instant",
 			javaType: "java.time.Instant",
 			graphQLScalarTypeStaticField: "mil.dds.anet.graphql.DateTimeMapper.GraphQLInstant"
+		],
+		[
+			graphQLTypeName: "Base64String",
+			javaType: "byte[]",
+			graphQLScalarTypeStaticField: "com.graphql_java_generator.customscalars.GraphQLScalarTypeBase64String.GraphQLBase64String"
 		],
 		[
 			graphQLTypeName: "Long",

--- a/client/src/components/AvatarDisplayComponent.js
+++ b/client/src/components/AvatarDisplayComponent.js
@@ -2,6 +2,8 @@ import PropTypes from "prop-types"
 import React from "react"
 import DEFAULT_AVATAR from "resources/default_avatar.svg"
 
+export const AVATAR_DATA_PREAMBLE = "data:image/png;base64,"
+
 const AvatarDisplayComponent = ({
   avatar,
   height,
@@ -10,7 +12,7 @@ const AvatarDisplayComponent = ({
   className
 }) => (
   <img
-    src={avatar || DEFAULT_AVATAR}
+    src={avatar ? `${AVATAR_DATA_PREAMBLE}${avatar}` : DEFAULT_AVATAR}
     className={className}
     height={height}
     width={width}

--- a/client/src/components/AvatarEditModal.js
+++ b/client/src/components/AvatarEditModal.js
@@ -1,4 +1,5 @@
 import AvatarComponent from "components/AvatarComponent"
+import { AVATAR_DATA_PREAMBLE } from "components/AvatarDisplayComponent"
 import PropTypes from "prop-types"
 import React, { useState } from "react"
 import { Button, Modal } from "react-bootstrap"
@@ -48,7 +49,10 @@ const AvatarEditModal = ({ title, onAvatarUpdate }) => {
   }
 
   function save() {
-    onAvatarUpdate(currentPreview)
+    // Strip preamble, only leaving the base64-encoded data
+    const re = new RegExp(`^${AVATAR_DATA_PREAMBLE}`)
+    const b64 = currentPreview?.replace(re, "") || null
+    onAvatarUpdate(b64)
     close()
   }
 }

--- a/src/main/java/mil/dds/anet/database/PersonDao.java
+++ b/src/main/java/mil/dds/anet/database/PersonDao.java
@@ -153,6 +153,7 @@ public class PersonDao extends AnetSubscribableObjectDao<Person, PersonSearchQue
     getDbHandle().createUpdate(sql).bindBean(p)
         .bind("createdAt", DaoUtils.asLocalDateTime(p.getCreatedAt()))
         .bind("updatedAt", DaoUtils.asLocalDateTime(p.getUpdatedAt()))
+        .bind("avatar", p.getAvatarData())
         .bind("endOfTourDate", DaoUtils.asLocalDateTime(p.getEndOfTourDate()))
         .bind("status", DaoUtils.getEnumId(p.getStatus()))
         .bind("role", DaoUtils.getEnumId(p.getRole())).execute();
@@ -188,6 +189,7 @@ public class PersonDao extends AnetSubscribableObjectDao<Person, PersonSearchQue
 
     final int nr = getDbHandle().createUpdate(sql).bindBean(p)
         .bind("updatedAt", DaoUtils.asLocalDateTime(p.getUpdatedAt()))
+        .bind("avatar", p.getAvatarData())
         .bind("endOfTourDate", DaoUtils.asLocalDateTime(p.getEndOfTourDate()))
         .bind("status", DaoUtils.getEnumId(p.getStatus()))
         .bind("role", DaoUtils.getEnumId(p.getRole())).execute();

--- a/src/test/java/mil/dds/anet/test/beans/PersonTest.java
+++ b/src/test/java/mil/dds/anet/test/beans/PersonTest.java
@@ -5,8 +5,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.util.Base64;
 import mil.dds.anet.beans.Person;
 import mil.dds.anet.utils.Utils;
 import org.junit.jupiter.api.Test;
@@ -20,33 +20,32 @@ public class PersonTest {
   @Test
   public void testAvatarResizingNoAvatar() {
     final Person person = new Person();
-    person.setAvatar((String) null);
+    person.setAvatar((byte[]) null);
     assertThat(person.resizeAvatar(32)).isNull();
   }
 
   @Test
   public void testAvatarResizingMalformedData() {
     final Person person = new Person();
-    person.setAvatar("malformedImageData");
+    person.setAvatar("malformedImageData".getBytes(StandardCharsets.UTF_8));
     assertThat(person.resizeAvatar(32)).isNull();
   }
 
   @Test
   public void testAvatarResizing() throws IOException {
     final Person person = new Person();
-    byte[] fileContent = Files.readAllBytes(DEFAULT_AVATAR.toPath());
-    String defaultAvatarData = Base64.getEncoder().encodeToString(fileContent);
+    byte[] defaultAvatarData = Files.readAllBytes(DEFAULT_AVATAR.toPath());
     person.setAvatar(defaultAvatarData);
 
-    BufferedImage imageBinary = Utils.convert(person.getAvatar());
+    BufferedImage imageBinary = Utils.convert(person.getAvatarData());
     assertThat(imageBinary.getWidth()).isNotEqualTo(32);
     assertThat(imageBinary.getHeight()).isNotEqualTo(32);
 
-    String resizedAvatar = person.resizeAvatar(32);
+    byte[] resizedAvatar = person.resizeAvatar(32);
     assertThat(resizedAvatar).isNotNull();
 
     person.setAvatar(resizedAvatar);
-    imageBinary = Utils.convert(person.getAvatar());
+    imageBinary = Utils.convert(person.getAvatarData());
 
     assertThat(imageBinary.getWidth()).isEqualTo(32);
     assertThat(imageBinary.getHeight()).isEqualTo(32);

--- a/src/test/java/mil/dds/anet/test/resources/PersonResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/PersonResourceTest.java
@@ -14,7 +14,6 @@ import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
-import java.util.Base64;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -102,27 +101,27 @@ public class PersonResourceTest extends AbstractResourceTest {
     assertThat(newPerson.getCustomFields())
         .isEqualTo(UtilsTest.getCombinedJsonTestCase().getOutput());
 
-    newPerson.setName("testCreatePerson updated name");
-    newPerson.setCountry("The Commonwealth of Canada");
-    newPerson.setCode("A123456");
+    final PersonInput updatedNewPersonInput = getPersonInput(newPerson);
+    updatedNewPersonInput.setName("testCreatePerson updated name");
+    updatedNewPersonInput.setCountry("The Commonwealth of Canada");
+    updatedNewPersonInput.setCode("A123456");
 
     // update avatar
-    byte[] fileContent = Files.readAllBytes(DEFAULT_AVATAR.toPath());
-    String defaultAvatarData = Base64.getEncoder().encodeToString(fileContent);
-    newPerson.setAvatar(defaultAvatarData);
+    byte[] defaultAvatarData = Files.readAllBytes(DEFAULT_AVATAR.toPath());
+    updatedNewPersonInput.setAvatar(defaultAvatarData);
 
     // update HTML of biography
-    newPerson.setBiography(UtilsTest.getCombinedHtmlTestCase().getInput());
+    updatedNewPersonInput.setBiography(UtilsTest.getCombinedHtmlTestCase().getInput());
     // update JSON of customFields
-    newPerson.setCustomFields(UtilsTest.getCombinedJsonTestCase().getInput());
+    updatedNewPersonInput.setCustomFields(UtilsTest.getCombinedJsonTestCase().getInput());
 
-    Integer nrUpdated = adminMutationExecutor.updatePerson("", getPersonInput(newPerson));
+    Integer nrUpdated = adminMutationExecutor.updatePerson("", updatedNewPersonInput);
     assertThat(nrUpdated).isEqualTo(1);
 
-    retPerson = jackQueryExecutor.person(FIELDS, newPerson.getUuid());
-    assertThat(retPerson.getName()).isEqualTo(newPerson.getName());
-    assertThat(retPerson.getCode()).isEqualTo(newPerson.getCode());
-    assertThat(retPerson.getAvatar()).isNotNull();
+    retPerson = jackQueryExecutor.person(FIELDS, updatedNewPersonInput.getUuid());
+    assertThat(retPerson.getName()).isEqualTo(updatedNewPersonInput.getName());
+    assertThat(retPerson.getCode()).isEqualTo(updatedNewPersonInput.getCode());
+    assertThat(retPerson.getAvatar()).isNotEmpty();
     // check that HTML of biography is sanitized after update
     assertThat(retPerson.getBiography()).isEqualTo(UtilsTest.getCombinedHtmlTestCase().getOutput());
     // check that JSON of customFields is sanitized after update
@@ -186,7 +185,7 @@ public class PersonResourceTest extends AbstractResourceTest {
     // Now newPerson2 who is a superuser, should NOT be able to edit newPerson
     // Because they are not in newPerson2's organization.
     try {
-      newPerson2MutationExecutor.updatePerson("", getPersonInput(newPerson));
+      newPerson2MutationExecutor.updatePerson("", updatedNewPersonInput);
       fail("Expected ForbiddenException");
     } catch (ForbiddenException expectedException) {
     }

--- a/src/test/resources/anet.graphql
+++ b/src/test/resources/anet.graphql
@@ -224,6 +224,9 @@ enum AuthorizationGroupSearchSortBy {
   RECENT
 }
 
+"""Base64-encoded binary"""
+scalar Base64String
+
 """"""
 type Comment {
   author: Person
@@ -523,7 +526,7 @@ enum OrganizationType {
 type Person {
   attendedReports(query: ReportSearchQueryInput): AnetBeanList_Report
   authoredReports(query: ReportSearchQueryInput): AnetBeanList_Report
-  avatar(size: Int = 256): String
+  avatar(size: Int = 256): Base64String
   biography: String
   code: String
   country: String
@@ -551,7 +554,7 @@ type Person {
 
 """"""
 input PersonInput {
-  avatar: String
+  avatar: Base64String
   biography: String
   code: String
   country: String
@@ -857,7 +860,7 @@ type ReportPerson {
   attendee: Boolean!
   author: Boolean!
   authoredReports(query: ReportSearchQueryInput): AnetBeanList_Report
-  avatar(size: Int = 256): String
+  avatar(size: Int = 256): Base64String
   biography: String
   code: String
   country: String
@@ -888,7 +891,7 @@ type ReportPerson {
 input ReportPersonInput {
   attendee: Boolean!
   author: Boolean!
-  avatar: String
+  avatar: Base64String
   biography: String
   code: String
   country: String


### PR DESCRIPTION
Instead of self-{en,de}coding a Base64 String, directly use the binary data; GraphQL SPQR and the test framework support it.

Part of [AB#221](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/221)

#### User changes
- none

#### Superuser changes
- none

#### Admin changes
- none

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [x] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [x] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here