### PR TITLE
Replace clearValue() with deleteInput()

### DIFF
--- a/client/tests/webdriver/customFieldsSpecs/createReport.spec.js
+++ b/client/tests/webdriver/customFieldsSpecs/createReport.spec.js
@@ -252,9 +252,11 @@ describe("Create report form page", () => {
       await (
         await CreateReport.getTestMultiReferenceFieldButton("People")
       ).click()
-      // Set value to empty
       await (await CreateReport.getTestMultiReferenceField()).click()
-      await (await CreateReport.getTestMultiReferenceField()).clearValue()
+      // After preserving search query, setValue does not work consistently
+      // input field values are sometimes concatenated
+      // Therefore, clear input field previous value before setting new value.
+      await CreateReport.deleteInput(await CreateReport.getTestMultiReferenceField())
       // Click outside the overlay
       await (await CreateReport.getEngagementInformationTitle()).click()
 
@@ -268,7 +270,7 @@ describe("Create report form page", () => {
       // After preserving search query, setValue does not work consistently
       // input field values are sometimes concatenated
       // Therefore, clear input field previous value before setting new value.
-      await (await CreateReport.getTestMultiReferenceField()).clearValue()
+      await CreateReport.deleteInput(await CreateReport.getTestMultiReferenceField())
       await (await CreateReport.getTestMultiReferenceField()).setValue(PERSON)
       await CreateReport.waitForAdvancedSelectToChange(
         CreateReport.getTestMultiReferenceFieldAdvancedSelectItemLabel(1),
@@ -332,7 +334,7 @@ describe("Create report form page", () => {
       // After preserving search query, setValue does not work consistently
       // input field values are sometimes concatenated
       // Therefore, clear input field previous value before setting new value.
-      await (await CreateReport.getTestMultiReferenceField()).clearValue()
+      await CreateReport.deleteInput(await CreateReport.getTestMultiReferenceField())
       await (await CreateReport.getTestMultiReferenceField()).setValue(POSITION)
       await CreateReport.waitForAdvancedSelectToChange(
         CreateReport.getTestMultiReferenceFieldAdvancedSelectItemLabel(1),


### PR DESCRIPTION
As clearValue() does not always clear the input, replace it with the deleteInput() work-around.

Closes [AB#830](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/830) 

#### User changes
- none

#### Superuser changes
- none

#### Admin changes
- none

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [x] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here