### PR TITLE
Replace all `await expect` with just `expect`

### DIFF
--- a/client/tests/webdriver/baseSpecs/advancedSearch.spec.js
+++ b/client/tests/webdriver/baseSpecs/advancedSearch.spec.js
@@ -42,7 +42,7 @@ describe("When using advanced search", () => {
       await AdvancedSearch.getAdvancedSearchPopoverTrigger()
     ).waitForDisplayed()
 
-    await expect(
+    expect(
       await (await AdvancedSearch.getAdvancedSearchPopoverTrigger()).getText()
     ).to.equal("Everything filtered on Status: Active")
   })
@@ -54,16 +54,16 @@ describe("When using advanced search", () => {
   it("Should show a list of anet object types on toggle buttons in the popover", async() => {
     const buttons = await AdvancedSearch.getAnetObjectSearchToggleButtons()
     for (const [i, button] of buttons.entries()) {
-      await expect(await button.getText()).to.equal(await getObjectType(i))
+      expect(await button.getText()).to.equal(await getObjectType(i))
     }
   })
   it("Should show the common filter even when no object type selected", async() => {
-    await expect(
+    expect(
       await (await AdvancedSearch.getCommonSearchFilter()).getText()
     ).to.equal(COMMON_FILTER_TEXT)
   })
   it("Should show the additional common filters when no object type selected", async() => {
-    await expect(
+    expect(
       await (await AdvancedSearch.getAddFilterButtonText()).getText()
     ).to.equal(ADD_FILTER_BUTTON_TEXT)
     await (await AdvancedSearch.getAddFilterButton()).click()
@@ -83,7 +83,7 @@ describe("When using advanced search", () => {
     const buttons = await AdvancedSearch.getAnetObjectSearchToggleButtons()
     for (const [i, button] of buttons.entries()) {
       await button.click()
-      await expect(
+      expect(
         await (await AdvancedSearch.getCommonSearchFilter()).isExisting()
       ).to.equal(true)
       if (i === PERSON_INDEX) {
@@ -93,7 +93,7 @@ describe("When using advanced search", () => {
         await (
           await AdvancedSearch.getPendingVerificationFilter()
         ).waitForDisplayed()
-        await expect(
+        expect(
           await (await AdvancedSearch.getPendingVerificationFilter()).getText()
         ).to.equal(PERSON_DEFAULT_FILTER)
       }
@@ -105,7 +105,7 @@ describe("When using advanced search", () => {
       await button.click()
       await (await AdvancedSearch.getAddFilterButtonText()).waitForExist()
       await (await AdvancedSearch.getAddFilterButtonText()).waitForDisplayed()
-      await expect(
+      expect(
         await (await AdvancedSearch.getAddFilterButtonText()).getText()
       ).to.equal(ADD_FILTER_BUTTON_TEXT)
     }

--- a/client/tests/webdriver/baseSpecs/assessmentsForPeople.spec.js
+++ b/client/tests/webdriver/baseSpecs/assessmentsForPeople.spec.js
@@ -51,7 +51,7 @@ describe("For the periodic person assessments", () => {
 
     it("Should display validation error messages on every level", async() => {
       await (await ShowPerson.getSaveAssessmentButton()).click()
-      await expect(await ShowPerson.getValidationErrorMessages()).to.eql(
+      expect(await ShowPerson.getValidationErrorMessages()).to.eql(
         ERROR_MESSAGES
       )
     })
@@ -67,7 +67,7 @@ describe("For the periodic person assessments", () => {
     it("Should show the same assessment details with the details just created", async() => {
       const details = await ShowPerson.getShownAssessmentDetails()
       for (const [index, detail] of details.entries()) {
-        await expect((await prefix(index)) + (await detail.getText())).to.equal(
+        expect((await prefix(index)) + (await detail.getText())).to.equal(
           (await prefix(index)) +
             (VALUE_TO_TEXT_FOR_PERSON[ADVISOR_1_PERSON_CREATE_DETAILS[index]] ||
               ADVISOR_1_PERSON_CREATE_DETAILS[index])
@@ -94,7 +94,7 @@ describe("For the periodic person assessments", () => {
     it("Should show the same assessment details with the details just edited", async() => {
       const details = await ShowPerson.getShownAssessmentDetails()
       for (const [index, detail] of details.entries()) {
-        await expect((await prefix(index)) + (await detail.getText())).to.equal(
+        expect((await prefix(index)) + (await detail.getText())).to.equal(
           (await prefix(index)) +
             (VALUE_TO_TEXT_FOR_PERSON[ADVISOR_1_PERSON_EDIT_DETAILS[index]] ||
               ADVISOR_1_PERSON_EDIT_DETAILS[index])
@@ -117,7 +117,7 @@ describe("For the periodic person assessments", () => {
     })
 
     it("Should not show make assessment button when there is an assessment on that period", async() => {
-      await expect(
+      expect(
         await (await ShowPerson.getAddPeriodicAssessmentButton()).isExisting()
       ).to.equal(false)
     })
@@ -141,7 +141,7 @@ describe("For the periodic person assessments", () => {
     it("Should show the same assessment details with the details just edited", async() => {
       const details = await ShowPerson.getShownAssessmentDetails()
       for (const [index, detail] of details.entries()) {
-        await expect((await prefix(index)) + (await detail.getText())).to.equal(
+        expect((await prefix(index)) + (await detail.getText())).to.equal(
           (await prefix(index)) +
             (VALUE_TO_TEXT_FOR_PERSON[ADMIN_PERSON_EDIT_DETAILS[index]] ||
               ADMIN_PERSON_EDIT_DETAILS[index])

--- a/client/tests/webdriver/baseSpecs/assessmentsForTasks.spec.js
+++ b/client/tests/webdriver/baseSpecs/assessmentsForTasks.spec.js
@@ -45,7 +45,7 @@ describe("For the periodic task assessments", () => {
     it("Should show the same assessment details with the details just created", async() => {
       const details = await ShowTask.getShownAssessmentDetails()
       for (const [index, detail] of details.entries()) {
-        await expect((await prefix(index)) + (await detail.getText())).to.equal(
+        expect((await prefix(index)) + (await detail.getText())).to.equal(
           (await // Only some values are mapped, others are same
           prefix(index)) +
             (VALUE_TO_TEXT_FOR_TASK[ADVISOR_1_TASK_CREATE_DETAILS[index]] ||
@@ -72,7 +72,7 @@ describe("For the periodic task assessments", () => {
     it("Should show the same assessment details with the details just edited", async() => {
       const details = await ShowTask.getShownAssessmentDetails()
       for (const [index, detail] of details.entries()) {
-        await expect((await prefix(index)) + (await detail.getText())).to.equal(
+        expect((await prefix(index)) + (await detail.getText())).to.equal(
           (await // Only some values are mapped, others are same
           prefix(index)) +
             (VALUE_TO_TEXT_FOR_TASK[ADVISOR_1_TASK_EDIT_DETAILS[index]] ||
@@ -94,7 +94,7 @@ describe("For the periodic task assessments", () => {
     })
 
     it("Should not show make assessment button when there is an assessment on that period", async() => {
-      await expect(
+      expect(
         await (await ShowTask.getAddMonthlyAssessmentButton()).isExisting()
       ).to.equal(false)
     })
@@ -118,7 +118,7 @@ describe("For the periodic task assessments", () => {
     it("Should show the same assessment details with the details just edited", async() => {
       const details = await ShowTask.getShownAssessmentDetails()
       for (const [index, detail] of details.entries()) {
-        await expect((await prefix(index)) + (await detail.getText())).to.equal(
+        expect((await prefix(index)) + (await detail.getText())).to.equal(
           (await // Only some values are mapped, others are same
           prefix(index)) +
             (VALUE_TO_TEXT_FOR_TASK[ADMIN_TASK_EDIT_DETAILS[index]] ||
@@ -140,7 +140,7 @@ describe("For the periodic task assessments", () => {
     })
 
     it("Should not show make assessment button when there is an assessment on that period", async() => {
-      await expect(
+      expect(
         await (await ShowTask.getAddMonthlyAssessmentButton()).isExisting()
       ).to.equal(false)
     })
@@ -164,7 +164,7 @@ describe("For the periodic task assessments", () => {
     it("Should show the same assessment details with the details just edited", async() => {
       const details = await ShowTask.getShownAssessmentDetails()
       for (const [index, detail] of details.entries()) {
-        await expect((await prefix(index)) + (await detail.getText())).to.equal(
+        expect((await prefix(index)) + (await detail.getText())).to.equal(
           (await // Only some values are mapped, others are same
           prefix(index)) +
             (VALUE_TO_TEXT_FOR_TASK[ADVISOR_2_TASK_EDIT_DETAILS[index]] ||

--- a/client/tests/webdriver/baseSpecs/createAuthorizationGroup.spec.js
+++ b/client/tests/webdriver/baseSpecs/createAuthorizationGroup.spec.js
@@ -27,13 +27,13 @@ describe("Create authorization group form page", () => {
       await (
         await CreateAuthorizationGroup.getStatusActiveButton()
       ).waitForDisplayed()
-      await expect(
+      expect(
         await (await CreateAuthorizationGroup.getStatusActiveInput()).getValue()
       ).to.be.equal("ACTIVE")
       await (
         await CreateAuthorizationGroup.getStatusInactiveButton()
       ).waitForDisplayed()
-      await expect(
+      expect(
         await (
           await CreateAuthorizationGroup.getStatusInactiveInput()
         ).getValue()
@@ -48,7 +48,7 @@ describe("Create authorization group form page", () => {
       await CreateAuthorizationGroup.waitForPositionsAdvancedSelectToChange(
         POSITION_COMPLETE
       )
-      await expect(
+      expect(
         await (
           await CreateAuthorizationGroup.getPositionsAdvancedSelectFirstItem()
         ).getText()
@@ -59,7 +59,7 @@ describe("Create authorization group form page", () => {
       // Click outside the positions overlay
       await (await CreateAuthorizationGroup.getName()).click()
       // Advanced select input gets empty, the position is added to a table underneath
-      await expect(
+      expect(
         await (await CreateAuthorizationGroup.getPositionsInput()).getValue()
       ).to.equal("")
       // positions table exists now
@@ -70,7 +70,7 @@ describe("Create authorization group form page", () => {
       const alertMessage = await (
         await CreateAuthorizationGroup.getAlertSuccess()
       ).getText()
-      await expect(alertMessage).to.equal("Authorization Group saved")
+      expect(alertMessage).to.equal("Authorization Group saved")
     })
   })
 })

--- a/client/tests/webdriver/baseSpecs/createNewLocation.spec.js
+++ b/client/tests/webdriver/baseSpecs/createNewLocation.spec.js
@@ -41,7 +41,7 @@ describe("When creating a new Location", () => {
     await (
       await CreateNewLocation.getModalContent()
     ).waitForDisplayed({ reverse: true })
-    await expect(similar).to.equal("Kabul Hospital")
+    expect(similar).to.equal("Kabul Hospital")
   })
 
   it("Should not accept invalid latitude-longitude inputs", async() => {
@@ -65,15 +65,15 @@ describe("When creating a new Location", () => {
     await (await CreateNewLocation.getAllFormatsPopover()).click()
     await (await CreateNewLocation.getAllFormatsPopoverLat()).waitForExist()
     await (await CreateNewLocation.getAllFormatsPopoverMGRS()).waitForExist()
-    await expect(
+    expect(
       await (await CreateNewLocation.getAllFormatsPopoverLat()).getText()
     ).to.equal(LOCATION_COORDS.lat)
 
-    await expect(
+    expect(
       await (await CreateNewLocation.getAllFormatsPopoverLng()).getText()
     ).to.equal(LOCATION_COORDS.lng)
 
-    await expect(
+    expect(
       await (await CreateNewLocation.getAllFormatsPopoverMGRS()).getText()
     ).to.equal(LOCATION_COORDS.mgrs)
   })

--- a/client/tests/webdriver/baseSpecs/createNewOrganization.spec.js
+++ b/client/tests/webdriver/baseSpecs/createNewOrganization.spec.js
@@ -28,7 +28,7 @@ describe("When creating an organization", () => {
     await (await CreateOrganization.getLocationInput()).click()
     await (await CreateOrganization.getLocationInput()).setValue(LOCATION)
     await CreateOrganization.waitForLocationAdvancedSelectToChange(LOCATION)
-    await expect(
+    expect(
       await (
         await CreateOrganization.getLocationAdvancedSelectFirstItem()
       ).getText()
@@ -39,19 +39,19 @@ describe("When creating an organization", () => {
     await CreateOrganization.fillOrganizationProfile(PROFILE)
     await CreateOrganization.submitForm()
     await ShowOrganization.waitForAlertSuccessToLoad()
-    await expect(
-      await (await ShowOrganization.getAlertSuccess()).getText()
-    ).to.equal("Organization saved")
+    expect(await (await ShowOrganization.getAlertSuccess()).getText()).to.equal(
+      "Organization saved"
+    )
   })
   it("Should display the newly created organization", async() => {
-    await expect(
-      await (await ShowOrganization.getLongName()).getText()
-    ).to.equal(DESCRIPTION)
-    await expect(
-      await (await ShowOrganization.getLocation()).getText()
-    ).to.include(LOCATION)
-    await expect(
-      await (await ShowOrganization.getProfile()).getText()
-    ).to.include(PROFILE)
+    expect(await (await ShowOrganization.getLongName()).getText()).to.equal(
+      DESCRIPTION
+    )
+    expect(await (await ShowOrganization.getLocation()).getText()).to.include(
+      LOCATION
+    )
+    expect(await (await ShowOrganization.getProfile()).getText()).to.include(
+      PROFILE
+    )
   })
 })

--- a/client/tests/webdriver/baseSpecs/createNewPerson.spec.js
+++ b/client/tests/webdriver/baseSpecs/createNewPerson.spec.js
@@ -40,7 +40,7 @@ describe("Create new Person form page", () => {
       )
       await errorMessage.waitForExist()
       await errorMessage.waitForDisplayed()
-      await expect(await errorMessage.getText()).to.equal(
+      expect(await errorMessage.getText()).to.equal(
         "You must provide the Gender"
       )
 
@@ -61,7 +61,7 @@ describe("Create new Person form page", () => {
       const alertMessage = await (
         await CreatePerson.getAlertSuccess()
       ).getText()
-      await expect(alertMessage).to.equal("Person saved")
+      expect(alertMessage).to.equal("Person saved")
     })
     it("Should save a principle without first name", async() => {
       await (await CreatePerson.getLastName()).waitForDisplayed()
@@ -85,7 +85,7 @@ describe("Create new Person form page", () => {
       const alertMessage = await (
         await CreatePerson.getAlertSuccess()
       ).getText()
-      await expect(alertMessage).to.equal("Person saved")
+      expect(alertMessage).to.equal("Person saved")
     })
     it("Should not save a principle without a valid email address", async() => {
       await (await CreatePerson.getLastName()).waitForDisplayed()
@@ -111,7 +111,7 @@ describe("Create new Person form page", () => {
       )
       await errorMessage.waitForExist()
       await errorMessage.waitForDisplayed()
-      await expect(await errorMessage.getText()).to.equal(
+      expect(await errorMessage.getText()).to.equal(
         "Email must be a valid email"
       )
 
@@ -124,7 +124,7 @@ describe("Create new Person form page", () => {
       const alertMessage = await (
         await CreatePerson.getAlertSuccess()
       ).getText()
-      await expect(alertMessage).to.equal("Person saved")
+      expect(alertMessage).to.equal("Person saved")
     })
   })
 
@@ -151,7 +151,7 @@ describe("Create new Person form page", () => {
       await (
         await CreatePerson.getModalContent()
       ).waitForDisplayed({ reverse: true })
-      await expect(similar).to.equal("CIV ERINSON, Erin")
+      expect(similar).to.equal("CIV ERINSON, Erin")
     })
     it("Should display a warning message specific for duplicate accounts", async() => {
       // Only admin users can create an advisor user
@@ -163,7 +163,7 @@ describe("Create new Person form page", () => {
       const warningMessage = await browser.$(".alert.alert-warning")
       await warningMessage.waitForExist()
       await warningMessage.waitForDisplayed()
-      await expect(await warningMessage.getText()).to.equal(
+      expect(await warningMessage.getText()).to.equal(
         "Creating a NATO Member in ANET could result in duplicate accounts if this person logs in later. If you notice duplicate accounts, please contact an ANET administrator."
       )
       // Don't logout, next test continues…
@@ -216,7 +216,7 @@ describe("Create new Person form page", () => {
         .$("div.invalid-feedback")
       await errorMessage.waitForExist()
       await errorMessage.waitForDisplayed()
-      await expect(await errorMessage.getText()).to.equal(
+      expect(await errorMessage.getText()).to.equal(
         "You must provide the End of tour"
       )
       // Don't logout, next test continues…
@@ -270,7 +270,7 @@ describe("Create new Person form page", () => {
       const alertMessage = await (
         await CreatePerson.getAlertSuccess()
       ).getText()
-      await expect(alertMessage).to.equal("Person saved")
+      expect(alertMessage).to.equal("Person saved")
       await CreatePerson.logout()
     })
   })

--- a/client/tests/webdriver/baseSpecs/createNewPosition.spec.js
+++ b/client/tests/webdriver/baseSpecs/createNewPosition.spec.js
@@ -24,22 +24,22 @@ describe("Create position page", () => {
 
       await (await CreatePosition.getTypeAdvisorButton()).click()
 
-      await expect(
+      expect(
         await (await CreatePosition.getPositionNameHelpBlock()).getText()
       ).to.equal("Position name is required")
-      await expect(
+      expect(
         await (await CreatePosition.getOrganizationHelpBlock()).getText()
       ).to.equal("Organization is required")
-      await expect(
+      expect(
         await (await CreatePosition.getLocationHelpBlock()).getText()
       ).to.equal("Location is required for NATO Billet")
 
       await (await CreatePosition.getTypePrincipalButton()).click()
 
-      await expect(
+      expect(
         await (await CreatePosition.getPositionNameHelpBlock()).getText()
       ).to.equal("Position name is required")
-      await expect(
+      expect(
         await (await CreatePosition.getOrganizationHelpBlock()).getText()
       ).to.equal("Organization is required")
     })
@@ -60,7 +60,7 @@ describe("Create position page", () => {
       await (
         await CreatePosition.getModalContent()
       ).waitForDisplayed({ reverse: true })
-      await expect(similar).to.equal("EF 1.1 Advisor for Agriculture")
+      expect(similar).to.equal("EF 1.1 Advisor for Agriculture")
     })
 
     it("Should successfully create an advisor position when required fields are filled", async() => {
@@ -72,7 +72,7 @@ describe("Create position page", () => {
       await (await CreatePosition.getOrganizationInput()).click()
       await (await CreatePosition.getOrganizationInput()).setValue(ADMIN_ORG)
       await CreatePosition.waitForOrgAdvancedSelectToChange(ADMIN_ORG_COMPLETE)
-      await expect(
+      expect(
         await (await CreatePosition.getOrgAdvancedSelectFirstItem()).getText()
       ).to.include(ADMIN_ORG_COMPLETE)
 
@@ -102,7 +102,7 @@ describe("Create position page", () => {
       await CreatePosition.waitForOrgAdvancedSelectToChange(
         PRINCIPAL_ORG_COMPLETE
       )
-      await expect(
+      expect(
         await (await CreatePosition.getOrgAdvancedSelectFirstItem()).getText()
       ).to.include(PRINCIPAL_ORG_COMPLETE)
 
@@ -121,7 +121,7 @@ describe("Create position page", () => {
       await (await CreatePosition.getForm()).waitForDisplayed()
 
       await (await CreatePosition.getTypePrincipalButton()).waitForDisplayed()
-      await expect(
+      expect(
         await (
           await CreatePosition.getTypePrincipalButton()
         ).getAttribute("class")
@@ -130,7 +130,7 @@ describe("Create position page", () => {
       // expect(CreatePosition.getTypeAdvisorButton().getAttribute("class")).to.include(
       //   "active"
       // )
-      await expect(
+      expect(
         await (await CreatePosition.getOrganizationInput()).getValue()
       ).to.equal("")
 
@@ -154,17 +154,17 @@ describe("Create position page", () => {
       await CreatePosition.waitForOrgAdvancedSelectToChange(
         ADVISOR_ORG_COMPLETE
       )
-      await expect(
+      expect(
         await (await CreatePosition.getOrgAdvancedSelectFirstItem()).getText()
       ).to.include(ADVISOR_ORG_COMPLETE)
 
       await (await CreatePosition.getOrgAdvancedSelectFirstItem()).click()
-      await expect(
+      expect(
         await (await CreatePosition.getOrganizationInput()).getValue()
       ).to.equal(ADVISOR_ORG)
 
       await (await CreatePosition.getTypePrincipalButton()).click()
-      await expect(
+      expect(
         await (await CreatePosition.getOrganizationInput()).getValue()
       ).to.equal("")
 
@@ -175,12 +175,12 @@ describe("Create position page", () => {
       await CreatePosition.waitForOrgAdvancedSelectToChange(
         PRINCIPAL_ORG_COMPLETE
       )
-      await expect(
+      expect(
         await (await CreatePosition.getOrgAdvancedSelectFirstItem()).getText()
       ).to.include(PRINCIPAL_ORG_COMPLETE)
 
       await (await CreatePosition.getOrgAdvancedSelectFirstItem()).click()
-      await expect(
+      expect(
         await (await CreatePosition.getOrganizationInput()).getValue()
       ).to.equal(PRINCIPAL_ORG)
       await (await CreatePosition.getCancelButton()).click()

--- a/client/tests/webdriver/baseSpecs/createNewTask.spec.js
+++ b/client/tests/webdriver/baseSpecs/createNewTask.spec.js
@@ -22,19 +22,15 @@ describe("When creating an task", () => {
     await CreateTask.fillTaskDescription(DESCRIPTION)
     await CreateTask.submitForm()
     await ShowTask.waitForAlertSuccessToLoad()
-    await expect(await (await ShowTask.getAlertSuccess()).getText()).to.equal(
+    expect(await (await ShowTask.getAlertSuccess()).getText()).to.equal(
       "Task saved"
     )
   })
 
   it("Should display the newly created task", async() => {
-    await expect(await (await ShowTask.getShortName()).getText()).to.equal(
-      SHORT_NAME
-    )
-    await expect(await (await ShowTask.getLongName()).getText()).to.equal(
-      LONG_NAME
-    )
-    await expect(await (await ShowTask.getDescription()).getText()).to.equal(
+    expect(await (await ShowTask.getShortName()).getText()).to.equal(SHORT_NAME)
+    expect(await (await ShowTask.getLongName()).getText()).to.equal(LONG_NAME)
+    expect(await (await ShowTask.getDescription()).getText()).to.equal(
       DESCRIPTION
     )
   })

--- a/client/tests/webdriver/baseSpecs/createReportWithPlanningConflict.spec.js
+++ b/client/tests/webdriver/baseSpecs/createReportWithPlanningConflict.spec.js
@@ -37,38 +37,38 @@ describe("When creating a Report with conflicts", () => {
     await browser.pause(500) // wait for the page transition and rendering of custom fields
     await CreateReport.fillForm(report01)
 
-    await expect(await (await CreateReport.getIntent()).getValue()).to.equal(
+    expect(await (await CreateReport.getIntent()).getValue()).to.equal(
       report01.intent
     )
-    await expect(
-      await (await CreateReport.getEngagementDate()).getValue()
-    ).to.equal(report01.engagementDate.format("DD-MM-YYYY HH:mm"))
-    await expect(await (await CreateReport.getDuration()).getValue()).to.equal(
+    expect(await (await CreateReport.getEngagementDate()).getValue()).to.equal(
+      report01.engagementDate.format("DD-MM-YYYY HH:mm")
+    )
+    expect(await (await CreateReport.getDuration()).getValue()).to.equal(
       report01.duration
     )
     const advisor01 = await CreateReport.getPersonByName("CIV ERINSON, Erin")
-    await expect(advisor01.name).to.equal("CIV ERINSON, Erin")
-    await expect(await advisor01.conflictButton.isExisting()).to.equal(false)
+    expect(advisor01.name).to.equal("CIV ERINSON, Erin")
+    expect(await advisor01.conflictButton.isExisting()).to.equal(false)
 
     const advisor02 = await CreateReport.getPersonByName(report01.advisors[0])
-    await expect(advisor02.name).to.equal(report01.advisors[0])
-    await expect(await advisor02.conflictButton.isExisting()).to.equal(false)
+    expect(advisor02.name).to.equal(report01.advisors[0])
+    expect(await advisor02.conflictButton.isExisting()).to.equal(false)
 
     const principal01 = await CreateReport.getPersonByName(
       report01.principals[0]
     )
-    await expect(principal01.name).to.equal(report01.principals[0])
-    await expect(await principal01.conflictButton.isExisting()).to.equal(false)
+    expect(principal01.name).to.equal(report01.principals[0])
+    expect(await principal01.conflictButton.isExisting()).to.equal(false)
 
     await CreateReport.submitForm()
     await ShowReport.waitForShowReportToLoad()
 
     const text = "This is a DRAFT planned engagement and hasn't been submitted."
-    await expect(await ShowReport.getReportStatusText()).to.equal(text)
-    await expect(await ShowReport.getIntent()).to.equal(report01.intent)
+    expect(await ShowReport.getReportStatusText()).to.equal(text)
+    expect(await ShowReport.getIntent()).to.equal(report01.intent)
 
     firstReportUUID = await ShowReport.getUuid()
-    await expect(firstReportUUID.length).to.equal(36)
+    expect(firstReportUUID.length).to.equal(36)
   })
 
   it("Should create second draft report with conflicts", async() => {
@@ -76,92 +76,92 @@ describe("When creating a Report with conflicts", () => {
     await browser.pause(500) // wait for the page transition and rendering of custom fields
     await CreateReport.fillForm(report02)
 
-    await expect(await (await CreateReport.getIntent()).getValue()).to.equal(
+    expect(await (await CreateReport.getIntent()).getValue()).to.equal(
       report02.intent
     )
-    await expect(
-      await (await CreateReport.getEngagementDate()).getValue()
-    ).to.equal(report02.engagementDate.format("DD-MM-YYYY HH:mm"))
-    await expect(await (await CreateReport.getDuration()).getValue()).to.equal(
+    expect(await (await CreateReport.getEngagementDate()).getValue()).to.equal(
+      report02.engagementDate.format("DD-MM-YYYY HH:mm")
+    )
+    expect(await (await CreateReport.getDuration()).getValue()).to.equal(
       report02.duration
     )
     const advisor01 = await CreateReport.getPersonByName("CIV ERINSON, Erin")
-    await expect(advisor01.name).to.equal("CIV ERINSON, Erin")
-    await expect(await advisor01.conflictButton.isExisting()).to.equal(true)
+    expect(advisor01.name).to.equal("CIV ERINSON, Erin")
+    expect(await advisor01.conflictButton.isExisting()).to.equal(true)
 
     const advisor02 = await CreateReport.getPersonByName(report02.advisors[0])
-    await expect(advisor02.name).to.equal(report02.advisors[0])
-    await expect(await advisor02.conflictButton.isExisting()).to.equal(true)
+    expect(advisor02.name).to.equal(report02.advisors[0])
+    expect(await advisor02.conflictButton.isExisting()).to.equal(true)
 
     const advisor03 = await CreateReport.getPersonByName(report02.advisors[1])
-    await expect(advisor03.name).to.equal(report02.advisors[1])
-    await expect(await advisor03.conflictButton.isExisting()).to.equal(false)
+    expect(advisor03.name).to.equal(report02.advisors[1])
+    expect(await advisor03.conflictButton.isExisting()).to.equal(false)
 
     const principal01 = await CreateReport.getPersonByName(
       report02.principals[0]
     )
-    await expect(principal01.name).to.equal(report02.principals[0])
-    await expect(await principal01.conflictButton.isExisting()).to.equal(true)
+    expect(principal01.name).to.equal(report02.principals[0])
+    expect(await principal01.conflictButton.isExisting()).to.equal(true)
 
     const principal02 = await CreateReport.getPersonByName(
       report02.principals[1]
     )
-    await expect(principal02.name).to.equal(report02.principals[1])
-    await expect(await principal02.conflictButton.isExisting()).to.equal(false)
+    expect(principal02.name).to.equal(report02.principals[1])
+    expect(await principal02.conflictButton.isExisting()).to.equal(false)
 
     await CreateReport.submitForm()
     await ShowReport.waitForShowReportToLoad()
 
     const text = "This is a DRAFT planned engagement and hasn't been submitted."
-    await expect(await ShowReport.getReportStatusText()).to.equal(text)
-    await expect(await ShowReport.getIntent()).to.equal(report02.intent)
+    expect(await ShowReport.getReportStatusText()).to.equal(text)
+    expect(await ShowReport.getIntent()).to.equal(report02.intent)
 
     secondReportUUID = await ShowReport.getUuid()
-    await expect(secondReportUUID.length).to.equal(36)
+    expect(secondReportUUID.length).to.equal(36)
   })
 
   it("Should display first report with conflicts", async() => {
     await ShowReport.open(firstReportUUID)
     await ShowReport.waitForShowReportToLoad()
 
-    await expect((await ShowReport.getUuid()).length).to.equal(36)
+    expect((await ShowReport.getUuid()).length).to.equal(36)
 
     const statusText =
       "This is a DRAFT planned engagement and hasn't been submitted."
-    await expect(await ShowReport.getReportStatusText()).to.equal(statusText)
+    expect(await ShowReport.getReportStatusText()).to.equal(statusText)
 
-    await expect(await ShowReport.getIntent()).to.equal(report01.intent)
-    await expect(await ShowReport.getEngagementDate()).to.equal(
+    expect(await ShowReport.getIntent()).to.equal(report01.intent)
+    expect(await ShowReport.getEngagementDate()).to.equal(
       report01.engagementDate.format("dddd, D MMMM YYYY @ HH:mm")
     )
-    await expect(
+    expect(
       await (await ShowReport.getReportConflictIcon()).isExisting()
     ).to.equal(true)
 
     await (await ShowReport.getReportConflictIcon()).moveTo()
-    await expect(await ShowReport.getReportConflictTooltipTitle()).to.equal(
+    expect(await ShowReport.getReportConflictTooltipTitle()).to.equal(
       "3 of 3 attendees are busy at the selected time!"
     )
 
-    await expect(await ShowReport.getDuration()).to.equal(report01.duration)
-    await expect(await ShowReport.getLocation()).to.equal("Unspecified")
+    expect(await ShowReport.getDuration()).to.equal(report01.duration)
+    expect(await ShowReport.getLocation()).to.equal("Unspecified")
     expect(await ShowReport.getAuthors()).to.match(/CIV ERINSON, Erin/)
 
     const advisor01 = await ShowReport.getAttendeeByName("CIV ERINSON, Erin")
-    await expect(advisor01.name).to.equal("CIV ERINSON, Erin")
-    await expect(await advisor01.conflictButton.isExisting()).to.equal(true)
+    expect(advisor01.name).to.equal("CIV ERINSON, Erin")
+    expect(await advisor01.conflictButton.isExisting()).to.equal(true)
     expect(await advisor01.conflictButton.getText()).to.match(/conflict/)
 
     const advisor02 = await ShowReport.getAttendeeByName(report01.advisors[0])
-    await expect(advisor02.name).to.equal(report01.advisors[0])
-    await expect(await advisor02.conflictButton.isExisting()).to.equal(true)
+    expect(advisor02.name).to.equal(report01.advisors[0])
+    expect(await advisor02.conflictButton.isExisting()).to.equal(true)
     expect(await advisor02.conflictButton.getText()).to.match(/conflict/)
 
     const principal01 = await ShowReport.getAttendeeByName(
       report01.principals[0]
     )
-    await expect(principal01.name).to.equal(report01.principals[0])
-    await expect(await principal01.conflictButton.isExisting()).to.equal(true)
+    expect(principal01.name).to.equal(report01.principals[0])
+    expect(await principal01.conflictButton.isExisting()).to.equal(true)
     expect(await principal01.conflictButton.getText()).to.match(/conflict/)
   })
 
@@ -169,17 +169,17 @@ describe("When creating a Report with conflicts", () => {
     await ShowReport.open(secondReportUUID)
     await ShowReport.waitForShowReportToLoad()
 
-    await expect((await ShowReport.getUuid()).length).to.equal(36)
+    expect((await ShowReport.getUuid()).length).to.equal(36)
 
     const statusText =
       "This is a DRAFT planned engagement and hasn't been submitted."
-    await expect(await ShowReport.getReportStatusText()).to.equal(statusText)
+    expect(await ShowReport.getReportStatusText()).to.equal(statusText)
 
-    await expect(await ShowReport.getIntent()).to.equal(report02.intent)
-    await expect(await ShowReport.getEngagementDate()).to.equal(
+    expect(await ShowReport.getIntent()).to.equal(report02.intent)
+    expect(await ShowReport.getEngagementDate()).to.equal(
       report02.engagementDate.format("dddd, D MMMM YYYY @ HH:mm")
     )
-    await expect(
+    expect(
       await (await ShowReport.getReportConflictIcon()).isExisting()
     ).to.equal(true)
 
@@ -189,37 +189,37 @@ describe("When creating a Report with conflicts", () => {
       /(3|5) of 5 attendees are busy at the selected time!/
     )
 
-    await expect(await ShowReport.getDuration()).to.equal(report02.duration)
-    await expect(await ShowReport.getLocation()).to.equal("Unspecified")
+    expect(await ShowReport.getDuration()).to.equal(report02.duration)
+    expect(await ShowReport.getLocation()).to.equal("Unspecified")
     expect(await ShowReport.getAuthors()).to.match(/CIV ERINSON, Erin/)
 
     const advisor01 = await ShowReport.getAttendeeByName("CIV ERINSON, Erin")
-    await expect(advisor01.name).to.equal("CIV ERINSON, Erin")
-    await expect(await advisor01.conflictButton.isExisting()).to.equal(true)
+    expect(advisor01.name).to.equal("CIV ERINSON, Erin")
+    expect(await advisor01.conflictButton.isExisting()).to.equal(true)
     expect(await advisor01.conflictButton.getText()).to.match(/conflict/)
 
     const advisor02 = await ShowReport.getAttendeeByName("CIV REPORTGIRL, Ima")
-    await expect(await advisor02.conflictButton.isExisting()).to.equal(false)
+    expect(await advisor02.conflictButton.isExisting()).to.equal(false)
 
     const advisor03 = await ShowReport.getAttendeeByName("CIV REPORTGUY, Ima")
-    await expect(await advisor03.conflictButton.isExisting()).to.equal(true)
+    expect(await advisor03.conflictButton.isExisting()).to.equal(true)
     expect(await advisor03.conflictButton.getText()).to.match(/conflict/)
 
     const principal01 = await ShowReport.getAttendeeByName("CIV KYLESON, Kyle")
-    await expect(await principal01.conflictButton.isExisting()).to.equal(true)
+    expect(await principal01.conflictButton.isExisting()).to.equal(true)
     expect(await principal01.conflictButton.getText()).to.match(/conflict/)
 
     const principal02 = await ShowReport.getAttendeeByName(
       "Maj CHRISVILLE, Chris"
     )
-    await expect(await principal02.conflictButton.isExisting()).to.equal(false)
+    expect(await principal02.conflictButton.isExisting()).to.equal(false)
   })
 
   it("Should delete the first report", async() => {
     await EditReport.open(firstReportUUID)
     await EditReport.deleteReport(firstReportUUID)
 
-    await expect(await (await EditReport.getAlertSuccess()).getText()).to.equal(
+    expect(await (await EditReport.getAlertSuccess()).getText()).to.equal(
       "Report deleted"
     )
   })
@@ -228,7 +228,7 @@ describe("When creating a Report with conflicts", () => {
     await EditReport.open(secondReportUUID)
     await EditReport.deleteReport(secondReportUUID)
 
-    await expect(await (await EditReport.getAlertSuccess()).getText()).to.equal(
+    expect(await (await EditReport.getAlertSuccess()).getText()).to.equal(
       "Report deleted"
     )
   })

--- a/client/tests/webdriver/baseSpecs/createReportWithoutPrincipal.spec.js
+++ b/client/tests/webdriver/baseSpecs/createReportWithoutPrincipal.spec.js
@@ -31,21 +31,21 @@ describe("When creating a report without a principal", () => {
     await CreateReport.fillForm(REPORT_FIELDS)
     await browser.pause(500)
     await CreateReport.submitForm()
-    await expect(await (await CreateReport.getAlert()).getText()).to.include(
+    expect(await (await CreateReport.getAlert()).getText()).to.include(
       NO_PRINCIPAL_WARNING
     )
   })
   it("Should warn user about missing primary principal", async() => {
     await (await ShowReport.getSubmitButton()).click()
     await (await ShowReport.getReportModal()).waitForDisplayed()
-    await expect(
-      await (await ShowReport.getModalWarning()).getText()
-    ).to.include(NO_PRINCIPAL_WARNING)
+    expect(await (await ShowReport.getModalWarning()).getText()).to.include(
+      NO_PRINCIPAL_WARNING
+    )
   })
   it("Should submit report without primary principal attendee", async() => {
     await (await ShowReport.getConfirmSubmitButton()).click()
     await browser.pause(1000) // Wait for status text to be updated
-    await expect(await ShowReport.getReportStatusText()).to.equal(
+    expect(await ShowReport.getReportStatusText()).to.equal(
       REPORT_SUBMITTED_STATUS
     )
   })
@@ -58,9 +58,9 @@ describe("When creating a report without a principal", () => {
     await (await ShowReport.getApproveButton()).waitForDisplayed()
     await (await ShowReport.getApproveButton()).click()
     await (await ShowReport.getReportModal()).waitForDisplayed()
-    await expect(
-      await (await ShowReport.getModalWarning()).getText()
-    ).to.include(NO_PRINCIPAL_WARNING)
+    expect(await (await ShowReport.getModalWarning()).getText()).to.include(
+      NO_PRINCIPAL_WARNING
+    )
     await (await ShowReport.getConfirmApproveButton()).click()
     await (await ShowReport.getSuccessfullApprovalToast()).waitForDisplayed()
     await ShowReport.logout()
@@ -73,9 +73,9 @@ describe("When creating a report without a principal", () => {
     await (await ShowReport.getApproveButton()).waitForDisplayed()
     await (await ShowReport.getApproveButton()).click()
     await (await ShowReport.getReportModal()).waitForDisplayed()
-    await expect(
-      await (await ShowReport.getModalWarning()).getText()
-    ).to.include(NO_PRINCIPAL_WARNING)
+    expect(await (await ShowReport.getModalWarning()).getText()).to.include(
+      NO_PRINCIPAL_WARNING
+    )
     await (await ShowReport.getConfirmApproveButton()).click()
     await (await ShowReport.getSuccessfullApprovalToast()).waitForDisplayed()
     await ShowReport.logout()
@@ -88,9 +88,9 @@ describe("When creating a report without a principal", () => {
     await (await ShowReport.getApproveButton()).waitForDisplayed()
     await (await ShowReport.getApproveButton()).click()
     await (await ShowReport.getReportModal()).waitForDisplayed()
-    await expect(
-      await (await ShowReport.getModalWarning()).getText()
-    ).to.include(NO_PRINCIPAL_WARNING)
+    expect(await (await ShowReport.getModalWarning()).getText()).to.include(
+      NO_PRINCIPAL_WARNING
+    )
     await (await ShowReport.getConfirmApproveButton()).click()
     await (await ShowReport.getSuccessfullApprovalToast()).waitForDisplayed()
     await ShowReport.logout(true)
@@ -98,7 +98,7 @@ describe("When creating a report without a principal", () => {
   it("Should complete the approval chain", async() => {
     await MyReports.open("erin")
     await MyReports.selectReport(REPORT_FIELDS.intent, REPORT_STATES.APPROVED)
-    await expect(await ShowReport.getReportStatusText()).to.equal(
+    expect(await ShowReport.getReportStatusText()).to.equal(
       REPORT_APPROVED_STATUS
     )
   })

--- a/client/tests/webdriver/baseSpecs/editLocation.spec.js
+++ b/client/tests/webdriver/baseSpecs/editLocation.spec.js
@@ -35,7 +35,7 @@ describe("When editing a location", () => {
       await (await EditLocation.getLocationTypeLabel()).waitForExist()
       await (await EditLocation.getLocationTypeLabel()).waitForDisplayed()
 
-      await expect(
+      expect(
         await (await EditLocation.getLocationTypeField()).getValue()
       ).to.equal(LOCATION_TYPE.type)
     })
@@ -44,12 +44,12 @@ describe("When editing a location", () => {
       await (await EditLocation.getLatLngLabel()).waitForExist()
       await (await EditLocation.getLatLngLabel()).waitForDisplayed()
 
-      await expect(
-        await (await EditLocation.getLatInputField()).getValue()
-      ).to.equal(LOCATION_COORDS.lat)
-      await expect(
-        await (await EditLocation.getLngInputField()).getValue()
-      ).to.equal(LOCATION_COORDS.lng)
+      expect(await (await EditLocation.getLatInputField()).getValue()).to.equal(
+        LOCATION_COORDS.lat
+      )
+      expect(await (await EditLocation.getLngInputField()).getValue()).to.equal(
+        LOCATION_COORDS.lng
+      )
     })
 
     it("Should correctly edit and save input fields and display the correct values in both formats in the popover window", async() => {
@@ -58,13 +58,13 @@ describe("When editing a location", () => {
       await (await EditLocation.getAllFormatsPopoverLat()).waitForExist()
       await (await EditLocation.getAllFormatsPopoverMGRS()).waitForExist()
 
-      await expect(
+      expect(
         await (await EditLocation.getAllFormatsPopoverLat()).getText()
       ).to.equal(NEW_COORDS.lat)
-      await expect(
+      expect(
         await (await EditLocation.getAllFormatsPopoverLng()).getText()
       ).to.equal(NEW_COORDS.lng)
-      await expect(
+      expect(
         await (await EditLocation.getAllFormatsPopoverMGRS()).getText()
       ).to.equal(NEW_COORDS.mgrs)
 
@@ -72,10 +72,10 @@ describe("When editing a location", () => {
       await (await ShowLocation.getSuccessMsg()).waitForExist()
       await (await ShowLocation.getSuccessMsg()).waitForDisplayed()
 
-      await expect(await (await ShowLocation.getLatField()).getText()).to.equal(
+      expect(await (await ShowLocation.getLatField()).getText()).to.equal(
         NEW_COORDS.lat
       )
-      await expect(await (await ShowLocation.getLngField()).getText()).to.equal(
+      expect(await (await ShowLocation.getLngField()).getText()).to.equal(
         NEW_COORDS.lng
       )
     })

--- a/client/tests/webdriver/baseSpecs/homeTiles.spec.js
+++ b/client/tests/webdriver/baseSpecs/homeTiles.spec.js
@@ -7,8 +7,8 @@ describe("When checking the home page tiles", () => {
     await (await Home.getHomeTilesContainer()).waitForExist()
     await (await Home.getHomeTilesContainer()).waitForDisplayed()
     // Depends on test data
-    await expect(
-      await (await Home.getPendingMyApprovalOfCount()).getText()
-    ).to.eq("2")
+    expect(await (await Home.getPendingMyApprovalOfCount()).getText()).to.eq(
+      "2"
+    )
   })
 })

--- a/client/tests/webdriver/baseSpecs/mergeLocations.spec.js
+++ b/client/tests/webdriver/baseSpecs/mergeLocations.spec.js
@@ -33,7 +33,7 @@ describe("Merge locations page", () => {
       "left"
     )
 
-    await expect(
+    expect(
       await (await MergeLocations.getColumnLocationName("left")).getText()
     ).to.eq(EXAMPLE_LOCATIONS.left.name)
 
@@ -50,7 +50,7 @@ describe("Merge locations page", () => {
       "right"
     )
 
-    await expect(
+    expect(
       await (await MergeLocations.getColumnLocationName("right")).getText()
     ).to.eq(EXAMPLE_LOCATIONS.right.name)
   })
@@ -63,7 +63,7 @@ describe("Merge locations page", () => {
       "mid"
     )
 
-    await expect(
+    expect(
       await (await MergeLocations.getColumnLocationName("mid")).getText()
     ).to.eq(EXAMPLE_LOCATIONS.left.name)
   })
@@ -76,7 +76,7 @@ describe("Merge locations page", () => {
       "mid"
     )
 
-    await expect(
+    expect(
       await (await MergeLocations.getColumnLocationName("mid")).getText()
     ).to.eq(EXAMPLE_LOCATIONS.right.name)
   })

--- a/client/tests/webdriver/baseSpecs/mergePeople.spec.js
+++ b/client/tests/webdriver/baseSpecs/mergePeople.spec.js
@@ -95,39 +95,39 @@ describe("Merge people of the same role", () => {
       "Name"
     )
 
-    await expect(
+    expect(
       await (await MergePeople.getColumnContent("left", "Name")).getText()
     ).to.eq(EXAMPLE_PEOPLE.validLeft.name)
-    await expect(
+    expect(
       await (await MergePeople.getColumnContent("left", "Role")).getText()
     ).to.eq(EXAMPLE_PEOPLE.validLeft.role)
-    await expect(
+    expect(
       await (await MergePeople.getColumnContent("left", "Position")).getText()
     ).to.eq(EXAMPLE_PEOPLE.validLeft.position)
-    await expect(await MergePeople.getPreviousPositions("left")).to.eql(
+    expect(await MergePeople.getPreviousPositions("left")).to.eql(
       EXAMPLE_PEOPLE.validLeft.previousPositions
     )
-    await expect(
+    expect(
       await (await MergePeople.getColumnContent("left", "Status")).getText()
     ).to.eq(EXAMPLE_PEOPLE.validLeft.status)
-    await expect(
+    expect(
       await (await MergePeople.getColumnContent("left", "Email")).getText()
     ).to.eq(EXAMPLE_PEOPLE.validLeft.email)
-    await expect(
+    expect(
       await (await MergePeople.getColumnContent("left", "Phone")).getText()
     ).to.eq(EXAMPLE_PEOPLE.validLeft.phone)
-    await expect(
+    expect(
       await (await MergePeople.getColumnContent("left", "Rank")).getText()
     ).to.eq(EXAMPLE_PEOPLE.validLeft.rank)
-    await expect(
+    expect(
       await (await MergePeople.getColumnContent("left", "Gender")).getText()
     ).to.eq(EXAMPLE_PEOPLE.validLeft.gender)
-    await expect(
+    expect(
       await (
         await MergePeople.getColumnContent("left", "Nationality")
       ).getText()
     ).to.eq(EXAMPLE_PEOPLE.validLeft.nationality)
-    await expect(
+    expect(
       await (await MergePeople.getColumnContent("left", "Biography")).getText()
     ).to.eq(EXAMPLE_PEOPLE.validLeft.biography)
   })
@@ -159,39 +159,39 @@ describe("Merge people of the same role", () => {
       "Name"
     )
 
-    await expect(
+    expect(
       await (await MergePeople.getColumnContent("right", "Name")).getText()
     ).to.eq(EXAMPLE_PEOPLE.validRight.name)
-    await expect(
+    expect(
       await (await MergePeople.getColumnContent("right", "Role")).getText()
     ).to.eq(EXAMPLE_PEOPLE.validRight.role)
-    await expect(
+    expect(
       await (await MergePeople.getColumnContent("right", "Position")).getText()
     ).to.eq(EXAMPLE_PEOPLE.validRight.position)
-    await expect(await MergePeople.getPreviousPositions("right")).to.eql(
+    expect(await MergePeople.getPreviousPositions("right")).to.eql(
       EXAMPLE_PEOPLE.validRight.previousPositions
     )
-    await expect(
+    expect(
       await (await MergePeople.getColumnContent("right", "Status")).getText()
     ).to.eq(EXAMPLE_PEOPLE.validRight.status)
-    await expect(
+    expect(
       await (await MergePeople.getColumnContent("right", "Email")).getText()
     ).to.eq(EXAMPLE_PEOPLE.validRight.email)
-    await expect(
+    expect(
       await (await MergePeople.getColumnContent("right", "Phone")).getText()
     ).to.eq(EXAMPLE_PEOPLE.validRight.phone)
-    await expect(
+    expect(
       await (await MergePeople.getColumnContent("right", "Rank")).getText()
     ).to.eq(EXAMPLE_PEOPLE.validRight.rank)
-    await expect(
+    expect(
       await (await MergePeople.getColumnContent("right", "Gender")).getText()
     ).to.eq(EXAMPLE_PEOPLE.validRight.gender)
-    await expect(
+    expect(
       await (
         await MergePeople.getColumnContent("right", "Nationality")
       ).getText()
     ).to.eq(EXAMPLE_PEOPLE.validRight.nationality)
-    await expect(
+    expect(
       await (await MergePeople.getColumnContent("left", "Biography")).getText()
     ).to.eq(EXAMPLE_PEOPLE.validLeft.biography)
   })
@@ -204,37 +204,37 @@ describe("Merge people of the same role", () => {
       "Name"
     )
 
-    await expect(
+    expect(
       await (await MergePeople.getColumnContent("mid", "Name")).getText()
     ).to.eq(EXAMPLE_PEOPLE.validLeft.name)
-    await expect(
+    expect(
       await (await MergePeople.getColumnContent("mid", "Role")).getText()
     ).to.eq(EXAMPLE_PEOPLE.validLeft.role)
-    await expect(
+    expect(
       await (await MergePeople.getColumnContent("mid", "Position")).getText()
     ).to.eq(EXAMPLE_PEOPLE.validLeft.position)
-    await expect(await MergePeople.getPreviousPositions("mid")).to.eql(
+    expect(await MergePeople.getPreviousPositions("mid")).to.eql(
       EXAMPLE_PEOPLE.validLeft.previousPositions
     )
-    await expect(
+    expect(
       await (await MergePeople.getColumnContent("mid", "Status")).getText()
     ).to.eq(EXAMPLE_PEOPLE.validLeft.status)
-    await expect(
+    expect(
       await (await MergePeople.getColumnContent("mid", "Email")).getText()
     ).to.eq(EXAMPLE_PEOPLE.validLeft.email)
-    await expect(
+    expect(
       await (await MergePeople.getColumnContent("mid", "Phone")).getText()
     ).to.eq(EXAMPLE_PEOPLE.validLeft.phone)
-    await expect(
+    expect(
       await (await MergePeople.getColumnContent("mid", "Rank")).getText()
     ).to.eq(EXAMPLE_PEOPLE.validLeft.rank)
-    await expect(
+    expect(
       await (await MergePeople.getColumnContent("mid", "Gender")).getText()
     ).to.eq(EXAMPLE_PEOPLE.validLeft.gender)
-    await expect(
+    expect(
       await (await MergePeople.getColumnContent("mid", "Nationality")).getText()
     ).to.eq(EXAMPLE_PEOPLE.validLeft.nationality)
-    await expect(
+    expect(
       await (await MergePeople.getColumnContent("mid", "Biography")).getText()
     ).to.eq(EXAMPLE_PEOPLE.validLeft.biography)
   })
@@ -247,37 +247,37 @@ describe("Merge people of the same role", () => {
       "Name"
     )
 
-    await expect(
+    expect(
       await (await MergePeople.getColumnContent("mid", "Name")).getText()
     ).to.eq(EXAMPLE_PEOPLE.validRight.name)
-    await expect(
+    expect(
       await (await MergePeople.getColumnContent("mid", "Role")).getText()
     ).to.eq(EXAMPLE_PEOPLE.validRight.role)
-    await expect(
+    expect(
       await (await MergePeople.getColumnContent("mid", "Position")).getText()
     ).to.eq(EXAMPLE_PEOPLE.validRight.position)
-    await expect(await MergePeople.getPreviousPositions("mid")).to.eql(
+    expect(await MergePeople.getPreviousPositions("mid")).to.eql(
       EXAMPLE_PEOPLE.validRight.previousPositions
     )
-    await expect(
+    expect(
       await (await MergePeople.getColumnContent("mid", "Status")).getText()
     ).to.eq(EXAMPLE_PEOPLE.validRight.status)
-    await expect(
+    expect(
       await (await MergePeople.getColumnContent("mid", "Email")).getText()
     ).to.eq(EXAMPLE_PEOPLE.validRight.email)
-    await expect(
+    expect(
       await (await MergePeople.getColumnContent("mid", "Phone")).getText()
     ).to.eq(EXAMPLE_PEOPLE.validRight.phone)
-    await expect(
+    expect(
       await (await MergePeople.getColumnContent("mid", "Rank")).getText()
     ).to.eq(EXAMPLE_PEOPLE.validRight.rank)
-    await expect(
+    expect(
       await (await MergePeople.getColumnContent("mid", "Gender")).getText()
     ).to.eq(EXAMPLE_PEOPLE.validRight.gender)
-    await expect(
+    expect(
       await (await MergePeople.getColumnContent("mid", "Nationality")).getText()
     ).to.eq(EXAMPLE_PEOPLE.validRight.nationality)
-    await expect(
+    expect(
       await (await MergePeople.getColumnContent("mid", "Biography")).getText()
     ).to.eq(EXAMPLE_PEOPLE.validRight.biography)
   })
@@ -288,7 +288,7 @@ describe("Merge people of the same role", () => {
       "mid",
       "Name"
     )
-    await expect(
+    expect(
       await (await MergePeople.getColumnContent("mid", "Name")).getText()
     ).to.eq(EXAMPLE_PEOPLE.validLeft.name)
 
@@ -298,7 +298,7 @@ describe("Merge people of the same role", () => {
       "mid",
       "Role"
     )
-    await expect(
+    expect(
       await (await MergePeople.getColumnContent("mid", "Role")).getText()
     ).to.equal(EXAMPLE_PEOPLE.validLeft.role)
 
@@ -308,7 +308,7 @@ describe("Merge people of the same role", () => {
       "mid",
       "Position"
     )
-    await expect(
+    expect(
       await (await MergePeople.getColumnContent("mid", "Position")).getText()
     ).to.equal(EXAMPLE_PEOPLE.validLeft.position)
 
@@ -318,7 +318,7 @@ describe("Merge people of the same role", () => {
       "mid",
       "Status"
     )
-    await expect(
+    expect(
       await (await MergePeople.getColumnContent("mid", "Status")).getText()
     ).to.equal(EXAMPLE_PEOPLE.validLeft.status)
 
@@ -328,7 +328,7 @@ describe("Merge people of the same role", () => {
       "mid",
       "Email"
     )
-    await expect(
+    expect(
       await (await MergePeople.getColumnContent("mid", "Email")).getText()
     ).to.equal(EXAMPLE_PEOPLE.validLeft.email)
 
@@ -338,7 +338,7 @@ describe("Merge people of the same role", () => {
       "mid",
       "Phone"
     )
-    await expect(
+    expect(
       await (await MergePeople.getColumnContent("mid", "Phone")).getText()
     ).to.equal(EXAMPLE_PEOPLE.validLeft.phone)
 
@@ -348,7 +348,7 @@ describe("Merge people of the same role", () => {
       "mid",
       "Email"
     )
-    await expect(
+    expect(
       await (await MergePeople.getColumnContent("mid", "Email")).getText()
     ).to.equal(EXAMPLE_PEOPLE.validLeft.email)
 
@@ -358,7 +358,7 @@ describe("Merge people of the same role", () => {
       "mid",
       "Rank"
     )
-    await expect(
+    expect(
       await (await MergePeople.getColumnContent("mid", "Rank")).getText()
     ).to.equal(EXAMPLE_PEOPLE.validLeft.rank)
 
@@ -368,7 +368,7 @@ describe("Merge people of the same role", () => {
       "mid",
       "Gender"
     )
-    await expect(
+    expect(
       await (await MergePeople.getColumnContent("mid", "Gender")).getText()
     ).to.equal(EXAMPLE_PEOPLE.validLeft.gender)
 
@@ -378,7 +378,7 @@ describe("Merge people of the same role", () => {
       "mid",
       "Nationality"
     )
-    await expect(
+    expect(
       await (await MergePeople.getColumnContent("mid", "Nationality")).getText()
     ).to.equal(EXAMPLE_PEOPLE.validLeft.nationality)
 
@@ -388,14 +388,14 @@ describe("Merge people of the same role", () => {
       "mid",
       "Biography"
     )
-    await expect(
+    expect(
       await (await MergePeople.getColumnContent("mid", "Biography")).getText()
     ).to.equal(EXAMPLE_PEOPLE.validLeft.biography)
 
     await (
       await MergePeople.getSelectButton("left", "Previous Positions")
     ).click()
-    await expect(await MergePeople.getPreviousPositions("mid")).to.eql(
+    expect(await MergePeople.getPreviousPositions("mid")).to.eql(
       EXAMPLE_PEOPLE.validLeft.previousPositions
     )
   })
@@ -407,7 +407,7 @@ describe("Merge people of the same role", () => {
     await (await MergePeople.getShowNotesButton()).click()
     // Wait for offcanvas to open
     await browser.pause(100)
-    await expect(
+    expect(
       await MergePeople.areNotesExist([
         ...EXAMPLE_PEOPLE.validLeft.notes,
         ...EXAMPLE_PEOPLE.validRight.notes
@@ -417,7 +417,7 @@ describe("Merge people of the same role", () => {
   it("Should be able to delete the loser person", async() => {
     await MergePeople.openPage(`/people/${EXAMPLE_PEOPLE.validRight.perUuid}`)
     await (await MergePeople.getErrorTitle()).waitForExist()
-    await expect(await (await MergePeople.getErrorTitle()).getText()).to.equal(
+    expect(await (await MergePeople.getErrorTitle()).getText()).to.equal(
       `User #${EXAMPLE_PEOPLE.validRight.perUuid} not found.`
     )
   })
@@ -425,7 +425,7 @@ describe("Merge people of the same role", () => {
     await MergePeople.openPage(
       `/positions/${EXAMPLE_PEOPLE.validRight.posUuid}`
     )
-    await expect(
+    expect(
       await (await MergePeople.getUnoccupiedPositionPersonMessage()).getText()
     ).to.equal("Chief of Merge People Test 2 is currently empty.")
   })
@@ -490,37 +490,37 @@ describe("Merge people of different roles", () => {
       "mid",
       "Name"
     )
-    await expect(
+    expect(
       await (await MergePeople.getColumnContent("mid", "Name")).getText()
     ).to.eq(EXAMPLE_PEOPLE.validLeft.name)
-    await expect(
+    expect(
       await (await MergePeople.getColumnContent("mid", "Role")).getText()
     ).to.eq(EXAMPLE_PEOPLE.validLeft.role)
-    await expect(
+    expect(
       await (await MergePeople.getColumnContent("mid", "Position")).getText()
     ).to.eq(EXAMPLE_PEOPLE.validLeft.position)
-    await expect(await MergePeople.getPreviousPositions("mid")).to.eql(
+    expect(await MergePeople.getPreviousPositions("mid")).to.eql(
       EXAMPLE_PEOPLE.validLeft.previousPositions
     )
-    await expect(
+    expect(
       await (await MergePeople.getColumnContent("mid", "Status")).getText()
     ).to.eq(EXAMPLE_PEOPLE.validLeft.status)
-    await expect(
+    expect(
       await (await MergePeople.getColumnContent("mid", "Email")).getText()
     ).to.eq(EXAMPLE_PEOPLE.validLeft.email)
-    await expect(
+    expect(
       await (await MergePeople.getColumnContent("mid", "Phone")).getText()
     ).to.eq(EXAMPLE_PEOPLE.validLeft.phone)
-    await expect(
+    expect(
       await (await MergePeople.getColumnContent("mid", "Rank")).getText()
     ).to.eq(EXAMPLE_PEOPLE.validLeft.rank)
-    await expect(
+    expect(
       await (await MergePeople.getColumnContent("mid", "Gender")).getText()
     ).to.eq(EXAMPLE_PEOPLE.validLeft.gender)
-    await expect(
+    expect(
       await (await MergePeople.getColumnContent("mid", "Nationality")).getText()
     ).to.eq(EXAMPLE_PEOPLE.validLeft.nationality)
-    await expect(
+    expect(
       await (await MergePeople.getColumnContent("mid", "Biography")).getText()
     ).to.eq(EXAMPLE_PEOPLE.validLeft.biography)
   })
@@ -532,42 +532,42 @@ describe("Merge people of different roles", () => {
       "mid",
       "Name"
     )
-    await expect(
+    expect(
       await (await MergePeople.getColumnContent("mid", "Name")).getText()
     ).to.eq(EXAMPLE_PEOPLE.advisorRight.name)
-    await expect(
+    expect(
       await (await MergePeople.getColumnContent("mid", "Role")).getText()
     ).to.eq(EXAMPLE_PEOPLE.advisorRight.role)
-    await expect(
+    expect(
       await (await MergePeople.getColumnContent("mid", "Position")).getText()
     ).to.eq(EXAMPLE_PEOPLE.advisorRight.position)
-    await expect(await MergePeople.getPreviousPositions("mid")).to.eql(
+    expect(await MergePeople.getPreviousPositions("mid")).to.eql(
       EXAMPLE_PEOPLE.advisorRight.previousPositions
     )
-    await expect(
+    expect(
       await (await MergePeople.getColumnContent("mid", "Status")).getText()
     ).to.eq(EXAMPLE_PEOPLE.advisorRight.status)
-    await expect(
+    expect(
       await (await MergePeople.getColumnContent("mid", "Email")).getText()
     ).to.eq(EXAMPLE_PEOPLE.advisorRight.email)
-    await expect(
+    expect(
       await (await MergePeople.getColumnContent("mid", "Phone")).getText()
     ).to.eq(EXAMPLE_PEOPLE.advisorRight.phone)
-    await expect(
+    expect(
       await (await MergePeople.getColumnContent("mid", "Rank")).getText()
     ).to.eq(EXAMPLE_PEOPLE.advisorRight.rank)
-    await expect(
+    expect(
       await (await MergePeople.getColumnContent("mid", "Gender")).getText()
     ).to.eq(EXAMPLE_PEOPLE.advisorRight.gender)
-    await expect(
+    expect(
       await (await MergePeople.getColumnContent("mid", "Nationality")).getText()
     ).to.eq(EXAMPLE_PEOPLE.advisorRight.nationality)
-    await expect(
+    expect(
       await (await MergePeople.getColumnContent("mid", "Biography")).getText()
     ).to.eq(EXAMPLE_PEOPLE.advisorRight.biography)
   })
   it("Should not display clear field buttons on the middle column", async() => {
-    await expect((await MergePeople.getClearValueButtons()).length).to.eq(0)
+    expect((await MergePeople.getClearValueButtons()).length).to.eq(0)
   })
   it("Should not display edit history button on the middle column", async() => {
     await (
@@ -583,7 +583,7 @@ describe("Merge people of different roles", () => {
     // Wait for offcanvas to open
     await browser.pause(100)
     // As validRight and validLeft merged before, notes should include notes from three people
-    await expect(
+    expect(
       await MergePeople.areNotesExist([
         ...EXAMPLE_PEOPLE.validLeft.notes,
         ...EXAMPLE_PEOPLE.validRight.notes,
@@ -594,7 +594,7 @@ describe("Merge people of different roles", () => {
   it("Should be able to delete the loser person", async() => {
     await MergePeople.openPage(`/people/${EXAMPLE_PEOPLE.validLeft.perUuid}`)
     await (await MergePeople.getErrorTitle()).waitForExist()
-    await expect(await (await MergePeople.getErrorTitle()).getText()).to.equal(
+    expect(await (await MergePeople.getErrorTitle()).getText()).to.equal(
       `User #${EXAMPLE_PEOPLE.validLeft.perUuid} not found.`
     )
   })

--- a/client/tests/webdriver/baseSpecs/mergePositions.spec.js
+++ b/client/tests/webdriver/baseSpecs/mergePositions.spec.js
@@ -69,30 +69,30 @@ describe("Merge positions page", () => {
       "left",
       "Name"
     )
-    await expect(
+    expect(
       await (await MergePositions.getColumnContent("left", "Name")).getText()
     ).to.eq(EXAMPLE_POSITIONS.validLeft.fullName)
-    await expect(
+    expect(
       await (
         await MergePositions.getColumnContent("left", "Organization")
       ).getText()
     ).to.eq(EXAMPLE_POSITIONS.validLeft.organization)
-    await expect(
+    expect(
       await (await MergePositions.getColumnContent("left", "Type")).getText()
     ).to.eq(EXAMPLE_POSITIONS.validLeft.type)
-    await expect(
+    expect(
       await (await MergePositions.getColumnContent("left", "Code")).getText()
     ).to.eq(EXAMPLE_POSITIONS.validLeft.code)
-    await expect(
+    expect(
       await (await MergePositions.getColumnContent("left", "Status")).getText()
     ).to.eq(EXAMPLE_POSITIONS.validLeft.status)
-    await expect(
+    expect(
       await (await MergePositions.getColumnContent("left", "Person")).getText()
     ).to.eq(EXAMPLE_POSITIONS.validLeft.person)
-    await expect(await MergePositions.getAssociatedPositions("left")).to.eql(
+    expect(await MergePositions.getAssociatedPositions("left")).to.eql(
       EXAMPLE_POSITIONS.validLeft.associatedPositions
     )
-    await expect(await MergePositions.getPreviousPeople("left")).to.eql(
+    expect(await MergePositions.getPreviousPeople("left")).to.eql(
       EXAMPLE_POSITIONS.validLeft.previousPeople
     )
   })
@@ -134,30 +134,30 @@ describe("Merge positions page", () => {
       "right",
       "Name"
     )
-    await expect(
+    expect(
       await (await MergePositions.getColumnContent("right", "Name")).getText()
     ).to.eq(EXAMPLE_POSITIONS.validRight.fullName)
-    await expect(
+    expect(
       await (
         await MergePositions.getColumnContent("right", "Organization")
       ).getText()
     ).to.eq(EXAMPLE_POSITIONS.validRight.organization)
-    await expect(
+    expect(
       await (await MergePositions.getColumnContent("right", "Type")).getText()
     ).to.eq(EXAMPLE_POSITIONS.validRight.type)
-    await expect(
+    expect(
       await (await MergePositions.getColumnContent("right", "Code")).getText()
     ).to.eq(EXAMPLE_POSITIONS.validRight.code)
-    await expect(
+    expect(
       await (await MergePositions.getColumnContent("right", "Status")).getText()
     ).to.eq(EXAMPLE_POSITIONS.validRight.status)
-    await expect(
+    expect(
       await (await MergePositions.getColumnContent("right", "Person")).getText()
     ).to.eq(EXAMPLE_POSITIONS.validRight.person)
-    await expect(await MergePositions.getAssociatedPositions("right")).to.eql(
+    expect(await MergePositions.getAssociatedPositions("right")).to.eql(
       EXAMPLE_POSITIONS.validRight.associatedPositions
     )
-    await expect(await MergePositions.getPreviousPeople("right")).to.eql(
+    expect(await MergePositions.getPreviousPeople("right")).to.eql(
       EXAMPLE_POSITIONS.validRight.previousPeople
     )
   })
@@ -170,33 +170,33 @@ describe("Merge positions page", () => {
       "mid",
       "Name"
     )
-    await expect(
+    expect(
       await (await MergePositions.getColumnContent("mid", "Name")).getText()
     ).to.eq(EXAMPLE_POSITIONS.validLeft.fullName)
-    await expect(
+    expect(
       await (
         await MergePositions.getColumnContent("mid", "Organization")
       ).getText()
     ).to.eq(EXAMPLE_POSITIONS.validLeft.organization)
-    await expect(
+    expect(
       await (await MergePositions.getColumnContent("mid", "Type")).getText()
     ).to.eq(EXAMPLE_POSITIONS.validLeft.type)
-    await expect(
+    expect(
       await (await MergePositions.getColumnContent("mid", "Code")).getText()
     ).to.eq(EXAMPLE_POSITIONS.validLeft.code)
-    await expect(
+    expect(
       await (await MergePositions.getColumnContent("mid", "Status")).getText()
     ).to.eq(EXAMPLE_POSITIONS.validLeft.status)
-    await expect(
+    expect(
       await (await MergePositions.getColumnContent("mid", "Person")).getText()
     ).to.eq(EXAMPLE_POSITIONS.validLeft.person)
-    await expect(await MergePositions.getAssociatedPositions("mid")).to.eql(
+    expect(await MergePositions.getAssociatedPositions("mid")).to.eql(
       EXAMPLE_POSITIONS.validLeft.associatedPositions
     )
-    await expect(await MergePositions.getPreviousPeople("mid")).to.eql(
+    expect(await MergePositions.getPreviousPeople("mid")).to.eql(
       EXAMPLE_POSITIONS.validLeft.previousPeople
     )
-    await expect(
+    expect(
       await (await MergePositions.getColumnContent("mid", "Location")).getText()
     ).to.eq(EXAMPLE_POSITIONS.validLeft.location)
   })
@@ -209,33 +209,33 @@ describe("Merge positions page", () => {
       "mid",
       "Name"
     )
-    await expect(
+    expect(
       await (await MergePositions.getColumnContent("mid", "Name")).getText()
     ).to.eq(EXAMPLE_POSITIONS.validRight.fullName)
-    await expect(
+    expect(
       await (
         await MergePositions.getColumnContent("mid", "Organization")
       ).getText()
     ).to.eq(EXAMPLE_POSITIONS.validRight.organization)
-    await expect(
+    expect(
       await (await MergePositions.getColumnContent("mid", "Type")).getText()
     ).to.eq(EXAMPLE_POSITIONS.validRight.type)
-    await expect(
+    expect(
       await (await MergePositions.getColumnContent("mid", "Code")).getText()
     ).to.eq(EXAMPLE_POSITIONS.validRight.code)
-    await expect(
+    expect(
       await (await MergePositions.getColumnContent("mid", "Status")).getText()
     ).to.eq(EXAMPLE_POSITIONS.validRight.status)
-    await expect(
+    expect(
       await (await MergePositions.getColumnContent("mid", "Person")).getText()
     ).to.eq(EXAMPLE_POSITIONS.validRight.person)
-    await expect(await MergePositions.getAssociatedPositions("mid")).to.eql(
+    expect(await MergePositions.getAssociatedPositions("mid")).to.eql(
       EXAMPLE_POSITIONS.validRight.associatedPositions
     )
-    await expect(await MergePositions.getPreviousPeople("mid")).to.eql(
+    expect(await MergePositions.getPreviousPeople("mid")).to.eql(
       EXAMPLE_POSITIONS.validRight.previousPeople
     )
-    await expect(
+    expect(
       await (await MergePositions.getColumnContent("mid", "Location")).getText()
     ).to.eq(EXAMPLE_POSITIONS.validRight.location)
   })
@@ -246,7 +246,7 @@ describe("Merge positions page", () => {
       "mid",
       "Name"
     )
-    await expect(
+    expect(
       await (await MergePositions.getColumnContent("mid", "Name")).getText()
     ).to.eq(EXAMPLE_POSITIONS.validLeft.fullName)
 
@@ -256,21 +256,21 @@ describe("Merge positions page", () => {
       "mid",
       "Code"
     )
-    await expect(
+    expect(
       await (await MergePositions.getColumnContent("mid", "Code")).getText()
     ).to.equal(EXAMPLE_POSITIONS.validLeft.code)
 
     await (
       await MergePositions.getSelectButton("left", "Associated Positions")
     ).click()
-    await expect(await MergePositions.getAssociatedPositions("mid")).to.eql(
+    expect(await MergePositions.getAssociatedPositions("mid")).to.eql(
       EXAMPLE_POSITIONS.validLeft.associatedPositions
     )
 
     await (
       await MergePositions.getSelectButton("left", "Previous People")
     ).click()
-    await expect(await MergePositions.getPreviousPeople("mid")).to.eql(
+    expect(await MergePositions.getPreviousPeople("mid")).to.eql(
       EXAMPLE_POSITIONS.validLeft.previousPeople
     )
   })
@@ -286,19 +286,19 @@ describe("Merge positions page", () => {
     await (
       await MergePositions.getEditAssociatedPositionsModal()
     ).waitForDisplayed()
-    await expect(
-      await MergePositions.getAssociatedPositionsInModal("left")
-    ).to.eql(EXAMPLE_POSITIONS.validLeft.associatedPositions)
+    expect(await MergePositions.getAssociatedPositionsInModal("left")).to.eql(
+      EXAMPLE_POSITIONS.validLeft.associatedPositions
+    )
   })
   it("Should display correct values on the right column", async() => {
-    await expect(
-      await MergePositions.getAssociatedPositionsInModal("right")
-    ).to.eql(EXAMPLE_POSITIONS.validRight.associatedPositions)
+    expect(await MergePositions.getAssociatedPositionsInModal("right")).to.eql(
+      EXAMPLE_POSITIONS.validRight.associatedPositions
+    )
   })
   it("Should display left column values on the middle column", async() => {
-    await expect(
-      await MergePositions.getAssociatedPositionsInModal("mid")
-    ).to.eql(await MergePositions.getAssociatedPositionsInModal("left"))
+    expect(await MergePositions.getAssociatedPositionsInModal("mid")).to.eql(
+      await MergePositions.getAssociatedPositionsInModal("left")
+    )
   })
   it("Should be able to remove items from the middle column", async() => {
     const index = 0
@@ -315,15 +315,15 @@ describe("Merge positions page", () => {
     await (
       await MergePositions.getAssociatedPositionActionButton("mid", index)
     ).click()
-    await expect(
-      await MergePositions.getAssociatedPositionsInModal("mid")
-    ).to.eql(afterFirstRemove)
+    expect(await MergePositions.getAssociatedPositionsInModal("mid")).to.eql(
+      afterFirstRemove
+    )
     await (
       await MergePositions.getAssociatedPositionActionButton("mid", index)
     ).click()
-    await expect(
-      await MergePositions.getAssociatedPositionsInModal("mid")
-    ).to.eql(afterSecondRemove)
+    expect(await MergePositions.getAssociatedPositionsInModal("mid")).to.eql(
+      afterSecondRemove
+    )
   })
   it("Should be able to select items from right and left and save", async() => {
     const leftItemIndex = 0
@@ -344,11 +344,11 @@ describe("Merge positions page", () => {
         rightItemIndex
       )
     ).click()
-    await expect(
-      await MergePositions.getAssociatedPositionsInModal("mid")
-    ).to.eql(afterPicked)
+    expect(await MergePositions.getAssociatedPositionsInModal("mid")).to.eql(
+      afterPicked
+    )
     await (await MergePositions.getSaveAssociatedPositionsButton()).click()
-    await expect(await MergePositions.getAssociatedPositions("mid")).to.eql(
+    expect(await MergePositions.getAssociatedPositions("mid")).to.eql(
       afterPicked
     )
   })
@@ -361,7 +361,7 @@ describe("Merge positions page", () => {
       { person: "Unfilled", position: "EF 1.1 Advisor B" },
       { person: "Unfilled", position: "EF 1.1 Advisor D" }
     ]
-    await expect(await MergePositions.getWinnerAssociatedPositions()).to.eql(
+    expect(await MergePositions.getWinnerAssociatedPositions()).to.eql(
       winnerApsAfterMerge
     )
   })
@@ -369,7 +369,7 @@ describe("Merge positions page", () => {
     await (await MergePositions.getShowNotesButton()).click()
     // Wait for offcanvas to open
     await browser.pause(100)
-    await expect(
+    expect(
       await MergePositions.areNotesExist([
         ...EXAMPLE_POSITIONS.validLeft.notes,
         ...EXAMPLE_POSITIONS.validRight.notes
@@ -381,8 +381,8 @@ describe("Merge positions page", () => {
       `/positions/${EXAMPLE_POSITIONS.validRight.posUuid}`
     )
     await (await MergePositions.getErrorTitle()).waitForExist()
-    await expect(
-      await (await MergePositions.getErrorTitle()).getText()
-    ).to.equal(`Position #${EXAMPLE_POSITIONS.validRight.posUuid} not found.`)
+    expect(await (await MergePositions.getErrorTitle()).getText()).to.equal(
+      `Position #${EXAMPLE_POSITIONS.validRight.posUuid} not found.`
+    )
   })
 })

--- a/client/tests/webdriver/baseSpecs/onboardNewUser.spec.js
+++ b/client/tests/webdriver/baseSpecs/onboardNewUser.spec.js
@@ -23,7 +23,7 @@ describe("Onboard new user login", () => {
     await OnboardPage.waitForWelcomeMessage(welcomeText)
 
     const securityText = await (await OnboardPage.getWelcomeText()).getText()
-    await expect(securityText).to.equal(welcomeText)
+    expect(securityText).to.equal(welcomeText)
   })
 
   it("Should click on create your account", async() => {
@@ -34,19 +34,19 @@ describe("Onboard new user login", () => {
     // Check that these are properly copied from the authentication server
     await (await OnboardPage.getLastName()).waitForDisplayed()
     await (await OnboardPage.getLastName()).waitForExist()
-    await expect(await (await OnboardPage.getLastName()).getValue()).to.equal(
+    expect(await (await OnboardPage.getLastName()).getValue()).to.equal(
       ONBOARD_USER.lastName
     )
     await (await OnboardPage.getFirstName()).waitForDisplayed()
     await (await OnboardPage.getFirstName()).waitForExist()
-    await expect(await (await OnboardPage.getFirstName()).getValue()).to.equal(
+    expect(await (await OnboardPage.getFirstName()).getValue()).to.equal(
       ONBOARD_USER.firstName
     )
     await (await OnboardPage.getEmailAddress()).waitForDisplayed()
     await (await OnboardPage.getEmailAddress()).waitForExist()
-    await expect(
-      await (await OnboardPage.getEmailAddress()).getValue()
-    ).to.equal(ONBOARD_USER.emailAddress)
+    expect(await (await OnboardPage.getEmailAddress()).getValue()).to.equal(
+      ONBOARD_USER.emailAddress
+    )
   })
 
   it("Should not save if endOfTourDate is not in the future", async() => {
@@ -66,7 +66,7 @@ describe("Onboard new user login", () => {
       .$("div.invalid-feedback")
     await errorMessage.waitForExist()
     await errorMessage.waitForDisplayed()
-    await expect(await errorMessage.getText()).to.equal(
+    expect(await errorMessage.getText()).to.equal(
       "The End of tour date must be in the future"
     )
   })

--- a/client/tests/webdriver/baseSpecs/printPerson.spec.js
+++ b/client/tests/webdriver/baseSpecs/printPerson.spec.js
@@ -133,7 +133,7 @@ describe("Show person page", () => {
       await (await ShowPerson.getSelectAllButton()).click()
       await (await ShowPerson.getLeftColumnNumber()).setValue(4)
       // Left column contains 2 additional fields name and avatar
-      await expect((await ShowPerson.getLeftTableFields()).length).to.equal(6)
+      expect((await ShowPerson.getLeftTableFields()).length).to.equal(6)
     })
     it("Should return to the show person page when detailed view button clicked", async() => {
       await (await ShowPerson.getDetailedViewButton()).click()

--- a/client/tests/webdriver/baseSpecs/printReport.spec.js
+++ b/client/tests/webdriver/baseSpecs/printReport.spec.js
@@ -30,10 +30,10 @@ describe("Show print report page", () => {
       await detailedViewButton.click()
       await (await ShowReport.getDefaultReportView()).waitForExist()
       await (await ShowReport.getDefaultReportView()).waitForDisplayed()
-      await expect(
-        await (await ShowReport.getCompactView()).isDisplayed()
-      ).to.equal(false)
-      await expect(
+      expect(await (await ShowReport.getCompactView()).isDisplayed()).to.equal(
+        false
+      )
+      expect(
         await (await ShowReport.getCompactViewButton()).isDisplayed()
       ).to.equal(true)
     })
@@ -52,12 +52,12 @@ describe("Show print report page", () => {
         Array.from(fields).map(async field => await field.getText())
       )
       for (const mustHave of mustHaveFieldTexts) {
-        await expect(fieldTexts).to.contain(mustHave)
+        expect(fieldTexts).to.contain(mustHave)
       }
     })
     it("We should see a title with the correct text", async() => {
       const title = await (await ShowReport.getCompactTitle()).getText()
-      await expect(title).to.equal("Summary / Print")
+      expect(title).to.equal("Summary / Print")
     })
     it("We should see buttons with the correct text", async() => {
       const printButtonText = await (
@@ -66,8 +66,8 @@ describe("Show print report page", () => {
       const detailedViewButtonText = await (
         await ShowReport.getDetailedViewButton()
       ).getText()
-      await expect(printButtonText).to.equal("Print")
-      await expect(detailedViewButtonText).to.equal("Detailed View")
+      expect(printButtonText).to.equal("Print")
+      expect(detailedViewButtonText).to.equal("Detailed View")
     })
     it("Printable report banner should be the same as security banner", async() => {
       const compactBannerText = await (
@@ -77,7 +77,7 @@ describe("Show print report page", () => {
       const bannerSecurityText = await (
         await Home.getBannerSecurityText()
       ).getText()
-      await expect(compactBannerText).to.equal(bannerSecurityText)
+      expect(compactBannerText).to.equal(bannerSecurityText)
     })
     it("Should display all attendees", async() => {
       const displayedPrincipals = await ShowReport.getCompactViewElements(
@@ -87,10 +87,10 @@ describe("Show print report page", () => {
         "advisors"
       )
       for (const principal of PRINCIPALS) {
-        await expect(displayedPrincipals).to.contain(principal)
+        expect(displayedPrincipals).to.contain(principal)
       }
       for (const advisor of ADVISORS) {
-        await expect(displayedAdvisors).to.contain(advisor)
+        expect(displayedAdvisors).to.contain(advisor)
       }
     })
     it("Should display all attendees when assessments are shown", async() => {
@@ -100,20 +100,20 @@ describe("Show print report page", () => {
         true
       )
       for (const principal of PRINCIPALS) {
-        await expect(displayedPrincipals).to.contain(principal)
+        expect(displayedPrincipals).to.contain(principal)
       }
       const displayedAdvisors = await ShowReport.getCompactViewElements(
         "advisors",
         true
       )
       for (const advisor of ADVISORS) {
-        await expect(displayedAdvisors).to.contain(advisor)
+        expect(displayedAdvisors).to.contain(advisor)
       }
     })
     it("Should display all tasks", async() => {
       const displayedTasks = await ShowReport.getCompactViewElements("tasks")
       for (const task of TASKS) {
-        await expect(displayedTasks).to.contain(task)
+        expect(displayedTasks).to.contain(task)
       }
     })
     it("Should display all tasks when assessments are shown", async() => {
@@ -123,7 +123,7 @@ describe("Show print report page", () => {
         true
       )
       for (const task of TASKS) {
-        await expect(displayedTasks).to.contain(task)
+        expect(displayedTasks).to.contain(task)
       }
     })
   })

--- a/client/tests/webdriver/baseSpecs/richTextField.spec.js
+++ b/client/tests/webdriver/baseSpecs/richTextField.spec.js
@@ -56,7 +56,7 @@ describe("When reports have rich text content", () => {
       index,
       content
     } of RICH_TEXT_CONTENT) {
-      await expect(
+      expect(
         await (
           await getRichTextContent(
             await ShowReport.getReportText(),
@@ -76,7 +76,7 @@ describe("When reports have rich text content", () => {
       index,
       content
     } of RICH_TEXT_CONTENT) {
-      await expect(
+      expect(
         await (
           await getRichTextContent(
             await EditReport.getReportText(),

--- a/client/tests/webdriver/baseSpecs/unpublishReport.spec.js
+++ b/client/tests/webdriver/baseSpecs/unpublishReport.spec.js
@@ -15,9 +15,9 @@ describe("When unpublishing a report", () => {
     it("Should unpublish the report successfully", async() => {
       const unpublishedReportUuid = await ShowReport.getUuid()
       await EditReport.unpublishReport(unpublishedReportUuid)
-      await expect(
-        await (await EditReport.getAlertSuccess()).getText()
-      ).to.equal("Report unpublished")
+      expect(await (await EditReport.getAlertSuccess()).getText()).to.equal(
+        "Report unpublished"
+      )
     })
   })
 })

--- a/client/tests/webdriver/baseSpecs/userLogin.spec.js
+++ b/client/tests/webdriver/baseSpecs/userLogin.spec.js
@@ -8,24 +8,24 @@ describe("Anet home page", () => {
     await (await Home.getLogoutButton()).waitForDisplayed()
     await (await Home.getLogoutButton()).click()
     const title = await browser.getTitle()
-    await expect(title).to.equal("ANET Sign Out")
+    expect(title).to.equal("ANET Sign Out")
     await (await Home.getLoginButton()).waitForDisplayed()
     await (await Home.getLoginButton()).click()
     const titleLogin = await browser.getTitle()
-    await expect(titleLogin).to.equal("Sign in to ANET")
+    expect(titleLogin).to.equal("Sign in to ANET")
   })
   it("should have the right title", async() => {
     await Home.open()
     await browser.pause(5000) // Wait until the title is set
     const title = await browser.getTitle()
-    await expect(title).to.equal("Home - ANET")
+    expect(title).to.equal("Home - ANET")
     await Home.logout()
   })
   it("should have the right security marking", async() => {
     await Home.open()
     const securityMarking = await (await Home.getBannerSecurityText()).getText()
     const defaultSecurityMarking = "DEMO USE ONLY Releasable to DEMO MISSION"
-    await expect(securityMarking).to.equal(defaultSecurityMarking)
+    expect(securityMarking).to.equal(defaultSecurityMarking)
     await Home.logout()
   })
 })
@@ -35,7 +35,7 @@ describe("Anet default user login", () => {
     await Home.open()
     const bannerUser = await (await Home.getBannerUser()).getText()
     const defaultUserValue = "ERINSON, Erin"
-    await expect(bannerUser).to.equal(defaultUserValue)
+    expect(bannerUser).to.equal(defaultUserValue)
     await Home.logout()
   })
 })
@@ -45,7 +45,7 @@ describe("Anet superuser login", () => {
     await Home.openAsSuperuser()
     const bannerUser = await (await Home.getBannerUser()).getText()
     const superuserValue = "BECCABON, Rebecca"
-    await expect(bannerUser).to.equal(superuserValue)
+    expect(bannerUser).to.equal(superuserValue)
     await Home.logout()
   })
 })
@@ -55,7 +55,7 @@ describe("Anet admin user login", () => {
     await Home.openAsAdminUser()
     const bannerUser = await (await Home.getBannerUser()).getText()
     const adminUserValue = "DMIN, Arthur"
-    await expect(bannerUser).to.equal(adminUserValue)
+    expect(bannerUser).to.equal(adminUserValue)
     await Home.logout()
   })
 })

--- a/client/tests/webdriver/customFieldsSpecs/createFutureReport.spec.js
+++ b/client/tests/webdriver/customFieldsSpecs/createFutureReport.spec.js
@@ -33,7 +33,7 @@ describe("Create report form page", () => {
         CreateFutureReport.getAttendeesFieldAdvancedSelectFirstItem(),
         PRINCIPAL_VALUE
       )
-      await expect(
+      expect(
         await (
           await CreateFutureReport.getAttendeesFieldAdvancedSelectFirstItem()
         ).getText()
@@ -52,7 +52,7 @@ describe("Create report form page", () => {
         await (await CreateFutureReport.getAttendeesFieldValue()).isExisting()
       ).to.be.true
       /* eslint-enable no-unused-expressions */
-      await expect(
+      expect(
         await (await CreateFutureReport.getAttendeesFieldValueRow(2)).getText()
       ).to.include(PRINCIPAL_VALUE)
 
@@ -63,7 +63,7 @@ describe("Create report form page", () => {
         CreateFutureReport.getTasksFieldAdvancedSelectFirstItem(),
         TASK_VALUE
       )
-      await expect(
+      expect(
         await (
           await CreateFutureReport.getTasksFieldAdvancedSelectFirstItem()
         ).getText()
@@ -81,7 +81,7 @@ describe("Create report form page", () => {
       expect(await (await CreateFutureReport.getTasksFieldValue()).isExisting())
         .to.be.true
       /* eslint-enable no-unused-expressions */
-      await expect(
+      expect(
         await (await CreateFutureReport.getTasksFieldValueRow(1)).getText()
       ).to.include(TASK_VALUE)
     })
@@ -101,9 +101,9 @@ describe("Create report form page", () => {
       // Save report
       await CreateFutureReport.submitForm()
       await CreateFutureReport.waitForAlertToLoad()
-      await expect(
-        await (await CreateFutureReport.getAlert()).getText()
-      ).to.include("The following errors must be fixed")
+      expect(await (await CreateFutureReport.getAlert()).getText()).to.include(
+        "The following errors must be fixed"
+      )
 
       /* eslint-disable no-unused-expressions */
       // Attendee assessments should not be shown in the display
@@ -154,9 +154,9 @@ describe("Create report form page", () => {
       // Save report
       await CreateFutureReport.submitForm()
       await CreateFutureReport.waitForAlertToLoad()
-      await expect(
-        await (await CreateFutureReport.getAlert()).getText()
-      ).to.include("The following errors must be fixed")
+      expect(await (await CreateFutureReport.getAlert()).getText()).to.include(
+        "The following errors must be fixed"
+      )
 
       /* eslint-disable no-unused-expressions */
       // Attendee assessments should be shown in the display
@@ -210,9 +210,7 @@ describe("Create report form page", () => {
       // Save report
       await CreateFutureReport.submitForm()
       await CreateFutureReport.waitForAlertToLoad()
-      await expect(
-        await (await CreateFutureReport.getAlert()).getText()
-      ).to.include(
+      expect(await (await CreateFutureReport.getAlert()).getText()).to.include(
         "You'll need to fill out these required fields before you can submit your final planned engagement"
       )
 
@@ -248,9 +246,9 @@ describe("Create report form page", () => {
       await browser.pause(SHORT_WAIT_MS) // wait for the modal to slide out (transition is 300 ms)
       // Report should be deleted
       await CreateFutureReport.waitForAlertToLoad()
-      await expect(
-        await (await CreateFutureReport.getAlert()).getText()
-      ).to.include("Report deleted")
+      expect(await (await CreateFutureReport.getAlert()).getText()).to.include(
+        "Report deleted"
+      )
     })
   })
 })

--- a/client/tests/webdriver/customFieldsSpecs/createReport.spec.js
+++ b/client/tests/webdriver/customFieldsSpecs/createReport.spec.js
@@ -72,19 +72,19 @@ describe("Create report form page", () => {
     it("Should be able to select an ANET object reference", async() => {
       await (await CreateReport.getTestReferenceFieldLabel()).waitForExist()
       await (await CreateReport.getTestReferenceFieldLabel()).waitForDisplayed()
-      await expect(
+      expect(
         await (await CreateReport.getTestReferenceFieldLabel()).getText()
       ).to.equal("Related report")
       await (await CreateReport.getTestReferenceFieldHelpText()).waitForExist()
       await (
         await CreateReport.getTestReferenceFieldHelpText()
       ).waitForDisplayed()
-      await expect(
+      expect(
         await (await CreateReport.getTestReferenceFieldHelpText()).getText()
       ).to.equal("Here you can link to a related report")
 
       // Only input type is Reports, so there should be no button to select a type
-      await expect(
+      expect(
         await (
           await CreateReport.getTestReferenceField()
         ).getAttribute("placeholder")
@@ -103,7 +103,7 @@ describe("Create report form page", () => {
         CreateReport.getTestReferenceFieldAdvancedSelectFirstItem(),
         REPORT_COMPLETE
       )
-      await expect(
+      expect(
         await (
           await CreateReport.getTestReferenceFieldAdvancedSelectFirstItem()
         ).getText()
@@ -120,7 +120,7 @@ describe("Create report form page", () => {
       expect(
         await (await CreateReport.getTestReferenceFieldValue()).isExisting()
       ).to.be.true
-      await expect(
+      expect(
         await (await CreateReport.getTestReferenceFieldValue()).getText()
       ).to.include(REPORT_VALUE)
 
@@ -152,7 +152,7 @@ describe("Create report form page", () => {
       await (
         await CreateReport.getTestMultiReferenceFieldLabel()
       ).waitForDisplayed()
-      await expect(
+      expect(
         await (await CreateReport.getTestMultiReferenceFieldLabel()).getText()
       ).to.equal("Additional engagement needed for")
       await (
@@ -161,7 +161,7 @@ describe("Create report form page", () => {
       await (
         await CreateReport.getTestMultiReferenceFieldHelpText()
       ).waitForDisplayed()
-      await expect(
+      expect(
         await (
           await CreateReport.getTestMultiReferenceFieldHelpText()
         ).getText()
@@ -170,7 +170,7 @@ describe("Create report form page", () => {
       )
 
       // Default input type is People
-      await expect(
+      expect(
         await (
           await CreateReport.getTestMultiReferenceField()
         ).getAttribute("placeholder")
@@ -181,7 +181,7 @@ describe("Create report form page", () => {
         CreateReport.getTestMultiReferenceFieldAdvancedSelectItemLabel(1),
         PERSON_COMPLETE_1
       )
-      await expect(
+      expect(
         await (
           await CreateReport.getTestMultiReferenceFieldAdvancedSelectItemLabel(
             1
@@ -191,7 +191,7 @@ describe("Create report form page", () => {
       await (
         await CreateReport.getTestMultiReferenceFieldAdvancedSelectItem(1)
       ).click()
-      await expect(
+      expect(
         await (
           await CreateReport.getTestMultiReferenceFieldAdvancedSelectItemLabel(
             2
@@ -214,12 +214,12 @@ describe("Create report form page", () => {
           await CreateReport.getTestMultiReferenceFieldValue()
         ).isExisting()
       ).to.be.true
-      await expect(
+      expect(
         await (
           await CreateReport.getTestMultiReferenceFieldValueRow(1)
         ).getText()
       ).to.include(PERSON_VALUE_1)
-      await expect(
+      expect(
         await (
           await CreateReport.getTestMultiReferenceFieldValueRow(2)
         ).getText()
@@ -231,7 +231,7 @@ describe("Create report form page", () => {
           await CreateReport.getTestMultiReferenceFieldFormGroup()
         ).$('//button[text()="Positions"]')
       ).click()
-      await expect(
+      expect(
         await (
           await CreateReport.getTestMultiReferenceField()
         ).getAttribute("placeholder")
@@ -242,7 +242,7 @@ describe("Create report form page", () => {
         CreateReport.getTestMultiReferenceFieldAdvancedSelectItemLabel(1),
         POSITION_COMPLETE_1
       )
-      await expect(
+      expect(
         await (
           await CreateReport.getTestMultiReferenceFieldAdvancedSelectItemLabel(
             1
@@ -252,7 +252,7 @@ describe("Create report form page", () => {
       await (
         await CreateReport.getTestMultiReferenceFieldAdvancedSelectItem(1)
       ).click()
-      await expect(
+      expect(
         await (
           await CreateReport.getTestMultiReferenceFieldAdvancedSelectItemLabel(
             2
@@ -262,7 +262,7 @@ describe("Create report form page", () => {
       await (
         await CreateReport.getTestMultiReferenceFieldAdvancedSelectItem(2)
       ).click()
-      await expect(
+      expect(
         await (
           await CreateReport.getTestMultiReferenceFieldAdvancedSelectItemLabel(
             3
@@ -285,24 +285,24 @@ describe("Create report form page", () => {
           await CreateReport.getTestMultiReferenceFieldValue()
         ).isExisting()
       ).to.be.true
-      await expect(
+      expect(
         await (
           await CreateReport.getTestMultiReferenceFieldValueRow(3)
         ).getText()
       ).to.include(POSITION_VALUE_1)
-      await expect(
+      expect(
         await (
           await CreateReport.getTestMultiReferenceFieldValueRow(4)
         ).getText()
       ).to.include(POSITION_VALUE_2)
-      await expect(
+      expect(
         await (
           await CreateReport.getTestMultiReferenceFieldValueRow(5)
         ).getText()
       ).to.include(POSITION_VALUE_3)
 
       // Should have 5 values
-      await expect(
+      expect(
         await CreateReport.getTestMultiReferenceFieldValueRows()
       ).to.have.lengthOf(5)
       // Delete one of the selected values
@@ -312,11 +312,11 @@ describe("Create report form page", () => {
         ).$("button")
       ).click()
       // Should have only 4 values left
-      await expect(
+      expect(
         await CreateReport.getTestMultiReferenceFieldValueRows()
       ).to.have.lengthOf(4)
       // 3rd value should have changed
-      await expect(
+      expect(
         await (
           await CreateReport.getTestMultiReferenceFieldValueRow(3)
         ).getText()
@@ -327,14 +327,14 @@ describe("Create report form page", () => {
       // Submit the report
       await CreateReport.submitForm()
       await CreateReport.waitForAlertToLoad()
-      await expect(await (await CreateReport.getAlert()).getText()).to.include(
+      expect(await (await CreateReport.getAlert()).getText()).to.include(
         "The following errors must be fixed"
       )
 
       // Check ANET object reference
       await (await CreateReport.getTestReferenceFieldLabel()).waitForExist()
       await (await CreateReport.getTestReferenceFieldLabel()).waitForDisplayed()
-      await expect(
+      expect(
         await (await CreateReport.getTestReferenceFieldValue()).getText()
       ).to.include(REPORT_VALUE)
 
@@ -345,25 +345,25 @@ describe("Create report form page", () => {
       await (
         await CreateReport.getTestMultiReferenceFieldLabel()
       ).waitForDisplayed()
-      await expect(
+      expect(
         await CreateReport.getTestMultiReferenceFieldValueRows()
       ).to.have.lengthOf(4)
-      await expect(
+      expect(
         await (
           await CreateReport.getTestMultiReferenceFieldValueRow(1)
         ).getText()
       ).to.include(PERSON_VALUE_1)
-      await expect(
+      expect(
         await (
           await CreateReport.getTestMultiReferenceFieldValueRow(2)
         ).getText()
       ).to.include(PERSON_VALUE_2)
-      await expect(
+      expect(
         await (
           await CreateReport.getTestMultiReferenceFieldValueRow(3)
         ).getText()
       ).to.include(POSITION_VALUE_2)
-      await expect(
+      expect(
         await (
           await CreateReport.getTestMultiReferenceFieldValueRow(4)
         ).getText()
@@ -377,13 +377,13 @@ describe("Create report form page", () => {
       await (await CreateReport.getTestReferenceFieldLabel()).waitForExist()
       await (await CreateReport.getTestReferenceFieldLabel()).waitForDisplayed()
       // Default input type is People
-      await expect(
+      expect(
         await (
           await CreateReport.getTestReferenceField()
         ).getAttribute("placeholder")
       ).to.equal("Find reports")
       // Check ANET object reference
-      await expect(
+      expect(
         await (await CreateReport.getTestReferenceFieldValue()).getText()
       ).to.include(REPORT_VALUE)
       // Delete selected value
@@ -402,31 +402,31 @@ describe("Create report form page", () => {
         await CreateReport.getTestMultiReferenceFieldLabel()
       ).scrollIntoView()
       // Default input type is People
-      await expect(
+      expect(
         await (
           await CreateReport.getTestMultiReferenceField()
         ).getAttribute("placeholder")
       ).to.equal("Find people")
       // Check ANET object multi-references
-      await expect(
+      expect(
         await CreateReport.getTestMultiReferenceFieldValueRows()
       ).to.have.lengthOf(4)
-      await expect(
+      expect(
         await (
           await CreateReport.getTestMultiReferenceFieldValueRow(1)
         ).getText()
       ).to.include(PERSON_VALUE_1)
-      await expect(
+      expect(
         await (
           await CreateReport.getTestMultiReferenceFieldValueRow(2)
         ).getText()
       ).to.include(PERSON_VALUE_2)
-      await expect(
+      expect(
         await (
           await CreateReport.getTestMultiReferenceFieldValueRow(3)
         ).getText()
       ).to.include(POSITION_VALUE_2)
-      await expect(
+      expect(
         await (
           await CreateReport.getTestMultiReferenceFieldValueRow(4)
         ).getText()
@@ -445,9 +445,7 @@ describe("Create report form page", () => {
       await CreateReport.submitForm()
       await CreateReport.waitForAlertToLoad()
       const alertMessage = await (await CreateReport.getAlert()).getText()
-      await expect(alertMessage).to.include(
-        "The following errors must be fixed"
-      )
+      expect(alertMessage).to.include("The following errors must be fixed")
 
       // Check ANET object reference
       await (await CreateReport.getTestReferenceFieldLabel()).waitForExist()
@@ -490,7 +488,7 @@ describe("Create report form page", () => {
       await browser.pause(SHORT_WAIT_MS) // wait for the modal to slide out (transition is 300 ms)
       // Report should be deleted
       await CreateReport.waitForAlertToLoad()
-      await expect(await (await CreateReport.getAlert()).getText()).to.include(
+      expect(await (await CreateReport.getAlert()).getText()).to.include(
         "Report deleted"
       )
     })

--- a/client/tests/webdriver/customFieldsSpecs/customFields.spec.js
+++ b/client/tests/webdriver/customFieldsSpecs/customFields.spec.js
@@ -25,13 +25,13 @@ describe("When working with custom fields for different anet objects", () => {
       const toggleFields =
         await CreateReport.getFieldsToggledVisibilityByTrainButton()
       for (const invisField of toggleFields) {
-        await expect(await invisField.isExisting()).to.equal(false)
+        expect(await invisField.isExisting()).to.equal(false)
       }
 
       const notToggleFields =
         await CreateReport.getFieldsNotToggledVisibilityByTrainButton()
       for (const invisField of notToggleFields) {
-        await expect(await invisField.isExisting()).to.equal(false)
+        expect(await invisField.isExisting()).to.equal(false)
       }
     })
 
@@ -54,7 +54,7 @@ describe("When working with custom fields for different anet objects", () => {
       const notToggleFields =
         await CreateReport.getFieldsNotToggledVisibilityByTrainButton()
       for (const stillInvisField of notToggleFields) {
-        await expect(await stillInvisField.isExisting()).to.equal(false)
+        expect(await stillInvisField.isExisting()).to.equal(false)
       }
     })
 
@@ -74,7 +74,7 @@ describe("When working with custom fields for different anet objects", () => {
       await trainButton.click()
       await (await CreateReport.getNumberTrainedFormGroup()).waitForExist()
 
-      await expect(
+      expect(
         await (await CreateReport.getNumberTrainedField()).getValue()
       ).to.equal(VALID_NUMBER_INPUT)
     })
@@ -86,7 +86,7 @@ describe("When working with custom fields for different anet objects", () => {
       ).setValue(INVALID_NUMBER_INPUT)
       await (await CreateReport.getNumberTrainedErrorText()).waitForExist()
       // Actually see the validation warning
-      await expect(
+      expect(
         await (await CreateReport.getNumberTrainedErrorText()).getText()
       ).to.equal("Number trained must be greater than or equal to 1")
       const trainButton = await CreateReport.getEngagementTypesButtonByName(
@@ -101,7 +101,7 @@ describe("When working with custom fields for different anet objects", () => {
       await trainButton.click()
       await (await CreateReport.getNumberTrainedFormGroup()).waitForExist()
 
-      await expect(
+      expect(
         await (await CreateReport.getNumberTrainedField()).getValue()
       ).to.equal(INVALID_NUMBER_INPUT)
     })
@@ -112,13 +112,13 @@ describe("When working with custom fields for different anet objects", () => {
         await CreateReport.getNumberTrainedField()
       ).setValue(INVALID_NUMBER_INPUT)
       await (await CreateReport.getNumberTrainedErrorText()).waitForExist()
-      await expect(
+      expect(
         await (await CreateReport.getNumberTrainedErrorText()).getText()
       ).to.include("Number trained must be greater than or equal to 1")
       await CreateReport.submitForm()
       await CreateReport.waitForAlertToLoad()
 
-      await expect(await (await CreateReport.getAlert()).getText()).to.include(
+      expect(await (await CreateReport.getAlert()).getText()).to.include(
         "Number trained must be greater than or equal to 1"
       )
     })
@@ -138,9 +138,9 @@ describe("When working with custom fields for different anet objects", () => {
       await CreateReport.submitForm()
       await CreateReport.waitForAlertToLoad()
 
-      await expect(
-        await (await CreateReport.getAlert()).getText()
-      ).to.not.include("Number trained must be greater than or equal to 1")
+      expect(await (await CreateReport.getAlert()).getText()).to.not.include(
+        "Number trained must be greater than or equal to 1"
+      )
     })
 
     it("Should show valid visible field after saving", async() => {
@@ -163,7 +163,7 @@ describe("When working with custom fields for different anet objects", () => {
       await CreateReport.submitForm()
       await CreateReport.waitForAlertToLoad()
 
-      await expect(
+      expect(
         await (await CreateReport.getNumberTrainedFieldShowed()).getText()
       ).to.include(VALID_NUMBER_INPUT.toString())
     })
@@ -186,7 +186,7 @@ describe("When working with custom fields for different anet objects", () => {
       await CreateReport.submitForm()
       await CreateReport.waitForAlertToLoad()
 
-      await expect(
+      expect(
         await (await CreateReport.getNumberTrainedFieldShowed()).getText()
       ).to.not.include(VALID_NUMBER_INPUT.toString())
     })
@@ -216,7 +216,7 @@ describe("When working with custom fields for different anet objects", () => {
     it("Should not show default invisible fields", async() => {
       const fields = await CreatePerson.getDefaultInvisibleCustomFields()
       for (const field of fields) {
-        await expect(await field.isExisting()).to.eq(false)
+        expect(await field.isExisting()).to.eq(false)
       }
       // Date field is invisible by default
       await (await CreatePerson.getAddArrayObjectButton()).click()
@@ -251,7 +251,7 @@ describe("When working with custom fields for different anet objects", () => {
       await (await CreatePerson.getGreenButton()).click()
       await (await CreatePerson.getNumberCustomFieldContainer()).waitForExist()
 
-      await expect(
+      expect(
         await (await CreatePerson.getNumberCustomField()).getValue()
       ).be.equal(VALID_NUMBER_INPUT)
     })
@@ -274,7 +274,7 @@ describe("When working with custom fields for different anet objects", () => {
       await (await CreatePerson.getGreenButton()).click()
       await (await CreatePerson.getNumberCustomFieldContainer()).waitForExist()
 
-      await expect(
+      expect(
         await (await CreatePerson.getNumberCustomField()).getValue()
       ).to.equal(INVALID_NUMBER_INPUT)
     })
@@ -285,7 +285,7 @@ describe("When working with custom fields for different anet objects", () => {
         await CreatePerson.getNumberCustomField()
       ).setValue(INVALID_NUMBER_INPUT)
       await (await CreatePerson.getNumberCustomFieldHelpText()).waitForExist()
-      await expect(
+      expect(
         await (await CreatePerson.getNumberCustomFieldHelpText()).getText()
       ).to.include("greater than")
     })

--- a/client/tests/webdriver/customFieldsSpecs/customSensitiveFields.spec.js
+++ b/client/tests/webdriver/customFieldsSpecs/customSensitiveFields.spec.js
@@ -53,7 +53,7 @@ describe("Visibility of custom sensitive information", () => {
     })
     it("Should be able to see birthday field with the correct value if authorized", async() => {
       await (await ShowPerson.getBirthday()).waitForDisplayed()
-      await expect(await (await ShowPerson.getBirthday()).getText()).to.equal(
+      expect(await (await ShowPerson.getBirthday()).getText()).to.equal(
         NON_COUNTERPART_PRINCIPLE.birthday
       )
     })
@@ -69,13 +69,13 @@ describe("Visibility of custom sensitive information", () => {
     })
     it("Should be able to see political position field with the correct value if counterpart", async() => {
       await (await ShowPerson.getPoliticalPosition()).waitForDisplayed()
-      await expect(
+      expect(
         await (await ShowPerson.getPoliticalPosition()).getText()
       ).to.equal(COUNTERPART_PRINCIPLE.politicalPosition)
     })
     it("Should be able to see birthday field with the correct value if counterpart", async() => {
       await (await ShowPerson.getBirthday()).waitForDisplayed()
-      await expect(await (await ShowPerson.getBirthday()).getText()).to.equal(
+      expect(await (await ShowPerson.getBirthday()).getText()).to.equal(
         COUNTERPART_PRINCIPLE.birthday
       )
     })
@@ -107,7 +107,7 @@ describe("Visibility of custom sensitive information", () => {
     })
     it("Should be able to see birthday field with the correct value if authorized", async() => {
       await (await ShowPerson.getBirthday()).waitForDisplayed()
-      await expect(await (await ShowPerson.getBirthday()).getText()).to.equal(
+      expect(await (await ShowPerson.getBirthday()).getText()).to.equal(
         NON_COUNTERPART_PRINCIPLE.birthday
       )
     })
@@ -131,13 +131,13 @@ describe("Visibility of custom sensitive information", () => {
     })
     it("Should be able to see political position field with the correct value", async() => {
       await (await ShowPerson.getPoliticalPosition()).waitForDisplayed()
-      await expect(
+      expect(
         await (await ShowPerson.getPoliticalPosition()).getText()
       ).to.equal(NON_COUNTERPART_PRINCIPLE.politicalPosition)
     })
     it("Should be able to see birthday field with the correct value", async() => {
       await (await ShowPerson.getBirthday()).waitForDisplayed()
-      await expect(await (await ShowPerson.getBirthday()).getText()).to.equal(
+      expect(await (await ShowPerson.getBirthday()).getText()).to.equal(
         NON_COUNTERPART_PRINCIPLE.birthday
       )
     })
@@ -178,7 +178,7 @@ describe("Creating and editing custom sensitive information", () => {
       await (await CreatePerson.getLastName()).click()
       await CreatePerson.submitForm()
       await CreatePerson.waitForAlertSuccessToLoad()
-      await expect(await (await ShowPerson.getBirthday()).getText()).to.equal(
+      expect(await (await ShowPerson.getBirthday()).getText()).to.equal(
         "8 June 1963"
       )
     })
@@ -191,7 +191,7 @@ describe("Creating and editing custom sensitive information", () => {
       await (await CreatePerson.getLastName()).click()
       await CreatePerson.submitForm()
       await CreatePerson.waitForAlertSuccessToLoad()
-      await expect(await (await ShowPerson.getBirthday()).getText()).to.equal(
+      expect(await (await ShowPerson.getBirthday()).getText()).to.equal(
         "1 January 1956"
       )
     })
@@ -223,10 +223,10 @@ describe("Creating and editing custom sensitive information", () => {
       await (await CreatePerson.getMiddleButton()).click()
       await CreatePerson.submitForm()
       await CreatePerson.waitForAlertSuccessToLoad()
-      await expect(await (await ShowPerson.getBirthday()).getText()).to.equal(
+      expect(await (await ShowPerson.getBirthday()).getText()).to.equal(
         "1 January 1956"
       )
-      await expect(
+      expect(
         await (await ShowPerson.getPoliticalPosition()).getText()
       ).to.equal("Middle")
     })
@@ -240,10 +240,10 @@ describe("Creating and editing custom sensitive information", () => {
       await (await CreatePerson.getLeftButton()).click()
       await CreatePerson.submitForm()
       await CreatePerson.waitForAlertSuccessToLoad()
-      await expect(await (await ShowPerson.getBirthday()).getText()).to.equal(
+      expect(await (await ShowPerson.getBirthday()).getText()).to.equal(
         "8 June 1963"
       )
-      await expect(
+      expect(
         await (await ShowPerson.getPoliticalPosition()).getText()
       ).to.equal("Left")
     })

--- a/client/tests/webdriver/customFieldsSpecs/myOrg.spec.js
+++ b/client/tests/webdriver/customFieldsSpecs/myOrg.spec.js
@@ -27,7 +27,7 @@ describe("My Organization page", () => {
         await MyOrg.getEngagementDateStatistics()
       ).$$(".fc-event-title-container")
       // There is at least one date with events in the calendar
-      await expect(daysWithEvent).to.have.length.above(0)
+      expect(daysWithEvent).to.have.length.above(0)
 
       // Location statistics map is being loaded
       await (await MyOrg.getLocationStatistics()).waitForDisplayed()
@@ -50,7 +50,7 @@ describe("My Organization page", () => {
         }
       }
       // There is at least one bar
-      await expect(countTasksBars).to.be.above(0)
+      expect(countTasksBars).to.be.above(0)
 
       await (await MyOrg.getTrainingEvent()).waitForDisplayed()
       // There are 3 training event options
@@ -62,11 +62,11 @@ describe("My Organization page", () => {
       const trainignEventTotal = await (
         await MyOrg.getTrainingEvent()
       ).$("svg g text")
-      await expect(+(await trainignEventTotal.getText())).to.be.above(0)
+      expect(+(await trainignEventTotal.getText())).to.be.above(0)
 
       await (await MyOrg.getNumberTrained()).waitForDisplayed()
       const numberTrained = await (await MyOrg.getNumberTrained()).$("div em")
-      await expect(await numberTrained.getText()).to.equal("Not specified")
+      expect(await numberTrained.getText()).to.equal("Not specified")
     })
   })
 })

--- a/client/tests/webdriver/customFieldsSpecs/notifications.spec.js
+++ b/client/tests/webdriver/customFieldsSpecs/notifications.spec.js
@@ -14,7 +14,7 @@ describe("Home page", () => {
       await (await Home.getMyCounterpartsLink()).waitForDisplayed()
       await (await Home.getMyTasksLink()).waitForDisplayed()
       await browser.pause(1000)
-      await expect(
+      expect(
         await (await Home.getMyCounterpartsNotifications()).getText()
       ).to.equal("1")
       // eslint-disable-next-line no-unused-expressions
@@ -30,9 +30,9 @@ describe("Home page", () => {
       // eslint-disable-next-line no-unused-expressions
       expect(await (await Home.getMyCounterpartsNotifications()).isExisting())
         .to.be.false
-      await expect(
-        await (await Home.getMyTasksNotifications()).getText()
-      ).to.equal("1")
+      expect(await (await Home.getMyTasksNotifications()).getText()).to.equal(
+        "1"
+      )
     })
     it("Should see that Jack has no counterpart and 1 task with pending assessments", async() => {
       await Home.open("/", "jack")
@@ -43,9 +43,9 @@ describe("Home page", () => {
       // eslint-disable-next-line no-unused-expressions
       expect(await (await Home.getMyCounterpartsNotifications()).isExisting())
         .to.be.false
-      await expect(
-        await (await Home.getMyTasksNotifications()).getText()
-      ).to.equal("1")
+      expect(await (await Home.getMyTasksNotifications()).getText()).to.equal(
+        "1"
+      )
     })
     it("Should see that Nick has no counterparts and no tasks with pending assessments", async() => {
       await Home.open("/", "nick")

--- a/client/tests/webdriver/customFieldsSpecs/pendingAssessments.spec.js
+++ b/client/tests/webdriver/customFieldsSpecs/pendingAssessments.spec.js
@@ -273,7 +273,7 @@ describe("In new report page", () => {
             )
             break
           default:
-            await expect.fail("unexpected task")
+            expect.fail("unexpected task")
             break
         }
       }
@@ -313,7 +313,7 @@ describe("In new report page", () => {
             expect(questions).to.have.length(1)
             break
           default:
-            await expect.fail("unexpected attendee")
+            expect.fail("unexpected attendee")
             break
         }
         expect(await questions[0].getAttribute("id")).to.match(/\.question1$/)
@@ -341,7 +341,7 @@ describe("In new report page", () => {
             expect(questions).to.have.length(2)
             break
           default:
-            await expect.fail("unexpected attendee")
+            expect.fail("unexpected attendee")
             break
         }
         expect(
@@ -366,9 +366,9 @@ describe("In new report page", () => {
         await browser.pause(SHORT_WAIT_MS) // wait for the modal to slide out (transition is 300 ms)
         // Report should be deleted
         await CreateReport.waitForAlertToLoad()
-        await expect(
-          await (await CreateReport.getAlert()).getText()
-        ).to.include("Report deleted")
+        expect(await (await CreateReport.getAlert()).getText()).to.include(
+          "Report deleted"
+        )
       }
     })
   })

--- a/client/tests/webdriver/customFieldsSpecs/showTask.spec.js
+++ b/client/tests/webdriver/customFieldsSpecs/showTask.spec.js
@@ -38,7 +38,7 @@ describe("Show task page", () => {
       await (await ShowTask.getParentTaskField()).waitForDisplayed()
       // eslint-disable-next-line no-unused-expressions
       expect(await parentTaskField.isExisting()).to.be.true
-      await expect(await (await ShowTask.getParentTask()).getText()).to.equal(
+      expect(await (await ShowTask.getParentTask()).getText()).to.equal(
         "EF 1 » EF 1.2"
       )
     })
@@ -74,7 +74,7 @@ describe("Show task page", () => {
         await (await ShowTask.getChildrenTasksField()).waitForDisplayed()
         // eslint-disable-next-line no-unused-expressions
         expect(await childrenTasksField.isExisting()).to.be.true
-        await expect(
+        expect(
           await (await ShowTask.getFirstItemFromChildrenTasks()).getText()
         ).to.equal("1.1")
       }

--- a/client/tests/webdriver/ie/ie11RetiredBanner.spec.js
+++ b/client/tests/webdriver/ie/ie11RetiredBanner.spec.js
@@ -4,18 +4,18 @@ import Home from "../pages/home.page"
 describe("ANET home page on IE 11", () => {
   it("should have the correct title", async() => {
     await Home.openWithoutWaiting() // no loading indicator appears
-    await expect(await browser.getTitle()).to.equal("ANET")
+    expect(await browser.getTitle()).to.equal("ANET")
   })
 
   it("should have the IE not supported banner", async() => {
-    await expect(await Home.getIeBannerText()).to.equal(
+    expect(await Home.getIeBannerText()).to.equal(
       "Internet Explorer is not fully supported by ANET. Some features may not work. Please consider switching to a modern browser."
     )
   })
 
   it("should display banner text in one line when screen resolution is 1024x768", async() => {
     const size = await (await Home.getIeBanner()).getSize()
-    await expect(size.width).to.equal(1024)
-    await expect(size.height).to.equal(32)
+    expect(size.width).to.equal(1024)
+    expect(size.height).to.equal(32)
   })
 })


### PR DESCRIPTION
We don't check for rejected promises, so the extra `await` is unnecessary.

#### User changes
- none

#### Superuser changes
- none

#### Admin changes
- none

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [x] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here