### PR TITLE
Delete attachments when deleting report

### DIFF
--- a/src/main/java/mil/dds/anet/database/ReportDao.java
+++ b/src/main/java/mil/dds/anet/database/ReportDao.java
@@ -404,6 +404,10 @@ public class ReportDao extends AnetSubscribableObjectDao<Report, ReportSearchQue
     // Delete orphan notes
     noteDao.deleteOrphanNotes();
 
+    final AttachmentDao attachmentDao = instance.getAttachmentDao();
+    // Delete attachments
+    attachmentDao.deleteAttachments(TABLE_NAME, reportUuid);
+
     // Delete report
     // GraphQL mutations *have* to return something, so we return the number of deleted report rows
     return getDbHandle()

--- a/src/test/java/mil/dds/anet/test/resources/AttachmentResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/AttachmentResourceTest.java
@@ -83,6 +83,7 @@ public class AttachmentResourceTest extends AbstractResourceTest {
     final Report updatedReport = adminQueryExecutor.report(REPORT_FIELDS, testReport.getUuid());
     assertThat(updatedReport.getAttachments()).hasSize(1);
     final Attachment reportAttachment = updatedReport.getAttachments().get(0);
+    assertThat(reportAttachment.getUuid()).isEqualTo(createdAttachmentUuid);
     assertThat(reportAttachment.getAttachmentRelatedObjects()).hasSize(1);
     assertThat(reportAttachment.getDescription()).isEqualTo(testAttachmentInput.getDescription());
     assertThat(reportAttachment.getClassification())
@@ -122,13 +123,14 @@ public class AttachmentResourceTest extends AbstractResourceTest {
     final Report updatedReport = adminQueryExecutor.report(REPORT_FIELDS, testReport.getUuid());
     assertThat(updatedReport.getAttachments()).hasSize(1);
     final Attachment reportAttachment = updatedReport.getAttachments().get(0);
+    assertThat(reportAttachment.getUuid()).isEqualTo(createdAttachmentUuid);
     assertThat(reportAttachment.getAttachmentRelatedObjects()).hasSize(1);
     assertThat(reportAttachment.getDescription()).isEqualTo(testAttachmentInput.getDescription());
     assertThat(reportAttachment.getClassification())
         .isEqualTo(testAttachmentInput.getClassification());
     assertThat(reportAttachment.getFileName()).isEqualTo(testAttachmentInput.getFileName());
 
-    // F - delete attachment classification as someone else
+    // F - delete attachment as someone else
     final MutationExecutor erinMutationExecutor =
         getMutationExecutor(getRegularUser().getDomainUsername());
     failAttachmentDelete(erinMutationExecutor, reportAttachment.getUuid());
@@ -221,8 +223,7 @@ public class AttachmentResourceTest extends AbstractResourceTest {
   private String succeedAttachmentCreate(final MutationExecutor mutationExecutor,
       final AttachmentInput attachmentInput)
       throws GraphQLRequestPreparationException, GraphQLRequestExecutionException {
-    final String createdAttachmentUuid =
-        mutationExecutor.createAttachment(attachmentInput.getUuid(), attachmentInput);
+    final String createdAttachmentUuid = mutationExecutor.createAttachment("", attachmentInput);
     assertThat(createdAttachmentUuid).isNotNull();
     return createdAttachmentUuid;
   }
@@ -230,7 +231,7 @@ public class AttachmentResourceTest extends AbstractResourceTest {
   private void failAttachmentCreate(final MutationExecutor mutationExecutor,
       final AttachmentInput attachmentInput) {
     try {
-      mutationExecutor.createAttachment(attachmentInput.getUuid(), attachmentInput);
+      mutationExecutor.createAttachment("", attachmentInput);
       fail("Expected exception creating attachment");
     } catch (Exception expected) {
       // OK


### PR DESCRIPTION
When a report is deleted, also delete the attachments that are linked (only) to this report.

Closes [AB#912](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/912)

#### User changes
- No visible changes

#### Superuser changes
- None

#### Admin changes
- None

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [x] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
