### PR TITLE
Make all draft reports accessible to admins

### DIFF
--- a/client/src/pages/reports/Show.js
+++ b/client/src/pages/reports/Show.js
@@ -374,10 +374,11 @@ const ReportShow = ({ setSearchQuery, pageDispatchers }) => {
   // Authors and approvers can always read assessments
   const canReadAssessments = isAuthor || canApprove
 
-  // Only an author can submit when report is in draft or rejected AND author has a position
+  // Only an admin or an author can submit when report is in draft or rejected AND author has an active position
   const hasActivePosition = currentUser.hasActivePosition()
   const canSubmit =
-    isAuthor && hasActivePosition && (report.isDraft() || report.isRejected())
+    (isAdmin || (isAuthor && hasActivePosition)) &&
+    (report.isDraft() || report.isRejected())
 
   const hasAssignedPosition = currentUser.hasAssignedPosition()
 

--- a/client/tests/webdriver/baseSpecs/createReportWithPlanningConflict.spec.js
+++ b/client/tests/webdriver/baseSpecs/createReportWithPlanningConflict.spec.js
@@ -63,8 +63,9 @@ describe("When creating a Report with conflicts", () => {
     await CreateReport.submitForm()
     await ShowReport.waitForShowReportToLoad()
 
-    const text = "This is a DRAFT planned engagement and hasn't been submitted."
-    expect(await ShowReport.getReportStatusText()).to.equal(text)
+    expect(await ShowReport.getReportStatusText()).to.equal(
+      ShowReport.REPORT_IS_PLANNED_DRAFT
+    )
     expect(await ShowReport.getIntent()).to.equal(report01.intent)
 
     firstReportUUID = await ShowReport.getUuid()
@@ -112,8 +113,9 @@ describe("When creating a Report with conflicts", () => {
     await CreateReport.submitForm()
     await ShowReport.waitForShowReportToLoad()
 
-    const text = "This is a DRAFT planned engagement and hasn't been submitted."
-    expect(await ShowReport.getReportStatusText()).to.equal(text)
+    expect(await ShowReport.getReportStatusText()).to.equal(
+      ShowReport.REPORT_IS_PLANNED_DRAFT
+    )
     expect(await ShowReport.getIntent()).to.equal(report02.intent)
 
     secondReportUUID = await ShowReport.getUuid()
@@ -125,11 +127,9 @@ describe("When creating a Report with conflicts", () => {
     await ShowReport.waitForShowReportToLoad()
 
     expect((await ShowReport.getUuid()).length).to.equal(36)
-
-    const statusText =
-      "This is a DRAFT planned engagement and hasn't been submitted."
-    expect(await ShowReport.getReportStatusText()).to.equal(statusText)
-
+    expect(await ShowReport.getReportStatusText()).to.equal(
+      ShowReport.REPORT_IS_PLANNED_DRAFT
+    )
     expect(await ShowReport.getIntent()).to.equal(report01.intent)
     expect(await ShowReport.getEngagementDate()).to.equal(
       report01.engagementDate.format("dddd, D MMMM YYYY @ HH:mm")
@@ -170,11 +170,9 @@ describe("When creating a Report with conflicts", () => {
     await ShowReport.waitForShowReportToLoad()
 
     expect((await ShowReport.getUuid()).length).to.equal(36)
-
-    const statusText =
-      "This is a DRAFT planned engagement and hasn't been submitted."
-    expect(await ShowReport.getReportStatusText()).to.equal(statusText)
-
+    expect(await ShowReport.getReportStatusText()).to.equal(
+      ShowReport.REPORT_IS_PLANNED_DRAFT
+    )
     expect(await ShowReport.getIntent()).to.equal(report02.intent)
     expect(await ShowReport.getEngagementDate()).to.equal(
       report02.engagementDate.format("dddd, D MMMM YYYY @ HH:mm")

--- a/client/tests/webdriver/baseSpecs/createReportWithoutPrincipal.spec.js
+++ b/client/tests/webdriver/baseSpecs/createReportWithoutPrincipal.spec.js
@@ -21,8 +21,6 @@ const REPORT_FIELDS = {
 
 const NO_PRINCIPAL_WARNING =
   "No primary Afghan Partner has been provided for the Engagement"
-const REPORT_SUBMITTED_STATUS = "This report is PENDING approvals."
-const REPORT_APPROVED_STATUS = "This report is APPROVED."
 
 describe("When creating a report without a principal", () => {
   it("Should save draft report without primary principal attendee", async() => {
@@ -46,7 +44,7 @@ describe("When creating a report without a principal", () => {
     await (await ShowReport.getConfirmSubmitButton()).click()
     await browser.pause(1000) // Wait for status text to be updated
     expect(await ShowReport.getReportStatusText()).to.equal(
-      REPORT_SUBMITTED_STATUS
+      ShowReport.REPORT_IS_PENDING_APPROVALS
     )
   })
   it("Should show missing principal warning to initial approver", async() => {
@@ -99,7 +97,7 @@ describe("When creating a report without a principal", () => {
     await MyReports.open("erin")
     await MyReports.selectReport(REPORT_FIELDS.intent, REPORT_STATES.APPROVED)
     expect(await ShowReport.getReportStatusText()).to.equal(
-      REPORT_APPROVED_STATUS
+      ShowReport.REPORT_IS_APPROVED
     )
   })
 })

--- a/client/tests/webdriver/baseSpecs/homeTiles.spec.js
+++ b/client/tests/webdriver/baseSpecs/homeTiles.spec.js
@@ -1,14 +1,78 @@
 import { expect } from "chai"
 import Home from "../pages/home.page"
+import Search from "../pages/search.page"
+
+const ARTHURS_DRAFT_REPORT = "Test report with rich text"
+const ERINS_DRAFT_REPORT = "Erin's Draft report, ready for submission"
 
 describe("When checking the home page tiles", () => {
-  it("Should see correct number of pendingApprovalOf reports count when logged in as Arthur", async() => {
-    await Home.openAsAdminUser()
-    await (await Home.getHomeTilesContainer()).waitForExist()
-    await (await Home.getHomeTilesContainer()).waitForDisplayed()
-    // Depends on test data
-    expect(await (await Home.getPendingMyApprovalOfCount()).getText()).to.eq(
-      "2"
-    )
+  afterEach("Should logout", async() => {
+    await Home.logout()
+  })
+
+  describe("As admin", async() => {
+    it("Should see correct number of pending reports when logged in as Arthur", async() => {
+      await Home.openAsAdminUser()
+      await (await Home.getHomeTilesContainer()).waitForExist()
+      await (await Home.getHomeTilesContainer()).waitForDisplayed()
+      // Depends on test data
+      const pending = await (
+        await Home.getReportsPendingMyApprovalCount()
+      ).getText()
+      expect(parseInt(pending, 10)).to.eq(2)
+    })
+  })
+
+  describe("As admin", async() => {
+    it("Should see correct number of draft reports when logged in as Arthur", async() => {
+      await Home.openAsAdminUser()
+      await (await Home.getHomeTilesContainer()).waitForExist()
+      await (await Home.getHomeTilesContainer()).waitForDisplayed()
+      // We should at least see Arthur's and Erin's own drafts (might be more if tests have run)
+      const draft = await (await Home.getAllDraftReportsCount()).getText()
+      expect(parseInt(draft, 10)).to.be.at.least(2)
+      // Load drafts
+      await (await Home.getAllDraftReports()).click()
+      // Search for Erin's draft report
+      await (await Home.getSearchBar()).setValue(ERINS_DRAFT_REPORT)
+      await (await Home.getSubmitSearch()).click()
+      await Search.selectReportTable()
+      await browser.pause(500)
+      // eslint-disable-next-line no-unused-expressions
+      expect(
+        await (await Search.linkOfReportFound(ERINS_DRAFT_REPORT)).isExisting()
+      ).to.be.true
+    })
+  })
+
+  describe("As normal user", async() => {
+    it("Should see correct number of draft reports when logged in as Erin", async() => {
+      await Home.open()
+      await (await Home.getHomeTilesContainer()).waitForExist()
+      await (await Home.getHomeTilesContainer()).waitForDisplayed()
+      // We should see Erin's own draft (there may be more, depending on the order of the tests)
+      const draft = await (await Home.getMyDraftReportsCount()).getText()
+      expect(parseInt(draft, 10)).to.be.at.least(1)
+      // Load drafts
+      await (await Home.getMyDraftReports()).click()
+      await Search.selectReportTable()
+      await browser.pause(500)
+      // Erin's draft report should be there
+      // eslint-disable-next-line no-unused-expressions
+      expect(
+        await (await Search.linkOfReportFound(ERINS_DRAFT_REPORT)).isExisting()
+      ).to.be.true
+      // Search for Arthur's draft report
+      await (await Home.getSearchBar()).setValue(ARTHURS_DRAFT_REPORT)
+      await (await Home.getSubmitSearch()).click()
+      await Search.selectReportTable()
+      await browser.pause(500)
+      // eslint-disable-next-line no-unused-expressions
+      expect(
+        await (
+          await Search.linkOfReportFound(ARTHURS_DRAFT_REPORT)
+        ).isExisting()
+      ).to.be.false
+    })
   })
 })

--- a/client/tests/webdriver/baseSpecs/submitReport.spec.js
+++ b/client/tests/webdriver/baseSpecs/submitReport.spec.js
@@ -1,0 +1,68 @@
+import { expect } from "chai"
+import ShowReport from "../pages/report/showReport.page"
+
+const DRAFT_REPORT_UUID = "530b735e-1134-4daa-9e87-4491c888a4f7"
+
+describe("Submit report", () => {
+  afterEach("Should logout", async() => {
+    await ShowReport.logout()
+  })
+
+  describe("As author", async() => {
+    it("Should be able to open Draft report", async() => {
+      await ShowReport.open(DRAFT_REPORT_UUID)
+      await ShowReport.waitForShowReportToLoad()
+      expect(await ShowReport.getUuid()).to.equal(DRAFT_REPORT_UUID)
+      expect(await ShowReport.getReportStatusText()).to.equal(
+        ShowReport.REPORT_IS_DRAFT
+      )
+      // eslint-disable-next-line no-unused-expressions
+      expect(await (await ShowReport.getSubmitButton()).isExisting()).to.be.true
+    })
+  })
+
+  describe("As superuser", async() => {
+    it("Should not be able to submit Draft report", async() => {
+      await ShowReport.openAsSuperuser(DRAFT_REPORT_UUID)
+      await ShowReport.waitForShowReportToLoad()
+      // eslint-disable-next-line no-unused-expressions
+      expect(await (await ShowReport.getSubmitButton()).isExisting()).to.be
+        .false
+    })
+  })
+
+  describe("As admin", async() => {
+    it("Should be able to submit Draft report", async() => {
+      await ShowReport.openAsAdminUser(DRAFT_REPORT_UUID)
+      await ShowReport.waitForShowReportToLoad()
+      // eslint-disable-next-line no-unused-expressions
+      expect(await (await ShowReport.getSubmitButton()).isExisting()).to.be.true
+      // Submit the report
+      await (await ShowReport.getSubmitButton()).click()
+      // Should be successful
+      await browser.pause(1000) // Wait for status text to be updated
+      expect(await ShowReport.getReportStatusText()).to.equal(
+        ShowReport.REPORT_IS_PENDING_APPROVALS
+      )
+    })
+  })
+
+  describe("As author", async() => {
+    it("Should be able to set report back to Draft", async() => {
+      await ShowReport.open(DRAFT_REPORT_UUID)
+      await ShowReport.waitForShowReportToLoad()
+      expect(await ShowReport.getReportStatusText()).to.equal(
+        ShowReport.REPORT_IS_PENDING_APPROVALS
+      )
+      // Edit the report
+      await (await ShowReport.getEditReportButton()).click()
+      // Save the report
+      await (await ShowReport.getPreviewAndSubmitButton()).click()
+      // Should be successful
+      await ShowReport.waitForShowReportToLoad()
+      expect(await ShowReport.getReportStatusText()).to.equal(
+        ShowReport.REPORT_IS_DRAFT
+      )
+    })
+  })
+})

--- a/client/tests/webdriver/pages/home.page.js
+++ b/client/tests/webdriver/pages/home.page.js
@@ -48,14 +48,6 @@ class Home extends Page {
     return browser.$("fieldset.home-tile-row")
   }
 
-  async getPendingMyApprovalOfCount() {
-    return (
-      await browser.$(
-        '//button[contains(text(), "Reports pending my approval")]'
-      )
-    ).$("h1")
-  }
-
   async getSubmitSearch() {
     return browser.$("#topbar #searchBarSubmit")
   }
@@ -84,8 +76,28 @@ class Home extends Page {
     return (await this.getMyTasksLink()).$("span.badge")
   }
 
+  async getAllDraftReports() {
+    return browser.$('//button[contains(text(), "All draft reports")]')
+  }
+
+  async getAllDraftReportsCount() {
+    return (await this.getAllDraftReports()).$("h1")
+  }
+
+  async getMyDraftReports() {
+    return browser.$('//button[contains(text(), "My draft reports")]')
+  }
+
+  async getMyDraftReportsCount() {
+    return (await this.getMyDraftReports()).$("h1")
+  }
+
   async getReportsPendingMyApproval() {
     return browser.$('//button[text()="Reports pending my approval"]')
+  }
+
+  async getReportsPendingMyApprovalCount() {
+    return (await this.getReportsPendingMyApproval()).$("h1")
   }
 
   async waitForSecurityBannerValue(value) {

--- a/client/tests/webdriver/pages/report/showReport.page.js
+++ b/client/tests/webdriver/pages/report/showReport.page.js
@@ -3,6 +3,13 @@ import Page from "../page"
 const PAGE_URL = "/reports/:uuid"
 
 class ShowReport extends Page {
+  REPORT_IS_DRAFT = "This is a DRAFT report and hasn't been submitted."
+  REPORT_IS_PLANNED_DRAFT =
+    "This is a DRAFT planned engagement and hasn't been submitted."
+
+  REPORT_IS_PENDING_APPROVALS = "This report is PENDING approvals."
+  REPORT_IS_APPROVED = "This report is APPROVED."
+
   async getEditReportButton() {
     return browser.$("//a[text()='Edit']")
   }
@@ -113,6 +120,10 @@ class ShowReport extends Page {
     return browser.$('//button[text()="Submit report"]')
   }
 
+  async getPreviewAndSubmitButton() {
+    return browser.$("#formBottomSubmit")
+  }
+
   async getReportModal() {
     return browser.$(".modal-dialog")
   }
@@ -160,6 +171,14 @@ class ShowReport extends Page {
 
   async open(uuid) {
     await super.open(PAGE_URL.replace(":uuid", uuid))
+  }
+
+  async openAsSuperuser(uuid) {
+    await super.openAsSuperuser(PAGE_URL.replace(":uuid", uuid))
+  }
+
+  async openAsAdminUser(uuid) {
+    await super.openAsAdminUser(PAGE_URL.replace(":uuid", uuid))
   }
 
   async waitForShowReportToLoad() {

--- a/client/tests/webdriver/pages/search.page.js
+++ b/client/tests/webdriver/pages/search.page.js
@@ -9,6 +9,10 @@ class Search extends Page {
     return browser.$("div#tasks #tasks-search-results")
   }
 
+  async getFoundReportTable() {
+    return browser.$("div#reports .report-collection")
+  }
+
   async linkOfPersonFound(name) {
     return (await this.getFoundPeopleTable()).$(
       `//tbody/tr//a[contains(text(), "${name}")]`
@@ -21,14 +25,24 @@ class Search extends Page {
     )
   }
 
-  async selectReport(linkText) {
-    const tableTab = await browser.$(
-      ".report-collection div header div button[value='table']"
-    )
+  async getReportTableButton() {
+    return browser.$(".report-collection div header div button[value='table']")
+  }
+
+  async linkOfReportFound(linkText) {
+    return browser.$(`*=${linkText}`)
+  }
+
+  async selectReportTable() {
+    const tableTab = await this.getReportTableButton()
     await tableTab.waitForExist()
     await tableTab.waitForDisplayed()
     await tableTab.click()
-    const reportLink = await browser.$(`*=${linkText}`)
+  }
+
+  async selectReport(linkText) {
+    await this.selectReportTable()
+    const reportLink = await this.linkOfReportFound(linkText)
     await reportLink.waitForExist()
     await reportLink.waitForDisplayed()
     await reportLink.click()

--- a/insertBaseData-psql.sql
+++ b/insertBaseData-psql.sql
@@ -385,7 +385,6 @@ INSERT INTO approvers ("approvalStepUuid", "positionUuid")
 	VALUES ((SELECT uuid from "approvalSteps" WHERE name='EF 1.1 Approvers'), (SELECT uuid from positions where name = 'EF 1.1 Superuser'));
 
 -- Create the EF 2.2 approval process
--- DECLARE :approvalStepUuid varchar(36);
 SELECT ('''' || uuid_generate_v4() || '''') AS "approvalStepUuid" \gset
 INSERT INTO "approvalSteps" (uuid, name, "relatedObjectUuid", type)
 	VALUES (:approvalStepUuid, 'EF 2.2 Secondary Reviewers', (SELECT uuid from organizations where "shortName"='EF 2.2'), 1);
@@ -630,8 +629,7 @@ UPDATE positions SET "currentPersonUuid" = (SELECT uuid from people where "email
 UPDATE positions SET "locationUuid" = (SELECT uuid from LOCATIONS where name = 'Kabul Police Academy') WHERE name = 'Chief of Police';
 UPDATE positions SET "locationUuid" = (SELECT uuid from LOCATIONS where name = 'MoD Headquarters Kabul') WHERE name = 'Cost Adder - MoD';
 
---Write a couple reports!
--- DECLARE :reportuuid varchar(36);
+-- Write a couple of reports!
 
 SELECT ('''' || N'9bb1861c-1f55-4a1b-bd3d-3c1f56d739b5' || '''') AS reportuuid \gset
 INSERT INTO reports (uuid, "createdAt", "updatedAt", "locationUuid", intent, text, "nextSteps", state, "engagementDate", atmosphere, "advisorOrganizationUuid", "principalOrganizationUuid")
@@ -868,6 +866,20 @@ INSERT INTO "reportPeople" ("personUuid", "reportUuid", "isPrimary", "isAuthor")
 INSERT INTO "reportPeople" ("personUuid", "reportUuid", "isPrimary", "isAuthor")
 	VALUES ((SELECT uuid FROM people where "emailAddress"='hunter+jack@example.com'), :reportuuid, FALSE, FALSE);
 
+-- Erin's Draft report
+SELECT ('''530b735e-1134-4daa-9e87-4491c888a4f7''') AS reportuuid \gset
+INSERT INTO reports (uuid, "createdAt", "updatedAt", "locationUuid", intent, text, "nextSteps", "keyOutcomes", state, "engagementDate", atmosphere, "advisorOrganizationUuid", "principalOrganizationUuid", "customFields")
+	VALUES (:reportuuid, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, (SELECT uuid from locations where name='General Hospital'), 'Erin''s Draft report, ready for submission',
+	'This is just a draft.', 'This is just a draft.', 'This is just a draft.', 0, '2023-05-25', 0,
+	(SELECT uuid FROM organizations where "shortName" = 'EF 2.2'), (SELECT uuid FROM organizations WHERE "longName" LIKE 'Ministry of Defense'),
+	'{"invisibleCustomFields":["formCustomFields.trainingEvent","formCustomFields.numberTrained","formCustomFields.levelTrained","formCustomFields.trainingDate","formCustomFields.systemProcess","formCustomFields.echelons","formCustomFields.itemsAgreed","formCustomFields.assetsUsed"],"multipleButtons":[],"additionalEngagementNeeded":[],"relatedObject":null,"relatedReport":null}');
+INSERT INTO "reportPeople" ("personUuid", "reportUuid", "isPrimary")
+	VALUES ((SELECT uuid FROM people where "emailAddress"='hunter+christopf@example.com'), :reportuuid, TRUE);
+INSERT INTO "reportPeople" ("personUuid", "reportUuid", "isPrimary", "isAuthor")
+	VALUES ((SELECT uuid FROM people where "emailAddress"='hunter+erin@example.com'), :reportuuid, TRUE, TRUE);
+INSERT INTO "reportTasks" ("taskUuid", "reportUuid")
+	VALUES ((SELECT uuid from tasks where "shortName" = '2.A'), :reportuuid);
+
 -- Release all of the reports right now, so they show up in the rollup.
 UPDATE reports SET "releasedAt" = reports."createdAt" WHERE state = 2 OR state = 4;
 
@@ -919,8 +931,6 @@ INSERT INTO PEOPLE (uuid, name, status, role, "createdAt", "updatedAt")
 	SELECT uuid_generate_v4(), 'ANET Importer', 1, 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
 	WHERE NOT EXISTS (SELECT uuid FROM people WHERE name = 'ANET Importer' AND role = 0);
 
--- DECLARE :authorUuid varchar(36);
--- DECLARE :noteUuid varchar(36);
 SELECT ('''' || uuid || '''') AS "authorUuid" FROM people WHERE name = 'ANET Importer' AND role = 0 \gset
 
 -- Tag some reports

--- a/insertBaseData-psql.sql
+++ b/insertBaseData-psql.sql
@@ -932,7 +932,8 @@ INSERT INTO notes (uuid, "authorUuid", type, text, "createdAt", "updatedAt")
 INSERT INTO "noteRelatedObjects" ("noteUuid", "relatedObjectType", "relatedObjectUuid")
 	SELECT :noteUuid, 'reports', r.uuid
 	FROM reports r
-	WHERE SUBSTRING(r.uuid, 1, 1) IN ('0', '2', '4', '6', '8', 'a', 'c', 'e');
+	WHERE SUBSTRING(r.uuid, 1, 1) IN ('0', '2', '4', '6', '8', 'a', 'c', 'e')
+	AND r.state != 0;
 
 SELECT ('''' || uuid_generate_v4() || '''') AS "noteUuid" \gset
 INSERT INTO notes (uuid, "authorUuid", type, text, "createdAt", "updatedAt")
@@ -942,7 +943,8 @@ INSERT INTO notes (uuid, "authorUuid", type, text, "createdAt", "updatedAt")
 INSERT INTO "noteRelatedObjects" ("noteUuid", "relatedObjectType", "relatedObjectUuid")
 	SELECT :noteUuid, 'reports', r.uuid
 	FROM reports r
-	WHERE SUBSTRING(r.uuid, 1, 1) IN ('0', '3', '6', '9', 'c', 'f');
+	WHERE SUBSTRING(r.uuid, 1, 1) IN ('0', '3', '6', '9', 'c', 'f')
+	AND r.state != 0;
 
 SELECT ('''' || uuid_generate_v4() || '''') AS "noteUuid" \gset
 INSERT INTO notes (uuid, "authorUuid", type, text, "createdAt", "updatedAt")
@@ -952,7 +954,8 @@ INSERT INTO notes (uuid, "authorUuid", type, text, "createdAt", "updatedAt")
 INSERT INTO "noteRelatedObjects" ("noteUuid", "relatedObjectType", "relatedObjectUuid")
 	SELECT :noteUuid, 'reports', r.uuid
 	FROM reports r
-	WHERE SUBSTRING(r.uuid, 1, 1) IN ('1', '3', '5', '7', '9', 'b', 'd', 'f');
+	WHERE SUBSTRING(r.uuid, 1, 1) IN ('1', '3', '5', '7', '9', 'b', 'd', 'f')
+	AND r.state != 0;
 
 SELECT ('''' || uuid_generate_v4() || '''') AS "noteUuid" \gset
 INSERT INTO notes (uuid, "authorUuid", type, text, "createdAt", "updatedAt")
@@ -962,7 +965,8 @@ INSERT INTO notes (uuid, "authorUuid", type, text, "createdAt", "updatedAt")
 INSERT INTO "noteRelatedObjects" ("noteUuid", "relatedObjectType", "relatedObjectUuid")
 	SELECT :noteUuid, 'reports', r.uuid
 	FROM reports r
-	WHERE SUBSTRING(r.uuid, 1, 1) IN ('1', '4', '7', 'a', 'd');
+	WHERE SUBSTRING(r.uuid, 1, 1) IN ('1', '4', '7', 'a', 'd')
+	AND r.state != 0;
 
 -- Insert report with created at and updated at date for two days before current timestamp
 SELECT ('''' || uuid_generate_v4() || '''') AS reportuuid \gset
@@ -1085,7 +1089,8 @@ INSERT INTO notes (uuid, "authorUuid", type, text, "createdAt", "updatedAt")
 INSERT INTO "noteRelatedObjects" ("noteUuid", "relatedObjectType", "relatedObjectUuid")
 	SELECT :noteUuid, 'reports', r.uuid
 	FROM reports r
-	WHERE r.atmosphere = 0;
+	WHERE r.atmosphere = 0
+	AND r.state != 0;
 
 SELECT ('''' || uuid_generate_v4() || '''') AS "noteUuid" \gset
 INSERT INTO notes (uuid, "authorUuid", type, text, "createdAt", "updatedAt")

--- a/src/main/java/mil/dds/anet/resources/ReportResource.java
+++ b/src/main/java/mil/dds/anet/resources/ReportResource.java
@@ -362,11 +362,9 @@ public class ReportResource {
         r, r.getAdvisorOrg(), r.getPrimaryAdvisor());
 
     final boolean isAuthor = r.isAuthor(user);
-    if (!isAuthor && !AuthUtils.canAdministrateOrg(user, r.getAdvisorOrgUuid(), true)
-        && !AuthUtils.isAdmin(user)) {
+    if (!isAuthor && !AuthUtils.isAdmin(user)) {
       throw new WebApplicationException(
-          "Cannot submit report unless you are a report's author, his/her superuser or an admin",
-          Status.FORBIDDEN);
+          "Cannot submit report unless you are a report's author, or an admin", Status.FORBIDDEN);
     }
 
     if (r.getState() != ReportState.DRAFT && r.getState() != ReportState.REJECTED) {

--- a/src/main/java/mil/dds/anet/search/AbstractReportSearcher.java
+++ b/src/main/java/mil/dds/anet/search/AbstractReportSearcher.java
@@ -31,6 +31,7 @@ import mil.dds.anet.beans.search.ReportSearchQuery;
 import mil.dds.anet.database.PositionDao;
 import mil.dds.anet.database.ReportDao;
 import mil.dds.anet.search.AbstractSearchQueryBuilder.Comparison;
+import mil.dds.anet.utils.AuthUtils;
 import mil.dds.anet.utils.DaoUtils;
 
 public abstract class AbstractReportSearcher extends AbstractSearcher<Report, ReportSearchQuery>
@@ -297,10 +298,10 @@ public abstract class AbstractReportSearcher extends AbstractSearcher<Report, Re
       qb.addSqlArg("userUuid", DaoUtils.getUuid(query.getUser()));
     }
 
-    if (!query.isSystemSearch()) {
+    if (!query.isSystemSearch() && !AuthUtils.isAdmin(query.getUser())) {
       // Apply a filter to restrict access to other's draft, rejected or approved reports.
       // When the search is performed by the system (for instance by a worker, systemSearch = true)
-      // do not apply this filter.
+      // or an admin, do not apply this filter.
       if (query.getUser() == null) {
         qb.addWhereClause("reports.state != :draftState");
         qb.addWhereClause("reports.state != :rejectedState");


### PR DESCRIPTION
Admins can now access all draft reports, not just their own.

Closes #3900, [AB#860](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/860)

#### User changes
- none

#### Superuser changes
- none

#### Admin changes
- admins can see all draft reports, e.g. when clicking the "All draft reports" tile on the Home page
- admins can submit other authors' draft reports (when complete and ready to be submitted)

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [x] Added and/or updated unit tests
  - [x] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here