### PR TITLE
Replace react-notification-badge

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -167,7 +167,6 @@
     "react-dom": "18.2.0",
     "react-moment-proptypes": "1.8.1",
     "react-mosaic-component": "6.0.1",
-    "react-notification-badge": "1.5.1",
     "react-redux": "8.1.2",
     "react-redux-loading-bar": "5.0.4",
     "react-router-bootstrap": "0.26.2",

--- a/client/src/components/RelatedObjectNotes.js
+++ b/client/src/components/RelatedObjectNotes.js
@@ -19,8 +19,7 @@ import { Person } from "models"
 import moment from "moment"
 import PropTypes from "prop-types"
 import React, { useContext, useState } from "react"
-import { Button, Card, Col, Offcanvas, Row } from "react-bootstrap"
-import NotificationBadge from "react-notification-badge"
+import { Badge, Button, Card, Col, Offcanvas, Row } from "react-bootstrap"
 import Settings from "settings"
 import utils from "utils"
 import "./BlueprintOverrides.css"
@@ -41,6 +40,41 @@ export const EXCLUDED_ASSESSMENT_FIELDS = [
 ]
 
 const EXCLUDED_NOTE_TYPES = [NOTE_TYPE.ASSESSMENT]
+
+const NotificationBadge = ({ pill, bg, text, children }) => (
+  <div style={{ position: "relative", width: "100%", height: "100%" }}>
+    <Badge
+      pill={pill}
+      bg={bg}
+      text={text}
+      style={{
+        display: "inline-block",
+        position: "absolute",
+        top: "-2px",
+        right: "-2px",
+        textAlign: "center",
+        whiteSpace: "nowrap",
+        padding: "3px 7px",
+        fontSize: "8px",
+        marginRight: "-8px",
+        marginTop: "-2px"
+      }}
+    >
+      {children}
+    </Badge>
+  </div>
+)
+NotificationBadge.propTypes = {
+  pill: PropTypes.bool,
+  bg: PropTypes.string,
+  text: PropTypes.string,
+  children: PropTypes.node
+}
+NotificationBadge.defaultProps = {
+  pill: true,
+  bg: "danger",
+  text: "light"
+}
 
 const RelatedObjectNotes = ({
   notesElemId,
@@ -63,7 +97,8 @@ const RelatedObjectNotes = ({
 
   const noNotes = _isEmpty(notesFiltered)
   const nrNotes = noNotes ? 0 : notesFiltered.length
-  const badgeLabel = nrNotes > 10 ? "10+" : null
+  const maxNotes = 10
+  const badgeLabel = nrNotes > maxNotes ? `${maxNotes}+` : nrNotes
 
   const handleClose = () => setShow(false)
   const handleShow = () => setShow(true)
@@ -71,12 +106,7 @@ const RelatedObjectNotes = ({
   return (
     <>
       <Button onClick={handleShow} title="Show notes">
-        <NotificationBadge
-          count={nrNotes}
-          label={badgeLabel}
-          style={{ fontSize: "8px", marginRight: "-8px", marginTop: "-2px" }}
-          effect={["none", "none"]}
-        />
+        {!noNotes && <NotificationBadge>{badgeLabel}</NotificationBadge>}
         <Icon icon={IconNames.COMMENT} />
       </Button>
 

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -7103,7 +7103,7 @@ core-js-pure@^3.23.3:
   resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.30.0.tgz#41b6c42e5f363bd53d79999bd35093b17e42e1bf"
   integrity sha512-+2KbMFGeBU0ln/csoPqTe0i/yfHbrd2EUhNMObsGtXMKS/RTtlkYyi+/3twLcevbgNR0yM/r0Psa3TEoQRpFMQ==
 
-core-js@3, core-js@3.32.0, core-js@^3.24.1:
+core-js@3.32.0, core-js@^3.24.1:
   version "3.32.0"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.32.0.tgz#7643d353d899747ab1f8b03d2803b0312a0fb3b6"
   integrity sha512-rd4rYZNlF3WuoYuRIDEmbR/ga9CeuWX9U05umAvgrrZoHY4Z++cp/xwPQMvUpBB4Ag6J8KfD80G0zwCyaSxDww==
@@ -13836,13 +13836,6 @@ react-mosaic-component@6.0.1:
     react-dnd-multi-backend "^8.0.0"
     react-dnd-touch-backend "^16.0.1"
     uuid "^9.0.0"
-
-react-notification-badge@1.5.1:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/react-notification-badge/-/react-notification-badge-1.5.1.tgz#20208cf8697cf448d177b4df753ef27ea30510df"
-  integrity sha512-4/kFrQcJ7eMfYh9SdXXgBaaEDCIV7UsLX5bgSS1aj+OnX2OpIFTatY3Dclo8qLpkX+Ue6x0Aiib+U9dkDKrSwQ==
-  dependencies:
-    core-js "3"
 
 react-popper@^1.3.11:
   version "1.3.11"


### PR DESCRIPTION
Replace the unmaintained react-notification-badge package with a simple component of our own.

Closes [AB#804](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/804)

#### User changes
- None

#### Superuser changes
- None

#### Admin changes
- None

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here