### PR TITLE
Be able to add assessment (periodic, ondemand) to organizations

### DIFF
--- a/anet-dictionary.yml
+++ b/anet-dictionary.yml
@@ -915,6 +915,19 @@ fields:
             widget: richTextEditor
             style:
               height: 15px
+      organizationOndemand:
+        label: Ondemand assessment of organization
+        recurrence: ondemand
+        questions:
+          assessmentDate:
+            type: date
+            label: Assessment date
+          question1:
+            type: special_field
+            label: General remarks
+            widget: richTextEditor
+            style:
+              height: 70px
     customFields:
       multipleButtons:
         type: enumset

--- a/anet-dictionary.yml
+++ b/anet-dictionary.yml
@@ -857,6 +857,64 @@ fields:
     shortName: Name
     parentOrg: Parent Organization
     profile: Profile
+    assessments:
+      organizationAnnually:
+        label: Interaction Plan
+        recurrence: annually
+        questions:         
+          question1:
+            type: enum
+            label: Priority
+            choices:
+              t1:
+                label: T1 # Critical
+                color: '#f50525' # Red
+              t2:
+                label: T2 # Vital
+                color: '#f59d05' # Orange
+              t3:
+                label: T3  # Highly Desirable
+                color: '#f5e505' # Yellow
+              t4:
+                label: T4 #  Desirable
+                color: '#07b50a' # Green
+              t5:
+                label: T5 # Dormant
+                color: '#939692' # Gray
+          question2:
+            type: enum
+            label: Interaction
+            choices:
+              noStatement:
+                label: No statement
+                color: '#5b5b5b' # Black
+              dormant:
+                label: Dormant
+                color: '#999999' # Gray
+              initiate:
+                label: Initiate
+                color: '#f50525' # Red
+              develop:
+                label: Develop
+                color: '#f59d05' # Orange
+              improve:
+                label: Improve
+                color: '#f5e505' # Yellow
+              maintain:
+                label: Maintain
+                color: '#07b50a' # Green
+          question3:
+            type: special_field
+            label: Plan
+            widget: richTextEditor
+            style:
+              height: 15px
+          question4:
+            type: special_field
+            label: Exercises
+            widget: richTextEditor
+            style:
+              height: 15px
     customFields:
       multipleButtons:
         type: enumset

--- a/client/src/models/Organization.js
+++ b/client/src/models/Organization.js
@@ -23,6 +23,9 @@ export default class Organization extends Model {
     REPORT_APPROVAL: "REPORT_APPROVAL"
   }
 
+  static assessmentDictionaryPath = "fields.organization.assessments"
+  static assessmentConfig = Settings.fields.organization.assessments
+
   // create yup schema for the customFields, based on the customFields config
   static customFieldsSchema = createCustomFieldsSchema(
     Settings.fields.organization.customFields
@@ -126,6 +129,14 @@ export default class Organization extends Model {
 
   constructor(props) {
     super(Model.fillObject(props, Organization.yupSchema))
+  }
+
+  getAssessmentDictionaryPath() {
+    return Organization.assessmentDictionaryPath
+  }
+
+  getAssessmentsConfig() {
+    return Organization.assessmentConfig
   }
 
   humanNameOfType(type) {

--- a/client/src/pages/organizations/Show.js
+++ b/client/src/pages/organizations/Show.js
@@ -3,6 +3,7 @@ import { DEFAULT_PAGE_PROPS, DEFAULT_SEARCH_PROPS } from "actions"
 import API from "api"
 import AppContext from "components/AppContext"
 import Approvals from "components/approvals/Approvals"
+import AssessmentResultsContainer from "components/assessments/AssessmentResultsContainer"
 import { ReadonlyCustomFields } from "components/CustomFields"
 import * as FieldHelper from "components/FieldHelper"
 import Fieldset from "components/Fieldset"
@@ -166,7 +167,7 @@ const GQL_GET_ORGANIZATION = gql`
 `
 
 const OrganizationShow = ({ pageDispatchers }) => {
-  const { currentUser } = useContext(AppContext)
+  const { currentUser, loadAppData } = useContext(AppContext)
   const routerLocation = useLocation()
   const stateSuccess = routerLocation.state && routerLocation.state.success
   const [stateError, setStateError] = useState(
@@ -526,6 +527,16 @@ const OrganizationShow = ({ pageDispatchers }) => {
                 </Fieldset>
               )}
             </Form>
+            <AssessmentResultsContainer
+              entity={organization}
+              entityType={Organization}
+              canAddPeriodicAssessment={canAdministrateOrg}
+              canAddOndemandAssessment={canAdministrateOrg}
+              onUpdateAssessment={() => {
+                loadAppData()
+                refetch()
+              }}
+            />
           </div>
         )
       }}

--- a/client/tests/webdriver/baseSpecs/assessmentsForOrganization.spec.js
+++ b/client/tests/webdriver/baseSpecs/assessmentsForOrganization.spec.js
@@ -1,0 +1,231 @@
+import { expect } from "chai"
+import Home from "../pages/home.page"
+import Search from "../pages/search.page"
+import ShowOrganization from "../pages/showOrganization.page"
+
+const ORGANIZATION_SEARCH_STRING = "EF 2.2"
+const SUPERUSER_ASSESSMENT_CREATE_DETAILS = [
+  "t2",
+  "noStatement",
+  "Develop relationship",
+  "TRJU-1"
+]
+const SUPERUSER_ASSESSMENT_EDIT_DETAILS = [
+  "t2",
+  "improve",
+  "Improve relationship",
+  "TRJU-1 TRJU-2"
+]
+const ADMIN_ASSESSMENT_EDIT_DETAILS = [
+  "t3",
+  "maintain",
+  "Maintain the connection network",
+  "TRJU-1 TRJU-2 JUJA"
+]
+
+const VALUE_TO_TEXT_FOR_PRIORITY = {
+  t1: "T1",
+  t2: "T2",
+  t3: "T3",
+  t4: "T4",
+  t5: "T5"
+}
+
+const VALUE_TO_TEXT_FOR_INTERACTION = {
+  noStatement: "No statement",
+  dormant: "Dormant",
+  initiate: "Initiate",
+  develop: "Develop",
+  improve: "Improve",
+  maintain: "Maintain"
+}
+
+describe("For the annualy organization assessments", () => {
+  describe("As a superuser assigned to the organization", () => {
+    it("Should first search, find and open the organization's page", async() => {
+      await Home.openAsSuperuser()
+      await (await Home.getSearchBar()).setValue(ORGANIZATION_SEARCH_STRING)
+      await (await Home.getSubmitSearch()).click()
+      await (
+        await Search.getFoundOrganizationTable()
+      ).waitForExist({ timeout: 20000 })
+      await (await Search.getFoundOrganizationTable()).waitForDisplayed()
+      await (
+        await Search.linkOfOrganizationFound(ORGANIZATION_SEARCH_STRING)
+      ).click()
+    })
+
+    it("Should allow superuser to successfully add an assessment", async() => {
+      await (
+        await ShowOrganization.getAssessmentsTable(
+          "organizationAnnually",
+          "annually"
+        )
+      ).waitForExist()
+      await (
+        await ShowOrganization.getAssessmentsTable(
+          "organizationAnnually",
+          "annually"
+        )
+      ).waitForDisplayed()
+
+      await (
+        await ShowOrganization.getAddAssessmentButton(
+          "organizationAnnually",
+          "annually"
+        )
+      ).click()
+
+      // NOTE: assuming assessment question content here, may change in future
+      await ShowOrganization.fillAssessmentQuestion(
+        SUPERUSER_ASSESSMENT_CREATE_DETAILS
+      )
+      await ShowOrganization.saveAssessmentAndWaitForModalClose(
+        "organizationAnnually",
+        "annually",
+        VALUE_TO_TEXT_FOR_PRIORITY[SUPERUSER_ASSESSMENT_CREATE_DETAILS[0]]
+      )
+    })
+
+    it("Should show the same assessment details with the details just created", async() => {
+      const details = await ShowOrganization.getShownAssessmentDetails(
+        "organizationAnnually",
+        "annually"
+      )
+      for (const [index, detail] of details.entries()) {
+        expect((await prefix(index)) + (await detail.getText())).to.equal(
+          (await prefix(index)) +
+            (VALUE_TO_TEXT_FOR_PRIORITY[
+              SUPERUSER_ASSESSMENT_CREATE_DETAILS[index]
+            ] ||
+              VALUE_TO_TEXT_FOR_INTERACTION[
+                SUPERUSER_ASSESSMENT_CREATE_DETAILS[index]
+              ] ||
+              SUPERUSER_ASSESSMENT_CREATE_DETAILS[index])
+        )
+      }
+    })
+
+    it("Should allow the author of the assessment to successfully edit it", async() => {
+      await (await ShowOrganization.getEditAssessmentButton()).waitForExist()
+      await (
+        await ShowOrganization.getEditAssessmentButton()
+      ).waitForDisplayed()
+
+      await (await ShowOrganization.getEditAssessmentButton()).click()
+      await ShowOrganization.waitForAssessmentModalForm()
+
+      await ShowOrganization.fillAssessmentQuestion(
+        SUPERUSER_ASSESSMENT_EDIT_DETAILS,
+        [
+          SUPERUSER_ASSESSMENT_CREATE_DETAILS[2],
+          SUPERUSER_ASSESSMENT_CREATE_DETAILS[3]
+        ]
+      )
+      await ShowOrganization.saveAssessmentAndWaitForModalClose(
+        "organizationAnnually",
+        "annually",
+        VALUE_TO_TEXT_FOR_PRIORITY[SUPERUSER_ASSESSMENT_EDIT_DETAILS[0]]
+      )
+    })
+
+    it("Should show the same assessment details with the details just edited", async() => {
+      const details = await ShowOrganization.getShownAssessmentDetails(
+        "organizationAnnually",
+        "annually"
+      )
+      for (const [index, detail] of details.entries()) {
+        expect((await prefix(index)) + (await detail.getText())).to.equal(
+          (await prefix(index)) +
+            (VALUE_TO_TEXT_FOR_PRIORITY[
+              SUPERUSER_ASSESSMENT_EDIT_DETAILS[index]
+            ] ||
+              VALUE_TO_TEXT_FOR_INTERACTION[
+                SUPERUSER_ASSESSMENT_EDIT_DETAILS[index]
+              ] ||
+              SUPERUSER_ASSESSMENT_EDIT_DETAILS[index])
+        )
+      }
+      await ShowOrganization.logout()
+    })
+  })
+
+  describe("As an admin", () => {
+    it("Should first search, find and open the organization's page", async() => {
+      await Home.openAsAdminUser()
+      await (await Home.getSearchBar()).setValue(ORGANIZATION_SEARCH_STRING)
+      await (await Home.getSubmitSearch()).click()
+      await (
+        await Search.getFoundOrganizationTable()
+      ).waitForExist({ timeout: 20000 })
+      await (await Search.getFoundOrganizationTable()).waitForDisplayed()
+      await (
+        await Search.linkOfOrganizationFound(ORGANIZATION_SEARCH_STRING)
+      ).click()
+    })
+
+    it("Should not show make assessment button when there is an assessment on that period", async() => {
+      expect(
+        await (
+          await ShowOrganization.getAddAssessmentButton(
+            "organizationAnnually",
+            "annually"
+          )
+        ).isExisting()
+      ).to.equal(false)
+    })
+
+    it("Should allow admins to successfully edit existing assessment", async() => {
+      await (await ShowOrganization.getEditAssessmentButton()).waitForExist()
+      await (
+        await ShowOrganization.getEditAssessmentButton()
+      ).waitForDisplayed()
+
+      await (await ShowOrganization.getEditAssessmentButton()).click()
+      await ShowOrganization.waitForAssessmentModalForm()
+
+      await ShowOrganization.fillAssessmentQuestion(
+        ADMIN_ASSESSMENT_EDIT_DETAILS,
+        [
+          SUPERUSER_ASSESSMENT_EDIT_DETAILS[2],
+          SUPERUSER_ASSESSMENT_EDIT_DETAILS[3]
+        ]
+      )
+      await ShowOrganization.saveAssessmentAndWaitForModalClose(
+        "organizationAnnually",
+        "annually",
+        VALUE_TO_TEXT_FOR_PRIORITY[ADMIN_ASSESSMENT_EDIT_DETAILS[0]]
+      )
+    })
+
+    it("Should show the same assessment details with the details just edited", async() => {
+      const details = await ShowOrganization.getShownAssessmentDetails(
+        "organizationAnnually",
+        "annually"
+      )
+      for (const [index, detail] of details.entries()) {
+        expect((await prefix(index)) + (await detail.getText())).to.equal(
+          (await prefix(index)) +
+            (VALUE_TO_TEXT_FOR_PRIORITY[ADMIN_ASSESSMENT_EDIT_DETAILS[index]] ||
+              VALUE_TO_TEXT_FOR_INTERACTION[
+                ADMIN_ASSESSMENT_EDIT_DETAILS[index]
+              ] ||
+              ADMIN_ASSESSMENT_EDIT_DETAILS[index])
+        )
+      }
+    })
+
+    it("Should allow an admin to delete the assessment", async() => {
+      await (await ShowOrganization.getDeleteAssessmentButton()).click()
+      await ShowOrganization.confirmDelete()
+      await ShowOrganization.waitForDeletedAssessmentToDisappear(
+        "organizationAnnually",
+        "annually"
+      )
+      await ShowOrganization.logout()
+    })
+  })
+})
+
+// use indexed prefix to see which one fails if any fails
+const prefix = async index => `${index}-) `

--- a/client/tests/webdriver/pages/showOrganization.page.js
+++ b/client/tests/webdriver/pages/showOrganization.page.js
@@ -51,6 +51,173 @@ class ShowOrganization extends Page {
       await (await this.getAlertSuccess()).waitForDisplayed()
     }
   }
+
+  async waitForAssessmentModalForm(reverse = false) {
+    await browser.pause(300) // wait for modal animation to finish
+    await (
+      await this.getAssessmentModalForm()
+    ).waitForExist({ reverse, timeout: 20000 })
+    await (await this.getAssessmentModalForm()).waitForDisplayed()
+  }
+
+  async getAddAssessmentButton(assessmentKey, recurrence) {
+    // get the add assessment button for latest assessable period (previous period)
+    return (await this.getAssessmentsTable(assessmentKey, recurrence)).$(
+      "tbody > tr:last-child > td:nth-child(2) > button"
+    )
+  }
+
+  async getEditAssessmentButton() {
+    return browser.$('div.card button[title="Edit assessment"]')
+  }
+
+  async getDeleteAssessmentButton() {
+    return browser.$("div.card button.btn.btn-outline-danger.btn-xs")
+  }
+
+  async getAssessmentsTable(assessmentKey, recurrence) {
+    return (await this.getAssessmentContainer(assessmentKey, recurrence)).$(
+      "table.assessments-table"
+    )
+  }
+
+  async getAssessmentModalForm() {
+    return browser.$(".modal-content form")
+  }
+
+  async getDeleteConfirmButton() {
+    return browser.$('//button[text()="Yes, I am sure"]')
+  }
+
+  async getSaveAssessmentButton() {
+    return (await this.getAssessmentModalForm()).$('//button[text()="Save"]')
+  }
+
+  async getShownAssessmentPanel(assessmentKey, recurrence) {
+    return (await this.getAssessmentsTable(assessmentKey, recurrence)).$(
+      "td:nth-child(2) .card"
+    )
+  }
+
+  async getShownAssessmentDetails(assessmentKey, recurrence) {
+    return (await this.getShownAssessmentPanel(assessmentKey, recurrence)).$$(
+      "div.card-body .form-control-plaintext"
+    )
+  }
+
+  async getAssessmentContainer(assessmentKey, recurrence) {
+    return browser.$(
+      `#entity-assessments-results-${assessmentKey}-${recurrence}`
+    )
+  }
+
+  async fillAssessmentQuestion(valuesArr, prevTextToClear) {
+    // NOTE: assuming assessment content, 4 questions
+    // first focus on the text editor input
+    await (
+      await (
+        await this.getAssessmentModalForm()
+      ).$(
+        "div[id='fg-entityAssessment.question3'] .editor-container > .editable"
+      )
+    ).click()
+    // Wait for the editor to be focused
+    await browser.pause(300)
+    if (prevTextToClear && prevTextToClear[0]) {
+      await this.deleteText(prevTextToClear[0])
+      // Wait for the previous value to be deleted
+      await browser.pause(300)
+    }
+    await browser.keys(valuesArr[2])
+
+    // focus on the second text editor input
+    await (
+      await (
+        await this.getAssessmentModalForm()
+      ).$(
+        "div[id='fg-entityAssessment.question4'] .editor-container > .editable"
+      )
+    ).click()
+    // Wait for the editor to be focused
+    await browser.pause(300)
+    if (prevTextToClear && prevTextToClear[1]) {
+      await this.deleteText(prevTextToClear[1])
+      // Wait for the previous value to be deleted
+      await browser.pause(300)
+    }
+    await browser.keys(valuesArr[3])
+
+    // Select first button group
+    const buttonPriority = await (
+      await this.getAssessmentModalForm()
+    ).$(
+      `div[id='fg-entityAssessment.question1'] label[for="entityAssessment.question1_${valuesArr[0]}"]`
+    )
+    // wait for a bit, clicks and do double click, sometimes it does not go through
+    await browser.pause(300)
+    await buttonPriority.click({ x: 10, y: 10 })
+    await buttonPriority.click({ x: 10, y: 10 })
+    await browser.pause(300)
+
+    // Select second button group
+    const buttonInteraction = await (
+      await this.getAssessmentModalForm()
+    ).$(
+      `div[id='fg-entityAssessment.question2'] label[for="entityAssessment.question2_${valuesArr[1]}"]`
+    )
+    // wait for a bit, clicks and do double click, sometimes it does not go through
+    await browser.pause(300)
+    await buttonInteraction.click({ x: 10, y: 10 })
+    await buttonInteraction.click({ x: 10, y: 10 })
+    await browser.pause(300)
+  }
+
+  async saveAssessmentAndWaitForModalClose(
+    assessmentKey,
+    recurrence,
+    detail0ToWaitFor
+  ) {
+    await (await this.getSaveAssessmentButton()).click()
+    await browser.pause(300) // wait for modal animation to finish
+
+    await (
+      await this.getAssessmentModalForm()
+    ).waitForExist({
+      reverse: true,
+      timeout: 20000
+    })
+    // wait until details to change, can take some time to update show page
+    await browser.waitUntil(
+      async() => {
+        return (
+          (await (
+            await this.getShownAssessmentDetails(assessmentKey, recurrence)
+          )[0].getText()) === detail0ToWaitFor
+        )
+      },
+      {
+        timeout: 5000,
+        timeoutMsg: "Expected change after save"
+      }
+    )
+  }
+
+  async confirmDelete() {
+    await browser.pause(500)
+    await (await this.getDeleteConfirmButton()).waitForExist()
+    await (await this.getDeleteConfirmButton()).waitForDisplayed()
+    await (await this.getDeleteConfirmButton()).click()
+  }
+
+  async waitForDeletedAssessmentToDisappear(assessmentKey, recurrence) {
+    await browser.pause(500)
+    await (
+      await this.getShownAssessmentPanel(assessmentKey, recurrence)
+    ).waitForExist({
+      reverse: true,
+      timeout: 20000
+    })
+  }
 }
 
 export default new ShowOrganization()

--- a/src/main/java/mil/dds/anet/database/NoteDao.java
+++ b/src/main/java/mil/dds/anet/database/NoteDao.java
@@ -440,9 +440,11 @@ public class NoteDao extends AnetBaseDao<Note, AbstractSearchQuery<?>> {
       throw new IllegalArgumentException(
           "On-demand assessment must have exactly one related object");
     }
-    final NoteRelatedObject nroPerson = noteRelatedObjects.get(0);
-    if (!checkPerson(nroPerson)) {
-      throw new IllegalArgumentException("On-demand assessment must link to a person");
+    final NoteRelatedObject nro = noteRelatedObjects.get(0);
+    boolean checkAssessmentEntity = checkPerson(nro) || checkOrganization(nro);
+    if (!checkAssessmentEntity) {
+      throw new IllegalArgumentException(
+          "On-demand assessment must link to a person or organization");
     }
   }
 

--- a/src/main/resources/anet-schema.yml
+++ b/src/main/resources/anet-schema.yml
@@ -766,6 +766,10 @@ properties:
             type: string
             title: The label for an organization's profile
             description: Used in the UI where an organization's profile is shown
+          assessments:
+            type: object
+            additionalProperties:
+              "$ref": "#/$defs/assessmentDef"
           customFields:
             type: object
             additionalProperties:

--- a/testDictionaries/no-custom-fields.yml
+++ b/testDictionaries/no-custom-fields.yml
@@ -510,6 +510,19 @@ fields:
             widget: richTextEditor
             style:
               height: 15px
+      organizationOndemand:
+        label: Ondemand assessment of organization
+        recurrence: ondemand
+        questions:
+          assessmentDate:
+            type: date
+            label: Assessment date
+          question1:
+            type: special_field
+            label: General remarks
+            widget: richTextEditor
+            style:
+              height: 70px
 
   advisor:
 

--- a/testDictionaries/no-custom-fields.yml
+++ b/testDictionaries/no-custom-fields.yml
@@ -452,6 +452,64 @@ fields:
     shortName: Name
     parentOrg: Parent Organization
     profile: Profile
+    assessments:
+      organizationAnnually:
+        label: Interaction Plan
+        recurrence: annually
+        questions:         
+          question1:
+            type: enum
+            label: Priority
+            choices:
+              t1:
+                label: T1 # Critical
+                color: '#f50525' # Red
+              t2:
+                label: T2 # Vital
+                color: '#f59d05' # Orange
+              t3:
+                label: T3  # Highly Desirable
+                color: '#f5e505' # Yellow
+              t4:
+                label: T4 #  Desirable
+                color: '#07b50a' # Green
+              t5:
+                label: T5 # Dormant
+                color: '#939692' # Gray
+          question2:
+            type: enum
+            label: Interaction
+            choices:
+              noStatement:
+                label: No statement
+                color: '#5b5b5b' # Black
+              dormant:
+                label: Dormant
+                color: '#999999' # Gray
+              initiate:
+                label: Initiate
+                color: '#f50525' # Red
+              develop:
+                label: Develop
+                color: '#f59d05' # Orange
+              improve:
+                label: Improve
+                color: '#f5e505' # Yellow
+              maintain:
+                label: Maintain
+                color: '#07b50a' # Green
+          question3:
+            type: special_field
+            label: Plan
+            widget: richTextEditor
+            style:
+              height: 15px
+          question4:
+            type: special_field
+            label: Exercises
+            widget: richTextEditor
+            style:
+              height: 15px
 
   advisor:
 


### PR DESCRIPTION
ANET now supports assessment for organizations. It is now possible to add periodic or ondemand assessment to organizations.

Closes [AB#884](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/884)

#### User changes
- None

#### Superuser changes
- Superuser can do assessments (periodic, ondemand) for the organizations assigned to them

#### Admin changes
- Admin can do assessments (periodic, ondemand) for organizations

#### System admin changes
- [x] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [x] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here