### PR TITLE
Fix SVG export

### DIFF
--- a/client/src/components/graphs/SVGCanvas.js
+++ b/client/src/components/graphs/SVGCanvas.js
@@ -60,7 +60,12 @@ const SVGCanvas = ({ width, height, exportTitle, zoomFn, children }) => {
           </Button>
         </div>
       )}
-      <svg width={width} height={height} ref={svgRef}>
+      <svg
+        width={width}
+        height={height}
+        ref={svgRef}
+        xmlns="http://www.w3.org/2000/svg"
+      >
         {children}
       </svg>
     </div>


### PR DESCRIPTION
Add XML namespace so exported SVG files also show correctly when opened directly in e.g. a browser.

Closes [AB#890](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/890)

#### User changes
- Charts exported to SVG will now also show correctly when opened directly in the browser.

#### Superuser changes
- none

#### Admin changes
- none

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
