### PR TITLE
Show a clear message when an ANET link points to a non-existing object

### DIFF
--- a/client/src/components/editor/LinkAnetEntity.js
+++ b/client/src/components/editor/LinkAnetEntity.js
@@ -6,14 +6,29 @@ import React, { useEffect, useState } from "react"
 
 const LinkAnetEntity = ({ type, uuid, displayCallback, children }) => {
   const [entity, setEntity] = useState()
+  const [whenNotFound, setWhenNotFound] = useState(null)
 
   useEffect(() => {
     let mounted = true
     const modelClass = Models[type]
-    modelClass &&
-      modelClass
-        .fetchByUuid(uuid, GRAPHQL_ENTITY_FIELDS)
-        .then(data => mounted && setEntity(data))
+    modelClass
+      ?.fetchByUuid(uuid, GRAPHQL_ENTITY_FIELDS)
+      .then(data => {
+        if (mounted) {
+          setEntity(data)
+          setWhenNotFound(null)
+        }
+      })
+      .catch(() => {
+        if (mounted) {
+          setEntity({ uuid })
+          setWhenNotFound(
+            <em>
+              [{type} with uuid {uuid} not found]
+            </em>
+          )
+        }
+      })
     return () => {
       mounted = false
     }
@@ -21,7 +36,7 @@ const LinkAnetEntity = ({ type, uuid, displayCallback, children }) => {
 
   return (
     <LinkTo modelType={type} model={entity} displayCallback={displayCallback}>
-      {children}
+      {whenNotFound || children}
     </LinkTo>
   )
 }


### PR DESCRIPTION
ANET links in rich-text editor fields can point to objects that don't exist anymore. Instead of simply showing "Unspecified", display it as a link with a clear text.

Closes #2816, [AB#909](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/909) 

#### User changes
- 'Dead links' to ANET objects now render in a more user-friendly way.

#### Superuser changes
- None

#### Admin changes
- None

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [ ] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
