### PR TITLE
Ability to save link element in rich-text editor without plain text

### DIFF
--- a/client/src/components/RichTextEditor.js
+++ b/client/src/components/RichTextEditor.js
@@ -291,6 +291,9 @@ const serialize = node => {
     case "block-quote":
       return `<blockquote>${children}</blockquote>`
     case ANET_LINK:
+      return `<a href="${getUrlFromEntityInfo(node)}">${node.entityType}:${
+        node.entityUuid
+      }</a>`
     case EXTERNAL_LINK:
       return `<a href="${getUrlFromEntityInfo(node)}">${children}</a>`
     default:


### PR DESCRIPTION
ANET object now can be saved without plain text in the rich-text editor.

Closes [AB#911](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/911)

#### User changes
- User can add ANET object and save it without entering text.

#### Superuser changes
- None

#### Admin changes
- None

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
