### PR TITLE
Allow any task as a parent

### DIFF
--- a/anet-dictionary.yml
+++ b/anet-dictionary.yml
@@ -258,7 +258,7 @@ fields:
 
     parentTask:
       label: Parent objective / effort
-      placeholder: Start typing to search for a higher level task
+      placeholder: Start typing to search for a higher level objective / effort
     childrenTasks: Sub efforts
     taskedOrganizations:
       label: Tasked organizations

--- a/client/src/pages/tasks/Form.js
+++ b/client/src/pages/tasks/Form.js
@@ -87,8 +87,8 @@ const TaskForm = ({ edit, title, initialValues, notesComponent }) => {
 
   const tasksFilters = {
     allObjectives: {
-      label: `All ${Settings.fields.task.topLevel.longLabel}`,
-      queryVars: { hasParentTask: false }
+      label: `All ${Settings.fields.task.longLabel}`,
+      queryVars: {}
     }
   }
   const positionsFilters = {


### PR DESCRIPTION
Allow any task, not just top-level tasks.

Closes [AB#828](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/828) 

#### User changes
- None

#### Superuser changes
- None

#### Admin changes
- Any task can now be chosen as a parent task, not only top-level tasks

#### System admin changes
- [x] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here