### PR TITLE
Summarize the leaders of organizations

### DIFF
--- a/anet-dictionary.yml
+++ b/anet-dictionary.yml
@@ -768,7 +768,7 @@ fields:
     name: Position Name
     role:
       label: Position Role
-      choices:
+      types:
         member: Member
         deputy: Deputy
         leader: Leader

--- a/client/src/components/previews/OrganizationPreview.js
+++ b/client/src/components/previews/OrganizationPreview.js
@@ -3,7 +3,8 @@ import API from "api"
 import { PreviewField } from "components/FieldHelper"
 import LinkTo from "components/LinkTo"
 import Model from "components/Model"
-import { Organization, Position } from "models"
+import { Organization } from "models"
+import { PositionRole } from "models/Position"
 import OrganizationLaydown from "pages/organizations/Laydown"
 import OrganizationTasks from "pages/organizations/OrganizationTasks"
 import PropTypes from "prop-types"
@@ -110,6 +111,31 @@ const OrganizationPreview = ({ className, uuid }) => {
     data.organization ? data.organization : {}
   )
 
+  function showLeadingPositions(positions, role, label) {
+    return (
+      positions &&
+      positions.some(pos => pos.role === role) && (
+        <PreviewField
+          label={label}
+          value={
+            <ListGroup>
+              {positions.map(
+                pos =>
+                  pos.role === role && (
+                    <ListGroupItem key={pos.uuid}>
+                      <LinkTo modelType="Position" model={pos}>
+                        {pos.name}
+                      </LinkTo>
+                    </ListGroupItem>
+                  )
+              )}
+            </ListGroup>
+          }
+        />
+      )
+    )
+  }
+
   const isPrincipalOrg = organization.type === Organization.TYPE.PRINCIPAL_ORG
   const orgSettings = isPrincipalOrg
     ? Settings.fields.principal.org
@@ -131,25 +157,16 @@ const OrganizationPreview = ({ className, uuid }) => {
           value={Organization.humanNameOfType(organization.type)}
         />
 
-        {organization.positions &&
-          organization.positions.some(pos => pos.role === Position.ROLE.LEADER) && (
-            <PreviewField
-              label="Leaders"
-              value={
-                <ListGroup>
-                  {organization.positions.map(pos => (pos.role === Position.ROLE.LEADER) && (
-                    <ListGroupItem key={pos.uuid}>
-                      <LinkTo
-                        modelType="Position"
-                        model={pos}
-                      >
-                        {pos.name}
-                      </LinkTo>
-                    </ListGroupItem>
-                  ))}
-                </ListGroup>
-              }
-            />
+        {showLeadingPositions(
+          organization.positions,
+          PositionRole.LEADER.toString(),
+          "Leaders"
+        )}
+
+        {showLeadingPositions(
+          organization.positions,
+          PositionRole.DEPUTY.toString(),
+          "Deputies"
         )}
 
         <PreviewField

--- a/client/src/components/previews/OrganizationPreview.js
+++ b/client/src/components/previews/OrganizationPreview.js
@@ -3,7 +3,7 @@ import API from "api"
 import { PreviewField } from "components/FieldHelper"
 import LinkTo from "components/LinkTo"
 import Model from "components/Model"
-import { Organization } from "models"
+import { Organization, Position } from "models"
 import OrganizationLaydown from "pages/organizations/Laydown"
 import OrganizationTasks from "pages/organizations/OrganizationTasks"
 import PropTypes from "prop-types"
@@ -130,6 +130,27 @@ const OrganizationPreview = ({ className, uuid }) => {
           label="Type"
           value={Organization.humanNameOfType(organization.type)}
         />
+
+        {organization.positions &&
+          organization.positions.some(pos => pos.role === Position.ROLE.LEADER) && (
+            <PreviewField
+              label="Leaders"
+              value={
+                <ListGroup>
+                  {organization.positions.map(pos => (pos.role === Position.ROLE.LEADER) && (
+                    <ListGroupItem key={pos.uuid}>
+                      <LinkTo
+                        modelType="Position"
+                        model={pos}
+                      >
+                        {pos.name}
+                      </LinkTo>
+                    </ListGroupItem>
+                  ))}
+                </ListGroup>
+              }
+            />
+        )}
 
         <PreviewField
           label={orgSettings.longName.label}

--- a/client/src/models/Position.js
+++ b/client/src/models/Position.js
@@ -24,7 +24,7 @@ export class PositionRole {
 
   constructor(value, dictionaryKey) {
     this.#value = value
-    this.#humanReadable = Settings.fields.position.role.choices[dictionaryKey]
+    this.#humanReadable = Settings.fields.position.role.types[dictionaryKey]
   }
 
   toString() {

--- a/client/src/pages/organizations/Show.js
+++ b/client/src/pages/organizations/Show.js
@@ -26,7 +26,8 @@ import ReportCollection from "components/ReportCollection"
 import RichTextEditor from "components/RichTextEditor"
 import SubNav from "components/SubNav"
 import { Field, Form, Formik } from "formik"
-import { Location, Organization, Report, Position } from "models"
+import { Location, Organization, Report } from "models"
+import { PositionRole } from "models/Position"
 import { orgTour } from "pages/HopscotchTour"
 import pluralize from "pluralize"
 import React, { useContext, useState } from "react"
@@ -261,6 +262,33 @@ const OrganizationShow = ({ pageDispatchers }) => {
     reportQueryParams.orgRecurseStrategy = RECURSE_STRATEGY.CHILDREN
   }
 
+  function showLeadingPositions(positions, role, label) {
+    return (
+      positions &&
+      positions.some(pos => pos.role === role) && (
+        <Field
+          name={label}
+          component={FieldHelper.ReadonlyField}
+          label={label}
+          humanValue={
+            <ListGroup>
+              {positions.map(
+                pos =>
+                  pos.role === role && (
+                    <ListGroupItem key={pos.uuid}>
+                      <LinkTo modelType="Position" model={pos}>
+                        {pos.name}
+                      </LinkTo>
+                    </ListGroupItem>
+                  )
+              )}
+            </ListGroup>
+          }
+        />
+      )
+    )
+  }
+
   return (
     <Formik enableReinitialize initialValues={organization}>
       {({ values }) => {
@@ -364,27 +392,16 @@ const OrganizationShow = ({ pageDispatchers }) => {
                   humanValue={Organization.humanNameOfType}
                 />
 
-                {organization.positions &&
-                  organization.positions.some(pos => pos.role === Position.ROLE.LEADER) && (
-                    <Field
-                      name="leaders"
-                      component={FieldHelper.ReadonlyField}
-                      label="Leaders"
-                      humanValue={
-                        <ListGroup>
-                          {organization.positions.map(pos => (pos.role === Position.ROLE.LEADER) && (
-                            <ListGroupItem key={pos.uuid}>
-                              <LinkTo
-                                modelType="Position"
-                                model={pos}
-                              >
-                                {pos.name}
-                              </LinkTo>
-                            </ListGroupItem>
-                          ))}
-                        </ListGroup>
-                      }
-                    />
+                {showLeadingPositions(
+                  organization.positions,
+                  PositionRole.LEADER.toString(),
+                  "Leaders"
+                )}
+
+                {showLeadingPositions(
+                  organization.positions,
+                  PositionRole.DEPUTY.toString(),
+                  "Deputies"
                 )}
 
                 <LongNameWithLabel

--- a/client/src/pages/organizations/Show.js
+++ b/client/src/pages/organizations/Show.js
@@ -26,10 +26,12 @@ import ReportCollection from "components/ReportCollection"
 import RichTextEditor from "components/RichTextEditor"
 import SubNav from "components/SubNav"
 import { Field, Form, Formik } from "formik"
+import _isEmpty from "lodash/isEmpty"
 import { Location, Organization, Report } from "models"
 import { PositionRole } from "models/Position"
 import { orgTour } from "pages/HopscotchTour"
 import pluralize from "pluralize"
+import { getPositionsForRole } from "positionUtil"
 import React, { useContext, useState } from "react"
 import {
   Badge,
@@ -262,33 +264,6 @@ const OrganizationShow = ({ pageDispatchers }) => {
     reportQueryParams.orgRecurseStrategy = RECURSE_STRATEGY.CHILDREN
   }
 
-  function showLeadingPositions(positions, role, label) {
-    return (
-      positions &&
-      positions.some(pos => pos.role === role) && (
-        <Field
-          name={label}
-          component={FieldHelper.ReadonlyField}
-          label={label}
-          humanValue={
-            <ListGroup>
-              {positions.map(
-                pos =>
-                  pos.role === role && (
-                    <ListGroupItem key={pos.uuid}>
-                      <LinkTo modelType="Position" model={pos}>
-                        {pos.name}
-                      </LinkTo>
-                    </ListGroupItem>
-                  )
-              )}
-            </ListGroup>
-          }
-        />
-      )
-    )
-  }
-
   return (
     <Formik enableReinitialize initialValues={organization}>
       {({ values }) => {
@@ -392,16 +367,20 @@ const OrganizationShow = ({ pageDispatchers }) => {
                   humanValue={Organization.humanNameOfType}
                 />
 
-                {showLeadingPositions(
+                {renderLeadingPositions(
                   organization.positions,
                   PositionRole.LEADER.toString(),
-                  "Leaders"
+                  pluralize(
+                    utils.titleCase(PositionRole.LEADER.humanNameOfRole())
+                  )
                 )}
 
-                {showLeadingPositions(
+                {renderLeadingPositions(
                   organization.positions,
                   PositionRole.DEPUTY.toString(),
-                  "Deputies"
+                  pluralize(
+                    utils.titleCase(PositionRole.DEPUTY.humanNameOfRole())
+                  )
                 )}
 
                 <LongNameWithLabel
@@ -552,6 +531,20 @@ const OrganizationShow = ({ pageDispatchers }) => {
       }}
     </Formik>
   )
+
+  function renderLeadingPositions(positions, role, label) {
+    const positionList = getPositionsForRole(positions, role)
+    if (!_isEmpty(positionList)) {
+      return (
+        <Field
+          name={label}
+          component={FieldHelper.ReadonlyField}
+          label={label}
+          humanValue={positionList}
+        />
+      )
+    }
+  }
 }
 
 OrganizationShow.propTypes = {

--- a/client/src/pages/organizations/Show.js
+++ b/client/src/pages/organizations/Show.js
@@ -26,7 +26,7 @@ import ReportCollection from "components/ReportCollection"
 import RichTextEditor from "components/RichTextEditor"
 import SubNav from "components/SubNav"
 import { Field, Form, Formik } from "formik"
-import { Location, Organization, Report } from "models"
+import { Location, Organization, Report, Position } from "models"
 import { orgTour } from "pages/HopscotchTour"
 import pluralize from "pluralize"
 import React, { useContext, useState } from "react"
@@ -363,6 +363,29 @@ const OrganizationShow = ({ pageDispatchers }) => {
                   component={FieldHelper.ReadonlyField}
                   humanValue={Organization.humanNameOfType}
                 />
+
+                {organization.positions &&
+                  organization.positions.some(pos => pos.role === Position.ROLE.LEADER) && (
+                    <Field
+                      name="leaders"
+                      component={FieldHelper.ReadonlyField}
+                      label="Leaders"
+                      humanValue={
+                        <ListGroup>
+                          {organization.positions.map(pos => (pos.role === Position.ROLE.LEADER) && (
+                            <ListGroupItem key={pos.uuid}>
+                              <LinkTo
+                                modelType="Position"
+                                model={pos}
+                              >
+                                {pos.name}
+                              </LinkTo>
+                            </ListGroupItem>
+                          ))}
+                        </ListGroup>
+                      }
+                    />
+                )}
 
                 <LongNameWithLabel
                   dictProps={orgSettings.longName}

--- a/client/src/positionUtil.js
+++ b/client/src/positionUtil.js
@@ -9,6 +9,13 @@ export function getPositionsForRole(positions, role) {
     .map(pos => (
       <ListGroupItem key={pos.uuid}>
         <LinkTo modelType="Position" model={pos} />
+        {(pos.person && (
+          <LinkTo
+            modelType="Person"
+            model={pos.person}
+            style={{ marginLeft: 5 }}
+          />
+        )) || <span className="ms-1 text-danger">— Unfilled</span>}
       </ListGroupItem>
     ))
   if (!_isEmpty(positionList)) {

--- a/client/src/positionUtil.js
+++ b/client/src/positionUtil.js
@@ -1,0 +1,17 @@
+import LinkTo from "components/LinkTo"
+import _isEmpty from "lodash/isEmpty"
+import React from "react"
+import { ListGroup, ListGroupItem } from "react-bootstrap"
+
+export function getPositionsForRole(positions, role) {
+  const positionList = positions
+    ?.filter(pos => pos.role === role)
+    .map(pos => (
+      <ListGroupItem key={pos.uuid}>
+        <LinkTo modelType="Position" model={pos} />
+      </ListGroupItem>
+    ))
+  if (!_isEmpty(positionList)) {
+    return <ListGroup>{positionList}</ListGroup>
+  }
+}

--- a/client/tests/webdriver/baseSpecs/showOrganization.spec.js
+++ b/client/tests/webdriver/baseSpecs/showOrganization.spec.js
@@ -1,0 +1,110 @@
+import { expect } from "chai"
+import Home from "../pages/home.page"
+import Search from "../pages/search.page"
+import ShowOrganization from "../pages/showOrganization.page"
+
+const ORGANIZATION_EF2_SEARCH_STRING = "EF 2"
+const ORGANIZATION_EF22_SEARCH_STRING = "EF 2.2"
+const LEADER_POSITION_TEXT = "EF 2.2 Final Reviewer"
+const LEADER_PERSON_TEXT = "CTR BECCABON, Rebecca"
+const DEPUTY_POSITION_TEXT = "EF 2.2 Superuser"
+const DEPUTY_PERSON_TEXT = "CIV JACOBSON, Jacob"
+
+describe("Show organization page", () => {
+  describe("As an admin", () => {
+    it("Should first search, find and open the organization page", async() => {
+      await Home.openAsAdminUser()
+      await (await Home.getSearchBar()).setValue(ORGANIZATION_EF2_SEARCH_STRING)
+      await (await Home.getSubmitSearch()).click()
+      await (
+        await Search.getFoundOrganizationTable()
+      ).waitForExist({ timeout: 20000 })
+      await (await Search.getFoundOrganizationTable()).waitForDisplayed()
+      await (
+        await Search.linkOfOrganizationFound(ORGANIZATION_EF2_SEARCH_STRING)
+      ).click()
+    })
+    it("Should see leader&deputy fields are not listed", async() => {
+      // Organization longName should be there
+      const longNameField = await ShowOrganization.getLongName()
+      await longNameField.waitForExist()
+      await longNameField.waitForDisplayed()
+      // eslint-disable-next-line no-unused-expressions
+      expect(await longNameField.isExisting()).to.be.true
+
+      // Organization type should be there
+      const typeField = await ShowOrganization.getType()
+      await typeField.waitForExist()
+      await typeField.waitForDisplayed()
+      // eslint-disable-next-line no-unused-expressions
+      expect(await typeField.isExisting()).to.be.true
+
+      // Organization leaders should not be there
+      const leaderField = await ShowOrganization.getLeaders()
+      // eslint-disable-next-line no-unused-expressions
+      expect(await leaderField.isExisting()).to.be.false
+
+      // Organization deputies should not be there
+      const deputyField = await ShowOrganization.getDeputies()
+      // eslint-disable-next-line no-unused-expressions
+      expect(await deputyField.isExisting()).to.be.false
+    })
+  })
+  describe("As an admin", () => {
+    it("Should first search, find and open the organization page", async() => {
+      await Home.openAsAdminUser()
+      await (
+        await Home.getSearchBar()
+      ).setValue(ORGANIZATION_EF22_SEARCH_STRING)
+      await (await Home.getSubmitSearch()).click()
+      await (
+        await Search.getFoundOrganizationTable()
+      ).waitForExist({ timeout: 20000 })
+      await (await Search.getFoundOrganizationTable()).waitForDisplayed()
+      await (
+        await Search.linkOfOrganizationFound(ORGANIZATION_EF22_SEARCH_STRING)
+      ).click()
+    })
+    it("Should see leader&deputy fields are listed", async() => {
+      // Organization longName should be there
+      const longNameField = await ShowOrganization.getLongName()
+      await longNameField.waitForExist()
+      await longNameField.waitForDisplayed()
+      // eslint-disable-next-line no-unused-expressions
+      expect(await longNameField.isExisting()).to.be.true
+
+      // Organization type should be there
+      const typeField = await ShowOrganization.getType()
+      await typeField.waitForExist()
+      await typeField.waitForDisplayed()
+      // eslint-disable-next-line no-unused-expressions
+      expect(await typeField.isExisting()).to.be.true
+
+      // Organization leaders should be there
+      const leaderField = await ShowOrganization.getLeaders()
+      await leaderField.waitForExist({ timeout: 5000 })
+      await leaderField.waitForDisplayed()
+      // eslint-disable-next-line no-unused-expressions
+      expect(await leaderField.isExisting()).to.be.true
+      expect(
+        await (await ShowOrganization.getLeaderPosition()).getText()
+      ).to.equal(LEADER_POSITION_TEXT)
+      expect(
+        await (await ShowOrganization.getLeaderPositionPerson()).getText()
+      ).to.equal(LEADER_PERSON_TEXT)
+
+      // Organization deputies should be there
+      const deputyField = await ShowOrganization.getDeputies()
+      await deputyField.waitForExist({ timeout: 5000 })
+      await deputyField.waitForDisplayed()
+      // eslint-disable-next-line no-unused-expressions
+      expect(await deputyField.isExisting()).to.be.true
+      expect(
+        await (await ShowOrganization.getDeputyPosition()).getText()
+      ).to.equal(DEPUTY_POSITION_TEXT)
+      expect(
+        await (await ShowOrganization.getDeputyPositionPerson()).getText()
+      ).to.equal(DEPUTY_PERSON_TEXT)
+    })
+  })
+})

--- a/client/tests/webdriver/pages/search.page.js
+++ b/client/tests/webdriver/pages/search.page.js
@@ -9,6 +9,10 @@ class Search extends Page {
     return browser.$("div#tasks #tasks-search-results")
   }
 
+  async getFoundOrganizationTable() {
+    return browser.$("div#organizations #organizations-search-results")
+  }
+
   async getFoundReportTable() {
     return browser.$("div#reports .report-collection")
   }
@@ -21,6 +25,12 @@ class Search extends Page {
 
   async linkOfTaskFound(name) {
     return (await this.getFoundTaskTable()).$(
+      `//tbody/tr//a[contains(text(), "${name}")]`
+    )
+  }
+
+  async linkOfOrganizationFound(name) {
+    return (await this.getFoundOrganizationTable()).$(
       `//tbody/tr//a[contains(text(), "${name}")]`
     )
   }

--- a/client/tests/webdriver/pages/showOrganization.page.js
+++ b/client/tests/webdriver/pages/showOrganization.page.js
@@ -17,6 +17,34 @@ class ShowOrganization extends Page {
     return browser.$('div[id="profile"')
   }
 
+  async getType() {
+    return browser.$('div[id="type"')
+  }
+
+  async getLeaders() {
+    return browser.$('div[id="fg-Leaders"')
+  }
+
+  async getLeaderPosition() {
+    return browser.$("div#Leaders span")
+  }
+
+  async getLeaderPositionPerson() {
+    return browser.$("div#Leaders span:nth-child(2)")
+  }
+
+  async getDeputies() {
+    return browser.$('div[id="fg-Deputies"')
+  }
+
+  async getDeputyPosition() {
+    return browser.$("div#Deputies span")
+  }
+
+  async getDeputyPositionPerson() {
+    return browser.$("div#Deputies span:nth-child(2)")
+  }
+
   async waitForAlertSuccessToLoad() {
     if (!(await (await this.getAlertSuccess()).isDisplayed())) {
       await (await this.getAlertSuccess()).waitForExist()

--- a/src/main/resources/anet-schema.yml
+++ b/src/main/resources/anet-schema.yml
@@ -459,7 +459,7 @@ properties:
   fields:
     type: object
     additionalProperties: false
-    required: [task, report, person, position, organization, advisor, principal, superuser, administrator]
+    required: [task, attachment, report, person, position, organization, advisor, principal, superuser, administrator]
     properties:
 
       task:
@@ -732,7 +732,7 @@ properties:
       position:
         type: object
         additionalProperties: false
-        required: [name]
+        required: [name, role]
         properties:
           name:
             type: string

--- a/testDictionaries/no-custom-fields.yml
+++ b/testDictionaries/no-custom-fields.yml
@@ -442,7 +442,7 @@ fields:
     name: Position Name
     role:
       label: Position Role
-      choices:
+      types:
         member: Member
         deputy: Deputy
         leader: Leader


### PR DESCRIPTION
The leaders and deputies of organizations are now shown on the organization pages (preview&show).

Closes [AB#825](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/825), [AB#840](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/840)

#### User changes
-  Users can see the organizations leaders and deputies

#### Superuser changes
- none

#### Admin changes
- none

#### System admin changes
- [x] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [x] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
