### PR TITLE
Allow position transfers on the same date

### DIFF
--- a/anet-dictionary.yml
+++ b/anet-dictionary.yml
@@ -365,7 +365,7 @@ fields:
           - Position
           - Organization
           - Location
-          - Task 
+          - Task
       additionalEngagementNeeded:
         type: array_of_anet_objects
         label: Additional engagement needed for
@@ -861,7 +861,7 @@ fields:
       organizationAnnually:
         label: Interaction Plan
         recurrence: annually
-        questions:         
+        questions:
           question1:
             type: enum
             label: Priority

--- a/client/src/components/EditHistory.js
+++ b/client/src/components/EditHistory.js
@@ -273,6 +273,7 @@ function EditHistory({
                                       )
                                       setFinalHistory(
                                         sortHistory(
+                                          historyEntityType,
                                           values.history.map((item, index) =>
                                             index === idx
                                               ? {
@@ -379,6 +380,7 @@ function EditHistory({
               function addItem(item) {
                 setValues({
                   history: sortHistory(
+                    historyEntityType,
                     [{ ...item, uuid: uuidv4() }, ...values.history],
                     hasCurrent
                   )
@@ -678,13 +680,22 @@ function getSingleSelectParameters(historyEntityType, parentEntityType) {
   }
 }
 
-function sortHistory(history, hasCurrent) {
+function compareHistory(entity, a, b) {
+  return (
+    a.startTime - b.startTime ||
+    a.endTime - b.endTime ||
+    a[entity]?.uuid?.localeCompare(b[entity]?.uuid) ||
+    a.uuid?.localeCompare(b.uuid)
+  )
+}
+
+function sortHistory(historyEntityType, history, hasCurrent) {
   if (!hasCurrent) {
-    return history.sort((a, b) => a.startTime - b.startTime)
+    return history.sort((a, b) => compareHistory(historyEntityType, a, b))
   }
   const historyWithoutCurrent = history.slice(0, history.length - 1)
-  const sortedWithoutCurrent = historyWithoutCurrent.sort(
-    (a, b) => a.startTime - b.startTime
+  const sortedWithoutCurrent = historyWithoutCurrent.sort((a, b) =>
+    compareHistory(historyEntityType, a, b)
   )
   return [...sortedWithoutCurrent, history[history.length - 1]]
 }

--- a/src/main/java/mil/dds/anet/database/PersonDao.java
+++ b/src/main/java/mil/dds/anet/database/PersonDao.java
@@ -552,13 +552,13 @@ public class PersonDao extends AnetSubscribableObjectDao<Person, PersonSearchQue
         final Instant endTime = pph.getEndTime();
         if (endTime == null) {
           q = getDbHandle().createQuery("SELECT COUNT(*) AS count FROM \"peoplePositions\"  WHERE ("
-              + " \"endedAt\" IS NULL OR (\"endedAt\" IS NOT NULL AND \"endedAt\" >= :startTime)"
+              + " \"endedAt\" IS NULL OR (\"endedAt\" IS NOT NULL AND \"endedAt\" > :startTime)"
               + ") AND " + personPositionClause);
         } else {
           q = getDbHandle().createQuery("SELECT COUNT(*) AS count FROM \"peoplePositions\" WHERE ("
-              + "(\"endedAt\" IS NULL AND \"createdAt\" <= :endTime)"
+              + "(\"endedAt\" IS NULL AND \"createdAt\" < :endTime)"
               + " OR (\"endedAt\" IS NOT NULL AND"
-              + " \"createdAt\" <= :endTime AND \"endedAt\" >= :startTime)) AND "
+              + " \"createdAt\" < :endTime AND \"endedAt\" > :startTime)) AND "
               + personPositionClause).bind("endTime", DaoUtils.asLocalDateTime(endTime));
         }
         final String histUuid = checkPerson ? pph.getPositionUuid() : pph.getPersonUuid();

--- a/testDictionaries/no-custom-fields.yml
+++ b/testDictionaries/no-custom-fields.yml
@@ -456,7 +456,7 @@ fields:
       organizationAnnually:
         label: Interaction Plan
         recurrence: annually
-        questions:         
+        questions:
           question1:
             type: enum
             label: Priority


### PR DESCRIPTION
Allow start time of position history record to equal end time.

Closes [AB#898](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/898)

#### User changes
- none

#### Superuser changes
- Manually changing the position history of a person (or the person history of a position) should no longer give an error if a history record has the exact same start time as the end time of a previous record.

#### Admin changes
- none

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here