### PR TITLE
Remove obsolete work-around for webpack

### DIFF
--- a/client/config/webpack.common.js
+++ b/client/config/webpack.common.js
@@ -99,15 +99,6 @@ module.exports = {
     entry: {
       anet: [require.resolve("./polyfills"), "./src/index-auth.js"]
     },
-    // A strange workaround for a strange compile-time bug:   Error in
-    // ./~/xmlhttprequest/lib/XMLHttpRequest.js   Module not found: 'child_process'
-    // in ./node_modules/xmlhttprequest/lib This fix suggested in:
-    // https://github.com/webpack/webpack-dev-server/issues/66#issuecomment-61577531
-    externals: [
-      {
-        xmlhttprequest: "{XMLHttpRequest:XMLHttpRequest}"
-      }
-    ],
     output: {
       path: paths.appBuild
     },


### PR DESCRIPTION
The xmlhttprequest package is no longer loaded, so the work-around is no longer needed.

#### User changes
- none

#### Superuser changes
- none

#### Admin changes
- none

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here