### PR TITLE
Superusers should be able to edit persons in their organization hierarchy

### DIFF
--- a/client/src/components/AssignPositionModal.js
+++ b/client/src/components/AssignPositionModal.js
@@ -196,14 +196,17 @@ const AssignPositionModal = ({ person, showModal, onCancel, onSuccess }) => {
       positionSearchQuery.type.push(Position.TYPE.SUPERUSER)
     } else if (currentUser.isSuperuser()) {
       // Only superusers can put people in superuser billets
-      // And they are limited to their organization.
       positionSearchQuery.type.push(Position.TYPE.SUPERUSER)
-      positionSearchQuery.organizationUuid =
-        currentUser.position.organization.uuid
-      positionSearchQuery.orgRecurseStrategy = RECURSE_STRATEGY.CHILDREN
     }
   } else if (person.role === Person.ROLE.PRINCIPAL) {
     positionSearchQuery.type = [Position.TYPE.PRINCIPAL]
+  }
+  if (currentUser.isSuperuser()) {
+    // Superusers are limited to their organizations
+    const administratingOrgUuids =
+      currentUser.position.organizationsAdministrated.map(org => org.uuid)
+    positionSearchQuery.organizationUuid = [...administratingOrgUuids]
+    positionSearchQuery.orgRecurseStrategy = RECURSE_STRATEGY.CHILDREN
   }
   const positionsFilters = {
     allAdvisorPositions: {

--- a/client/src/pages/organizations/Laydown.js
+++ b/client/src/pages/organizations/Laydown.js
@@ -43,7 +43,6 @@ const OrganizationLaydown = ({ organization, refetch }) => {
   const canAdministrateOrg =
     currentUser &&
     currentUser.hasAdministrativePermissionsForOrganization(organization)
-  const isSuperuser = currentUser && currentUser.isSuperuser()
   const isPrincipalOrg = organization.type === Organization.TYPE.PRINCIPAL_ORG
   const numInactivePos = organization.positions.filter(
     p => p.status === Model.STATUS.INACTIVE
@@ -56,8 +55,6 @@ const OrganizationLaydown = ({ organization, refetch }) => {
     position => positionsNeedingAttention.indexOf(position) === -1
   )
   const allAdministratingPositions = getAllAdministratingPositions(organization)
-  const canCreatePositions =
-    canAdministrateOrg || (isSuperuser && isPrincipalOrg)
 
   const orgSettings = isPrincipalOrg
     ? Settings.fields.principal.org
@@ -96,7 +93,7 @@ const OrganizationLaydown = ({ organization, refetch }) => {
         title="Supported positions"
         action={
           <div>
-            {canCreatePositions && (
+            {canAdministrateOrg && (
               <LinkTo
                 modelType="Position"
                 model={Position.pathForNew({

--- a/client/src/pages/people/Form.js
+++ b/client/src/pages/people/Form.js
@@ -163,13 +163,18 @@ const PersonForm = ({
           // Assign default country if there's only one
           values.country = countries[0]
         }
-        // admins can edit all persons, new users can be edited by superusers or themselves
+        // admins can edit all persons,
+        // superusers for their organization hierarchy or position-less people,
+        // and the user themselves when onboarding
         const canEditName =
           isAdmin ||
-          ((isPendingVerification || !edit) &&
-            currentUser &&
-            (currentUser.isSuperuser() || isSelf))
-        // admins and superusers with edit permissions can change status to INACTIVE, only admins can change back to ACTIVE (but nobody can change status of self!)
+          currentUser?.hasAdministrativePermissionsForOrganization(
+            values?.position?.organization
+          ) ||
+          (!values?.position?.uuid && currentUser?.isSuperuser()) ||
+          ((isPendingVerification || !edit) && isSelf)
+        // admins and superusers with edit permissions can change status to INACTIVE,
+        // only admins can change back to ACTIVE (but nobody can change status of self!)
         const disableStatusChange =
           (initialValues.status === Model.STATUS.INACTIVE && !isAdmin) || isSelf
         const fullName = Person.fullName(Person.parseFullName(values.name))

--- a/client/src/pages/people/Show.js
+++ b/client/src/pages/people/Show.js
@@ -186,16 +186,9 @@ const PersonShow = ({ pageDispatchers }) => {
       currentUser.hasAdministrativePermissionsForOrganization(
         position.organization
       )) ||
-    (!hasPosition && currentUser.isSuperuser()) ||
-    (person.role === Person.ROLE.PRINCIPAL && currentUser.isSuperuser())
-  const canChangePosition =
-    isAdmin ||
-    (!hasPosition && currentUser.isSuperuser()) ||
-    (hasPosition &&
-      currentUser.hasAdministrativePermissionsForOrganization(
-        position.organization
-      )) ||
-    (person.role === Person.ROLE.PRINCIPAL && currentUser.isSuperuser())
+    (!hasPosition && currentUser.isSuperuser())
+  // When the person is not in a position, any superuser can assign them.
+  const canAssignPosition = currentUser.isSuperuser()
   const canAddPeriodicAssessment =
     Position.isAdvisor(position) ||
     (Position.isPrincipal(position) &&
@@ -327,7 +320,7 @@ const PersonShow = ({ pageDispatchers }) => {
                   </Row>
                 </Container>
               </Fieldset>
-              {canChangePosition && (
+              {canEdit && (
                 <AssignPositionModal
                   showModal={showAssignPositionModal}
                   person={person}
@@ -340,7 +333,7 @@ const PersonShow = ({ pageDispatchers }) => {
                 <Fieldset
                   title={`Assigned ${assignedRole}`}
                   action={
-                    canChangePosition && (
+                    canEdit && (
                       <Button
                         onClick={() => setShowAssociatedPositionsModal(true)}
                         variant="outline-secondary"
@@ -351,7 +344,7 @@ const PersonShow = ({ pageDispatchers }) => {
                   }
                 >
                   {renderCounterparts(position)}
-                  {canChangePosition && (
+                  {canEdit && (
                     <EditAssociatedPositionsModal
                       position={position}
                       showModal={showAssociatedPositionsModal}
@@ -534,7 +527,7 @@ const PersonShow = ({ pageDispatchers }) => {
 
   function getPositionActions() {
     const editPositionButton =
-      hasPosition && canChangePosition ? (
+      hasPosition && canEdit ? (
         <OverlayTrigger
           key="edit-position-overlay"
           placement="top"
@@ -556,7 +549,7 @@ const PersonShow = ({ pageDispatchers }) => {
       ) : null
 
     const changePositionButton =
-      hasPosition && canChangePosition ? (
+      hasPosition && canEdit ? (
         <OverlayTrigger
           key="change-position-overlay"
           placement="top"
@@ -572,9 +565,6 @@ const PersonShow = ({ pageDispatchers }) => {
           </Button>
         </OverlayTrigger>
       ) : null
-
-    // when the person is not in a position, any superuser can assign them.
-    const canAssignPosition = currentUser.isSuperuser()
 
     const assignPositionButton =
       !hasPosition && canAssignPosition ? (

--- a/client/src/pages/positions/Form.js
+++ b/client/src/pages/positions/Form.js
@@ -22,7 +22,6 @@ import { jumpToTop } from "components/Page"
 import SimilarObjectsModal from "components/SimilarObjectsModal"
 import { FastField, Field, Form, Formik } from "formik"
 import DictionaryField from "HOC/DictionaryField"
-import _isEmpty from "lodash/isEmpty"
 import { Location, Organization, Position } from "models"
 import { PositionRole } from "models/Position"
 import PropTypes from "prop-types"
@@ -66,20 +65,7 @@ const PositionForm = ({ edit, title, initialValues, notesComponent }) => {
       label: "Inactive"
     }
   ]
-  const advisorDisabledTypeButtons = [
-    {
-      id: "typeAdvisorButton",
-      value: Position.TYPE.ADVISOR,
-      label: Settings.fields.advisor.position.name,
-      disabled: true
-    },
-    {
-      id: "typePrincipalButton",
-      value: Position.TYPE.PRINCIPAL,
-      label: Settings.fields.principal.position.name
-    }
-  ]
-  const regularTypeButtons = [
+  const typeButtons = [
     {
       id: "typeAdvisorButton",
       value: Position.TYPE.ADVISOR,
@@ -177,27 +163,13 @@ const PositionForm = ({ edit, title, initialValues, notesComponent }) => {
         // Only admin and superuser can assign high role (other than member role) to a position
         const positionRoleButtons =
           isAdmin || isSuperuser ? adminRolesButtons : nonAdminRolesButtons
-        const isSuperuserWithoutAdministratingOrgs =
-          isSuperuser && _isEmpty(administratingOrgUuids)
-        // Superusers without organizations administrated cannot create advisor positions
-        const typeButtons = isSuperuserWithoutAdministratingOrgs
-          ? advisorDisabledTypeButtons
-          : regularTypeButtons
-        if (
-          isSuperuserWithoutAdministratingOrgs &&
-          values.type !== Position.TYPE.PRINCIPAL
-        ) {
-          setFieldValue("type", Position.TYPE.PRINCIPAL)
-        }
         const orgSearchQuery = { status: Model.STATUS.ACTIVE }
-        if (isPrincipal) {
-          orgSearchQuery.type = Organization.TYPE.PRINCIPAL_ORG
-        } else {
-          orgSearchQuery.type = Organization.TYPE.ADVISOR_ORG
-          if (isSuperuser) {
-            orgSearchQuery.parentOrgUuid = [...administratingOrgUuids]
-            orgSearchQuery.orgRecurseStrategy = RECURSE_STRATEGY.CHILDREN
-          }
+        orgSearchQuery.type = isPrincipal
+          ? Organization.TYPE.PRINCIPAL_ORG
+          : Organization.TYPE.ADVISOR_ORG
+        if (isSuperuser) {
+          orgSearchQuery.parentOrgUuid = [...administratingOrgUuids]
+          orgSearchQuery.orgRecurseStrategy = RECURSE_STRATEGY.CHILDREN
         }
         // Reset the organization property when changing the organization type
         if (

--- a/client/src/pages/positions/Show.js
+++ b/client/src/pages/positions/Show.js
@@ -109,13 +109,10 @@ const PositionShow = ({ pageDispatchers }) => {
     : Settings.fields.advisor.position
 
   const canEdit =
-    // Superusers can edit any Principal
-    (currentUser.isSuperuser() && isPrincipal) ||
     // Admins can edit anybody
     currentUser.isAdmin() ||
     // Superusers can edit positions if they have administrative permissions for the organization of the position
-    (position.organization &&
-      position.organization.uuid &&
+    (position?.organization?.uuid &&
       currentUser.hasAdministrativePermissionsForOrganization(
         position.organization
       ))

--- a/client/stories/0-general/1-userRoles.stories.mdx
+++ b/client/stories/0-general/1-userRoles.stories.mdx
@@ -26,11 +26,9 @@ capabilities. A superuser not assigned to any organization can:
 -   create new locations
 -   update existing locations
 -   create new principals (interlocutors, persons)
--   update existing principals (interlocutors, persons)
--   create new positions in principal organizations
--   update existing position in principal organizations
 
-In addition, when an ANET administrator has assigned you as superuser to one or more organizations, you can also: 
+In addition, when an ANET administrator has assigned you as superuser to one or more organizations,
+you can also:
 -   update people in that organization hierarchy
 -   create new positions in that organization hierarchy
 -   update existing positions in that organization hierarchy

--- a/insertBaseData-psql.sql
+++ b/insertBaseData-psql.sql
@@ -507,6 +507,12 @@ INSERT INTO organizations (uuid, "shortName", "longName", type, "parentOrgUuid",
 	VALUES (uuid_generate_v4(), 'MOD-F', 'Ministry of Defense Finances', 1,
 	(SELECT uuid from organizations where "shortName" = 'MoD'), CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
 
+-- Assign responsible positions for organizations
+INSERT INTO "organizationAdministrativePositions" ("organizationUuid", "positionUuid") VALUES
+  ((SELECT uuid FROM organizations WHERE "shortName" = 'MoD'), (SELECT uuid FROM positions WHERE name = 'EF 1.1 Superuser')),
+  ((SELECT uuid FROM organizations WHERE "shortName" = 'MoD'), (SELECT uuid FROM positions WHERE name = 'EF 2.1 Superuser')),
+  ((SELECT uuid FROM organizations WHERE "shortName" = 'MoI'), (SELECT uuid FROM positions WHERE name = 'EF 2.2 Final Reviewer'));
+
 -- Create principal positions
 INSERT INTO positions (uuid, name, code, type, role, status, "currentPersonUuid", "organizationUuid", "createdAt", "updatedAt")
 	VALUES (N'879121d2-d265-4d26-8a2b-bd073caa474e', 'Minister of Defense', 'MOD-FO-00001', 1, 2, 0, NULL, (SELECT uuid FROM organizations WHERE "longName" LIKE 'Ministry of Defense'), CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);

--- a/src/main/java/mil/dds/anet/beans/search/PositionSearchQuery.java
+++ b/src/main/java/mil/dds/anet/beans/search/PositionSearchQuery.java
@@ -14,7 +14,7 @@ public class PositionSearchQuery extends SubscribableObjectSearchQuery<PositionS
   Boolean matchPersonName;
   @GraphQLQuery
   @GraphQLInputField
-  String organizationUuid;
+  List<String> organizationUuid;
   @GraphQLQuery
   @GraphQLInputField
   RecurseStrategy orgRecurseStrategy;
@@ -50,11 +50,11 @@ public class PositionSearchQuery extends SubscribableObjectSearchQuery<PositionS
     this.matchPersonName = matchPersonName;
   }
 
-  public String getOrganizationUuid() {
+  public List<String> getOrganizationUuid() {
     return organizationUuid;
   }
 
-  public void setOrganizationUuid(String orgUuid) {
+  public void setOrganizationUuid(List<String> orgUuid) {
     this.organizationUuid = orgUuid;
   }
 
@@ -143,6 +143,9 @@ public class PositionSearchQuery extends SubscribableObjectSearchQuery<PositionS
     final PositionSearchQuery clone = (PositionSearchQuery) super.clone();
     if (type != null) {
       clone.setType(new ArrayList<>(type));
+    }
+    if (organizationUuid != null) {
+      clone.setOrganizationUuid(new ArrayList<>(organizationUuid));
     }
     return clone;
   }

--- a/src/main/java/mil/dds/anet/resources/OrganizationResource.java
+++ b/src/main/java/mil/dds/anet/resources/OrganizationResource.java
@@ -59,7 +59,7 @@ public class OrganizationResource {
     final Person user = DaoUtils.getUserFromContext(context);
     // Check if user is authorized to create a sub organization
     if (!AuthUtils.isAdmin(user)) {
-      AuthUtils.assertCanAdministrateOrg(user, org.getParentOrgUuid(), false);
+      AuthUtils.assertCanAdministrateOrg(user, org.getParentOrgUuid());
     }
     final Organization created;
     try {
@@ -109,7 +109,7 @@ public class OrganizationResource {
 
     final Person user = DaoUtils.getUserFromContext(context);
     // Verify correct Organization
-    AuthUtils.assertCanAdministrateOrg(user, DaoUtils.getUuid(org), false);
+    AuthUtils.assertCanAdministrateOrg(user, DaoUtils.getUuid(org));
 
     // Load the existing organization, so we can check for differences.
     final Organization existing = dao.getByUuid(org.getUuid());
@@ -132,10 +132,10 @@ public class OrganizationResource {
                 "You cannot assign a different type of organization as the parent",
                 Status.FORBIDDEN);
           }
-          AuthUtils.assertCanAdministrateOrg(user, org.getParentOrgUuid(), false);
+          AuthUtils.assertCanAdministrateOrg(user, org.getParentOrgUuid());
         }
         if (existing.getParentOrgUuid() != null) {
-          AuthUtils.assertCanAdministrateOrg(user, existing.getParentOrgUuid(), false);
+          AuthUtils.assertCanAdministrateOrg(user, existing.getParentOrgUuid());
         }
       }
       // User is not authorized to change the organization type

--- a/src/main/java/mil/dds/anet/resources/PersonResource.java
+++ b/src/main/java/mil/dds/anet/resources/PersonResource.java
@@ -96,10 +96,6 @@ public class PersonResource {
       return true;
     }
     if (editorPos.getType() == PositionType.SUPERUSER) {
-      // Superusers can edit any principal
-      if (subject.getRole().equals(Role.PRINCIPAL)) {
-        return true;
-      }
       // Ensure that the editor is the superuser for the subject's organization.
       final Position subjectPos =
           create
@@ -110,7 +106,7 @@ public class PersonResource {
         // Superusers can edit position-less people.
         return true;
       }
-      return AuthUtils.canAdministrateOrg(editor, subjectPos.getOrganizationUuid(), true);
+      return AuthUtils.canAdministrateOrg(editor, subjectPos.getOrganizationUuid());
     }
     return false;
   }

--- a/src/main/java/mil/dds/anet/resources/PositionResource.java
+++ b/src/main/java/mil/dds/anet/resources/PositionResource.java
@@ -66,7 +66,7 @@ public class PositionResource {
       throw new WebApplicationException("A Position must belong to an organization",
           Status.BAD_REQUEST);
     }
-    AuthUtils.assertCanAdministrateOrg(user, pos.getOrganizationUuid(), true);
+    AuthUtils.assertCanAdministrateOrg(user, pos.getOrganizationUuid());
   }
 
   @GraphQLMutation(name = "createPosition")
@@ -94,7 +94,7 @@ public class PositionResource {
   public Integer updateAssociatedPosition(@GraphQLRootContext Map<String, Object> context,
       @GraphQLArgument(name = "position") Position pos) {
     final Person user = DaoUtils.getUserFromContext(context);
-    AuthUtils.assertCanAdministrateOrg(user, pos.getOrganizationUuid(), true);
+    AuthUtils.assertCanAdministrateOrg(user, pos.getOrganizationUuid());
 
     final Position current = dao.getByUuid(pos.getUuid());
     if (current == null) {
@@ -205,7 +205,7 @@ public class PositionResource {
     if (pos == null) {
       throw new WebApplicationException("Position not found", Status.NOT_FOUND);
     }
-    AuthUtils.assertCanAdministrateOrg(user, pos.getOrganizationUuid(), true);
+    AuthUtils.assertCanAdministrateOrg(user, pos.getOrganizationUuid());
 
     final int numRows = dao.setPersonInPosition(DaoUtils.getUuid(person), positionUuid);
     AnetAuditLogger.log("Person {} put in Position {} by {}", person, pos, user);
@@ -220,7 +220,7 @@ public class PositionResource {
     if (pos == null) {
       throw new WebApplicationException("Position not found", Status.NOT_FOUND);
     }
-    AuthUtils.assertCanAdministrateOrg(user, pos.getOrganizationUuid(), true);
+    AuthUtils.assertCanAdministrateOrg(user, pos.getOrganizationUuid());
 
     final int numRows = dao.removePersonFromPosition(positionUuid);
     if (numRows == 0) {

--- a/src/main/java/mil/dds/anet/search/AbstractPositionSearcher.java
+++ b/src/main/java/mil/dds/anet/search/AbstractPositionSearcher.java
@@ -87,7 +87,7 @@ public abstract class AbstractPositionSearcher
             "organizations", "\"parentOrgUuid\"", "orgUuid", query.getOrganizationUuid(),
             RecurseStrategy.CHILDREN.equals(query.getOrgRecurseStrategy()));
       } else {
-        qb.addStringEqualsClause("orgUuid", "positions.\"organizationUuid\"",
+        qb.addInListClause("orgUuid", "positions.\"organizationUuid\"",
             query.getOrganizationUuid());
       }
     }

--- a/src/main/java/mil/dds/anet/utils/AuthUtils.java
+++ b/src/main/java/mil/dds/anet/utils/AuthUtils.java
@@ -7,7 +7,6 @@ import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response.Status;
 import mil.dds.anet.AnetObjectEngine;
 import mil.dds.anet.beans.Organization;
-import mil.dds.anet.beans.Organization.OrganizationType;
 import mil.dds.anet.beans.Person;
 import mil.dds.anet.beans.Position;
 import mil.dds.anet.beans.Position.PositionType;
@@ -30,8 +29,7 @@ public class AuthUtils {
     throw new WebApplicationException(UNAUTH_MESSAGE, Status.FORBIDDEN);
   }
 
-  public static boolean canAdministrateOrg(final Person user, final String organizationUuid,
-      boolean allowPrincipalOrgs) {
+  public static boolean canAdministrateOrg(final Person user, final String organizationUuid) {
     if (organizationUuid == null) {
       logger.error("Organization {} is null or has a null UUID in canAdministrateOrg check for {}",
           organizationUuid, user);
@@ -49,13 +47,6 @@ public class AuthUtils {
     logger.debug("Position for user {} is {}", user, position);
     if (position.getType() != PositionType.SUPERUSER) {
       return false;
-    }
-
-    // Given that we know it's a superuser position, does it actually match this organization?
-    Organization loadedOrg =
-        AnetObjectEngine.getInstance().getOrganizationDao().getByUuid(organizationUuid);
-    if (loadedOrg.getType() == OrganizationType.PRINCIPAL_ORG && allowPrincipalOrgs) {
-      return true;
     }
 
     // Check the responsible organizations.
@@ -78,11 +69,10 @@ public class AuthUtils {
     return false;
   }
 
-  public static void assertCanAdministrateOrg(Person user, String organizationUuid,
-      boolean allowPrincipalOrgs) {
+  public static void assertCanAdministrateOrg(Person user, String organizationUuid) {
     // log injection possibility here?
     logger.debug("Asserting canAdministrateOrg status for {} in {}", user, organizationUuid);
-    if (canAdministrateOrg(user, organizationUuid, allowPrincipalOrgs)) {
+    if (canAdministrateOrg(user, organizationUuid)) {
       return;
     }
     throw new WebApplicationException(UNAUTH_MESSAGE, Status.FORBIDDEN);


### PR DESCRIPTION
Superusers can edit positions and people in the organizations they manage, including changing their names.

Closes [AB#892](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/892), [AB#900](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/900)

#### User changes
- None

#### Superuser changes
- Superusers can edit positions, and people occupying positions, in the organization hierarchy that they manage, and also change their names.

#### Admin changes
- None

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [x] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [x] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [x] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
