### PR TITLE
Fix IE11 test on BrowserStack

### DIFF
--- a/client/config/wdio.config.ie.js
+++ b/client/config/wdio.config.ie.js
@@ -8,7 +8,7 @@ const config = require("./wdio.config.js").config
 
 // override default wdio config for IE tests
 config.baseUrl = process.env.SERVER_URL
-config.specs = ["./tests/webdriver/ie/**/*.spec.js"]
+config.specs = ["../tests/webdriver/ie/**/*.spec.js"]
 config.exclude = []
 
 const capabilities = config.capabilities[0]

--- a/client/tests/util/wdio.ie.js
+++ b/client/tests/util/wdio.ie.js
@@ -23,13 +23,13 @@ if (testEnv === "local") {
  * For running the test runner programmatically, please see:
  * https://webdriver.io/docs/clioptions.html#run-the-test-runner-programmatically
  */
-const Launcher = require("@wdio/cli").default
-
-// config file path is relative to the directory where package.json resides
-new Launcher("./config/wdio.config.ie.js").run().then(
-  code => process.exit(code),
-  error => {
-    console.error("Launcher failed to start the test!", error.stacktrace)
-    process.exit(1)
-  }
+import("@wdio/cli").then(cli =>
+  // config file path is relative to the directory where package.json resides
+  new cli.Launcher("./config/wdio.config.ie.js").run().then(
+    code => process.exit(code),
+    error => {
+      console.error("Launcher failed to start the test!", error.stacktrace)
+      process.exit(1)
+    }
+  )
 )


### PR DESCRIPTION
Update the wdio configuration for the IE11 test on BrowserStack.

#### User changes
- none

#### Superuser changes
- none

#### Admin changes
- none

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [x] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here