### PR TITLE
Include cancelled reports in the Daily Rollup

### DIFF
--- a/client/src/pages/rollup/Show.js
+++ b/client/src/pages/rollup/Show.js
@@ -361,7 +361,11 @@ const RollupShow = ({ pageDispatchers, searchQuery, setSearchQuery }) => {
       renderer: renderReportMap
     }
   ]
-  const INITIAL_LAYOUT = VISUALIZATIONS[0].id
+  const INITIAL_LAYOUT = {
+    direction: "row",
+    first: VISUALIZATIONS[0].id,
+    second: VISUALIZATIONS[1].id
+  }
   const DESCRIPTION = "Number of reports released per organization."
   const flexStyle = {
     display: "flex",
@@ -561,7 +565,7 @@ const RollupShow = ({ pageDispatchers, searchQuery, setSearchQuery }) => {
 
   function setRollupDefaultSearchQuery() {
     const queryParams = {
-      state: [Report.STATE.PUBLISHED],
+      state: [Report.STATE.PUBLISHED, Report.STATE.CANCELLED],
       releasedAtStart: moment().startOf("day"),
       releasedAtEnd: moment().endOf("day")
     }


### PR DESCRIPTION
Include cancelled reports in the Daily Rollup search, and show the bar chart with published and cancelled reports by default.

Closes [AB#859](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/859)

#### User changes
- The Daily Rollup now shows cancelled reports in addition to published reports, and by default shows the bar chart next to the list of reports.

#### Superuser changes
- none

#### Admin changes
- none

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here