### PR TITLE
Select multiple ANET object references effectively  for a report

### DIFF
--- a/client/src/components/advancedSelectWidget/AdvancedSelect.js
+++ b/client/src/components/advancedSelectWidget/AdvancedSelect.js
@@ -92,6 +92,7 @@ export const propTypes = {
     PropTypes.func,
     PropTypes.object
   ]),
+  focus: PropTypes.object,
   extraAddon: PropTypes.object,
   value: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
   renderSelected: PropTypes.oneOfType([PropTypes.func, PropTypes.object]), // how to render the selected items
@@ -124,6 +125,7 @@ const AdvancedSelect = ({
   selectedValueAsString,
   keepSearchText,
   addon,
+  focus,
   extraAddon,
   value,
   renderSelected,
@@ -140,7 +142,6 @@ const AdvancedSelect = ({
   handleRemoveItem
 }) => {
   const firstFilter = Object.keys(filterDefs)[0]
-
   const latestSelectedValueAsString = useRef(selectedValueAsString)
   const latestQueryParams = useRef(queryParams)
   const [latestFilterDefs, setLatestFilterDefs] = useState(filterDefs)
@@ -420,7 +421,7 @@ const AdvancedSelect = ({
     // Make sure the overlay is being closed when clicking outside of it,
     // but keep it open when clicking on the input field.
     if (!disabled) {
-      const inputFocus = searchInput.current.contains(event && event.target)
+      const inputFocus = focus.current?.contains(event && event.target)
       const openOverlay = nextShowOverlay || inputFocus
       if (openOverlay !== showOverlay) {
         if (openOverlay) {
@@ -440,6 +441,9 @@ const AdvancedSelect = ({
           // and also to make sure the state updates are being batched in there
           setDoReset(true)
         }
+      }
+      if (!inputFocus) {
+        setSearchTerms("")
       }
     }
   }

--- a/client/src/components/advancedSelectWidget/MultiTypeAdvancedSelectComponent.js
+++ b/client/src/components/advancedSelectWidget/MultiTypeAdvancedSelectComponent.js
@@ -13,7 +13,7 @@ import ButtonToggleGroup from "components/ButtonToggleGroup"
 import Model from "components/Model"
 import * as Models from "models"
 import PropTypes from "prop-types"
-import React, { useCallback, useMemo, useState } from "react"
+import React, { useCallback, useMemo, useState, useRef } from "react"
 import { Button } from "react-bootstrap"
 import LOCATIONS_ICON from "resources/locations.png"
 import ORGANIZATIONS_ICON from "resources/organizations.png"
@@ -180,9 +180,15 @@ const MultiTypeAdvancedSelectComponent = ({
     typeof advancedSelectProps.filterDefs === "function"
       ? advancedSelectProps.filterDefs(filters[0]?.[entityType])
       : advancedSelectProps.filterDefs
-
+  const searchInput = useRef()
+  console.log(searchInput)
   return (
-    <>
+    <div
+      className="hahahah"
+      ref={ref => {
+        searchInput.current = ref
+      }}
+    >
       {entityTypes.length > 1 && (
         <ButtonToggleGroup
           size="sm"
@@ -214,6 +220,7 @@ const MultiTypeAdvancedSelectComponent = ({
         placeholder={searchPlaceholder}
         value={value}
         showEmbedded
+        focus={searchInput}
         keepSearchText={entityTypes.length > 1}
         overlayColumns={advancedSelectProps.overlayColumns}
         overlayRenderRow={advancedSelectProps.overlayRenderRow}
@@ -226,7 +233,7 @@ const MultiTypeAdvancedSelectComponent = ({
         className={className}
         {...extraSelectProps}
       />
-    </>
+    </div>
   )
 }
 MultiTypeAdvancedSelectComponent.propTypes = {


### PR DESCRIPTION
After keeping search text for ANET object, it becomes confusing to select ANET object in report page.
The user may think, the search text is being used for the field value. 

Closes [AB#841](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/841)

#### User changes
-

#### Superuser changes
-

#### Admin changes
-

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [ ] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
