### PR TITLE
Improve error reporting for schema validation

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -59,7 +59,6 @@
         "autoprefixer",
         "react-router-dom",
         "org.liquibase:liquibase-core",
-        "io.vertx:vertx-json-schema",
         "com.graphql-java:graphql-java",
         "com.graphql-java:graphql-java-extended-scalars",
         "io.leangen.graphql:spqr"

--- a/build.gradle
+++ b/build.gradle
@@ -116,13 +116,8 @@ dependencies {
 
 	// Used for converting GraphQL request output to XML:
 	implementation 'com.github.javadev:underscore-lodash:1.26'
-	// For JSON schema validation
-	implementation('io.vertx:vertx-json-schema:4.4.1') {
-		// We don't actually need most of these (dragged in through vertx-core)
-		exclude group: 'io.netty'
-	}
-	// But we do need io.netty.buffer.ByteBufOutputStream, so explicitly include that here
-	implementation 'io.netty:netty-buffer:4.1.92.Final'
+	// For JSON schema validation, supports detailed error reporting
+	implementation 'com.networknt:json-schema-validator:1.0.81'
 
 	// used for writing Excel documents
 	implementation 'org.apache.poi:poi:5.2.3'

--- a/src/main/resources/anet-schema.yml
+++ b/src/main/resources/anet-schema.yml
@@ -52,6 +52,7 @@ $defs:
           type: object
           title: Optional styling for the bootstrap component class
           description: Used for styling this field.
+          additionalProperties: true
 
 # definition for fields that present a choice to be selected from
   choiceField:


### PR DESCRIPTION
The library currently used to handle the schema validation error does not report error detail. Schema validation now provides detailed information and shows the full error path.

Closes [AB#833](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/833)

#### User changes
- None

#### Superuser changes
- None

#### Admin changes
- None

#### System admin changes
- [x] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [ ] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
