### PR TITLE
Improve ANET-schema for the position-role

### DIFF
--- a/src/main/resources/anet-schema.yml
+++ b/src/main/resources/anet-schema.yml
@@ -740,10 +740,29 @@ properties:
             description: Used in the UI where a position's name is shown.
           role:
             type: object
+            additionalProperties: false
+            required: [types]
             title: The label for a position's role
             description: Used in the UI where a position's roles are displayed as choices
             properties:
-               "$ref": "#/$defs/choiceField"
+              label:
+                type: string
+                description: UI label of position-role
+              types:
+                type: object
+                description: Enumeration of position role types
+                required: [member, deputy, leader]
+                additionalProperties: false
+                properties:
+                  member:
+                    type: string
+                    description: UI label of member position
+                  deputy:
+                    type: string
+                    description: UI label of deputy position
+                  leader:
+                    type: string
+                    description: UI label of leader position
           customFields:
             type: object
             additionalProperties:


### PR DESCRIPTION
Make ANET-schema more strict for position-role definition, to prevent runtime errors and receive better guidance what is required to change when validating out-dated ANET-dictionary.

Closes [AB#915](https://dev.azure.com/ncia-anet/ANET/_workitems/edit/915)

Related to PR #4366

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
