### PR TITLE
Distinguish between absent and empty authorizationGroupUuids

### DIFF
--- a/anet-dictionary.yml
+++ b/anet-dictionary.yml
@@ -113,6 +113,27 @@ fields:
               validations:
                 - type: required
                   params: [You must provide the Top 3 issues]
+        topTaskSemiannuallyNoWrite:
+          label: Semi-annual assessment of objective, no write
+          recurrence: semiannually
+          test: $.subject[?(@property === "noSuchProperty" && @.match(/^willNeverMatch/i))]
+          authorizationGroupUuids:
+            write: []
+          questions:
+            question1:
+              type: number
+              label: Test Question 1
+        topTaskOnceReportNoWrite:
+          label: Engagement assessment of objective, no write
+          recurrence: once
+          relatedObjectType: report
+          test: $.subject[?(@property === "noSuchProperty" && @.match(/^willNeverMatch/i))]
+          authorizationGroupUuids:
+            write: []
+          questions:
+            question1:
+              type: number
+              label: Test Question 1
 
     subLevel:
       shortLabel: Effort
@@ -1340,6 +1361,39 @@ fields:
               widget: richTextEditor
               style:
                 height: 70px
+        advisorQuarterlyNoWrite:
+          label: Quarterly assessment of advisor, no write
+          recurrence: quarterly
+          test: $.subject[?(@property === "noSuchProperty" && @.match(/^willNeverMatch/i))]
+          authorizationGroupUuids:
+            write: []
+          questions:
+            question1:
+              type: number
+              label: Test Question 1
+        advisorOnceReportNoWrite:
+          label: Engagement assessment of advisor, no write
+          recurrence: once
+          relatedObjectType: report
+          test: $.subject[?(@property === "noSuchProperty" && @.match(/^willNeverMatch/i))]
+          authorizationGroupUuids:
+            write: []
+          questions:
+            question1:
+              type: number
+              label: Test Question 1
+        advisorOndemandNoWrite:
+          label: Ondemand assessment of advisor, no write
+          recurrence: ondemand
+          authorizationGroupUuids:
+            write: []
+          questions:
+            assessmentDate:
+              type: date
+              label: Assessment date
+            question1:
+              type: number
+              label: Test Question 1
     position:
       name: NATO Billet
       type: ANET User

--- a/client/stories/0-general/authorizationForNotes.stories.mdx
+++ b/client/stories/0-general/authorizationForNotes.stories.mdx
@@ -50,19 +50,80 @@ distinguished by the assessmentKey, which is defined in the dictionary and recor
 Using this key, the type of assessment and its corresponding (optional) authorization groups can be
 looked up in the dictionary, and checked against the note. We distinguish groups with read
 permission and write permission (which includes create, update and delete, as well as read).
-Example:
+
+Note that there is a difference between this key being absent from the dictionary, and defining an
+empty list for this key. No key for `read` means anyone can read this information, and an empty list
+(`read: []`) means nobody can read this information (except for those with write access). The
+absence of the `write` key means anyone can write this information, and an empty list  (`write: []`)
+means nobody can write this information.
+
+Examples:
 
 ```
 fields:
   person:
     advisor:
       assessments:
-        advisorOnceReportLinguist:
+        example1:
           recurrence: once
           relatedObjectType: report
           authorizationGroupUuids:
+            # authorization group c21e7321-7ec5-4837-8805-a302f9575754 can read, and
+            # 39a78d51-c351-452c-9206-4305ec8dd76d can also read (because they have write access):
             read: ['c21e7321-7ec5-4837-8805-a302f9575754']
+            # only authorization group 39a78d51-c351-452c-9206-4305ec8dd76d can write:
             write: ['39a78d51-c351-452c-9206-4305ec8dd76d']
+          questions:
+            …
+          questionSets:
+            …
+
+        example2:
+          recurrence: once
+          relatedObjectType: report
+          authorizationGroupUuids:
+            # only authorization group 39a78d51-c351-452c-9206-4305ec8dd76d can read (because they
+            # have write access):
+            read: []
+            # only authorization group 39a78d51-c351-452c-9206-4305ec8dd76d can write:
+            write: ['39a78d51-c351-452c-9206-4305ec8dd76d']
+          questions:
+            …
+          questionSets:
+            …
+
+        example3:
+          recurrence: once
+          relatedObjectType: report
+          authorizationGroupUuids:
+            # anyone can read, because the `read` key is not defined;
+            # only authorization group 39a78d51-c351-452c-9206-4305ec8dd76d can write:
+            write: ['39a78d51-c351-452c-9206-4305ec8dd76d']
+          questions:
+            …
+          questionSets:
+            …
+
+        example4:
+          recurrence: once
+          relatedObjectType: report
+          authorizationGroupUuids:
+            # anyone can read, because the `read` key is not defined;
+            # nobody can write, because the list is empty:
+            write: []
+          questions:
+            …
+          questionSets:
+            …
+
+        example5:
+          recurrence: once
+          relatedObjectType: report
+          authorizationGroupUuids:
+            # only authorization group c21e7321-7ec5-4837-8805-a302f9575754 can read:
+            read: ['c21e7321-7ec5-4837-8805-a302f9575754']
+            # anyone can write, because the `write` key is not defined; although you probably never
+            # want to configure it like this!
           questions:
             …
           questionSets:

--- a/client/stories/0-general/sensitiveInformation.stories.mdx
+++ b/client/stories/0-general/sensitiveInformation.stories.mdx
@@ -17,6 +17,35 @@ allowed to select these authorization groups themselves. For the custom sensitiv
 fields, the authorization groups that have access are defined in the ANET configuration, by the
 application administrator.
 
+Note that there is a difference between this key being absent from the dictionary, and defining an
+empty list for this key. The absence of the key means anyone can access this information, and an
+empty list (`authorizationGroupUuids: []`) means nobody can access this information.
+
+Examples:
+
+```
+fields:
+  person:
+    customSensitiveInformation:
+      example1:
+        # only authorization groups 39a78d51-c351-452c-9206-4305ec8dd76d and
+        # c21e7321-7ec5-4837-8805-a302f9575754 can access this field:
+        authorizationGroupUuids: ['39a78d51-c351-452c-9206-4305ec8dd76d', 'c21e7321-7ec5-4837-8805-a302f9575754']
+        type: date
+        …
+
+      example2:
+        # nobody can access this field, because the list is empty:
+        authorizationGroupUuids: []
+        type: date
+        …
+
+      example3:
+        # anyone can access this field, because `authorizationGroupUuids` is not defined
+        type: date
+        …
+```
+
 In addition to people in the authorization groups, sensitive information in engagement reports is
 also accessible to the report's author(s). And sensitive information for people or positions is also
 accessible to those people's or position's counterparts.

--- a/src/main/java/mil/dds/anet/database/CustomSensitiveInformationDao.java
+++ b/src/main/java/mil/dds/anet/database/CustomSensitiveInformationDao.java
@@ -239,23 +239,21 @@ public class CustomSensitiveInformationDao
     // Check against the dictionary whether the user is authorized
     final List<String> authorizationGroupUuids =
         getAuthorizationGroupUuids(csi.getRelatedObjectType(), csi.getCustomFieldName());
-    if (Utils.isEmptyOrNull(authorizationGroupUuids)) {
-      // No authorization groups defined for this field
-      return false;
+    if (authorizationGroupUuids == null) {
+      // Not defined in dictionary: anyone can access!
+      return true;
     }
 
     // Check against authorization groups
     return DaoUtils.isInAuthorizationGroup(userAuthorizationGroupUuids, authorizationGroupUuids);
   }
 
+  @SuppressWarnings("unchecked")
   private List<String> getAuthorizationGroupUuids(final String tableName, final String fieldName) {
     final String keyPath =
         String.format("fields.%1$s.customSensitiveInformation.%2$s.authorizationGroupUuids",
             getObjectType(tableName), fieldName);
-    @SuppressWarnings("unchecked")
-    final List<String> authorizationGroupUuids =
-        (List<String>) AnetObjectEngine.getConfiguration().getDictionaryEntry(keyPath);
-    return authorizationGroupUuids;
+    return (List<String>) AnetObjectEngine.getConfiguration().getDictionaryEntry(keyPath);
   }
 
   private String getObjectType(final String tableName) {

--- a/src/main/resources/anet-schema.yml
+++ b/src/main/resources/anet-schema.yml
@@ -259,17 +259,15 @@ $defs:
         additionalProperties: false
         properties:
           read:
-            title: The list of authorization group uuid's that have read access to this assessment
+            title: The list of authorization group uuid's that have read access to this assessment. If not specified, anyone can read! An empty array denies everyone access (except those who can write).
             type: array
             uniqueItems: true
-            minItems: 1
             items:
               type: string
           write:
-            title: The list of authorization group uuid's that have write (i.e. create/update/delete) access to this assessment
+            title: The list of authorization group uuid's that have write (i.e. create/update/delete) access to this assessment. If not specified, anyone can write! An empty array denies everyone access.
             type: array
             uniqueItems: true
-            minItems: 1
             items:
               type: string
       questions:
@@ -307,10 +305,9 @@ $defs:
         authorizationGroupUuids:
           type: array
           uniqueItems: true
-          minItems: 1
           items:
             type: string
-            description: The list of authorizationGroup uuid's that have access to this custom sensitive information
+            description: The list of authorization group uuid's that have access to this custom sensitive information. If not specified, anyone has access! An empty array denies everyone access.
 
 #########################################################
 ### schema root

--- a/src/test/java/mil/dds/anet/test/resources/NoteResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/NoteResourceTest.java
@@ -388,6 +388,15 @@ public class NoteResourceTest extends AbstractResourceTest {
   }
 
   @Test
+  void testInstantPersonAssessmentsEmptyWriteAuthGroups()
+      throws GraphQLRequestExecutionException, GraphQLRequestPreparationException {
+    // Instant ('once') ASSESSMENT note tests for person through the NoteResource methods, with
+    // empty write authorization groups defined in the dictionary
+    testInstantAssessmentsEmptyWriteAuthGroups("testInstantPersonAssessmentsNoAuthGroups",
+        "fields.advisor.person.assessments.advisorOnceReportNoWrite", true, TEST_SUBTASK_UUID);
+  }
+
+  @Test
   public void testInstantPersonAssessmentsNoAuthGroups()
       throws GraphQLRequestExecutionException, GraphQLRequestPreparationException {
     // Instant ('once') ASSESSMENT note tests for person through the NoteResource methods, with no
@@ -403,6 +412,16 @@ public class NoteResourceTest extends AbstractResourceTest {
     // ReportResource::updateReportAssessments
     testInstantAssessmentsViaReport("testInstantPersonAssessmentsViaReport",
         "fields.advisor.person.assessments.advisorOnceReportLinguist", true, TEST_SUBTASK_UUID);
+  }
+
+  @Test
+  void testInstantPersonAssessmentsViaReportEmptyWriteAuthGroups()
+      throws GraphQLRequestExecutionException, GraphQLRequestPreparationException {
+    // Instant ('once') ASSESSMENT note tests for person through
+    // ReportResource::updateReportAssessments, with empty write authorization groups defined in the
+    // dictionary
+    testInstantAssessmentsViaReportEmptyWriteAuthGroups("testInstantPersonAssessmentsNoAuthGroups",
+        "fields.advisor.person.assessments.advisorOnceReportNoWrite", true, TEST_SUBTASK_UUID);
   }
 
   @Test
@@ -424,6 +443,15 @@ public class NoteResourceTest extends AbstractResourceTest {
   }
 
   @Test
+  void testInstantTaskAssessmentsEmptyWriteAuthGroups()
+      throws GraphQLRequestExecutionException, GraphQLRequestPreparationException {
+    // Instant ('once') ASSESSMENT note tests for task through the NoteResource methods, with empty
+    // write authorization groups defined in the dictionary
+    testInstantAssessmentsEmptyWriteAuthGroups("testInstantTaskAssessmentsNoAuthGroups",
+        "fields.task.topLevel.assessments.topTaskOnceReportNoWrite", false, TEST_SUBTASK_UUID);
+  }
+
+  @Test
   public void testInstantTaskAssessmentsNoAuthGroups()
       throws GraphQLRequestExecutionException, GraphQLRequestPreparationException {
     // Instant ('once') ASSESSMENT note tests for task through the NoteResource methods, with no
@@ -439,6 +467,17 @@ public class NoteResourceTest extends AbstractResourceTest {
     // ReportResource::updateReportAssessments
     testInstantAssessmentsViaReport("testInstantTaskAssessmentsViaReport",
         "fields.task.topLevel.assessments.topTaskOnceReport", false, TEST_TOPTASK_UUID);
+  }
+
+  @Test
+  void testInstantTaskAssessmentsViaReportEmptyWriteAuthGroups()
+      throws GraphQLRequestExecutionException, GraphQLRequestPreparationException {
+    // Instant ('once') ASSESSMENT note tests for task through
+    // ReportResource::updateReportAssessments, with empty write authorization groups defined in the
+    // dictionary
+    testInstantAssessmentsViaReportEmptyWriteAuthGroups(
+        "testInstantTaskAssessmentsViaReportNoAuthGroups",
+        "fields.task.topLevel.assessments.topTaskOnceReportNoWrite", false, TEST_SUBTASK_UUID);
   }
 
   @Test
@@ -550,13 +589,14 @@ public class NoteResourceTest extends AbstractResourceTest {
   }
 
   @Test
-  public void testOndemandAssessmentsNoAuthGroups()
+  void testOndemandAssessmentsEmptyWriteAuthGroups()
       throws GraphQLRequestExecutionException, GraphQLRequestPreparationException {
-    // On-demand ASSESSMENT note tests, with no authorization groups defined in the dictionary
-    final String assessmentKey = "fields.advisor.person.assessments.advisorOndemand";
+    // On-demand ASSESSMENT note tests, with empty write authorization groups defined in the
+    // dictionary
+    final String assessmentKey = "fields.advisor.person.assessments.advisorOndemandNoWrite";
     final String recurrence = "ondemand";
 
-    // - F: create for a person with no write auth.groups defined in the dictionary
+    // - F: create for a person with empty write auth.groups defined in the dictionary
     final Person principalPerson = getSteveSteveson();
     final String principalPersonUuid = principalPerson.getUuid();
     final NoteRelatedObjectInput testPrincipalNroInput =
@@ -575,17 +615,50 @@ public class NoteResourceTest extends AbstractResourceTest {
     final Person jackPerson = jackQueryExecutor.person(PERSON_FIELDS, principalPersonUuid);
     assertNotes(jackPerson.getNotes(), testNoteInputs, assessmentKey, 1);
 
-    // - F: update it with no write auth.groups defined in the dictionary
+    // - F: update it with empty write auth.groups defined in the dictionary
     final NoteInput updatedNoteInputJack = getNoteInput(createdNoteAdmin);
     updatedNoteInputJack.setText(createAssessmentText("updated by jack", recurrence));
     failNoteUpdate(jackMutationExecutor, updatedNoteInputJack);
 
-    // - F: delete it with no write auth.groups defined in the dictionary
+    // - F: delete it with empty write auth.groups defined in the dictionary
     failNoteDelete(jackMutationExecutor, createdNoteAdmin);
 
     // - S: delete it as admin
     succeedNoteDelete(adminMutationExecutor, createdNoteAdmin);
     testNoteInputs.remove(testNoteInputAdmin);
+    assertNotes(adminQueryExecutor.person(PERSON_FIELDS, principalPersonUuid).getNotes(),
+        testNoteInputs, assessmentKey, 1);
+  }
+
+  @Test
+  void testOndemandAssessmentsNoAuthGroups()
+      throws GraphQLRequestExecutionException, GraphQLRequestPreparationException {
+    // On-demand ASSESSMENT note tests, with no authorization groups defined in the dictionary
+    final String assessmentKey = "fields.advisor.person.assessments.advisorOndemand";
+    final String recurrence = "ondemand";
+
+    // - S: create for a person with no auth.groups defined in the dictionary
+    final Person principalPerson = getSteveSteveson();
+    final String principalPersonUuid = principalPerson.getUuid();
+    final NoteRelatedObjectInput testPrincipalNroInput =
+        createNoteRelatedObject(PersonDao.TABLE_NAME, principalPersonUuid);
+    final NoteInput testNoteInputJack =
+        createAssessment(assessmentKey, "jack", recurrence, testPrincipalNroInput);
+    final List<NoteInput> testNoteInputs = Lists.newArrayList(testNoteInputJack);
+    final Note createdNoteJack = succeedNoteCreate(jackMutationExecutor, testNoteInputJack);
+
+    // - S: read it with no auth.groups defined in the dictionary
+    final Person jackPerson = jackQueryExecutor.person(PERSON_FIELDS, principalPersonUuid);
+    assertNotes(jackPerson.getNotes(), testNoteInputs, assessmentKey, 1);
+
+    // - S: update it with no auth.groups defined in the dictionary
+    final NoteInput updatedNoteInputJack = getNoteInput(createdNoteJack);
+    updatedNoteInputJack.setText(createAssessmentText("updated by jack", recurrence));
+    succeedNoteUpdate(jackMutationExecutor, updatedNoteInputJack);
+
+    // - S: delete it with no auth.groups defined in the dictionary
+    succeedNoteDelete(jackMutationExecutor, createdNoteJack);
+    testNoteInputs.remove(testNoteInputJack);
     assertNotes(adminQueryExecutor.person(PERSON_FIELDS, principalPersonUuid).getNotes(),
         testNoteInputs, assessmentKey, 1);
   }
@@ -705,16 +778,18 @@ public class NoteResourceTest extends AbstractResourceTest {
   }
 
   @Test
-  public void testPeriodicPersonAssessmentsNoAuthGroups()
+  void testPeriodicPersonAssessmentsEmptyWriteAuthGroups()
       throws GraphQLRequestExecutionException, GraphQLRequestPreparationException {
-    // Periodic ASSESSMENT note tests for person, with no authorization groups defined in the
+    // Periodic ASSESSMENT note tests for person, with empty write authorization groups defined in
+    // the
     // dictionary
-    final String assessmentKey = "fields.principal.person.assessments.principalQuarterly";
+    final String assessmentKey = "fields.advisor.person.assessments.advisorQuarterlyNoWrite";
     final String recurrence = "quarterly";
     final MutationExecutor personCounterpartMutationExecutor =
         getMutationExecutor(getRegularUser().getDomainUsername());
 
-    // - F: create for a person as someone without counterpart and no write auth.groups defined in
+    // - F: create for a person as someone without counterpart and empty write auth.groups defined
+    // in
     // the dictionary
     final NoteRelatedObjectInput testPersonNroInput =
         createNoteRelatedObject(PersonDao.TABLE_NAME, TEST_COUNTERPART_PERSON_UUID);
@@ -724,7 +799,8 @@ public class NoteResourceTest extends AbstractResourceTest {
         getMutationExecutor(getAndrewAnderson().getDomainUsername());
     failNoteCreate(andrewMutationExecutor, testNoteInputFail);
 
-    // - S: create for a person as someone with counterpart and no write auth.groups defined in the
+    // - S: create for a person as someone with counterpart and empty write auth.groups defined in
+    // the
     // dictionary
     final NoteInput testNoteInput =
         createAssessment(assessmentKey, "erin", recurrence, testPersonNroInput);
@@ -738,26 +814,70 @@ public class NoteResourceTest extends AbstractResourceTest {
         andrewQueryExecutor.person(PERSON_FIELDS, TEST_COUNTERPART_PERSON_UUID);
     assertNotes(andrewPerson.getNotes(), testNoteInputs, assessmentKey, 1);
 
-    // - F: update it as someone without counterpart and with no write auth.groups defined in the
+    // - F: update it as someone without counterpart and with empty write auth.groups defined in the
     // dictionary
     final NoteInput updatedNoteInputAndrew = getNoteInput(createdNote);
     updatedNoteInputAndrew.setText(createAssessmentText("updated by andrew", recurrence));
     failNoteUpdate(andrewMutationExecutor, updatedNoteInputAndrew);
 
-    // - S: update it as someone with counterpart and with no write auth.groups defined in the
+    // - S: update it as someone with counterpart and with empty write auth.groups defined in the
     // dictionary
     final NoteInput updatedNoteInput = getNoteInput(createdNote);
     updatedNoteInput.setText(createAssessmentText("updated by erin", recurrence));
     final List<NoteInput> updatedNotesInput = Lists.newArrayList(updatedNoteInput);
     final Note updatedNote = succeedNoteUpdate(personCounterpartMutationExecutor, updatedNoteInput);
 
-    // - F: delete it as someone without counterpart and with no write auth.groups defined in the
+    // - F: delete it as someone without counterpart and with empty write auth.groups defined in the
     // dictionary
     failNoteDelete(andrewMutationExecutor, createdNote);
 
-    // - S: delete it as someone with counterpart and with no write auth.groups defined in the
+    // - S: delete it as someone with counterpart and with empty write auth.groups defined in the
     // dictionary
     succeedNoteDelete(personCounterpartMutationExecutor, updatedNote);
+    assertThat(updatedNotesInput.remove(updatedNoteInput)).isTrue();
+    assertNotes(andrewQueryExecutor.person(PERSON_FIELDS, TEST_COUNTERPART_PERSON_UUID).getNotes(),
+        updatedNotesInput, assessmentKey, 1);
+  }
+
+  @Test
+  void testPeriodicPersonAssessmentsNoAuthGroups()
+      throws GraphQLRequestExecutionException, GraphQLRequestPreparationException {
+    // Periodic ASSESSMENT note tests for person, with no authorization groups defined in the
+    // dictionary
+    final String assessmentKey = "fields.principal.person.assessments.principalQuarterly";
+    final String recurrence = "quarterly";
+    final MutationExecutor personCounterpartMutationExecutor =
+        getMutationExecutor(getRegularUser().getDomainUsername());
+
+    // - S: create for a person as someone without counterpart and no auth.groups defined in
+    // the dictionary
+    final NoteRelatedObjectInput testPersonNroInput =
+        createNoteRelatedObject(PersonDao.TABLE_NAME, TEST_COUNTERPART_PERSON_UUID);
+    final NoteInput testNoteInput =
+        createAssessment(assessmentKey, "andrew", recurrence, testPersonNroInput);
+    final MutationExecutor andrewMutationExecutor =
+        getMutationExecutor(getAndrewAnderson().getDomainUsername());
+    final List<NoteInput> testNoteInputs = Lists.newArrayList(testNoteInput);
+    final Note createdNote = succeedNoteCreate(personCounterpartMutationExecutor, testNoteInput);
+
+    // - S: read it with no auth.groups defined in the dictionary
+    final QueryExecutor andrewQueryExecutor =
+        getQueryExecutor(getAndrewAnderson().getDomainUsername());
+    final Person andrewPerson =
+        andrewQueryExecutor.person(PERSON_FIELDS, TEST_COUNTERPART_PERSON_UUID);
+    assertNotes(andrewPerson.getNotes(), testNoteInputs, assessmentKey, 1);
+
+    // - S: update it as someone without counterpart and with no auth.groups defined in the
+    // dictionary
+    final NoteInput updatedNoteInput = getNoteInput(createdNote);
+    updatedNoteInput.setText(createAssessmentText("updated by andrew", recurrence));
+    succeedNoteUpdate(andrewMutationExecutor, updatedNoteInput);
+    final List<NoteInput> updatedNotesInput = Lists.newArrayList(updatedNoteInput);
+    final Note updatedNote = succeedNoteUpdate(personCounterpartMutationExecutor, updatedNoteInput);
+
+    // - S: delete it as someone without counterpart and with no auth.groups defined in the
+    // dictionary
+    succeedNoteDelete(andrewMutationExecutor, updatedNote);
     assertThat(updatedNotesInput.remove(updatedNoteInput)).isTrue();
     assertNotes(andrewQueryExecutor.person(PERSON_FIELDS, TEST_COUNTERPART_PERSON_UUID).getNotes(),
         updatedNotesInput, assessmentKey, 1);
@@ -876,17 +996,18 @@ public class NoteResourceTest extends AbstractResourceTest {
   }
 
   @Test
-  public void testPeriodicTaskAssessmentsNoAuthGroups()
+  void testPeriodicTaskAssessmentsEmptyWriteAuthGroups()
       throws GraphQLRequestExecutionException, GraphQLRequestPreparationException {
-    // Periodic ASSESSMENT note tests for task, with no authorization groups defined in the
+    // Periodic ASSESSMENT note tests for task, with empty write authorization groups defined in the
     // dictionary
-    final String assessmentKey = "fields.task.subLevel.assessments.subTaskMonthly";
-    final String recurrence = "monthly";
+    final String assessmentKey = "fields.task.topLevel.assessments.topTaskSemiannuallyNoWrite";
+    final String recurrence = "semiannually";
     final Person taskResponsible = getAndrewAnderson();
     final MutationExecutor taskResponsibleMutationExecutor =
         getMutationExecutor(taskResponsible.getDomainUsername());
 
-    // - F: create for a task as someone without task permission and no write auth.groups defined in
+    // - F: create for a task as someone without task permission and empty write auth.groups defined
+    // in
     // the dictionary
     final NoteRelatedObjectInput testTaskNroInput =
         createNoteRelatedObject(TaskDao.TABLE_NAME, TEST_RESPONSIBLE_TASK_UUID);
@@ -896,7 +1017,7 @@ public class NoteResourceTest extends AbstractResourceTest {
         getMutationExecutor(getRegularUser().getDomainUsername());
     failNoteCreate(erinMutationExecutor, testNoteInputFail);
 
-    // - S: create for a task as someone with task permission and no write auth.groups defined in
+    // - S: create for a task as someone with task permission and empty write auth.groups defined in
     // the dictionary
     final NoteInput testNoteInput =
         createAssessment(assessmentKey, "andrew", recurrence, testTaskNroInput);
@@ -908,26 +1029,71 @@ public class NoteResourceTest extends AbstractResourceTest {
     final Task erinTask = erinQueryExecutor.task(TASK_FIELDS, TEST_RESPONSIBLE_TASK_UUID);
     assertNotes(erinTask.getNotes(), testNoteInputs, assessmentKey, 1);
 
-    // - F: update it as someone without task permission and with no write auth.groups defined in
+    // - F: update it as someone without task permission and with empty write auth.groups defined in
     // the dictionary
     final NoteInput updatedNoteInputErin = getNoteInput(createdNote);
     updatedNoteInputErin.setText(createAssessmentText("updated by erin", recurrence));
     failNoteUpdate(erinMutationExecutor, updatedNoteInputErin);
 
-    // - S: update it as someone with task permission and with no write auth.groups defined in the
+    // - S: update it as someone with task permission and with empty write auth.groups defined in
+    // the
     // dictionary
     final NoteInput updatedNoteInput = getNoteInput(createdNote);
     updatedNoteInput.setText(createAssessmentText("updated by andrew", recurrence));
     final List<NoteInput> updatedNotesInput = Lists.newArrayList(updatedNoteInput);
     final Note updatedNote = succeedNoteUpdate(taskResponsibleMutationExecutor, updatedNoteInput);
 
-    // - F: delete it as someone without task permission and with no write auth.groups defined in
+    // - F: delete it as someone without task permission and with empty write auth.groups defined in
     // the dictionary
     failNoteDelete(erinMutationExecutor, createdNote);
 
-    // - S: delete it as someone with task permission and with no write auth.groups defined in the
+    // - S: delete it as someone with task permission and with empty write auth.groups defined in
+    // the
     // dictionary
     succeedNoteDelete(taskResponsibleMutationExecutor, updatedNote);
+    assertThat(updatedNotesInput.remove(updatedNoteInput)).isTrue();
+    assertNotes(erinQueryExecutor.task(TASK_FIELDS, TEST_RESPONSIBLE_TASK_UUID).getNotes(),
+        updatedNotesInput, assessmentKey, 1);
+  }
+
+  @Test
+  void testPeriodicTaskAssessmentsNoAuthGroups()
+      throws GraphQLRequestExecutionException, GraphQLRequestPreparationException {
+    // Periodic ASSESSMENT note tests for task, with no authorization groups defined in the
+    // dictionary
+    final String assessmentKey = "fields.task.subLevel.assessments.subTaskMonthly";
+    final String recurrence = "monthly";
+    final Person taskResponsible = getAndrewAnderson();
+    final MutationExecutor taskResponsibleMutationExecutor =
+        getMutationExecutor(taskResponsible.getDomainUsername());
+
+    // - S: create for a task as someone without task permission and no auth.groups defined in
+    // the dictionary
+    final NoteRelatedObjectInput testTaskNroInput =
+        createNoteRelatedObject(TaskDao.TABLE_NAME, TEST_RESPONSIBLE_TASK_UUID);
+    final NoteInput testNoteInput =
+        createAssessment(assessmentKey, "erin", recurrence, testTaskNroInput);
+    final MutationExecutor erinMutationExecutor =
+        getMutationExecutor(getRegularUser().getDomainUsername());
+    final List<NoteInput> testNoteInputs = Lists.newArrayList(testNoteInput);
+    final Note createdNote = succeedNoteCreate(erinMutationExecutor, testNoteInput);
+
+    // - S: read it with no auth.groups defined in the dictionary
+    final QueryExecutor erinQueryExecutor = getQueryExecutor(getRegularUser().getDomainUsername());
+    final Task erinTask = erinQueryExecutor.task(TASK_FIELDS, TEST_RESPONSIBLE_TASK_UUID);
+    assertNotes(erinTask.getNotes(), testNoteInputs, assessmentKey, 1);
+
+    // - S: update it as someone without task permission and with no auth.groups defined in
+    // the dictionary
+    final NoteInput updatedNoteInput = getNoteInput(createdNote);
+    updatedNoteInput.setText(createAssessmentText("updated by erin", recurrence));
+    succeedNoteUpdate(erinMutationExecutor, updatedNoteInput);
+    final List<NoteInput> updatedNotesInput = Lists.newArrayList(updatedNoteInput);
+    final Note updatedNote = succeedNoteUpdate(erinMutationExecutor, updatedNoteInput);
+
+    // - S: delete it as someone without task permission and with no auth.groups defined in
+    // the dictionary
+    succeedNoteDelete(erinMutationExecutor, createdNote);
     assertThat(updatedNotesInput.remove(updatedNoteInput)).isTrue();
     assertNotes(erinQueryExecutor.task(TASK_FIELDS, TEST_RESPONSIBLE_TASK_UUID).getNotes(),
         updatedNotesInput, assessmentKey, 1);
@@ -1096,6 +1262,59 @@ public class NoteResourceTest extends AbstractResourceTest {
     reportAuthorMutationExecutor.deleteReport("", reportUuid);
   }
 
+  private void testInstantAssessmentsEmptyWriteAuthGroups(final String testName,
+      final String assessmentKey, final boolean forPerson, final String taskUuid)
+      throws GraphQLRequestExecutionException, GraphQLRequestPreparationException {
+    final String recurrence = "once";
+    final Person reportAuthor = getNickNicholson();
+    final MutationExecutor reportAuthorMutationExecutor =
+        getMutationExecutor(reportAuthor.getDomainUsername());
+
+    // Create a test report
+    final Person principalPerson = getSteveSteveson();
+    final ReportPerson principal = personToPrimaryReportPerson(principalPerson);
+    final TaskInput taskInput = TaskInput.builder().withUuid(taskUuid).build();
+    final ReportInput reportInput = ReportInput.builder().withEngagementDate(Instant.now())
+        .withIntent(testName)
+        .withReportPeople(
+            getReportPeopleInput(Lists.newArrayList(principal, personToReportAuthor(reportAuthor))))
+        .withTasks(Lists.newArrayList(taskInput)).build();
+    final Report createdReport =
+        reportAuthorMutationExecutor.createReport(REPORT_FIELDS, reportInput);
+
+    // - S: create as author for a report and a person
+    final NoteRelatedObjectInput testReportNroInput =
+        createNoteRelatedObject(ReportDao.TABLE_NAME, createdReport.getUuid());
+    final NoteRelatedObjectInput testPrincipalNroInput =
+        createNoteRelatedObject(PersonDao.TABLE_NAME, principalPerson.getUuid());
+    final NoteRelatedObjectInput testTaskNroInput =
+        createNoteRelatedObject(TaskDao.TABLE_NAME, taskUuid);
+    final NoteInput testNoteInputAuthor = createAssessment(assessmentKey, "author", recurrence,
+        testReportNroInput, forPerson ? testPrincipalNroInput : testTaskNroInput);
+    final List<NoteInput> testNoteInputs = Lists.newArrayList(testNoteInputAuthor);
+    final Note createdNoteAuthor =
+        succeedNoteCreate(reportAuthorMutationExecutor, testNoteInputAuthor);
+    assertNotes(jackQueryExecutor.report(REPORT_FIELDS, createdReport.getUuid()).getNotes(),
+        testNoteInputs, assessmentKey, 2);
+
+    // - F: update it as someone else with empty write auth.groups defined in the dictionary
+    final NoteInput updatedNoteInputJack = getNoteInput(createdNoteAuthor);
+    updatedNoteInputJack.setText(createAssessmentText("updated by jack", recurrence));
+    failNoteUpdate(jackMutationExecutor, updatedNoteInputJack);
+
+    // - F: delete it as someone else with empty write auth.groups defined in the dictionary
+    failNoteDelete(jackMutationExecutor, createdNoteAuthor);
+
+    // - S: delete it as author
+    succeedNoteDelete(reportAuthorMutationExecutor, createdNoteAuthor);
+    testNoteInputs.remove(testNoteInputAuthor);
+    assertNotes(jackQueryExecutor.report(REPORT_FIELDS, createdReport.getUuid()).getNotes(),
+        testNoteInputs, assessmentKey, 2);
+
+    // Delete the test report
+    reportAuthorMutationExecutor.deleteReport("", createdReport.getUuid());
+  }
+
   private void testInstantAssessmentsNoAuthGroups(final String testName, final String assessmentKey,
       final boolean forPerson, final String taskUuid)
       throws GraphQLRequestExecutionException, GraphQLRequestPreparationException {
@@ -1131,19 +1350,13 @@ public class NoteResourceTest extends AbstractResourceTest {
     assertNotes(jackQueryExecutor.report(REPORT_FIELDS, createdReport.getUuid()).getNotes(),
         testNoteInputs, assessmentKey, 2);
 
-    // - F: update it as someone else with no write auth.groups defined in the dictionary
+    // - S: update it as someone else with no auth.groups defined in the dictionary
     final NoteInput updatedNoteInputJack = getNoteInput(createdNoteAuthor);
     updatedNoteInputJack.setText(createAssessmentText("updated by jack", recurrence));
-    failNoteUpdate(jackMutationExecutor, updatedNoteInputJack);
+    succeedNoteUpdate(jackMutationExecutor, updatedNoteInputJack);
 
-    // - F: delete it as someone else with no write auth.groups defined in the dictionary
-    failNoteDelete(jackMutationExecutor, createdNoteAuthor);
-
-    // - S: delete it as author
-    succeedNoteDelete(reportAuthorMutationExecutor, createdNoteAuthor);
-    testNoteInputs.remove(testNoteInputAuthor);
-    assertNotes(jackQueryExecutor.report(REPORT_FIELDS, createdReport.getUuid()).getNotes(),
-        testNoteInputs, assessmentKey, 2);
+    // - S: delete it as someone else with no auth.groups defined in the dictionary
+    succeedNoteDelete(jackMutationExecutor, createdNoteAuthor);
 
     // Delete the test report
     reportAuthorMutationExecutor.deleteReport("", createdReport.getUuid());
@@ -1363,7 +1576,7 @@ public class NoteResourceTest extends AbstractResourceTest {
     assertThat(reportAuthorMutationExecutor.deleteReport("", reportUuid)).isOne();
   }
 
-  private void testInstantAssessmentsViaReportNoAuthGroups(final String testName,
+  private void testInstantAssessmentsViaReportEmptyWriteAuthGroups(final String testName,
       final String assessmentKey, final boolean forPerson, final String taskUuid)
       throws GraphQLRequestExecutionException, GraphQLRequestPreparationException {
     final String recurrence = "once";
@@ -1403,17 +1616,78 @@ public class NoteResourceTest extends AbstractResourceTest {
     final Report jackReport = jackQueryExecutor.report(REPORT_FIELDS, reportUuid);
     assertNotes(jackReport.getNotes(), testNoteInputs, assessmentKey, 2);
 
-    // - F: update it as someone else with no write auth.groups defined in the dictionary
+    // - F: update it as someone else with empty write auth.groups defined in the dictionary
     final List<NoteInput> updatedNotesInput = getNotesInput(jackReport.getNotes());
     final NoteInput updatedNoteInputJack = updatedNotesInput.get(0);
     updatedNoteInputJack.setText(createAssessmentText("updated by jack", recurrence));
     failUpdateReportAssessments(jackMutationExecutor, reportUuid,
         Iterables.toArray(updatedNotesInput, NoteInput.class));
 
-    // - F: delete it as someone else with no write auth.groups defined in the dictionary
+    // - F: delete it as someone else with empty write auth.groups defined in the dictionary
     failUpdateReportAssessments(jackMutationExecutor, reportUuid);
 
     // - S: delete it as author
+    succeedUpdateReportAssessments(reportAuthorMutationExecutor, reportUuid);
+    testNoteInputs.remove(testNoteInputAuthor);
+    assertNotes(jackQueryExecutor.report(REPORT_FIELDS, reportUuid).getNotes(), testNoteInputs,
+        assessmentKey, 2);
+
+    // Get the test report
+    final Report report = reportAuthorQueryExecutor.report(REPORT_FIELDS, reportUuid);
+    // Update it as author so it goes back to draft
+    reportAuthorMutationExecutor.updateReport(REPORT_FIELDS, getReportInput(report), false);
+    // Then delete it
+    assertThat(reportAuthorMutationExecutor.deleteReport("", reportUuid)).isOne();
+  }
+
+  private void testInstantAssessmentsViaReportNoAuthGroups(final String testName,
+      final String assessmentKey, final boolean forPerson, final String taskUuid)
+      throws GraphQLRequestExecutionException, GraphQLRequestPreparationException {
+    final String recurrence = "once";
+    final Person reportAuthor = getNickNicholson();
+    final QueryExecutor reportAuthorQueryExecutor =
+        getQueryExecutor(reportAuthor.getDomainUsername());
+    final MutationExecutor reportAuthorMutationExecutor =
+        getMutationExecutor(reportAuthor.getDomainUsername());
+
+    // Create a test report
+    final Person principalPerson = getSteveSteveson();
+    final ReportPerson principal = personToPrimaryReportPerson(principalPerson);
+    final TaskInput taskInput = TaskInput.builder().withUuid(taskUuid).build();
+    final ReportInput reportInput =
+        ReportInput.builder().withEngagementDate(Instant.now()).withIntent(testName)
+            .withReportPeople(getReportPeopleInput(
+                Lists.newArrayList(principal, personToPrimaryReportAuthor(reportAuthor))))
+            .withTasks(Lists.newArrayList(taskInput)).build();
+    final Report createdReport =
+        reportAuthorMutationExecutor.createReport(REPORT_FIELDS, reportInput);
+    final String reportUuid = createdReport.getUuid();
+    assertThat(reportAuthorMutationExecutor.submitReport("", reportUuid)).isOne();
+
+    // - S: create as author for a report and a person
+    final NoteRelatedObjectInput testReportNroInput =
+        createNoteRelatedObject(ReportDao.TABLE_NAME, reportUuid);
+    final NoteRelatedObjectInput testPrincipalNroInput =
+        createNoteRelatedObject(PersonDao.TABLE_NAME, principalPerson.getUuid());
+    final NoteRelatedObjectInput testTaskNroInput =
+        createNoteRelatedObject(TaskDao.TABLE_NAME, taskUuid);
+    final NoteInput testNoteInputAuthor = createAssessment(assessmentKey, "author", recurrence,
+        testReportNroInput, forPerson ? testPrincipalNroInput : testTaskNroInput);
+    final List<NoteInput> testNoteInputs = Lists.newArrayList(testNoteInputAuthor);
+    succeedUpdateReportAssessments(reportAuthorMutationExecutor, reportUuid, testNoteInputAuthor);
+
+    // - S: read it as someone else with no auth.groups defined in the dictionary
+    final Report jackReport = jackQueryExecutor.report(REPORT_FIELDS, reportUuid);
+    assertNotes(jackReport.getNotes(), testNoteInputs, assessmentKey, 2);
+
+    // - S: update it as someone else with no auth.groups defined in the dictionary
+    final List<NoteInput> updatedNotesInput = getNotesInput(jackReport.getNotes());
+    final NoteInput updatedNoteInputJack = updatedNotesInput.get(0);
+    updatedNoteInputJack.setText(createAssessmentText("updated by jack", recurrence));
+    succeedUpdateReportAssessments(jackMutationExecutor, reportUuid,
+        Iterables.toArray(updatedNotesInput, NoteInput.class));
+
+    // - S: delete it as someone else with no auth.groups defined in the dictionary
     succeedUpdateReportAssessments(reportAuthorMutationExecutor, reportUuid);
     testNoteInputs.remove(testNoteInputAuthor);
     assertNotes(jackQueryExecutor.report(REPORT_FIELDS, reportUuid).getNotes(), testNoteInputs,

--- a/testDictionaries/no-custom-fields.yml
+++ b/testDictionaries/no-custom-fields.yml
@@ -112,6 +112,27 @@ fields:
               validations:
                 - type: required
                   params: [You must provide the Top 3 issues]
+        topTaskSemiannuallyNoWrite:
+          label: Semi-annual assessment of objective, no write
+          recurrence: semiannually
+          test: $.subject[?(@property === "noSuchProperty" && @.match(/^willNeverMatch/i))]
+          authorizationGroupUuids:
+            write: []
+          questions:
+            question1:
+              type: number
+              label: Test Question 1
+        topTaskOnceReportNoWrite:
+          label: Engagement assessment of objective, no write
+          recurrence: once
+          relatedObjectType: report
+          test: $.subject[?(@property === "noSuchProperty" && @.match(/^willNeverMatch/i))]
+          authorizationGroupUuids:
+            write: []
+          questions:
+            question1:
+              type: number
+              label: Test Question 1
 
     subLevel:
       shortLabel: Effort
@@ -850,6 +871,39 @@ fields:
               widget: richTextEditor
               style:
                 height: 70px
+        advisorQuarterlyNoWrite:
+          label: Quarterly assessment of advisor, no write
+          recurrence: quarterly
+          test: $.subject[?(@property === "noSuchProperty" && @.match(/^willNeverMatch/i))]
+          authorizationGroupUuids:
+            write: []
+          questions:
+            question1:
+              type: number
+              label: Test Question 1
+        advisorOnceReportNoWrite:
+          label: Engagement assessment of advisor, no write
+          recurrence: once
+          relatedObjectType: report
+          test: $.subject[?(@property === "noSuchProperty" && @.match(/^willNeverMatch/i))]
+          authorizationGroupUuids:
+            write: []
+          questions:
+            question1:
+              type: number
+              label: Test Question 1
+        advisorOndemandNoWrite:
+          label: Ondemand assessment of advisor, no write
+          recurrence: ondemand
+          authorizationGroupUuids:
+            write: []
+          questions:
+            assessmentDate:
+              type: date
+              label: Assessment date
+            question1:
+              type: number
+              label: Test Question 1
     position:
       name: NATO Billet
       type: ANET User


### PR DESCRIPTION
Absent and empty authorizationGroupUuids settings in the dictionary are now distinguished: when a key is absent, it means anyone has access, when the key is an empty list (i.e. `[]`), then nobody has access.

Closes [AB#857](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/857)

#### User changes
- none

#### Superuser changes
- none

#### Admin changes
- none

#### System admin changes
- [x] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [x] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [x] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [x] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
