### PR TITLE
Include cancelled reports by default in the Daily Rollup

### DIFF
--- a/client/src/components/MosaicLayout.js
+++ b/client/src/components/MosaicLayout.js
@@ -25,6 +25,35 @@ import "./MosaicLayout.css"
 
 const MosaicLayout = ({ visualizations, initialNode, description, style }) => {
   const [currentNode, setCurrentNode] = useState(initialNode)
+  const viz = visualizations.filter(viz => currentNode.includes(viz.id))
+
+  const WINDOW_TITLE = {}
+  viz.forEach((item, index) => {
+    WINDOW_TITLE[String.fromCharCode(97 + index)] = item
+  })
+  console.log(WINDOW_TITLE)
+
+  const renderMosaicTile = (id, path) => {
+    const tile = WINDOW_TITLE[id]
+    console.log(tile)
+    console.log(path)
+    if (tile) {
+      const { title } = tile
+      return (
+        <MosaicWindow key={id} title={title} path={path}>
+          {tile.renderer(id)}
+        </MosaicWindow>
+      )
+    }
+    return null
+  }
+
+  const renderMosaicTiles = (path) => {
+    return Object.keys(WINDOW_TITLE).map((id, index) => {
+      return renderMosaicTile(id, path)
+    })
+  }
+
   return (
     <div className="mosaic-box" style={style}>
       <div className="mosaic-container">
@@ -33,14 +62,7 @@ const MosaicLayout = ({ visualizations, initialNode, description, style }) => {
           blueprintNamespace="bp4"
           value={currentNode}
           onChange={updateCurrentNode}
-          renderTile={(id, path) => {
-            const viz = visualizations.find(viz => viz.id === id)
-            return (
-              <MosaicWindow title={viz.title} path={path}>
-                {viz.renderer(id)}
-              </MosaicWindow>
-            )
-          }}
+          renderTile={(path) => renderMosaicTiles(path)}
         />
       </div>
     </div>
@@ -143,7 +165,7 @@ MosaicLayout.propTypes = {
       renderer: PropTypes.func.isRequired
     })
   ).isRequired,
-  initialNode: PropTypes.oneOfType([PropTypes.object, PropTypes.string]), // FIXME: actually MosaicNode
+  initialNode: PropTypes.oneOfType([PropTypes.array, PropTypes.object, PropTypes.string]), // FIXME: actually MosaicNode
   description: PropTypes.string,
   style: PropTypes.object
 }

--- a/client/src/pages/rollup/Show.js
+++ b/client/src/pages/rollup/Show.js
@@ -56,6 +56,7 @@ const GQL_GET_REPORT_LIST = gql`
       list {
         uuid
         state
+        cancelledReason
         advisorOrg {
           ascendantOrgs(query: { pageNum: 0, pageSize: 0 }) {
             uuid
@@ -361,7 +362,7 @@ const RollupShow = ({ pageDispatchers, searchQuery, setSearchQuery }) => {
       renderer: renderReportMap
     }
   ]
-  const INITIAL_LAYOUT = VISUALIZATIONS[0].id
+  const INITIAL_LAYOUT = [VISUALIZATIONS[0].id, VISUALIZATIONS[1].id]
   const DESCRIPTION = "Number of reports released per organization."
   const flexStyle = {
     display: "flex",


### PR DESCRIPTION
Cancelled Reports have been added by default and are displayed first as a bar chart to the user on the Daily Rollup page by default.

Closes [AB#859](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/859)

#### User changes
- The user will now see the bar-chart chart by default on the Daily Rollup page.

#### Superuser changes
- none

#### Admin changes
- none

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [ ] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
