### PR TITLE
Handle links in rich-text editor during copy-paste

### DIFF
--- a/client/src/components/editor/LinkExternalHref.js
+++ b/client/src/components/editor/LinkExternalHref.js
@@ -3,15 +3,15 @@ import { IconNames } from "@blueprintjs/icons"
 import PropTypes from "prop-types"
 import React from "react"
 
-const LinkExternalHref = ({ url, children }) => {
+const LinkExternalHref = ({ url, children, attributes }) => {
   return (
-    <a href={url} target="_blank" rel="noreferrer">
-      {children}{" "}
+    <a href={url} target="_blank" {...attributes} rel="noreferrer">
+      {children}
       <Icon
         icon={IconNames.SHARE}
         intent={Intent.PRIMARY}
         size={IconSize.STANDARD * 0.75}
-        style={{ paddingBottom: "5px" }}
+        style={{ marginLeft: 2, paddingBottom: "5px" }}
       />
     </a>
   )
@@ -19,7 +19,8 @@ const LinkExternalHref = ({ url, children }) => {
 
 LinkExternalHref.propTypes = {
   url: PropTypes.string,
-  children: PropTypes.node
+  children: PropTypes.node,
+  attributes: PropTypes.object
 }
 
 export default LinkExternalHref

--- a/client/src/components/editor/LinkExternalHref.js
+++ b/client/src/components/editor/LinkExternalHref.js
@@ -11,7 +11,7 @@ const LinkExternalHref = ({ url, children, attributes }) => {
         icon={IconNames.SHARE}
         intent={Intent.PRIMARY}
         size={IconSize.STANDARD * 0.75}
-        style={{ marginLeft: 2, paddingBottom: "5px" }}
+        style={{ marginLeft: "2px", paddingBottom: "5px" }}
       />
     </a>
   )

--- a/client/src/components/editor/LinkSourceAnet.js
+++ b/client/src/components/editor/LinkSourceAnet.js
@@ -6,7 +6,7 @@ import React, { useCallback } from "react"
 import { Button, Form as FormBS, Modal } from "react-bootstrap"
 import { Transforms } from "slate"
 import { ReactEditor } from "slate-react"
-import { ANET_LINK, EXTERNAL_LINK } from "utils_links"
+import { ANET_LINK, EXTERNAL_LINK, getEntityInfoFromUrl } from "utils_links"
 import * as yup from "yup"
 
 const LinkSourceAnet = ({
@@ -145,6 +145,10 @@ function createAnetLinkNode(entityType, entityUuid) {
 }
 
 function createExternalLinkNode(url, text) {
+  const entityInfo = getEntityInfoFromUrl(url)
+  if (entityInfo.type === ANET_LINK) {
+    return createAnetLinkNode(entityInfo.entityType, entityInfo.entityUuid)
+  }
   return {
     type: EXTERNAL_LINK,
     url,

--- a/client/src/components/editor/LinkSourceAnet.js
+++ b/client/src/components/editor/LinkSourceAnet.js
@@ -6,7 +6,12 @@ import React, { useCallback } from "react"
 import { Button, Form as FormBS, Modal } from "react-bootstrap"
 import { Transforms } from "slate"
 import { ReactEditor } from "slate-react"
-import { ANET_LINK, EXTERNAL_LINK, getEntityInfoFromUrl } from "utils_links"
+import {
+  ANET_LINK,
+  createEntityUrl,
+  EXTERNAL_LINK,
+  getEntityInfoFromUrl
+} from "utils_links"
 import * as yup from "yup"
 
 const LinkSourceAnet = ({
@@ -140,6 +145,7 @@ function createAnetLinkNode(entityType, entityUuid) {
     type: ANET_LINK,
     entityType,
     entityUuid,
+    url: createEntityUrl(entityType, entityUuid),
     children: [{ text: "" }]
   }
 }

--- a/client/src/components/editor/LinkSourceAnet.js
+++ b/client/src/components/editor/LinkSourceAnet.js
@@ -6,12 +6,7 @@ import React, { useCallback } from "react"
 import { Button, Form as FormBS, Modal } from "react-bootstrap"
 import { Transforms } from "slate"
 import { ReactEditor } from "slate-react"
-import {
-  ANET_LINK,
-  createEntityUrl,
-  EXTERNAL_LINK,
-  getEntityInfoFromUrl
-} from "utils_links"
+import { ANET_LINK, EXTERNAL_LINK, getEntityInfoFromUrl } from "utils_links"
 import * as yup from "yup"
 
 const LinkSourceAnet = ({
@@ -145,7 +140,6 @@ function createAnetLinkNode(entityType, entityUuid) {
     type: ANET_LINK,
     entityType,
     entityUuid,
-    url: createEntityUrl(entityType, entityUuid),
     children: [{ text: "" }]
   }
 }

--- a/client/src/utils_links.js
+++ b/client/src/utils_links.js
@@ -32,18 +32,23 @@ export function getEntityInfoFromUrl(url) {
       /^anet:([^:]*):(.*)$/
     )
   }
-  if (urlObject.hostname === window.location.hostname) {
+  if (urlObject.host === window.location.host) {
     return getEntityFromUrlPattern(url, urlObject.pathname, /^\/([^/]*)\/(.*)$/)
   }
   return { type: EXTERNAL_LINK, url }
 }
 
-function getEntityFromUrlPattern(url, urlPath, pattern) {
-  const urnMatch = urlPath.match(pattern)
-  const entityType = RELATED_OBJECT_TYPE_TO_ENTITY_TYPE[urnMatch?.[1]]
-  const entityUuid = urnMatch?.[2]
+function getEntityFromUrlPattern(url, urlPath, entityPattern) {
+  const entityMatch = urlPath.match(entityPattern)
+  const entityType = RELATED_OBJECT_TYPE_TO_ENTITY_TYPE[entityMatch?.[1]]
+  const entityUuid = entityMatch?.[2]
   if (entityType && UUID_REGEX.test(entityUuid)) {
-    return { type: ANET_LINK, entityType, entityUuid }
+    return {
+      type: ANET_LINK,
+      entityType,
+      entityUuid,
+      url: createEntityUrl(entityType, entityUuid)
+    }
   } else {
     return { type: EXTERNAL_LINK, url }
   }
@@ -55,4 +60,8 @@ export function getUrlFromEntityInfo(node) {
     url ||
     `urn:anet:${ENTITY_TYPE_TO_RELATED_OBJECT_TYPE[entityType]}:${entityUuid}`
   )
+}
+
+export function createEntityUrl(entityType, entityUuid) {
+  return `urn:anet:${ENTITY_TYPE_TO_RELATED_OBJECT_TYPE[entityType]}:${entityUuid}`
 }

--- a/client/src/utils_links.js
+++ b/client/src/utils_links.js
@@ -24,8 +24,22 @@ const ENTITY_TYPE_TO_RELATED_OBJECT_TYPE = flip(
 )
 
 export function getEntityInfoFromUrl(url) {
-  const urnMatch =
-    url.match(/^urn:anet:([^:]*):(.*)$/) || url.match(/^\/([^.]*)\/(.*)$/)
+  const urlObject = new URL(url, window.location.href)
+  if (urlObject.protocol === "urn:") {
+    return getEntityFromUrlPattern(
+      url,
+      urlObject.pathname,
+      /^anet:([^:]*):(.*)$/
+    )
+  }
+  if (urlObject.hostname === window.location.hostname) {
+    return getEntityFromUrlPattern(url, urlObject.pathname, /^\/([^/]*)\/(.*)$/)
+  }
+  return { type: EXTERNAL_LINK, url }
+}
+
+function getEntityFromUrlPattern(url, urlPath, pattern) {
+  const urnMatch = urlPath.match(pattern)
   const entityType = RELATED_OBJECT_TYPE_TO_ENTITY_TYPE[urnMatch?.[1]]
   const entityUuid = urnMatch?.[2]
   if (entityType && UUID_REGEX.test(entityUuid)) {

--- a/client/src/utils_links.js
+++ b/client/src/utils_links.js
@@ -43,12 +43,7 @@ function getEntityFromUrlPattern(url, urlPath, entityPattern) {
   const entityType = RELATED_OBJECT_TYPE_TO_ENTITY_TYPE[entityMatch?.[1]]
   const entityUuid = entityMatch?.[2]
   if (entityType && UUID_REGEX.test(entityUuid)) {
-    return {
-      type: ANET_LINK,
-      entityType,
-      entityUuid,
-      url: createEntityUrl(entityType, entityUuid)
-    }
+    return { type: ANET_LINK, entityType, entityUuid }
   } else {
     return { type: EXTERNAL_LINK, url }
   }
@@ -60,8 +55,4 @@ export function getUrlFromEntityInfo(node) {
     url ||
     `urn:anet:${ENTITY_TYPE_TO_RELATED_OBJECT_TYPE[entityType]}:${entityUuid}`
   )
-}
-
-export function createEntityUrl(entityType, entityUuid) {
-  return `urn:anet:${ENTITY_TYPE_TO_RELATED_OBJECT_TYPE[entityType]}:${entityUuid}`
 }

--- a/client/src/utils_links.js
+++ b/client/src/utils_links.js
@@ -24,7 +24,8 @@ const ENTITY_TYPE_TO_RELATED_OBJECT_TYPE = flip(
 )
 
 export function getEntityInfoFromUrl(url) {
-  const urnMatch = url.match(/^urn:anet:([^:]*):(.*)$/)
+  const urnMatch =
+    url.match(/^urn:anet:([^:]*):(.*)$/) || url.match(/^\/([^.]*)\/(.*)$/)
   const entityType = RELATED_OBJECT_TYPE_TO_ENTITY_TYPE[urnMatch?.[1]]
   const entityUuid = urnMatch?.[2]
   if (entityType && UUID_REGEX.test(entityUuid)) {


### PR DESCRIPTION
ANET no longer 'crashes' (shows a blank page) when a user copy-pastes HTML into the rich-text editor. It also has better handling of links (both internal to ANET and external).

Closes [AB#886](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/886)

#### User changes
- User can paste HTML (including links) into the rich-text editor

#### Superuser changes
- None

#### Admin changes
- None

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
