### PR TITLE
Allow webp images for attachments and avatars

### DIFF
--- a/anet-dictionary.yml
+++ b/anet-dictionary.yml
@@ -330,6 +330,7 @@ fields:
       - image/jpeg
       - image/jpg
       - image/png
+      - image/webp
       - text/plain
 
   report:

--- a/client/src/components/AvatarComponent.js
+++ b/client/src/components/AvatarComponent.js
@@ -1,9 +1,13 @@
 import PropTypes from "prop-types"
 import React from "react"
 import Avatar from "react-avatar-edit"
+import Settings from "settings"
 
 // More info about this component: https://github.com/kirill3333/react-avatar
 const AvatarComponent = ({ onChangePreview }) => {
+  const imageTypes = Settings.fields.attachment.mimeTypes.filter(mimeType =>
+    mimeType.startsWith("image/")
+  )
   return (
     <span style={{ margin: "0 auto", display: "table", overflow: "scroll" }}>
       <Avatar
@@ -12,7 +16,8 @@ const AvatarComponent = ({ onChangePreview }) => {
         closeIconColor="white"
         backgroundColor="white"
         width="512"
-        imageWidth="512" // image
+        imageWidth="512"
+        mimeTypes={imageTypes}
       />
     </span>
   )

--- a/testDictionaries/no-custom-fields.yml
+++ b/testDictionaries/no-custom-fields.yml
@@ -313,6 +313,7 @@ fields:
       - image/jpeg
       - image/jpg
       - image/png
+      - image/webp
       - text/plain
 
   report:


### PR DESCRIPTION
Attachments and avatars can now also be webp images.

Closes [AB#896](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/896)

#### User changes
- Users can upload webp images as their avatar.

#### Superuser changes
- none

#### Admin changes
- none

#### System admin changes
- [x] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
