### PR TITLE
Update SUM document for superuser permission

### DIFF
--- a/client/stories/0-general/1-userRoles.stories.mdx
+++ b/client/stories/0-general/1-userRoles.stories.mdx
@@ -22,10 +22,20 @@ For more detailed information on users' duties, see
 ## Superusers
 
 In addition to everything the normal, unprivileged users can do, ANET superusers have a few extra
-capabilities. A superuser can for example create new locations and new principals.
+capabilities. A superuser not assigned to any organization can:
+-   create new locations
+-   update existing locations
+-   create new principals (interlocutors, persons)
+-   update existing principals (interlocutors, persons)
+-   create new positions in principal organizations
+-   update existing position in principal organizations
 
-When an ANET administrator has assigned you as superuser to one or more organizations, you will be
-able to create new sub-organizations or positions in that organization hierarchy.
+In addition, when an ANET administrator has assigned you as superuser to one or more organizations, you can also: 
+-   update people in that organization hierarchy
+-   create new positions in that organization hierarchy
+-   update existing positions in that organization hierarchy
+-   create new sub-organizations in that organization hierarchy
+-   update existing organizations in that organization hierarchy
 
 For more detailed information on superusers' duties, see
 [ANET Superuser Stories](/story/2-anet-superuser-stories-0-introduction--page)


### PR DESCRIPTION
To keep consistency between the documentation and the application in the aspect of superuser permission,  ANET has been reviewed and Sum document updated based on superuser permission.

Closes [AB#850](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/850)

#### User changes
- None

#### Superuser changes
- None

#### Admin changes
- None

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [x] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [x] Updated documentation
  - [ ] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
