### PR TITLE
Fix assessment saving problem with filtered-out questions

### DIFF
--- a/anet-dictionary.yml
+++ b/anet-dictionary.yml
@@ -128,6 +128,20 @@ fields:
         subTaskMonthly:
           recurrence: monthly
           questions:
+            requiredButFilteredOutQuestion:
+              test: $.subject[?(@property === "noSuchProperty" && @.match(/^willNeverMatch/i))]
+              type: text
+              label: This question is required but will be filtered out
+              validations:
+                - type: required
+                  params: [You must provide the answer to subTaskMonthly.requiredButFilteredOutQuestion]
+            questionFor11B:
+              test: $.subject[?(@property === "shortName" && @ === "1.1.B")]
+              type: text
+              label: This question applies only to 1.1.B
+              validations:
+                - type: required
+                  params: [You must provide the answer to subTaskMonthly.questionFor11B]
             issues:
               type: special_field
               label: Top 3 issues
@@ -172,6 +186,27 @@ fields:
           recurrence: once
           relatedObjectType: report
           questions:
+            requiredButFilteredOutQuestion:
+              test: $.subject[?(@property === "noSuchProperty" && @.match(/^willNeverMatch/i))]
+              type: text
+              label: This question is required but will be filtered out
+              validations:
+                - type: required
+                  params: [You must provide the answer to subTaskOnceReport.requiredButFilteredOutQuestion]
+            questionFor11B:
+              test: $.subject[?(@property === "shortName" && @ === "1.1.B")]
+              type: text
+              label: This question applies only to 1.1.B
+              validations:
+                - type: required
+                  params: [You must provide the answer to subTaskOnceReport.questionFor11B]
+            questionForNegative:
+              test: $.relatedObject[?(@property === "atmosphere" && @ === "NEGATIVE")]
+              type: text
+              label: This question applies only to Negative engagements
+              validations:
+                - type: required
+                  params: [You must provide the answer to subTaskOnceReport.questionForNegative]
             question1:
               type: special_field
               widget: likertScale
@@ -195,6 +230,31 @@ fields:
             question3:
               type: number
               label: Instant assessment Question 3
+        subTask11COnceReport:
+          recurrence: once
+          relatedObjectType: report
+          test: $.subject[?(@property === "shortName" && @ === "1.1.C")]
+          questions:
+            requiredButFilteredOutQuestion:
+              test: $.subject[?(@property === "noSuchProperty" && @.match(/^willNeverMatch/i))]
+              type: text
+              label: This question is required but will be filtered out
+              validations:
+                - type: required
+                  params: [You must provide the answer to subTask11COnceReport.requiredButFilteredOutQuestion]
+            requiredQuestion:
+              type: text
+              label: This question is required
+              validations:
+                - type: required
+                  params: [You must provide the answer to subTask11COnceReport.requiredQuestion]
+            questionForNegative:
+              test: $.relatedObject[?(@property === "atmosphere" && @ === "NEGATIVE")]
+              type: text
+              label: This question applies only to Negative engagements
+              validations:
+                - type: required
+                  params: [You must provide the answer to subTask11COnceReport.questionForNegative]
 
     parentTask:
       label: Parent objective / effort
@@ -642,7 +702,7 @@ fields:
             visibleWhen: $[?(@ && @.colourOptions === 'GREEN')]
 
   position:
-    name: 'Position Name'
+    name: Position Name
     customFields:
       multipleButtons:
         type: enumset
@@ -848,6 +908,27 @@ fields:
             read: ['c21e7321-7ec5-4837-8805-a302f9575754']
             write: ['39a78d51-c351-452c-9206-4305ec8dd76d']
           questions:
+            requiredButFilteredOutQuestion:
+              test: $.subject[?(@property === "noSuchProperty" && @.match(/^willNeverMatch/i))]
+              type: text
+              label: This question is required but will be filtered out
+              validations:
+                - type: required
+                  params: [You must provide the answer to advisorOnceReportLinguist.requiredButFilteredOutQuestion]
+            questionForNegative:
+              test: $.relatedObject[?(@property === "atmosphere" && @ === "NEGATIVE")]
+              type: text
+              label: This question applies only to Negative engagements
+              validations:
+                - type: required
+                  params: [You must provide the answer to advisorOnceReportLinguist.questionForNegative]
+            questionForLin:
+              test: $.subject[?(@property === "name" && @ === "GUIST, Lin")]
+              type: text
+              label: This question applies only to Lin
+              validations:
+                - type: required
+                  params: [You must provide the answer to advisorOnceReportLinguist.questionForLin]
             preparedDocuments:
               type: enum
               helpText: "Did the linguist prepare any written documents used for the engagement meeting?"
@@ -1156,8 +1237,33 @@ fields:
                   widget: richTextEditor
                   style:
                     height: 100px
+        advisorOnceReportLinguistLin:
+          recurrence: once
+          relatedObjectType: report
+          test: $.subject[?(@property === "name" && @ === "GUIST, Lin")]
+          questions:
+            requiredButFilteredOutQuestion:
+              test: $.subject[?(@property === "noSuchProperty" && @.match(/^willNeverMatch/i))]
+              type: text
+              label: This question is required but will be filtered out
+              validations:
+                - type: required
+                  params: [You must provide the answer to advisorOnceReportLinguistLin.requiredButFilteredOutQuestion]
+            requiredQuestion:
+              type: text
+              label: This question is required
+              validations:
+                - type: required
+                  params: [You must provide the answer to advisorOnceReportLinguistLin.requiredQuestion]
+            questionForNegative:
+              test: $.relatedObject[?(@property === "atmosphere" && @ === "NEGATIVE")]
+              type: text
+              label: This question applies only to Negative engagements
+              validations:
+                - type: required
+                  params: [You must provide the answer to advisorOnceReportLinguistLin.questionForNegative]
         advisorPeriodic:
-          recurrence: "monthly"
+          recurrence: monthly
           questions:
             question1:
                 type: special_field
@@ -1215,6 +1321,20 @@ fields:
             read: ['c21e7321-7ec5-4837-8805-a302f9575754']
             write: ['39a78d51-c351-452c-9206-4305ec8dd76d']
           questions:
+            requiredButFilteredOutQuestion:
+              test: $.subject[?(@property === "noSuchProperty" && @.match(/^willNeverMatch/i))]
+              type: text
+              label: This question is required but will be filtered out
+              validations:
+                - type: required
+                  params: [You must provide the answer to principalMonthly.requiredButFilteredOutQuestion]
+            questionForChristopf:
+              test: $.subject[?(@property === "name" && @ === "TOPFERNESS, Christopf")]
+              type: text
+              label: This question applies only to Christopf
+              validations:
+                - type: required
+                  params: [You must provide the answer to principalMonthly.questionForChristopf]
             text:
               type: special_field
               label: Text
@@ -1341,6 +1461,20 @@ fields:
             read: ['c21e7321-7ec5-4837-8805-a302f9575754']
             write: ['39a78d51-c351-452c-9206-4305ec8dd76d']
           questions:
+            requiredButFilteredOutQuestion:
+              test: $.subject[?(@property === "noSuchProperty" && @.match(/^willNeverMatch/i))]
+              type: text
+              label: This question is required but will be filtered out
+              validations:
+                - type: required
+                  params: [You must provide the answer to principalOndemandScreeningAndVetting.requiredButFilteredOutQuestion]
+            questionForChristopf:
+              test: $.subject[?(@property === "name" && @ === "TOPFERNESS, Christopf")]
+              type: text
+              label: This question applies only to Christopf
+              validations:
+                - type: required
+                  params: [You must provide the answer to this principalOndemandScreeningAndVetting.questionForChristopf]
             assessmentDate:
               type: date
               label: Screening and vetting date

--- a/client/src/components/assessments/ondemand/OndemandAssessment.js
+++ b/client/src/components/assessments/ondemand/OndemandAssessment.js
@@ -7,10 +7,7 @@ import ConfirmDestructive from "components/ConfirmDestructive"
 import { ReadonlyCustomFields } from "components/CustomFields"
 import Fieldset from "components/Fieldset"
 import LinkTo from "components/LinkTo"
-import Model, {
-  ENTITY_ON_DEMAND_EXPIRATION_DATE,
-  NOTE_TYPE
-} from "components/Model"
+import { ENTITY_ON_DEMAND_EXPIRATION_DATE, NOTE_TYPE } from "components/Model"
 import PeriodsNavigation from "components/PeriodsNavigation"
 import { Formik } from "formik"
 import _isEmpty from "lodash/isEmpty"
@@ -64,27 +61,20 @@ const OnDemandAssessment = ({
   // 'assessmentConfig' has question set for ondemand assessments defined in the dictionary
   // and 'assessmentYupSchema' used for this question set.
   const { assessmentConfig, assessmentYupSchema } = useMemo(
-    () => entity.getPeriodicAssessmentDetails(assessmentKey),
+    () => entity.getAssessmentDetails(assessmentKey),
     [entity, assessmentKey]
   )
   const addAssessmentLabel = `Add ${
-    assessmentConfig.label || "a new assessment"
+    assessmentConfig?.label || "a new assessment"
   }`
 
-  const filteredAssessmentConfig = useMemo(
-    () => Model.filterAssessmentConfig(assessmentConfig, entity),
-    [assessmentConfig, entity]
-  )
-
   if (
-    filteredAssessmentConfig?.questions[ENTITY_ON_DEMAND_EXPIRATION_DATE] &&
-    filteredAssessmentConfig?.onDemandAssessmentExpirationDays
+    assessmentConfig?.questions[ENTITY_ON_DEMAND_EXPIRATION_DATE] &&
+    assessmentConfig?.onDemandAssessmentExpirationDays
   ) {
-    filteredAssessmentConfig.questions[
-      ENTITY_ON_DEMAND_EXPIRATION_DATE
-    ].helpText = `
+    assessmentConfig.questions[ENTITY_ON_DEMAND_EXPIRATION_DATE].helpText = `
       If this field is left empty, the assessment will be valid for
-      ${filteredAssessmentConfig.onDemandAssessmentExpirationDays} days.
+      ${assessmentConfig.onDemandAssessmentExpirationDays} days.
     `
   }
 
@@ -118,13 +108,13 @@ const OnDemandAssessment = ({
         <React.Fragment>
           <ValidationBar
             assessmentExpirationDays={
-              filteredAssessmentConfig?.onDemandAssessmentExpirationDays
+              assessmentConfig?.onDemandAssessmentExpirationDays
             }
             index={index}
             assessmentFieldsObject={assessmentFieldsObject}
             sortedOnDemandNotes={sortedOnDemandNotes}
           />
-          <Card key={index}>
+          <Card key={note.uuid}>
             <Card.Header>
               <Row>
                 <Col xs={8}>
@@ -191,20 +181,20 @@ const OnDemandAssessment = ({
                   {() => {
                     return (
                       <>
-                        {!_isEmpty(filteredAssessmentConfig?.questions) && (
+                        {!_isEmpty(assessmentConfig?.questions) && (
                           <ReadonlyCustomFields
                             parentFieldName={parentFieldName}
-                            fieldsConfig={filteredAssessmentConfig.questions}
+                            fieldsConfig={assessmentConfig.questions}
                             values={{
                               [parentFieldName]: assessmentFieldsObject
                             }}
                             vertical
                           />
                         )}
-                        {!_isEmpty(filteredAssessmentConfig?.questionSets) && (
+                        {!_isEmpty(assessmentConfig?.questionSets) && (
                           <QuestionSet
                             parentFieldName={`${parentFieldName}.questionSets`}
-                            questionSets={filteredAssessmentConfig.questionSets}
+                            questionSets={assessmentConfig.questionSets}
                             formikProps={{
                               values: {
                                 [parentFieldName]: assessmentFieldsObject
@@ -237,7 +227,7 @@ const OnDemandAssessment = ({
         })
     }
   }, [
-    filteredAssessmentConfig,
+    assessmentConfig,
     entity,
     onUpdateAssessment,
     hasWriteAccess,
@@ -286,7 +276,7 @@ const OnDemandAssessment = ({
       `Recurrence type is not ${RECURRENCE_TYPE.ON_DEMAND}. Component will not be rendered!`
     )
     return null
-  } else if (!filteredAssessmentConfig) {
+  } else if (_isEmpty(assessmentConfig)) {
     return null
   } else {
     return (
@@ -354,7 +344,7 @@ const OnDemandAssessment = ({
           title={`Assessment for ${entity.toString()}`}
           assessmentYupSchema={assessmentYupSchema}
           recurrence={recurrence}
-          assessmentConfig={filteredAssessmentConfig}
+          assessmentConfig={assessmentConfig}
           onSuccess={() => {
             setShowModal(false)
             onUpdateAssessment()

--- a/client/src/components/assessments/ondemand/ValidationBar.js
+++ b/client/src/components/assessments/ondemand/ValidationBar.js
@@ -32,9 +32,9 @@ const ValidationBar = ({
             ? index === sortedOnDemandNotes.length - 1
               ? "ondemand-red-validation-text"
               : "ondemand-grey-validation-text"
-            : index !== sortedOnDemandNotes.length - 1
-              ? "ondemand-grey-validation-text"
-              : "ondemand-green-validation-text"
+            : index === sortedOnDemandNotes.length - 1
+              ? "ondemand-green-validation-text"
+              : "ondemand-grey-validation-text"
         }
       >
         {/* Only the last object in the sortedOnDemandNotes can be valid.

--- a/client/src/components/assessments/periodic/PeriodicAssessmentResults.js
+++ b/client/src/components/assessments/periodic/PeriodicAssessmentResults.js
@@ -204,12 +204,8 @@ export const PeriodicAssessmentsRows = ({
   }
 
   const { assessmentConfig, assessmentYupSchema } =
-    entity.getPeriodicAssessmentDetails(assessmentKey)
-  const filteredAssessmentConfig = Model.filterAssessmentConfig(
-    assessmentConfig,
-    entity
-  )
-  if (_isEmpty(filteredAssessmentConfig)) {
+    entity.getAssessmentDetails(assessmentKey)
+  if (_isEmpty(assessmentConfig)) {
     return null
   }
 
@@ -243,7 +239,7 @@ export const PeriodicAssessmentsRows = ({
                       assessmentKey={assessmentKey}
                       assessment={assessment}
                       assessmentYupSchema={assessmentYupSchema}
-                      assessmentConfig={filteredAssessmentConfig}
+                      assessmentConfig={assessmentConfig}
                       entity={entity}
                       period={periods[index]}
                       recurrence={recurrence}
@@ -294,7 +290,7 @@ export const PeriodicAssessmentsRows = ({
                       assessmentYupSchema={assessmentYupSchema}
                       recurrence={recurrence}
                       assessmentPeriod={period}
-                      assessmentConfig={filteredAssessmentConfig}
+                      assessmentConfig={assessmentConfig}
                       onSuccess={() => {
                         setShowAssessmentModalKey(null)
                         onUpdateAssessment()

--- a/client/src/components/assessments/periodic/PeriodicAssessmentResultsTable.js
+++ b/client/src/components/assessments/periodic/PeriodicAssessmentResultsTable.js
@@ -1,7 +1,6 @@
 import { BreadcrumbTrail } from "components/BreadcrumbTrail"
 import Fieldset from "components/Fieldset"
 import LinkTo from "components/LinkTo"
-import Model from "components/Model"
 import PeriodsNavigation from "components/PeriodsNavigation"
 import _isEmpty from "lodash/isEmpty"
 import { Task } from "models"
@@ -25,7 +24,7 @@ import "./PeriodicAssessmentResultsTable.css"
  *   assessments made on tasks, while filling  report related to the tasks) or
  *   assessments made on the entity/subentity itself;
  *   the configuration of these assessments can be retrieved using
- *   entity.getInstantAssessmens()
+ *   entity.getInstantAssessments()
  * - periodic assessments => made on the entity/subentities periodically,
  *   as a measurement of the given period of time;
  *   the config and yupSchema for these assessments is to be found in
@@ -145,16 +144,11 @@ const PeriodicAssessmentResultsTable = ({
   const subEntitiesInstantAssessmentConfig = subEntities
     ?.map(s => s.getInstantAssessments())
     .filter(mc => !_isEmpty(mc))
-  const { assessmentConfig } =
-    entity.getPeriodicAssessmentDetails(assessmentKey)
-  const filteredAssessmentConfig = Model.filterAssessmentConfig(
-    assessmentConfig,
-    entity
-  )
+  const { assessmentConfig } = entity.getAssessmentDetails(assessmentKey)
   if (
     _isEmpty(entityInstantAssessmentConfig) &&
     _isEmpty(subEntitiesInstantAssessmentConfig) &&
-    _isEmpty(filteredAssessmentConfig)
+    _isEmpty(assessmentConfig)
   ) {
     return null
   }
@@ -162,7 +156,9 @@ const PeriodicAssessmentResultsTable = ({
     <>
       <div style={{ ...style }}>
         <Fieldset
-          title={`Assessment results - ${assessmentConfig.label || recurrence}`}
+          title={`Assessment results - ${
+            assessmentConfig?.label || recurrence
+          }`}
           id={`entity-assessments-results-${recurrence}`}
         >
           <PeriodsNavigation offset={offset} onChange={setOffset} />

--- a/client/src/models/Report.js
+++ b/client/src/models/Report.js
@@ -533,7 +533,7 @@ export default class Report extends Model {
     )
   }
 
-  static getReportSchema(tasks, reportPeople) {
+  static getReportSchema(report, tasks, reportPeople) {
     // Update the report schema according to the selected report tasks and attendees
     // instant assessments schema
     let reportSchema = Report.yupSchema
@@ -542,14 +542,16 @@ export default class Report extends Model {
       assessmentsSchema: tasksInstantAssessmentsSchema
     } = Task.getInstantAssessmentsDetailsForEntities(
       tasks,
-      Report.TASKS_ASSESSMENTS_PARENT_FIELD
+      Report.TASKS_ASSESSMENTS_PARENT_FIELD,
+      report
     )
     const {
       assessmentsConfig: attendeesInstantAssessmentsConfig,
       assessmentsSchema: attendeesInstantAssessmentsSchema
     } = Person.getInstantAssessmentsDetailsForEntities(
       reportPeople?.filter(rp => rp.attendee),
-      Report.ATTENDEES_ASSESSMENTS_PARENT_FIELD
+      Report.ATTENDEES_ASSESSMENTS_PARENT_FIELD,
+      report
     )
     if (!_isEmpty(tasksInstantAssessmentsConfig)) {
       reportSchema = reportSchema.concat(tasksInstantAssessmentsSchema)

--- a/client/src/pages/reports/Form.js
+++ b/client/src/pages/reports/Form.js
@@ -269,7 +269,11 @@ const ReportForm = ({
   const canWriteAssessments =
     canReadAssessments && !Report.isPublished(initialValues.state)
 
-  const reportSchema = Report.getReportSchema(reportTasks, reportPeople)
+  const reportSchema = Report.getReportSchema(
+    initialValues,
+    reportTasks,
+    reportPeople
+  )
   let validateFieldDebounced
   return (
     <Formik

--- a/client/src/pages/reports/Show.js
+++ b/client/src/pages/reports/Show.js
@@ -328,6 +328,7 @@ const ReportShow = ({ setSearchQuery, pageDispatchers }) => {
     }
 
     reportSchema = Report.getReportSchema(
+      data.report,
       data.report.tasks,
       data.report.reportPeople
     )

--- a/testDictionaries/no-custom-fields.yml
+++ b/testDictionaries/no-custom-fields.yml
@@ -57,7 +57,7 @@ fields:
         placeholder: Enter a Name for this Objective name, example ....
       longLabel: Objectives
       longName:
-        label: Long name of this Objective
+        label: Long Name of this Objective
         placeholder: Enter a long name for this Objective, example ....
         asA: textarea
         style:
@@ -127,6 +127,20 @@ fields:
         subTaskMonthly:
           recurrence: monthly
           questions:
+            requiredButFilteredOutQuestion:
+              test: $.subject[?(@property === "noSuchProperty" && @.match(/^willNeverMatch/i))]
+              type: text
+              label: This question is required but will be filtered out
+              validations:
+                - type: required
+                  params: [You must provide the answer to subTaskMonthly.requiredButFilteredOutQuestion]
+            questionFor11B:
+              test: $.subject[?(@property === "shortName" && @ === "1.1.B")]
+              type: text
+              label: This question applies only to 1.1.B
+              validations:
+                - type: required
+                  params: [You must provide the answer to subTaskMonthly.questionFor11B]
             issues:
               type: special_field
               label: Top 3 issues
@@ -171,6 +185,27 @@ fields:
           recurrence: once
           relatedObjectType: report
           questions:
+            requiredButFilteredOutQuestion:
+              test: $.subject[?(@property === "noSuchProperty" && @.match(/^willNeverMatch/i))]
+              type: text
+              label: This question is required but will be filtered out
+              validations:
+                - type: required
+                  params: [You must provide the answer to subTaskOnceReport.requiredButFilteredOutQuestion]
+            questionFor11B:
+              test: $.subject[?(@property === "shortName" && @ === "1.1.B")]
+              type: text
+              label: This question applies only to 1.1.B
+              validations:
+                - type: required
+                  params: [You must provide the answer to subTaskOnceReport.questionFor11B]
+            questionForNegative:
+              test: $.relatedObject[?(@property === "atmosphere" && @ === "NEGATIVE")]
+              type: text
+              label: This question applies only to Negative engagements
+              validations:
+                - type: required
+                  params: [You must provide the answer to subTaskOnceReport.questionForNegative]
             question1:
               type: special_field
               widget: likertScale
@@ -194,10 +229,36 @@ fields:
             question3:
               type: number
               label: Instant assessment Question 3
+        subTask11COnceReport:
+          recurrence: once
+          relatedObjectType: report
+          test: $.subject[?(@property === "shortName" && @ === "1.1.C")]
+          questions:
+            requiredButFilteredOutQuestion:
+              test: $.subject[?(@property === "noSuchProperty" && @.match(/^willNeverMatch/i))]
+              type: text
+              label: This question is required but will be filtered out
+              validations:
+                - type: required
+                  params: [You must provide the answer to subTask11COnceReport.requiredButFilteredOutQuestion]
+            requiredQuestion:
+              type: text
+              label: This question is required
+              validations:
+                - type: required
+                  params: [You must provide the answer to subTask11COnceReport.requiredQuestion]
+            questionForNegative:
+              test: $.relatedObject[?(@property === "atmosphere" && @ === "NEGATIVE")]
+              type: text
+              label: This question applies only to Negative engagements
+              validations:
+                - type: required
+                  params: [You must provide the answer to subTask11COnceReport.questionForNegative]
 
     parentTask:
-      label: Parent task
+      label: Parent objective / effort
       placeholder: Start typing to search for a higher level task
+    childrenTasks: Sub efforts
     taskedOrganizations:
       label: Tasked organizations
       placeholder: Search for an organization...
@@ -327,7 +388,7 @@ fields:
     format: LAT_LON
 
   position:
-    name: 'Position Name'
+    name: Position Name
 
   organization:
     shortName: Name
@@ -369,6 +430,27 @@ fields:
             read: ['c21e7321-7ec5-4837-8805-a302f9575754']
             write: ['39a78d51-c351-452c-9206-4305ec8dd76d']
           questions:
+            requiredButFilteredOutQuestion:
+              test: $.subject[?(@property === "noSuchProperty" && @.match(/^willNeverMatch/i))]
+              type: text
+              label: This question is required but will be filtered out
+              validations:
+                - type: required
+                  params: [You must provide the answer to advisorOnceReportLinguist.requiredButFilteredOutQuestion]
+            questionForNegative:
+              test: $.relatedObject[?(@property === "atmosphere" && @ === "NEGATIVE")]
+              type: text
+              label: This question applies only to Negative engagements
+              validations:
+                - type: required
+                  params: [You must provide the answer to advisorOnceReportLinguist.questionForNegative]
+            questionForLin:
+              test: $.subject[?(@property === "name" && @ === "GUIST, Lin")]
+              type: text
+              label: This question applies only to Lin
+              validations:
+                - type: required
+                  params: [You must provide the answer to advisorOnceReportLinguist.questionForLin]
             preparedDocuments:
               type: enum
               helpText: "Did the linguist prepare any written documents used for the engagement meeting?"
@@ -381,7 +463,7 @@ fields:
             documentQuality:
               test: $.relatedObject.attendeesAssessments[?(@property === @root.subject.uuid && @.advisorOnceReportLinguist && @.advisorOnceReportLinguist.preparedDocuments === "yes")]
               type: enum
-              helpText: "What was the quality of the document the linuist prepared?"
+              helpText: "What was the quality of the document the linguist prepared?"
               label: Document quality
               choices:
                 "EX":
@@ -677,8 +759,33 @@ fields:
                   widget: richTextEditor
                   style:
                     height: 100px
+        advisorOnceReportLinguistLin:
+          recurrence: once
+          relatedObjectType: report
+          test: $.subject[?(@property === "name" && @ === "GUIST, Lin")]
+          questions:
+            requiredButFilteredOutQuestion:
+              test: $.subject[?(@property === "noSuchProperty" && @.match(/^willNeverMatch/i))]
+              type: text
+              label: This question is required but will be filtered out
+              validations:
+                - type: required
+                  params: [You must provide the answer to advisorOnceReportLinguistLin.requiredButFilteredOutQuestion]
+            requiredQuestion:
+              type: text
+              label: This question is required
+              validations:
+                - type: required
+                  params: [You must provide the answer to advisorOnceReportLinguistLin.requiredQuestion]
+            questionForNegative:
+              test: $.relatedObject[?(@property === "atmosphere" && @ === "NEGATIVE")]
+              type: text
+              label: This question applies only to Negative engagements
+              validations:
+                - type: required
+                  params: [You must provide the answer to advisorOnceReportLinguistLin.questionForNegative]
         advisorPeriodic:
-          recurrence: "monthly"
+          recurrence: monthly
           questions:
             question1:
                 type: special_field
@@ -736,6 +843,20 @@ fields:
             read: ['c21e7321-7ec5-4837-8805-a302f9575754']
             write: ['39a78d51-c351-452c-9206-4305ec8dd76d']
           questions:
+            requiredButFilteredOutQuestion:
+              test: $.subject[?(@property === "noSuchProperty" && @.match(/^willNeverMatch/i))]
+              type: text
+              label: This question is required but will be filtered out
+              validations:
+                - type: required
+                  params: [You must provide the answer to principalMonthly.requiredButFilteredOutQuestion]
+            questionForChristopf:
+              test: $.subject[?(@property === "name" && @ === "TOPFERNESS, Christopf")]
+              type: text
+              label: This question applies only to Christopf
+              validations:
+                - type: required
+                  params: [You must provide the answer to principalMonthly.questionForChristopf]
             text:
               type: special_field
               label: Text
@@ -862,6 +983,20 @@ fields:
             read: ['c21e7321-7ec5-4837-8805-a302f9575754']
             write: ['39a78d51-c351-452c-9206-4305ec8dd76d']
           questions:
+            requiredButFilteredOutQuestion:
+              test: $.subject[?(@property === "noSuchProperty" && @.match(/^willNeverMatch/i))]
+              type: text
+              label: This question is required but will be filtered out
+              validations:
+                - type: required
+                  params: [You must provide the answer to principalOndemandScreeningAndVetting.requiredButFilteredOutQuestion]
+            questionForChristopf:
+              test: $.subject[?(@property === "name" && @ === "TOPFERNESS, Christopf")]
+              type: text
+              label: This question applies only to Christopf
+              validations:
+                - type: required
+                  params: [You must provide the answer to this principalOndemandScreeningAndVetting.questionForChristopf]
             assessmentDate:
               type: date
               label: Screening and vetting date


### PR DESCRIPTION
When some questions filtered out, assessments could not be saved as these questoins were still part of the validation. Fix this by creating a correct validation schema based on the filtered assessment configuration. To make sure we catch this, add some questions to the (test) dictionary that should be filtered out (or not, as the case may be), to all types of assessments (instant, ondemand and periodic).

Closes [AB#827](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/827)

#### User changes
- None

#### Superuser changes
- None

#### Admin changes
- None

#### System admin changes
- [x] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
