### PR TITLE
Work around a chromedriver bug

### DIFF
--- a/client/tests/e2e/permissions.js
+++ b/client/tests/e2e/permissions.js
@@ -54,7 +54,7 @@ test.serial("checking superuser permissions", async t => {
   )
 
   await $rebeccaLink.click()
-  await t.context.driver.wait(t.context.until.stalenessOf($rebeccaLink))
+  await t.context.driver.wait(t.context.untilStalenessOf($rebeccaLink))
 
   await validateUserCanEditUserForCurrentPage(t, true)
 
@@ -69,7 +69,7 @@ test.serial("checking superuser permissions", async t => {
   await pageHelpers.clickMyOrgLink()
   const $jacobLink = await findSuperuserLink(t, "CIV JACOBSON, Jacob", "EF 2.2")
   await $jacobLink.click()
-  await t.context.driver.wait(t.context.until.stalenessOf($jacobLink))
+  await t.context.driver.wait(t.context.untilStalenessOf($jacobLink))
 
   await validateUserCanEditUserForCurrentPage(t, true)
 
@@ -87,7 +87,7 @@ test.serial("checking superuser permissions", async t => {
   )
   await $otherAdvisorOrgPositionLink.click()
   await t.context.driver.wait(
-    t.context.until.stalenessOf($otherAdvisorOrgPositionLink)
+    t.context.untilStalenessOf($otherAdvisorOrgPositionLink)
   )
   await assertElementNotPresent(
     t,
@@ -124,7 +124,7 @@ test.serial("checking superuser permissions", async t => {
     "positions"
   )
   await $ownOrgPositionLink.click()
-  await t.context.driver.wait(t.context.until.stalenessOf($ownOrgPositionLink))
+  await t.context.driver.wait(t.context.untilStalenessOf($ownOrgPositionLink))
 
   const $editPositionButton = await $(".edit-position")
   await t.context.driver.wait(
@@ -170,7 +170,7 @@ test.serial("checking superuser permissions", async t => {
   )
   await $otherPrincipalOrgPositionLink.click()
   await t.context.driver.wait(
-    t.context.until.stalenessOf($otherPrincipalOrgPositionLink)
+    t.context.untilStalenessOf($otherPrincipalOrgPositionLink)
   )
   await assertElementNotPresent(
     t,
@@ -327,7 +327,7 @@ test.serial("admins can edit superusers and their positions", async t => {
     "people"
   )
   await $rebeccaPersonLink.click()
-  await t.context.driver.wait(t.context.until.stalenessOf($rebeccaPersonLink))
+  await t.context.driver.wait(t.context.untilStalenessOf($rebeccaPersonLink))
   await validateUserCanEditUserForCurrentPage(t, true)
 
   // User is admin, and can therefore edit a superuser position type

--- a/client/tests/e2e/position.js
+++ b/client/tests/e2e/position.js
@@ -51,7 +51,7 @@ test.serial("Move someone in and out of a position", async t => {
   )
   await $removePersonButton.click()
   await t.context.driver.wait(
-    until.stalenessOf($removePersonButton),
+    t.context.untilStalenessOf($removePersonButton),
     mediumWaitMs
   )
   await t.context.driver.sleep(mediumWaitMs) // wait (a bit longer) for dialog to disappear
@@ -126,7 +126,10 @@ test.serial("Move someone in and out of a position", async t => {
   )
   const $saveButton = await $("button.save-button")
   await $saveButton.click()
-  await t.context.driver.wait(until.stalenessOf($saveButton), mediumWaitMs)
+  await t.context.driver.wait(
+    t.context.untilStalenessOf($saveButton),
+    mediumWaitMs
+  )
   await t.context.driver.sleep(shortWaitMs) // wait for dialog to disappear
 
   await assertElementText(t, await $("h4.assigned-person-name"), personName)
@@ -341,7 +344,7 @@ test.serial("Update permissions while changing positions", async t => {
   await $removePersonButton.click()
   // Wait for button to be removed from the DOM.
   await t.context.driver.wait(
-    until.stalenessOf($removePersonButton),
+    t.context.untilStalenessOf($removePersonButton),
     mediumWaitMs
   )
   // Wait for transition.
@@ -355,7 +358,10 @@ test.serial("Update permissions while changing positions", async t => {
   // Click on the "Save" button.
   await $saveButton.click()
   // Wait until "Save" button is removed from the DOM.
-  await t.context.driver.wait(until.stalenessOf($saveButton), mediumWaitMs)
+  await t.context.driver.wait(
+    t.context.untilStalenessOf($saveButton),
+    mediumWaitMs
+  )
   // Wait (a bit longer) for dialog to disappear
   await t.context.driver.sleep(mediumWaitMs)
   // Go back to organization page.
@@ -408,7 +414,7 @@ test.serial("Update permissions while changing positions", async t => {
   await $removePersonButton.click()
   // Wait for button to be removed from the DOM.
   await t.context.driver.wait(
-    until.stalenessOf($removePersonButton),
+    t.context.untilStalenessOf($removePersonButton),
     mediumWaitMs
   )
   // Wait for transition.

--- a/client/tests/e2e/report.js
+++ b/client/tests/e2e/report.js
@@ -209,7 +209,7 @@ test.serial("Draft and submit a report", async t => {
   const $submitReportButton = await $("#submitReportButton")
   await $submitReportButton.click()
   await t.context.driver.wait(
-    until.stalenessOf($submitReportButton),
+    t.context.untilStalenessOf($submitReportButton),
     mediumWaitMs
   )
   await assertElementNotPresent(
@@ -278,7 +278,10 @@ test.serial("Publish report chain", async t => {
     mediumWaitMs
   )
   await $approvedReports.click()
-  await t.context.driver.wait(until.stalenessOf($approvedReports), mediumWaitMs)
+  await t.context.driver.wait(
+    t.context.untilStalenessOf($approvedReports),
+    mediumWaitMs
+  )
 
   const $reportsApprovedSummaryTab = await $(
     ".report-collection button[value='summary']"
@@ -298,7 +301,7 @@ test.serial("Publish report chain", async t => {
   const $arthurPublishButton = await $(".publish-button")
   await $arthurPublishButton.click()
   await t.context.driver.wait(
-    until.stalenessOf($arthurPublishButton),
+    t.context.untilStalenessOf($arthurPublishButton),
     mediumWaitMs
   )
 
@@ -366,7 +369,10 @@ async function approveReport(t, user) {
     mediumWaitMs
   )
   await $reportsPending.click()
-  await t.context.driver.wait(until.stalenessOf($reportsPending), mediumWaitMs)
+  await t.context.driver.wait(
+    t.context.untilStalenessOf($reportsPending),
+    mediumWaitMs
+  )
 
   const $reportsPendingSummaryTab = await $(
     ".report-collection button[value='summary']"
@@ -392,7 +398,10 @@ async function approveReport(t, user) {
     mediumWaitMs
   )
   await $ApproveButton.click()
-  await t.context.driver.wait(until.stalenessOf($ApproveButton), mediumWaitMs)
+  await t.context.driver.wait(
+    t.context.untilStalenessOf($ApproveButton),
+    mediumWaitMs
+  )
 
   await t.context.logout()
 }


### PR DESCRIPTION
Version of chromedriver > 112.x started throwing NoSuchElementError intermittently instead of StaleElementReferenceError, which breaks the Selenium conditional wait until.stalenessOf.
Work around this by (also) accepting NoSuchElementError in this case.