### PR TITLE
Filter out non-applicable assessments

### DIFF
--- a/client/src/components/Model.js
+++ b/client/src/components/Model.js
@@ -778,19 +778,22 @@ export default class Model {
       return false
     }
     // "for loop" to break early
-    for (let i = 0; i < periodicAssessments.length; i++) {
-      // offset 1 so that the period is the previous (not current) period
-      const prevPeriod = PERIOD_FACTORIES[periodicAssessments[i][1].recurrence](
-        moment(),
-        1
-      )
-      const prevPeriodAssessments = entity.getPeriodAssessments(
-        periodicAssessments[i][0],
-        prevPeriod
-      )
-      // if there is no assessment in the last period, we have pending assessment
-      if (prevPeriodAssessments.length === 0) {
-        return true
+    for (const [paKey, paDefinition] of periodicAssessments) {
+      if (!_isEmpty(Model.filterAssessmentConfig(paDefinition, entity))) {
+        // periodic assessment applies;
+        // check with offset 1 so that the period is the previous (not current) period
+        const prevPeriod = PERIOD_FACTORIES[paDefinition.recurrence](
+          moment(),
+          1
+        )
+        const prevPeriodAssessments = entity.getPeriodAssessments(
+          paKey,
+          prevPeriod
+        )
+        // if there is no assessment in the last period, we have pending assessment
+        if (prevPeriodAssessments.length === 0) {
+          return true
+        }
       }
     }
     // if we didn't early return, there is no pending assessment

--- a/client/src/notificationsUtils.js
+++ b/client/src/notificationsUtils.js
@@ -14,19 +14,11 @@ export const GRAPHQL_NOTIFICATIONS_NOTE_FIELDS = `
   }
 `
 
-export const getNotifications = position => {
-  const counterpartsWithPendingAssessments =
-    getCounterpartsWithPendingAssessments(position)
-
-  const tasksWithPendingAssessments = getTasksWithPendingAssessments(position)
-
-  const notifications = {
-    counterpartsWithPendingAssessments,
-    tasksWithPendingAssessments
-  }
-
-  return notifications
-}
+export const getNotifications = position => ({
+  counterpartsWithPendingAssessments:
+    getCounterpartsWithPendingAssessments(position),
+  tasksWithPendingAssessments: getTasksWithPendingAssessments(position)
+})
 
 export const getTasksWithPendingAssessments = position => {
   if (position?.responsibleTasks?.length) {

--- a/client/src/pages/tasks/Show.js
+++ b/client/src/pages/tasks/Show.js
@@ -184,7 +184,10 @@ const TaskShow = ({ pageDispatchers }) => {
 
   Model.populateEntitiesNotesCustomFields(task.descendantTasks)
 
-  const subTasks = task.descendantTasks?.map(task => new Task(task))
+  // Top-level tasks and sub-tasks have different assessment definitions!
+  const subTasks = _isEmpty(task.parentTask)
+    ? []
+    : task.descendantTasks?.map(task => new Task(task))
 
   const fieldSettings = task.fieldSettings()
   const ShortNameField = DictionaryField(Field)

--- a/client/tests/webdriver/customFieldsSpecs/pendingAssessments.spec.js
+++ b/client/tests/webdriver/customFieldsSpecs/pendingAssessments.spec.js
@@ -14,16 +14,16 @@ describe("In my counterparts page", () => {
       await MyCounterparts.open()
       await (await MyCounterparts.getMyPendingCounterparts()).waitForDisplayed()
       const myPendingCounterpartsItems = await (
-        await MyCounterparts.getMyPendingCounterpartsContent()
+        await MyCounterparts.getMyPendingCounterpartsBody()
       ).$$("tr")
       expect(myPendingCounterpartsItems).to.have.length(1)
+    })
+    it("Should be able to add a quarterly assessment with 4 questions for the counterpart", async() => {
       await (
         await MyCounterparts.getMyPendingCounterpart(
           "CIV TOPFERNESS, Christopf"
         )
       ).click()
-    })
-    it("Should be able to add a quarterly assessment with 4 questions for the counterpart", async() => {
       await (
         await AssessmentsSection.getAssessmentsSection(
           "principalQuarterly",
@@ -79,20 +79,17 @@ describe("In my counterparts page", () => {
   })
 
   describe("When Jack is checking the contents of the page", () => {
-    it("Should see no counterparts in the table of pending my counterparts that has pending assessments", async() => {
+    it("Should see an empty table of my counterparts that have pending assessments", async() => {
       await MyCounterparts.openAs("jack")
       await (await MyCounterparts.getMyPendingCounterparts()).waitForDisplayed()
-      // eslint-disable-next-line no-unused-expressions
       expect(
-        await (
-          await MyCounterparts.getMyPendingCounterpartsContent()
-        ).isExisting()
-      ).to.be.false
+        await (await MyCounterparts.getMyPendingCounterpartsContent()).getText()
+      ).to.equal("No positions found")
+    })
+    it("Should be able to add a quarterly assessment with 1 question for the counterpart", async() => {
       await (
         await MyCounterparts.getMyCounterpart("Maj ROGWELL, Roger")
       ).click()
-    })
-    it("Should be able to add a quarterly assessment with 1 question for the counterpart", async() => {
       await (
         await AssessmentsSection.getAssessmentsSection(
           "principalQuarterly",
@@ -153,9 +150,9 @@ describe("In my tasks page", () => {
     it("Should see an empty table of my tasks that have pending assessments", async() => {
       await MyTasks.open()
       await (await MyTasks.getMyPendingTasks()).waitForDisplayed()
-      // eslint-disable-next-line no-unused-expressions
-      expect(await (await MyTasks.getMyPendingTasksContent()).isExisting()).to
-        .be.false
+      expect(
+        await (await MyTasks.getMyPendingTasksContent()).getText()
+      ).to.equal("No tasks found")
       await MyTasks.logout()
     })
   })
@@ -165,12 +162,12 @@ describe("In my tasks page", () => {
       await MyTasks.openAs("jack")
       await (await MyTasks.getMyPendingTasks()).waitForDisplayed()
       const myPendingTasks = await (
-        await MyTasks.getMyPendingTasksContent()
+        await MyTasks.getMyPendingTasksBody()
       ).$$("tr")
       expect(myPendingTasks).to.have.length(1)
-      await (await MyTasks.getMyPendingTask("2.B")).click()
     })
     it("Should be able to add a monthly assessment with 2 questions for the task", async() => {
+      await (await MyTasks.getMyPendingTask("2.B")).click()
       await (
         await AssessmentsSection.getAssessmentsSection(
           "subTaskMonthly",

--- a/client/tests/webdriver/pages/myCounterparts.page.js
+++ b/client/tests/webdriver/pages/myCounterparts.page.js
@@ -28,13 +28,15 @@ class MyTasks extends Page {
   }
 
   async getMyPendingCounterpartsContent() {
-    return (await browser.$("#my-counterparts-with-pending-assessments")).$(
-      "tbody"
-    )
+    return (await this.getMyPendingCounterparts()).$("fieldset")
+  }
+
+  async getMyPendingCounterpartsBody() {
+    return (await this.getMyPendingCounterpartsContent()).$("tbody")
   }
 
   async getMyPendingCounterpart(name) {
-    return (await this.getMyPendingCounterpartsContent()).$(
+    return (await this.getMyPendingCounterpartsBody()).$(
       `//a[text()="${name}"]`
     )
   }

--- a/client/tests/webdriver/pages/myTasks.page.js
+++ b/client/tests/webdriver/pages/myTasks.page.js
@@ -28,11 +28,15 @@ class MyTasks extends Page {
   }
 
   async getMyPendingTasksContent() {
-    return (await browser.$("#my-tasks-with-pending-assessments")).$("tbody")
+    return (await this.getMyPendingTasks()).$("fieldset")
+  }
+
+  async getMyPendingTasksBody() {
+    return (await this.getMyPendingTasksContent()).$("tbody")
   }
 
   async getMyPendingTask(name) {
-    return (await this.getMyPendingTasksContent()).$(
+    return (await this.getMyPendingTasksBody()).$(
       `//a[contains(text(), "${name}")]`
     )
   }


### PR DESCRIPTION
Under "My Work" and in the AssessmentResultsContainer on various objects' pages, filter out ondemand and periodic assessments that don't apply (when they have a top-level test that return false).

Closes [AB#891](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/891) 

#### User changes
- non-applicable (ondemand and periodic) assessments should no longer be shown unnecessarily

#### Superuser changes
- none

#### Admin changes
- none

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [x] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here