### PR TITLE
Show all superusers

### DIFF
--- a/client/src/components/EditAdministratingPositionsModal.js
+++ b/client/src/components/EditAdministratingPositionsModal.js
@@ -31,6 +31,11 @@ const EditAdministratingPositionsModal = ({
   onSuccess
 }) => {
   const [error, setError] = useState(null)
+  organization.administratingPositions =
+    (organization.administratingPositions ||
+      organization.ascendantOrgs?.find(o => o.uuid === organization.uuid)
+        ?.administratingPositions) ??
+    []
 
   const AdministratingPositionsMultiSelect = DictionaryField(FastField)
   const positionsFilters = {

--- a/client/src/components/PendingAssessmentsByPosition.js
+++ b/client/src/components/PendingAssessmentsByPosition.js
@@ -83,7 +83,7 @@ const GQL_GET_POSITION_LIST = gql`
             uuid
             shortName
           }
-          ascendantTasks(query: { pageNum: 0, pageSize: 0 }) {
+          ascendantTasks {
             uuid
             shortName
             parentTask {

--- a/client/src/components/PositionTable.js
+++ b/client/src/components/PositionTable.js
@@ -109,6 +109,7 @@ const BasePositionTable = ({
   showDelete,
   onDelete,
   positions,
+  showOrganizationsAdministrated,
   pageSize,
   pageNum,
   totalCount,
@@ -134,6 +135,7 @@ const BasePositionTable = ({
               <th>Name</th>
               <th>Location</th>
               <th>Organization</th>
+              {showOrganizationsAdministrated && <th>Superuser of</th>}
               <th>Current Occupant</th>
               <th>Status</th>
               <th />
@@ -162,6 +164,16 @@ const BasePositionTable = ({
                       />
                     )}
                   </td>
+                  {showOrganizationsAdministrated && (
+                    <td>
+                      {pos.organizationsAdministrated?.map((o, i) => (
+                        <React.Fragment key={o.uuid}>
+                          {i > 0 && ", "}
+                          <LinkTo modelType="Organization" model={o} />
+                        </React.Fragment>
+                      ))}
+                    </td>
+                  )}
                   <td>
                     {pos.person && (
                       <LinkTo modelType="Person" model={pos.person} />
@@ -192,6 +204,7 @@ BasePositionTable.propTypes = {
   onDelete: PropTypes.func,
   // list of positions:
   positions: PropTypes.array.isRequired,
+  showOrganizationsAdministrated: PropTypes.bool,
   // fill these when pagination wanted:
   totalCount: PropTypes.number,
   pageNum: PropTypes.number,

--- a/client/src/components/ReportSummary.js
+++ b/client/src/components/ReportSummary.js
@@ -69,7 +69,7 @@ const GQL_GET_REPORT_LIST = gql`
             uuid
             shortName
           }
-          ascendantTasks(query: { pageNum: 0, pageSize: 0 }) {
+          ascendantTasks {
             uuid
             shortName
             parentTask {

--- a/client/src/components/TaskTable.js
+++ b/client/src/components/TaskTable.js
@@ -28,7 +28,7 @@ const GQL_GET_TASK_LIST = gql`
           uuid
           shortName
         }
-        ascendantTasks(query: { pageNum: 0, pageSize: 0 }) {
+        ascendantTasks {
           uuid
           shortName
           parentTask {

--- a/client/src/components/graphs/OrganizationalChart.js
+++ b/client/src/components/graphs/OrganizationalChart.js
@@ -43,15 +43,15 @@ const GQL_GET_CHART_DATA = gql`
           avatar(size: 32)
         }
       }
-      childrenOrgs(query: { pageNum: 0, pageSize: 0, status: ACTIVE }) {
+      childrenOrgs(query: { status: ACTIVE }) {
         uuid
       }
-      descendantOrgs(query: { pageNum: 0, pageSize: 0, status: ACTIVE }) {
+      descendantOrgs(query: { status: ACTIVE }) {
         uuid
         shortName
         longName
         type
-        childrenOrgs(query: { pageNum: 0, pageSize: 0, status: ACTIVE }) {
+        childrenOrgs(query: { status: ACTIVE }) {
           uuid
         }
         parentOrg {

--- a/client/src/components/previews/OrganizationPreview.js
+++ b/client/src/components/previews/OrganizationPreview.js
@@ -11,84 +11,87 @@ import React from "react"
 import { ListGroup, ListGroupItem } from "react-bootstrap"
 import Settings from "settings"
 
+const GQL_LOCATION_FIELDS = `
+  fragment locationFields on Location {
+    uuid
+    name
+    type
+  }
+`
+const GQL_ORGANIZATION_FIELDS = `
+  fragment organizationFields on Organization {
+    uuid
+    shortName
+    longName
+    identificationCode
+    type
+  }
+`
+const GQL_PERSON_FIELDS = `
+  fragment personFields on Person {
+    uuid
+    name
+    status
+    rank
+    role
+    avatar(size: 32)
+  }
+`
+const GQL_POSITION_FIELDS = `
+  fragment positionFields on Position {
+    uuid
+    name
+    code
+    status
+    type
+    role
+  }
+`
 const GQL_GET_ORGANIZATION = gql`
   query ($uuid: String) {
     organization(uuid: $uuid) {
-      uuid
-      shortName
-      longName
+      ...organizationFields
       status
-      identificationCode
-      type
       parentOrg {
-        uuid
-        shortName
-        longName
-        identificationCode
+        ...organizationFields
       }
       childrenOrgs(query: { status: ACTIVE }) {
-        uuid
-        shortName
-        longName
-        identificationCode
+        ...organizationFields
       }
-      positions {
-        uuid
-        name
-        code
-        status
-        type
-        role
-        person {
-          uuid
-          name
-          status
-          rank
-          role
-          avatar(size: 32)
-        }
-        associatedPositions {
-          uuid
-          name
-          type
-          role
-          code
-          status
+      ascendantOrgs(query: { status: ACTIVE }) {
+        ...organizationFields
+        administratingPositions {
+          ...positionFields
+          location {
+            ...locationFields
+          }
+          organization {
+            ...organizationFields
+          }
           person {
-            uuid
-            name
-            status
-            rank
-            role
-            avatar(size: 32)
+            ...personFields
           }
         }
       }
-      administratingPositions {
-        uuid
-        name
-        code
-        type
-        role
-        status
-        location {
-          uuid
-          name
-        }
-        organization {
-          uuid
-          shortName
-        }
+      positions {
+        ...positionFields
         person {
-          uuid
-          name
-          rank
-          role
-          avatar(size: 32)
+          ...personFields
+        }
+        associatedPositions {
+          ...positionFields
+          person {
+            ...personFields
+          }
         }
       }
     }
   }
+
+  ${GQL_LOCATION_FIELDS}
+  ${GQL_ORGANIZATION_FIELDS}
+  ${GQL_PERSON_FIELDS}
+  ${GQL_POSITION_FIELDS}
 `
 
 const OrganizationPreview = ({ className, uuid }) => {

--- a/client/src/components/previews/OrganizationPreview.js
+++ b/client/src/components/previews/OrganizationPreview.js
@@ -26,7 +26,7 @@ const GQL_GET_ORGANIZATION = gql`
         longName
         identificationCode
       }
-      childrenOrgs(query: { pageNum: 0, pageSize: 0, status: ACTIVE }) {
+      childrenOrgs(query: { status: ACTIVE }) {
         uuid
         shortName
         longName

--- a/client/src/components/previews/ReportPreview.js
+++ b/client/src/components/previews/ReportPreview.js
@@ -67,7 +67,7 @@ const GQL_GET_REPORT = gql`
           uuid
           shortName
         }
-        ascendantTasks(query: { pageNum: 0, pageSize: 0 }) {
+        ascendantTasks {
           uuid
           shortName
           parentTask {

--- a/client/src/components/previews/TaskPreview.js
+++ b/client/src/components/previews/TaskPreview.js
@@ -34,7 +34,7 @@ const GQL_GET_TASK = gql`
           uuid
         }
       }
-      ascendantTasks(query: { pageNum: 0, pageSize: 0 }) {
+      ascendantTasks {
         uuid
         shortName
         parentTask {

--- a/client/src/models/Organization.js
+++ b/client/src/models/Organization.js
@@ -158,7 +158,13 @@ export default class Organization extends Model {
       }`
   }
 
-  static FILTERED_CLIENT_SIDE_FIELDS = ["childrenOrgs", "positions", "tasks"]
+  static FILTERED_CLIENT_SIDE_FIELDS = [
+    "childrenOrgs",
+    "ascendantOrgs",
+    "descendantOrgs",
+    "positions",
+    "tasks"
+  ]
 
   static filterClientSideFields(obj, ...additionalFields) {
     return Model.filterClientSideFields(

--- a/client/src/models/Task.js
+++ b/client/src/models/Task.js
@@ -139,7 +139,7 @@ export default class Task extends Model {
 
   static autocompleteQuery =
     "uuid shortName longName parentTask { uuid shortName }" +
-    " ascendantTasks(query: { pageNum: 0, pageSize: 0 }) { uuid shortName parentTask { uuid } }" +
+    " ascendantTasks { uuid shortName parentTask { uuid } }" +
     " taskedOrganizations { uuid shortName } customFields"
 
   static autocompleteQueryWithNotes = `${this.autocompleteQuery} ${GRAPHQL_NOTES_FIELDS}`

--- a/client/src/pages/App.js
+++ b/client/src/pages/App.js
@@ -109,7 +109,7 @@ const GQL_GET_APP_DATA = gql`
             uuid
             shortName
           }
-          ascendantTasks(query: { pageNum: 0, pageSize: 0 }) {
+          ascendantTasks {
             uuid
             shortName
             parentTask {

--- a/client/src/pages/Help.js
+++ b/client/src/pages/Help.js
@@ -185,16 +185,6 @@ const HelpConditional = ({
           Technical issues may be able to be resolved by the ANET
           administrators: <a href={`mailto:${email}`}>{email}</a>
         </p>
-
-        {currentUser.isAdmin() && (
-          <div>
-            <h4>Advanced troubleshooting</h4>
-            <p>
-              Admins, you can also consult the{" "}
-              <a href="/assets/client/changelog.html">changelog</a>.
-            </p>
-          </div>
-        )}
       </Fieldset>
     </div>
   )

--- a/client/src/pages/dashboards/KanbanDashboard.js
+++ b/client/src/pages/dashboards/KanbanDashboard.js
@@ -34,7 +34,7 @@ const GQL_GET_TASK_LIST = gql`
           uuid
           shortName
         }
-        ascendantTasks(query: { pageNum: 0, pageSize: 0 }) {
+        ascendantTasks {
           uuid
           shortName
           parentTask {

--- a/client/src/pages/organizations/Laydown.js
+++ b/client/src/pages/organizations/Laydown.js
@@ -14,6 +14,24 @@ import { Element } from "react-scroll"
 import Settings from "settings"
 import utils from "utils"
 
+function getAllAdministratingPositions(organization) {
+  return Object.values(
+    organization.ascendantOrgs?.reduce((acc, o) => {
+      const org = Object.without(o, "administratingPositions")
+      o.administratingPositions.forEach(p => {
+        const found = acc[p.uuid]
+        if (found) {
+          found.organizationsAdministrated.push(org)
+        } else {
+          p.organizationsAdministrated = [org]
+          acc[p.uuid] = p
+        }
+      })
+      return acc
+    }, {}) || {}
+  )
+}
+
 const OrganizationLaydown = ({ organization, refetch }) => {
   const { currentUser } = useContext(AppContext)
   const [showInactivePositions, setShowInactivePositions] = useState(false)
@@ -37,6 +55,7 @@ const OrganizationLaydown = ({ organization, refetch }) => {
   const supportedPositions = organization.positions.filter(
     position => positionsNeedingAttention.indexOf(position) === -1
   )
+  const allAdministratingPositions = getAllAdministratingPositions(organization)
   const canCreatePositions =
     canAdministrateOrg || (isSuperuser && isPrincipalOrg)
 
@@ -132,8 +151,9 @@ const OrganizationLaydown = ({ organization, refetch }) => {
         }
       >
         <PositionTable
-          positions={organization.administratingPositions}
           id="superuser-table"
+          positions={allAdministratingPositions}
+          showOrganizationsAdministrated
         />
         <EditAdministratingPositionsModal
           organization={organization}

--- a/client/src/pages/organizations/Show.js
+++ b/client/src/pages/organizations/Show.js
@@ -47,92 +47,86 @@ import DictionaryField from "../../HOC/DictionaryField"
 import OrganizationLaydown from "./Laydown"
 import OrganizationTasks from "./OrganizationTasks"
 
+const GQL_LOCATION_FIELDS = `
+  fragment locationFields on Location {
+    uuid
+    name
+    type
+  }
+`
+const GQL_ORGANIZATION_FIELDS = `
+  fragment organizationFields on Organization {
+    uuid
+    shortName
+    longName
+    identificationCode
+    type
+  }
+`
+const GQL_PERSON_FIELDS = `
+  fragment personFields on Person {
+    uuid
+    name
+    status
+    rank
+    role
+    avatar(size: 32)
+  }
+`
+const GQL_POSITION_FIELDS = `
+  fragment positionFields on Position {
+    uuid
+    name
+    code
+    status
+    type
+    role
+  }
+`
 const GQL_GET_ORGANIZATION = gql`
-  query($uuid: String) {
+  query ($uuid: String) {
     organization(uuid: $uuid) {
-      uuid
-      shortName
-      longName
+      ...organizationFields
       status
       isSubscribed
+      profile
       updatedAt
-      identificationCode
-      type
       location {
-        uuid
-        name
+        ...locationFields
         lat
         lng
-        type
       }
-      profile
       parentOrg {
-        uuid
-        shortName
-        longName
-        identificationCode
-        type
+        ...organizationFields
       }
       childrenOrgs(query: { status: ACTIVE }) {
-        uuid
-        shortName
-        longName
-        identificationCode
-        type
+        ...organizationFields
       }
-      positions {
-        uuid
-        name
-        code
-        status
-        type
-        role
-        person {
-          uuid
-          name
-          status
-          rank
-          role
-          avatar(size: 32)
-        }
-        associatedPositions {
-          uuid
-          name
-          type
-          role
-          code
-          status
+      ascendantOrgs(query: { status: ACTIVE }) {
+        ...organizationFields
+        administratingPositions {
+          ...positionFields
+          location {
+            ...locationFields
+          }
+          organization {
+            ...organizationFields
+          }
           person {
-            uuid
-            name
-            status
-            rank
-            role
-            avatar(size: 32)
+            ...personFields
           }
         }
       }
-      administratingPositions {
-        uuid
-        name
-        code
-        type
-        role
-        status
-        location {
-          uuid
-          name
-        }
-        organization {
-          uuid
-          shortName
-        }
+      positions {
+        ...positionFields
         person {
-          uuid
-          name
-          rank
-          role
-          avatar(size: 32)
+          ...personFields
+        }
+        associatedPositions {
+          ...positionFields
+          person {
+          ...personFields
+          }
         }
       }
       planningApprovalSteps {
@@ -142,11 +136,7 @@ const GQL_GET_ORGANIZATION = gql`
           uuid
           name
           person {
-            uuid
-            name
-            rank
-            role
-            avatar(size: 32)
+            ...personFields
           }
         }
       }
@@ -157,11 +147,7 @@ const GQL_GET_ORGANIZATION = gql`
           uuid
           name
           person {
-            uuid
-            name
-            rank
-            role
-            avatar(size: 32)
+            ...personFields
           }
         }
       }
@@ -169,6 +155,11 @@ const GQL_GET_ORGANIZATION = gql`
       ${GRAPHQL_NOTES_FIELDS}
     }
   }
+
+  ${GQL_LOCATION_FIELDS}
+  ${GQL_ORGANIZATION_FIELDS}
+  ${GQL_PERSON_FIELDS}
+  ${GQL_POSITION_FIELDS}
 `
 
 const OrganizationShow = ({ pageDispatchers }) => {

--- a/client/src/pages/organizations/Show.js
+++ b/client/src/pages/organizations/Show.js
@@ -73,7 +73,7 @@ const GQL_GET_ORGANIZATION = gql`
         identificationCode
         type
       }
-      childrenOrgs(query: { pageNum: 0, pageSize: 0, status: ACTIVE }) {
+      childrenOrgs(query: { status: ACTIVE }) {
         uuid
         shortName
         longName

--- a/client/src/pages/reports/Compact.js
+++ b/client/src/pages/reports/Compact.js
@@ -144,7 +144,7 @@ const GQL_GET_REPORT = gql`
           uuid
           shortName
         }
-        ascendantTasks(query: { pageNum: 0, pageSize: 0 }) {
+        ascendantTasks {
           uuid
           shortName
           parentTask {

--- a/client/src/pages/reports/Edit.js
+++ b/client/src/pages/reports/Edit.js
@@ -82,7 +82,7 @@ const GQL_GET_REPORT = gql`
           uuid
           shortName
         }
-        ascendantTasks(query: { pageNum: 0, pageSize: 0 }) {
+        ascendantTasks {
           uuid
           shortName
           parentTask {

--- a/client/src/pages/reports/Show.js
+++ b/client/src/pages/reports/Show.js
@@ -149,7 +149,7 @@ const GQL_GET_REPORT = gql`
           uuid
           shortName
         }
-        ascendantTasks(query: { pageNum: 0, pageSize: 0 }) {
+        ascendantTasks {
           uuid
           shortName
           parentTask {

--- a/client/src/pages/rollup/Show.js
+++ b/client/src/pages/rollup/Show.js
@@ -57,7 +57,7 @@ const GQL_GET_REPORT_LIST = gql`
         uuid
         state
         advisorOrg {
-          ascendantOrgs(query: { pageNum: 0, pageSize: 0 }) {
+          ascendantOrgs {
             uuid
             shortName
             type
@@ -67,7 +67,7 @@ const GQL_GET_REPORT_LIST = gql`
           type
         }
         principalOrg {
-          ascendantOrgs(query: { pageNum: 0, pageSize: 0 }) {
+          ascendantOrgs {
             uuid
             shortName
             type

--- a/client/src/pages/searches/Search.js
+++ b/client/src/pages/searches/Search.js
@@ -169,7 +169,7 @@ const GQL_GET_TASK_LIST = gql`
           uuid
           shortName
         }
-        ascendantTasks(query: { pageNum: 0, pageSize: 0 }) {
+        ascendantTasks {
           uuid
           shortName
           parentTask {

--- a/client/src/pages/tasks/Edit.js
+++ b/client/src/pages/tasks/Edit.js
@@ -40,7 +40,7 @@ const GQL_GET_TASK = gql`
         uuid
         shortName
       }
-      ascendantTasks(query: { pageNum: 0, pageSize: 0 }) {
+      ascendantTasks {
         uuid
         shortName
         parentTask {

--- a/client/src/pages/tasks/Show.js
+++ b/client/src/pages/tasks/Show.js
@@ -61,7 +61,7 @@ const GQL_GET_TASK = gql`
           uuid
         }
       }
-      ascendantTasks(query: { pageNum: 0, pageSize: 0 }) {
+      ascendantTasks {
         uuid
         shortName
         parentTask {
@@ -72,14 +72,14 @@ const GQL_GET_TASK = gql`
         uuid
         shortName
       }
-      descendantTasks(query: { pageNum: 0, pageSize: 0 }) {
+      descendantTasks {
         uuid
         shortName
         parentTask {
           uuid
           shortName
         }
-        ascendantTasks(query: { pageNum: 0, pageSize: 0 }) {
+        ascendantTasks {
           uuid
           shortName
           parentTask {


### PR DESCRIPTION
When viewing an organization, show all superusers: the directly assigned ones, and the ones from higher-level parent organizations.

Closes [AB#858](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/858), [AB#905](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/905)

#### User changes
- All superusers are shown on the organization page, including the ones from parent organizations.
- The Help page now also shows all these superusers.

#### Superuser changes
- none

#### Admin changes
- none

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [x] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here