### PR TITLE
Allow administrator positions in position history editing by administrators

### DIFF
--- a/client/src/components/EditHistory.js
+++ b/client/src/components/EditHistory.js
@@ -668,7 +668,7 @@ function getSingleSelectParameters(historyEntityType, parentEntityType) {
               : [
                 Position.TYPE.ADVISOR,
                 Position.TYPE.SUPERUSER,
-                Position.TYPE.ADMINSTRATOR
+                Position.TYPE.ADMINISTRATOR
               ]
         }
       }

--- a/client/src/pages/positions/Show.js
+++ b/client/src/pages/positions/Show.js
@@ -361,6 +361,7 @@ const PositionShow = ({ pageDispatchers }) => {
                       initialHistory={position.previousPeople}
                       currentlyOccupyingEntity={position.person}
                       midColTitle="New History"
+                      showEditButton
                       parentEntityType={position.type}
                       parentEntityUuid1={position.uuid}
                       showModal={showEditHistoryModal}

--- a/src/main/java/mil/dds/anet/database/EmailDao.java
+++ b/src/main/java/mil/dds/anet/database/EmailDao.java
@@ -1,5 +1,7 @@
 package mil.dds.anet.database;
 
+import static org.jdbi.v3.core.statement.EmptyHandling.NULL_KEYWORD;
+
 import java.time.Instant;
 import java.util.List;
 import javax.inject.Inject;
@@ -38,7 +40,7 @@ public class EmailDao {
       getDbHandle()
           .createUpdate(
               "/* PendingEmailDelete*/ DELETE FROM \"pendingEmails\" WHERE id IN ( <emailIds> )")
-          .bindList("emailIds", processedEmails).execute();
+          .bindList(NULL_KEYWORD, "emailIds", processedEmails).execute();
     }
   }
 

--- a/src/main/java/mil/dds/anet/database/ForeignKeyBatcher.java
+++ b/src/main/java/mil/dds/anet/database/ForeignKeyBatcher.java
@@ -1,5 +1,7 @@
 package mil.dds.anet.database;
 
+import static org.jdbi.v3.core.statement.EmptyHandling.NULL_KEYWORD;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -48,7 +50,7 @@ public class ForeignKeyBatcher<T extends AbstractAnetBean> {
   @InTransaction
   public List<List<T>> getByForeignKeys(List<String> foreignKeys) {
     final List<String> args = foreignKeys.isEmpty() ? defaultIfEmpty : foreignKeys;
-    final Query query = getDbHandle().createQuery(sql).bindList(paramName, args);
+    final Query query = getDbHandle().createQuery(sql).bindList(NULL_KEYWORD, paramName, args);
     if (additionalParams != null && !additionalParams.isEmpty()) {
       query.bindMap(additionalParams);
     }

--- a/src/main/java/mil/dds/anet/database/IdBatcher.java
+++ b/src/main/java/mil/dds/anet/database/IdBatcher.java
@@ -1,5 +1,7 @@
 package mil.dds.anet.database;
 
+import static org.jdbi.v3.core.statement.EmptyHandling.NULL_KEYWORD;
+
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -34,7 +36,7 @@ public class IdBatcher<T extends AbstractAnetBean> {
   @InTransaction
   public List<T> getByIds(List<String> uuids) {
     final List<String> args = uuids.isEmpty() ? defaultIfEmpty : uuids;
-    return getDbHandle().createQuery(sql).bindList(paramName, args).map(mapper)
+    return getDbHandle().createQuery(sql).bindList(NULL_KEYWORD, paramName, args).map(mapper)
         .withStream(result -> {
           final Map<String, T> map = result.collect(Collectors.toMap(obj -> obj.getUuid(), // key
               obj -> obj)); // value

--- a/src/main/java/mil/dds/anet/database/OrganizationDao.java
+++ b/src/main/java/mil/dds/anet/database/OrganizationDao.java
@@ -1,5 +1,7 @@
 package mil.dds.anet.database;
 
+import static org.jdbi.v3.sqlobject.customizer.BindList.EmptyHandling.NULL_STRING;
+
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -130,7 +132,8 @@ public class OrganizationDao
         + ", \"updatedAt\" AS \"organizations_updatedAt\""
         + ", \"locationUuid\" AS \"organizations_locationUuid\""
         + " FROM organizations WHERE \"shortName\" IN ( <shortNames> )")
-    public List<Organization> getOrgsByShortNames(@BindList("shortNames") List<String> shortNames);
+    public List<Organization> getOrgsByShortNames(
+        @BindList(value = "shortNames", onEmpty = NULL_STRING) List<String> shortNames);
   }
 
   @InTransaction

--- a/src/main/java/mil/dds/anet/database/PositionDao.java
+++ b/src/main/java/mil/dds/anet/database/PositionDao.java
@@ -1,5 +1,7 @@
 package mil.dds.anet.database;
 
+import static org.jdbi.v3.core.statement.EmptyHandling.NULL_KEYWORD;
+
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -513,7 +515,7 @@ public class PositionDao extends AnetSubscribableObjectDao<Position, PositionSea
               + " WHERE (\"positionUuid_a\" IN (<winnerExApUuids>)"
               + " OR \"positionUuid_b\" IN (<winnerExApUuids>))"
               + " AND (\"positionUuid_a\" = :loserUuid OR \"positionUuid_b\" = :loserUuid)")
-          .bind("deleted", true).bindList("winnerExApUuids", existingApUuids)
+          .bind("deleted", true).bindList(NULL_KEYWORD, "winnerExApUuids", existingApUuids)
           .bind("loserUuid", loserUuid).execute();
     }
     // transfer loser's relations to winners
@@ -549,7 +551,7 @@ public class PositionDao extends AnetSubscribableObjectDao<Position, PositionSea
               + " AND \"positionUuid_a\" NOT IN (<winnerList>)"
               + " AND \"positionUuid_b\" NOT IN (<winnerList>)")
           .bind("deleted", true).bind("winnerUuid", winnerUuid)
-          .bindList("winnerList", winnerApUuids)
+          .bindList(NULL_KEYWORD, "winnerList", winnerApUuids)
           .bind("updatedAt", DaoUtils.asLocalDateTime(Instant.now())).execute();
     }
 

--- a/src/main/java/mil/dds/anet/database/ReportDao.java
+++ b/src/main/java/mil/dds/anet/database/ReportDao.java
@@ -1,5 +1,7 @@
 package mil.dds.anet.database;
 
+import static org.jdbi.v3.core.statement.EmptyHandling.NULL_KEYWORD;
+
 import com.google.common.collect.ObjectArrays;
 import io.leangen.graphql.annotations.GraphQLRootContext;
 import java.lang.invoke.MethodHandles;
@@ -642,7 +644,7 @@ public class ReportDao extends AnetSubscribableObjectDao<Report, ReportSearchQue
 
     final Query q = getDbHandle().createQuery(sql.toString()).bindMap(sqlArgs);
     for (final Map.Entry<String, List<?>> listArg : listArgs.entrySet()) {
-      q.bindList(listArg.getKey(), listArg.getValue());
+      q.bindList(NULL_KEYWORD, listArg.getKey(), listArg.getValue());
     }
     return q.map(new MapMapper(false)).list();
   }

--- a/src/main/java/mil/dds/anet/search/pg/PostgresqlSearchQueryBuilder.java
+++ b/src/main/java/mil/dds/anet/search/pg/PostgresqlSearchQueryBuilder.java
@@ -1,5 +1,7 @@
 package mil.dds.anet.search.pg;
 
+import static org.jdbi.v3.core.statement.EmptyHandling.NULL_KEYWORD;
+
 import com.google.common.base.Joiner;
 import java.util.List;
 import java.util.Map;
@@ -76,7 +78,7 @@ public class PostgresqlSearchQueryBuilder<B, T extends AbstractSearchQuery<?>>
       q.bind("offset", query.getPageSize() * query.getPageNum()).bind("limit", query.getPageSize());
     }
     for (final Map.Entry<String, List<?>> listArg : listArgs.entrySet()) {
-      q.bindList(listArg.getKey(), listArg.getValue());
+      q.bindList(NULL_KEYWORD, listArg.getKey(), listArg.getValue());
     }
     return q;
   }


### PR DESCRIPTION
Administrator positions were inadvertently absent from the edit history dialog due to a typo.
Show the "Edit History Manually" button also on the position page.
Also make 'IN' queries with empty parameter lists more robust.

#### User changes
- none

#### Superuser changes
- Position history can now also be edited through the position page.

#### Admin changes
- Administrators can now also assign administrator positions in the edit history dialog.

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here