### PR TITLE
Merge position role

### DIFF
--- a/client/src/pages/admin/merge/MergePositions.js
+++ b/client/src/pages/admin/merge/MergePositions.js
@@ -380,7 +380,16 @@ const MergePositions = ({ pageDispatchers }) => {
           style={{ width: "98%", margin: "16px 1%" }}
           variant="primary"
           onClick={mergePositions}
-          disabled={!areAllSet(position1, position2, mergedPosition?.name)}
+          disabled={
+            !areAllSet(
+              position1,
+              position2,
+              mergedPosition?.name,
+              mergedPosition?.type,
+              mergedPosition?.role,
+              mergedPosition?.status
+            )
+          }
         >
           Merge Positions
         </Button>

--- a/client/src/pages/admin/merge/MergePositions.js
+++ b/client/src/pages/admin/merge/MergePositions.js
@@ -171,6 +171,15 @@ const MergePositions = ({ pageDispatchers }) => {
                 dispatchMergeActions={dispatchMergeActions}
               />
               <PositionField
+                label={Settings.fields.position.role.label}
+                value={Position.humanNameOfRole(mergedPosition.role)}
+                align={ALIGN_OPTIONS.CENTER}
+                action={getInfoButton("Role is required.")}
+                fieldName="role"
+                mergeState={mergeState}
+                dispatchMergeActions={dispatchMergeActions}
+              />
+              <PositionField
                 label="Code"
                 value={mergedPosition.code}
                 align={ALIGN_OPTIONS.CENTER}
@@ -518,6 +527,23 @@ const PositionColumn = ({ align, label, mergeState, dispatchMergeActions }) => {
             fieldName="type"
             value={position.type}
             align={align}
+            mergeState={mergeState}
+            dispatchMergeActions={dispatchMergeActions}
+          />
+          <PositionField
+            label={Settings.fields.position.role.label}
+            fieldName="role"
+            value={position.humanNameOfRole()}
+            align={align}
+            action={getActionButton(
+              () =>
+                dispatchMergeActions(
+                  setAMergedField("role", position.role, align)
+                ),
+              align,
+              mergeState,
+              "role"
+            )}
             mergeState={mergeState}
             dispatchMergeActions={dispatchMergeActions}
           />

--- a/client/tests/webdriver/baseSpecs/mergePositions.spec.js
+++ b/client/tests/webdriver/baseSpecs/mergePositions.spec.js
@@ -8,6 +8,7 @@ const EXAMPLE_POSITIONS = {
     fullName: "Merge One",
     organization: "MoD",
     type: "PRINCIPAL",
+    role: "Deputy",
     code: "MOD-M1-HQ-00001",
     status: "ACTIVE",
     person: "CIV BEMERGED, Myposwill",
@@ -29,6 +30,7 @@ const EXAMPLE_POSITIONS = {
     fullName: "Merge Two",
     organization: "MoD",
     type: "PRINCIPAL",
+    role: "Leader",
     code: "MOD-M2-HQ-00001",
     status: "ACTIVE",
     person: "Unspecified",
@@ -80,6 +82,11 @@ describe("Merge positions page", () => {
     expect(
       await (await MergePositions.getColumnContent("left", "Type")).getText()
     ).to.eq(EXAMPLE_POSITIONS.validLeft.type)
+    expect(
+      await (
+        await MergePositions.getColumnContent("left", "Position Role")
+      ).getText()
+    ).to.eq(EXAMPLE_POSITIONS.validLeft.role)
     expect(
       await (await MergePositions.getColumnContent("left", "Code")).getText()
     ).to.eq(EXAMPLE_POSITIONS.validLeft.code)
@@ -146,6 +153,11 @@ describe("Merge positions page", () => {
       await (await MergePositions.getColumnContent("right", "Type")).getText()
     ).to.eq(EXAMPLE_POSITIONS.validRight.type)
     expect(
+      await (
+        await MergePositions.getColumnContent("right", "Position Role")
+      ).getText()
+    ).to.eq(EXAMPLE_POSITIONS.validRight.role)
+    expect(
       await (await MergePositions.getColumnContent("right", "Code")).getText()
     ).to.eq(EXAMPLE_POSITIONS.validRight.code)
     expect(
@@ -181,6 +193,11 @@ describe("Merge positions page", () => {
     expect(
       await (await MergePositions.getColumnContent("mid", "Type")).getText()
     ).to.eq(EXAMPLE_POSITIONS.validLeft.type)
+    expect(
+      await (
+        await MergePositions.getColumnContent("mid", "Position Role")
+      ).getText()
+    ).to.eq(EXAMPLE_POSITIONS.validLeft.role)
     expect(
       await (await MergePositions.getColumnContent("mid", "Code")).getText()
     ).to.eq(EXAMPLE_POSITIONS.validLeft.code)
@@ -221,6 +238,11 @@ describe("Merge positions page", () => {
       await (await MergePositions.getColumnContent("mid", "Type")).getText()
     ).to.eq(EXAMPLE_POSITIONS.validRight.type)
     expect(
+      await (
+        await MergePositions.getColumnContent("mid", "Position Role")
+      ).getText()
+    ).to.eq(EXAMPLE_POSITIONS.validRight.role)
+    expect(
       await (await MergePositions.getColumnContent("mid", "Code")).getText()
     ).to.eq(EXAMPLE_POSITIONS.validRight.code)
     expect(
@@ -249,6 +271,20 @@ describe("Merge positions page", () => {
     expect(
       await (await MergePositions.getColumnContent("mid", "Name")).getText()
     ).to.eq(EXAMPLE_POSITIONS.validLeft.fullName)
+
+    await (
+      await MergePositions.getSelectButton("left", "Position Role")
+    ).click()
+    await MergePositions.waitForColumnToChange(
+      EXAMPLE_POSITIONS.validLeft.role,
+      "mid",
+      "Position Role"
+    )
+    expect(
+      await (
+        await MergePositions.getColumnContent("mid", "Position Role")
+      ).getText()
+    ).to.equal(EXAMPLE_POSITIONS.validLeft.role)
 
     await (await MergePositions.getSelectButton("left", "Code")).click()
     await MergePositions.waitForColumnToChange(

--- a/insertBaseData-psql.sql
+++ b/insertBaseData-psql.sql
@@ -508,34 +508,34 @@ INSERT INTO organizations (uuid, "shortName", "longName", type, "parentOrgUuid",
 	(SELECT uuid from organizations where "shortName" = 'MoD'), CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
 
 -- Create principal positions
-INSERT INTO positions (uuid, name, code, type, status, "currentPersonUuid", "organizationUuid", "createdAt", "updatedAt")
-	VALUES (N'879121d2-d265-4d26-8a2b-bd073caa474e', 'Minister of Defense', 'MOD-FO-00001', 1, 0, NULL, (SELECT uuid FROM organizations WHERE "longName" LIKE 'Ministry of Defense'), CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
-INSERT INTO positions (uuid, name, code, type, status, "currentPersonUuid", "organizationUuid", "createdAt", "updatedAt")
-	VALUES (N'1a45ccd6-40e3-4c51-baf5-15e7e9b8f03d', 'Chief of Staff - MoD', 'MOD-FO-00002', 1, 0, NULL, (SELECT uuid FROM organizations WHERE "longName" LIKE 'Ministry of Defense'), CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
-INSERT INTO positions (uuid, name, code, type, status, "currentPersonUuid", "organizationUuid", "createdAt", "updatedAt")
-	VALUES (N'4be6baa5-c611-4c70-a2a8-c01bf9b7d2bc', 'Executive Assistant to the MoD', 'MOD-FO-00003', 1, 0, NULL, (SELECT uuid FROM organizations WHERE "longName" LIKE 'Ministry of Defense'), CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
-INSERT INTO positions (uuid, name, code, type, status, "currentPersonUuid", "organizationUuid", "createdAt", "updatedAt")
-	VALUES (N'a9ab507e-cda9-469b-8d9e-b47445852af4', 'Planning Captain', 'MOD-FO-00004', 1, 0, NULL, (SELECT uuid FROM organizations WHERE "longName" LIKE 'Ministry of Defense'), CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
-INSERT INTO positions (uuid, name, code, type, status, "currentPersonUuid", "organizationUuid", "createdAt", "updatedAt")
-	VALUES (N'61371573-eefc-4b85-81a0-27d6c0b78c58', 'Director of Budgeting - MoD', 'MOD-Bud-00001', 1, 0, NULL, (SELECT uuid FROM organizations WHERE "longName" LIKE 'Ministry of Defense'), CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
-INSERT INTO positions (uuid, name, code, type, status, "currentPersonUuid", "organizationUuid", "createdAt", "updatedAt")
-	VALUES (N'c2e3fdff-2b36-4ef9-9790-afbca0c53f57', 'Writer of Expenses - MoD', 'MOD-Bud-00002', 1, 0, NULL, (SELECT uuid FROM organizations WHERE "longName" LIKE 'Ministry of Defense'), CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
-INSERT INTO positions (uuid, name, code, type, status, "currentPersonUuid", "organizationUuid", "createdAt", "updatedAt")
-	VALUES (N'c065c2b6-a04a-4ead-a3a2-5aabf921446d', 'Cost Adder - MoD', 'MOD-Bud-00003', 1, 0, NULL, (SELECT uuid FROM organizations WHERE "longName" LIKE 'Ministry of Defense'), CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
-INSERT INTO positions (uuid, name, code, type, status, "currentPersonUuid", "organizationUuid", "createdAt", "updatedAt")
-	VALUES (N'731ee4f9-f21b-4166-b03d-d7ba5e7f735c', 'Chief of Police', 'MOI-Pol-HQ-00001', 1, 0, NULL, (SELECT uuid FROM organizations WHERE "longName" LIKE 'Ministry of Interior'), CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
-INSERT INTO positions (uuid, name, code, type, status, "currentPersonUuid", "organizationUuid", "createdAt", "updatedAt")
-	VALUES (N'18f42d92-ada7-11eb-8529-0242ac130003', 'Chief of Tests', 'MOI-TST-HQ-00001', 1, 0, NULL, (SELECT uuid FROM organizations WHERE "longName" LIKE 'Ministry of Interior'), CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
-INSERT INTO positions (uuid, name, code, type, status, "currentPersonUuid", "organizationUuid", "createdAt", "updatedAt")
-	VALUES (N'338e4d54-ada7-11eb-8529-0242ac130003', 'Director of Tests', 'MOD-TST-HQ-00001', 1, 0, NULL, (SELECT uuid FROM organizations WHERE "longName" LIKE 'Ministry of Defense'), CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
-INSERT INTO positions (uuid, name, code, type, status, "currentPersonUuid", "organizationUuid", "createdAt", "updatedAt")
-	VALUES (N'25fe500c-3503-4ba8-a9a4-09b29b50c1f1', 'Merge One', 'MOD-M1-HQ-00001', 1, 0, NULL, (SELECT uuid FROM organizations WHERE "longName" LIKE 'Ministry of Defense'), CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
-INSERT INTO positions (uuid, name, code, type, status, "currentPersonUuid", "organizationUuid", "createdAt", "updatedAt")
-	VALUES (N'e87f0f60-ad13-4c1c-96f7-672c595b81c7', 'Merge Two', 'MOD-M2-HQ-00001', 1, 0, NULL, (SELECT uuid FROM organizations WHERE "longName" LIKE 'Ministry of Defense'), CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
-INSERT INTO positions (uuid, name, code, type, status, "currentPersonUuid", "organizationUuid", "createdAt", "updatedAt")
-	VALUES (N'885dd6bf-4647-4ef7-9bc4-4dd2826064bb', 'Chief of Merge People Test 1', 'MOI-MPT1-HQ-00001', 1, 0, NULL, (SELECT uuid FROM organizations WHERE "longName" LIKE 'Ministry of Interior'), CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
-INSERT INTO positions (uuid, name, code, type, status, "currentPersonUuid", "organizationUuid", "createdAt", "updatedAt")
-	VALUES (N'4dc40a27-19ae-4e03-a4f3-55b2c768725f', 'Chief of Merge People Test 2', 'MOI-MPT2-HQ-00001', 1, 0, NULL, (SELECT uuid FROM organizations WHERE "longName" LIKE 'Ministry of Interior'), CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+INSERT INTO positions (uuid, name, code, type, role, status, "currentPersonUuid", "organizationUuid", "createdAt", "updatedAt")
+	VALUES (N'879121d2-d265-4d26-8a2b-bd073caa474e', 'Minister of Defense', 'MOD-FO-00001', 1, 2, 0, NULL, (SELECT uuid FROM organizations WHERE "longName" LIKE 'Ministry of Defense'), CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+INSERT INTO positions (uuid, name, code, type, role, status, "currentPersonUuid", "organizationUuid", "createdAt", "updatedAt")
+	VALUES (N'1a45ccd6-40e3-4c51-baf5-15e7e9b8f03d', 'Chief of Staff - MoD', 'MOD-FO-00002', 1, 2, 0, NULL, (SELECT uuid FROM organizations WHERE "longName" LIKE 'Ministry of Defense'), CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+INSERT INTO positions (uuid, name, code, type, role, status, "currentPersonUuid", "organizationUuid", "createdAt", "updatedAt")
+	VALUES (N'4be6baa5-c611-4c70-a2a8-c01bf9b7d2bc', 'Executive Assistant to the MoD', 'MOD-FO-00003', 1, 1, 0, NULL, (SELECT uuid FROM organizations WHERE "longName" LIKE 'Ministry of Defense'), CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+INSERT INTO positions (uuid, name, code, type, role, status, "currentPersonUuid", "organizationUuid", "createdAt", "updatedAt")
+	VALUES (N'a9ab507e-cda9-469b-8d9e-b47445852af4', 'Planning Captain', 'MOD-FO-00004', 1, 1, 0, NULL, (SELECT uuid FROM organizations WHERE "longName" LIKE 'Ministry of Defense'), CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+INSERT INTO positions (uuid, name, code, type, role, status, "currentPersonUuid", "organizationUuid", "createdAt", "updatedAt")
+	VALUES (N'61371573-eefc-4b85-81a0-27d6c0b78c58', 'Director of Budgeting - MoD', 'MOD-Bud-00001', 1, 1, 0, NULL, (SELECT uuid FROM organizations WHERE "longName" LIKE 'Ministry of Defense'), CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+INSERT INTO positions (uuid, name, code, type, role, status, "currentPersonUuid", "organizationUuid", "createdAt", "updatedAt")
+	VALUES (N'c2e3fdff-2b36-4ef9-9790-afbca0c53f57', 'Writer of Expenses - MoD', 'MOD-Bud-00002', 1, 0, 0, NULL, (SELECT uuid FROM organizations WHERE "longName" LIKE 'Ministry of Defense'), CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+INSERT INTO positions (uuid, name, code, type, role, status, "currentPersonUuid", "organizationUuid", "createdAt", "updatedAt")
+	VALUES (N'c065c2b6-a04a-4ead-a3a2-5aabf921446d', 'Cost Adder - MoD', 'MOD-Bud-00003', 1, 0, 0, NULL, (SELECT uuid FROM organizations WHERE "longName" LIKE 'Ministry of Defense'), CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+INSERT INTO positions (uuid, name, code, type, role, status, "currentPersonUuid", "organizationUuid", "createdAt", "updatedAt")
+	VALUES (N'731ee4f9-f21b-4166-b03d-d7ba5e7f735c', 'Chief of Police', 'MOI-Pol-HQ-00001', 1, 2, 0, NULL, (SELECT uuid FROM organizations WHERE "longName" LIKE 'Ministry of Interior'), CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+INSERT INTO positions (uuid, name, code, type, role, status, "currentPersonUuid", "organizationUuid", "createdAt", "updatedAt")
+	VALUES (N'18f42d92-ada7-11eb-8529-0242ac130003', 'Chief of Tests', 'MOI-TST-HQ-00001', 1, 1, 0, NULL, (SELECT uuid FROM organizations WHERE "longName" LIKE 'Ministry of Interior'), CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+INSERT INTO positions (uuid, name, code, type, role, status, "currentPersonUuid", "organizationUuid", "createdAt", "updatedAt")
+	VALUES (N'338e4d54-ada7-11eb-8529-0242ac130003', 'Director of Tests', 'MOD-TST-HQ-00001', 1, 1, 0, NULL, (SELECT uuid FROM organizations WHERE "longName" LIKE 'Ministry of Defense'), CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+INSERT INTO positions (uuid, name, code, type, role, status, "currentPersonUuid", "organizationUuid", "createdAt", "updatedAt")
+	VALUES (N'25fe500c-3503-4ba8-a9a4-09b29b50c1f1', 'Merge One', 'MOD-M1-HQ-00001', 1, 1, 0, NULL, (SELECT uuid FROM organizations WHERE "longName" LIKE 'Ministry of Defense'), CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+INSERT INTO positions (uuid, name, code, type, role, status, "currentPersonUuid", "organizationUuid", "createdAt", "updatedAt")
+	VALUES (N'e87f0f60-ad13-4c1c-96f7-672c595b81c7', 'Merge Two', 'MOD-M2-HQ-00001', 1, 2, 0, NULL, (SELECT uuid FROM organizations WHERE "longName" LIKE 'Ministry of Defense'), CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+INSERT INTO positions (uuid, name, code, type, role, status, "currentPersonUuid", "organizationUuid", "createdAt", "updatedAt")
+	VALUES (N'885dd6bf-4647-4ef7-9bc4-4dd2826064bb', 'Chief of Merge People Test 1', 'MOI-MPT1-HQ-00001', 1, 1, 0, NULL, (SELECT uuid FROM organizations WHERE "longName" LIKE 'Ministry of Interior'), CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+INSERT INTO positions (uuid, name, code, type, role, status, "currentPersonUuid", "organizationUuid", "createdAt", "updatedAt")
+	VALUES (N'4dc40a27-19ae-4e03-a4f3-55b2c768725f', 'Chief of Merge People Test 2', 'MOI-MPT2-HQ-00001', 1, 1, 0, NULL, (SELECT uuid FROM organizations WHERE "longName" LIKE 'Ministry of Interior'), CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
 
 -- Put Steve into a Tashkil and associate with the EF 1.1 Advisor A Billet
 INSERT INTO "peoplePositions" ("positionUuid", "personUuid", "createdAt")


### PR DESCRIPTION
When merging positions, the role attribute can also be selected to merge.

Closes [AB#887](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/887)

#### User changes
- None

#### Superuser changes
- None

#### Admin changes
- Admin can merge position role attribute

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [x] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
