### PR TITLE
Minor fixes and improvements

### DIFF
--- a/client/src/components/assessments/AssessmentResultsContainer.js
+++ b/client/src/components/assessments/AssessmentResultsContainer.js
@@ -26,7 +26,7 @@ const AssessmentResultsContainer = ({
   if (!entity) {
     return null
   }
-  const entityAssessments = Object.entries(entity.getAssessmentsConfig())
+  const entityAssessments = Object.entries(entity.getAssessmentsConfig() ?? {})
   return (
     <div ref={contRef}>
       {entityAssessments.map(([assessmentKey, entityAssessment]) => {

--- a/client/src/pages/organizations/Show.js
+++ b/client/src/pages/organizations/Show.js
@@ -473,6 +473,15 @@ const OrganizationShow = ({ pageDispatchers }) => {
                 />
               </Fieldset>
 
+              {Settings.fields.organization.customFields && (
+                <Fieldset title="Organization information" id="custom-fields">
+                  <ReadonlyCustomFields
+                    fieldsConfig={Settings.fields.organization.customFields}
+                    values={values}
+                  />
+                </Fieldset>
+              )}
+
               <OrganizationLaydown
                 organization={organization}
                 refetch={refetch}
@@ -520,14 +529,6 @@ const OrganizationShow = ({ pageDispatchers }) => {
                   }
                 />
               </Fieldset>
-              {Settings.fields.organization.customFields && (
-                <Fieldset title="Organization information" id="custom-fields">
-                  <ReadonlyCustomFields
-                    fieldsConfig={Settings.fields.organization.customFields}
-                    values={values}
-                  />
-                </Fieldset>
-              )}
             </Form>
             <AssessmentResultsContainer
               entity={organization}

--- a/client/src/pages/tasks/Show.js
+++ b/client/src/pages/tasks/Show.js
@@ -372,6 +372,18 @@ const TaskShow = ({ pageDispatchers }) => {
               </div>
             </Form>
 
+            {Settings.fields.task.customFields && (
+              <Fieldset
+                title={`${fieldSettings.shortLabel} information`}
+                id="custom-fields"
+              >
+                <ReadonlyCustomFields
+                  fieldsConfig={Settings.fields.task.customFields}
+                  values={values}
+                />
+              </Fieldset>
+            )}
+
             <Fieldset title="Responsible positions">
               <PositionTable positions={task.responsiblePositions} />
             </Fieldset>
@@ -390,18 +402,6 @@ const TaskShow = ({ pageDispatchers }) => {
                 mapId="reports"
               />
             </Fieldset>
-
-            {Settings.fields.task.customFields && (
-              <Fieldset
-                title={`${fieldSettings.shortLabel} information`}
-                id="custom-fields"
-              >
-                <ReadonlyCustomFields
-                  fieldsConfig={Settings.fields.task.customFields}
-                  values={values}
-                />
-              </Fieldset>
-            )}
 
             <AssessmentResultsContainer
               entity={task}

--- a/client/src/utils.js
+++ b/client/src/utils.js
@@ -61,7 +61,7 @@ const fnRequiredWhenNot = (
 }
 
 const ellipsize = (value, maxLength) =>
-  value.length > maxLength
+  value?.length > maxLength
     ? value.substring(0, maxLength - 1) + "\u2026"
     : value
 

--- a/client/tests/webdriver/baseSpecs/assessmentsForOrganization.spec.js
+++ b/client/tests/webdriver/baseSpecs/assessmentsForOrganization.spec.js
@@ -40,7 +40,7 @@ const VALUE_TO_TEXT_FOR_INTERACTION = {
   maintain: "Maintain"
 }
 
-describe("For the annualy organization assessments", () => {
+describe("For the annual organization assessments", () => {
   describe("As a superuser assigned to the organization", () => {
     it("Should first search, find and open the organization's page", async() => {
       await Home.openAsSuperuser()
@@ -88,22 +88,11 @@ describe("For the annualy organization assessments", () => {
     })
 
     it("Should show the same assessment details with the details just created", async() => {
-      const details = await ShowOrganization.getShownAssessmentDetails(
+      await assertAssessmentDetails(
         "organizationAnnually",
-        "annually"
+        "annually",
+        SUPERUSER_ASSESSMENT_CREATE_DETAILS
       )
-      for (const [index, detail] of details.entries()) {
-        expect((await prefix(index)) + (await detail.getText())).to.equal(
-          (await prefix(index)) +
-            (VALUE_TO_TEXT_FOR_PRIORITY[
-              SUPERUSER_ASSESSMENT_CREATE_DETAILS[index]
-            ] ||
-              VALUE_TO_TEXT_FOR_INTERACTION[
-                SUPERUSER_ASSESSMENT_CREATE_DETAILS[index]
-              ] ||
-              SUPERUSER_ASSESSMENT_CREATE_DETAILS[index])
-        )
-      }
     })
 
     it("Should allow the author of the assessment to successfully edit it", async() => {
@@ -130,22 +119,11 @@ describe("For the annualy organization assessments", () => {
     })
 
     it("Should show the same assessment details with the details just edited", async() => {
-      const details = await ShowOrganization.getShownAssessmentDetails(
+      await assertAssessmentDetails(
         "organizationAnnually",
-        "annually"
+        "annually",
+        SUPERUSER_ASSESSMENT_EDIT_DETAILS
       )
-      for (const [index, detail] of details.entries()) {
-        expect((await prefix(index)) + (await detail.getText())).to.equal(
-          (await prefix(index)) +
-            (VALUE_TO_TEXT_FOR_PRIORITY[
-              SUPERUSER_ASSESSMENT_EDIT_DETAILS[index]
-            ] ||
-              VALUE_TO_TEXT_FOR_INTERACTION[
-                SUPERUSER_ASSESSMENT_EDIT_DETAILS[index]
-              ] ||
-              SUPERUSER_ASSESSMENT_EDIT_DETAILS[index])
-        )
-      }
       await ShowOrganization.logout()
     })
   })
@@ -199,20 +177,11 @@ describe("For the annualy organization assessments", () => {
     })
 
     it("Should show the same assessment details with the details just edited", async() => {
-      const details = await ShowOrganization.getShownAssessmentDetails(
+      await assertAssessmentDetails(
         "organizationAnnually",
-        "annually"
+        "annually",
+        ADMIN_ASSESSMENT_EDIT_DETAILS
       )
-      for (const [index, detail] of details.entries()) {
-        expect((await prefix(index)) + (await detail.getText())).to.equal(
-          (await prefix(index)) +
-            (VALUE_TO_TEXT_FOR_PRIORITY[ADMIN_ASSESSMENT_EDIT_DETAILS[index]] ||
-              VALUE_TO_TEXT_FOR_INTERACTION[
-                ADMIN_ASSESSMENT_EDIT_DETAILS[index]
-              ] ||
-              ADMIN_ASSESSMENT_EDIT_DETAILS[index])
-        )
-      }
     })
 
     it("Should allow an admin to delete the assessment", async() => {
@@ -227,5 +196,25 @@ describe("For the annualy organization assessments", () => {
   })
 })
 
-// use indexed prefix to see which one fails if any fails
-const prefix = async index => `${index}-) `
+// @assertionMethod
+const assertAssessmentDetails = async(
+  assessmentKey,
+  recurrence,
+  assessmentDetails
+) => {
+  const details = await ShowOrganization.getShownAssessmentDetails(
+    assessmentKey,
+    recurrence
+  )
+  for (const [index, detail] of await (await details).entries()) {
+    const pre = `${index}-) `
+    const det = await (await detail).getText()
+    expect(`${pre}${det}`).to.equal(
+      `${pre}${
+        VALUE_TO_TEXT_FOR_PRIORITY[assessmentDetails[index]] ||
+        VALUE_TO_TEXT_FOR_INTERACTION[assessmentDetails[index]] ||
+        assessmentDetails[index]
+      }`
+    )
+  }
+}

--- a/client/tests/webdriver/baseSpecs/assessmentsForPeople.spec.js
+++ b/client/tests/webdriver/baseSpecs/assessmentsForPeople.spec.js
@@ -76,17 +76,11 @@ describe("For the periodic person assessments", () => {
     })
 
     it("Should show the same assessment details with the details just created", async() => {
-      const details = await ShowPerson.getShownAssessmentDetails(
+      await assertAssessmentDetails(
         "principalQuarterly",
-        "quarterly"
+        "quarterly",
+        ADVISOR_1_PERSON_CREATE_DETAILS
       )
-      for (const [index, detail] of details.entries()) {
-        expect((await prefix(index)) + (await detail.getText())).to.equal(
-          (await prefix(index)) +
-            (VALUE_TO_TEXT_FOR_PERSON[ADVISOR_1_PERSON_CREATE_DETAILS[index]] ||
-              ADVISOR_1_PERSON_CREATE_DETAILS[index])
-        )
-      }
     })
 
     it("Should allow the author of the assessment to successfully edit it", async() => {
@@ -108,17 +102,11 @@ describe("For the periodic person assessments", () => {
     })
 
     it("Should show the same assessment details with the details just edited", async() => {
-      const details = await ShowPerson.getShownAssessmentDetails(
+      await assertAssessmentDetails(
         "principalQuarterly",
-        "quarterly"
+        "quarterly",
+        ADVISOR_1_PERSON_EDIT_DETAILS
       )
-      for (const [index, detail] of details.entries()) {
-        expect((await prefix(index)) + (await detail.getText())).to.equal(
-          (await prefix(index)) +
-            (VALUE_TO_TEXT_FOR_PERSON[ADVISOR_1_PERSON_EDIT_DETAILS[index]] ||
-              ADVISOR_1_PERSON_EDIT_DETAILS[index])
-        )
-      }
       await ShowPerson.logout()
     })
   })
@@ -165,17 +153,11 @@ describe("For the periodic person assessments", () => {
     })
 
     it("Should show the same assessment details with the details just edited", async() => {
-      const details = await ShowPerson.getShownAssessmentDetails(
+      await assertAssessmentDetails(
         "principalQuarterly",
-        "quarterly"
+        "quarterly",
+        ADMIN_PERSON_EDIT_DETAILS
       )
-      for (const [index, detail] of details.entries()) {
-        expect((await prefix(index)) + (await detail.getText())).to.equal(
-          (await prefix(index)) +
-            (VALUE_TO_TEXT_FOR_PERSON[ADMIN_PERSON_EDIT_DETAILS[index]] ||
-              ADMIN_PERSON_EDIT_DETAILS[index])
-        )
-      }
     })
 
     it("Should allow an admin to delete the assessment", async() => {
@@ -190,5 +172,23 @@ describe("For the periodic person assessments", () => {
   })
 })
 
-// use indexed prefix to see which one fails if any fails
-const prefix = async index => `${index}-) `
+const assertAssessmentDetails = async(
+  assessmentKey,
+  recurrence,
+  assessmentDetails
+) => {
+  const details = await ShowPerson.getShownAssessmentDetails(
+    assessmentKey,
+    recurrence
+  )
+  for (const [index, detail] of await (await details).entries()) {
+    const pre = `${index}-) `
+    const det = await (await detail).getText()
+    expect(`${pre}${det}`).to.equal(
+      `${pre}${
+        VALUE_TO_TEXT_FOR_PERSON[assessmentDetails[index]] ||
+        assessmentDetails[index]
+      }`
+    )
+  }
+}

--- a/client/tests/webdriver/baseSpecs/assessmentsForTasks.spec.js
+++ b/client/tests/webdriver/baseSpecs/assessmentsForTasks.spec.js
@@ -51,18 +51,11 @@ describe("For the periodic task assessments", () => {
     })
 
     it("Should show the same assessment details with the details just created", async() => {
-      const details = await ShowTask.getShownAssessmentDetails(
+      await assertAssessmentDetails(
         "subTaskMonthly",
-        "monthly"
+        "monthly",
+        ADVISOR_1_TASK_CREATE_DETAILS
       )
-      for (const [index, detail] of details.entries()) {
-        expect((await prefix(index)) + (await detail.getText())).to.equal(
-          (await // Only some values are mapped, others are same
-          prefix(index)) +
-            (VALUE_TO_TEXT_FOR_TASK[ADVISOR_1_TASK_CREATE_DETAILS[index]] ||
-              ADVISOR_1_TASK_CREATE_DETAILS[index])
-        )
-      }
     })
 
     it("Should allow the author of the assessment to successfully edit it", async() => {
@@ -89,18 +82,11 @@ describe("For the periodic task assessments", () => {
     })
 
     it("Should show the same assessment details with the details just edited", async() => {
-      const details = await ShowTask.getShownAssessmentDetails(
+      await assertAssessmentDetails(
         "subTaskMonthly",
-        "monthly"
+        "monthly",
+        ADVISOR_1_TASK_EDIT_DETAILS
       )
-      for (const [index, detail] of details.entries()) {
-        expect((await prefix(index)) + (await detail.getText())).to.equal(
-          (await // Only some values are mapped, others are same
-          prefix(index)) +
-            (VALUE_TO_TEXT_FOR_TASK[ADVISOR_1_TASK_EDIT_DETAILS[index]] ||
-              ADVISOR_1_TASK_EDIT_DETAILS[index])
-        )
-      }
       await ShowTask.logout()
     })
   })
@@ -148,18 +134,11 @@ describe("For the periodic task assessments", () => {
     })
 
     it("Should show the same assessment details with the details just edited", async() => {
-      const details = await ShowTask.getShownAssessmentDetails(
+      await assertAssessmentDetails(
         "subTaskMonthly",
-        "monthly"
+        "monthly",
+        ADMIN_TASK_EDIT_DETAILS
       )
-      for (const [index, detail] of details.entries()) {
-        expect((await prefix(index)) + (await detail.getText())).to.equal(
-          (await // Only some values are mapped, others are same
-          prefix(index)) +
-            (VALUE_TO_TEXT_FOR_TASK[ADMIN_TASK_EDIT_DETAILS[index]] ||
-              ADMIN_TASK_EDIT_DETAILS[index])
-        )
-      }
       await ShowTask.logout()
     })
   })
@@ -207,18 +186,11 @@ describe("For the periodic task assessments", () => {
     })
 
     it("Should show the same assessment details with the details just edited", async() => {
-      const details = await ShowTask.getShownAssessmentDetails(
+      await assertAssessmentDetails(
         "subTaskMonthly",
-        "monthly"
+        "monthly",
+        ADVISOR_2_TASK_EDIT_DETAILS
       )
-      for (const [index, detail] of details.entries()) {
-        expect((await prefix(index)) + (await detail.getText())).to.equal(
-          (await // Only some values are mapped, others are same
-          prefix(index)) +
-            (VALUE_TO_TEXT_FOR_TASK[ADVISOR_2_TASK_EDIT_DETAILS[index]] ||
-              ADVISOR_2_TASK_EDIT_DETAILS[index])
-        )
-      }
     })
 
     it("Should allow the other advisor to delete the assessment", async() => {
@@ -233,5 +205,23 @@ describe("For the periodic task assessments", () => {
   })
 })
 
-// use indexed prefix to see which one fails if any fails
-const prefix = async index => `${index}-) `
+const assertAssessmentDetails = async(
+  assessmentKey,
+  recurrence,
+  assessmentDetails
+) => {
+  const details = await ShowTask.getShownAssessmentDetails(
+    assessmentKey,
+    recurrence
+  )
+  for (const [index, detail] of await (await details).entries()) {
+    const pre = `${index}-) `
+    const det = await (await detail).getText()
+    expect(`${pre}${det}`).to.equal(
+      `${pre}${
+        VALUE_TO_TEXT_FOR_TASK[assessmentDetails[index]] ||
+        assessmentDetails[index]
+      }`
+    )
+  }
+}

--- a/client/tests/webdriver/pages/page.js
+++ b/client/tests/webdriver/pages/page.js
@@ -132,6 +132,65 @@ class Page {
     return options[index].getValue()
   }
 
+  async saveAssessmentAndWaitForModalClose(
+    saveButton,
+    getModalForm,
+    getAssessmentDetails,
+    detailIndex,
+    detailToWaitFor
+  ) {
+    await saveButton.click()
+    await browser.pause(300) // wait for modal animation to finish
+
+    await (
+      await getModalForm()
+    ).waitForExist({
+      reverse: true,
+      timeout: 20000
+    })
+    // wait until details to change, can take some time to update show page
+    await browser.waitUntil(
+      async() => {
+        return (
+          (await (await getAssessmentDetails())[detailIndex].getText()) ===
+          detailToWaitFor
+        )
+      },
+      {
+        timeout: 5000,
+        timeoutMsg: "Expected change after save"
+      }
+    )
+  }
+
+  async clickButton(buttonContainer, buttonSelector) {
+    const button = await buttonContainer.$(buttonSelector)
+    // wait for a bit and click twice, sometimes it does not go through
+    await browser.pause(300)
+    await button.click({ x: 10, y: 10 })
+    await button.click({ x: 10, y: 10 })
+    await browser.pause(300)
+  }
+
+  async fillRichTextInput(
+    editorContainer,
+    editorSelector,
+    editorValue,
+    oldValue
+  ) {
+    await (await editorContainer.$(editorSelector)).click()
+    // Wait for the editor to be focused
+    await browser.pause(300)
+    if (oldValue) {
+      await this.deleteText(oldValue)
+      // Wait for the previous value to be deleted
+      await browser.pause(300)
+    }
+    await browser.keys(editorValue)
+    // Wait for rich-text editor to update content
+    await browser.pause(300)
+  }
+
   async deleteText(text = "") {
     // Clumsy way to clear text…
     await browser.keys(["End"].concat(Array(text.length).fill("Backspace")))

--- a/client/tests/webdriver/pages/showOrganization.page.js
+++ b/client/tests/webdriver/pages/showOrganization.page.js
@@ -112,64 +112,35 @@ class ShowOrganization extends Page {
   }
 
   async fillAssessmentQuestion(valuesArr, prevTextToClear) {
-    // NOTE: assuming assessment content, 4 questions
-    // first focus on the text editor input
-    await (
-      await (
-        await this.getAssessmentModalForm()
-      ).$(
-        "div[id='fg-entityAssessment.question3'] .editor-container > .editable"
-      )
-    ).click()
-    // Wait for the editor to be focused
-    await browser.pause(300)
-    if (prevTextToClear && prevTextToClear[0]) {
-      await this.deleteText(prevTextToClear[0])
-      // Wait for the previous value to be deleted
-      await browser.pause(300)
-    }
-    await browser.keys(valuesArr[2])
-
-    // focus on the second text editor input
-    await (
-      await (
-        await this.getAssessmentModalForm()
-      ).$(
-        "div[id='fg-entityAssessment.question4'] .editor-container > .editable"
-      )
-    ).click()
-    // Wait for the editor to be focused
-    await browser.pause(300)
-    if (prevTextToClear && prevTextToClear[1]) {
-      await this.deleteText(prevTextToClear[1])
-      // Wait for the previous value to be deleted
-      await browser.pause(300)
-    }
-    await browser.keys(valuesArr[3])
+    // NOTE: assuming assessment content, 4 questions; process them in order
 
     // Select first button group
-    const buttonPriority = await (
-      await this.getAssessmentModalForm()
-    ).$(
+    await this.clickButton(
+      await this.getAssessmentModalForm(),
       `div[id='fg-entityAssessment.question1'] label[for="entityAssessment.question1_${valuesArr[0]}"]`
     )
-    // wait for a bit, clicks and do double click, sometimes it does not go through
-    await browser.pause(300)
-    await buttonPriority.click({ x: 10, y: 10 })
-    await buttonPriority.click({ x: 10, y: 10 })
-    await browser.pause(300)
 
     // Select second button group
-    const buttonInteraction = await (
-      await this.getAssessmentModalForm()
-    ).$(
+    await this.clickButton(
+      await this.getAssessmentModalForm(),
       `div[id='fg-entityAssessment.question2'] label[for="entityAssessment.question2_${valuesArr[1]}"]`
     )
-    // wait for a bit, clicks and do double click, sometimes it does not go through
-    await browser.pause(300)
-    await buttonInteraction.click({ x: 10, y: 10 })
-    await buttonInteraction.click({ x: 10, y: 10 })
-    await browser.pause(300)
+
+    // Select first text editor input
+    await this.fillRichTextInput(
+      await this.getAssessmentModalForm(),
+      "div[id='fg-entityAssessment.question3'] .editor-container > .editable",
+      valuesArr[2],
+      prevTextToClear?.[0]
+    )
+
+    // Select second text editor input
+    await this.fillRichTextInput(
+      await this.getAssessmentModalForm(),
+      "div[id='fg-entityAssessment.question4'] .editor-container > .editable",
+      valuesArr[3],
+      prevTextToClear?.[1]
+    )
   }
 
   async saveAssessmentAndWaitForModalClose(
@@ -177,28 +148,12 @@ class ShowOrganization extends Page {
     recurrence,
     detail0ToWaitFor
   ) {
-    await (await this.getSaveAssessmentButton()).click()
-    await browser.pause(300) // wait for modal animation to finish
-
-    await (
-      await this.getAssessmentModalForm()
-    ).waitForExist({
-      reverse: true,
-      timeout: 20000
-    })
-    // wait until details to change, can take some time to update show page
-    await browser.waitUntil(
-      async() => {
-        return (
-          (await (
-            await this.getShownAssessmentDetails(assessmentKey, recurrence)
-          )[0].getText()) === detail0ToWaitFor
-        )
-      },
-      {
-        timeout: 5000,
-        timeoutMsg: "Expected change after save"
-      }
+    return super.saveAssessmentAndWaitForModalClose(
+      await this.getSaveAssessmentButton(),
+      () => this.getAssessmentModalForm(),
+      () => this.getShownAssessmentDetails(assessmentKey, recurrence),
+      0,
+      detail0ToWaitFor
     )
   }
 

--- a/client/tests/webdriver/pages/showPerson.page.js
+++ b/client/tests/webdriver/pages/showPerson.page.js
@@ -151,39 +151,33 @@ class ShowPerson extends Page {
   }
 
   async fillAssessmentQuestion(valuesArr, prevTextToClear) {
-    // Second value in the valuesArr is the text editor value
-    const buttonGroupValues = valuesArr.filter((value, index) => index !== 1)
-    const textInputValue = valuesArr[1]
-    const buttonGroups = await (
-      await this.getAssessmentModalForm()
-    ).$$(".modal-content .btn-group")
-    for (const [index, btnGroup] of buttonGroups.entries()) {
-      const button = await btnGroup.$(
-        `label[for$=".test${index + 1}_${buttonGroupValues[index]}"]`
-      )
-      // wait for a bit, clicks and do double click, sometimes it does not go through
-      await browser.pause(300)
-      await button.click({ x: 10, y: 10 })
-      await button.click({ x: 10, y: 10 })
-      await browser.pause(300)
-    }
+    // NOTE: assuming assessment content, 4 questions; process them in order
 
-    // first focus on the text editor input
-    await (
-      await (
-        await this.getAssessmentModalForm()
-      ).$(".editor-container > .editable")
-    ).click()
-    // Wait for the editor to be focused
-    await browser.pause(300)
-    if (prevTextToClear) {
-      await this.deleteText(prevTextToClear)
-      // Wait for the previous value to be deleted
-      await browser.pause(300)
-    }
-    // fourth value is the text field
-    await browser.keys(textInputValue)
-    await browser.pause(300)
+    // Select first button
+    await this.clickButton(
+      await this.getAssessmentModalForm(),
+      `div[id='fg-entityAssessment.test1'] label[for="entityAssessment.test1_${valuesArr[0]}"]`
+    )
+
+    // Select text editor input
+    await this.fillRichTextInput(
+      await this.getAssessmentModalForm(),
+      "div[id='fg-entityAssessment.text'] .editor-container > .editable",
+      valuesArr[1],
+      prevTextToClear
+    )
+
+    // Select second button
+    await this.clickButton(
+      await this.getAssessmentModalForm(),
+      `div[id='fg-entityAssessment.questionSets.topLevelQs.questions.test2'] label[for="entityAssessment.questionSets.topLevelQs.questions.test2_${valuesArr[2]}"]`
+    )
+
+    // Select third button
+    await this.clickButton(
+      await this.getAssessmentModalForm(),
+      `div[id='fg-entityAssessment.questionSets.topLevelQs.questionSets.bottomLevelQs.questions.test3'] label[for="entityAssessment.questionSets.topLevelQs.questionSets.bottomLevelQs.questions.test3_${valuesArr[3]}"]`
+    )
   }
 
   async saveAssessmentAndWaitForModalClose(
@@ -191,27 +185,12 @@ class ShowPerson extends Page {
     recurrence,
     detail0ToWaitFor
   ) {
-    await (await this.getSaveAssessmentButton()).click()
-    await browser.pause(300) // wait for modal animation to finish
-    await (
-      await this.getAssessmentModalForm()
-    ).waitForExist({
-      reverse: true,
-      timeout: 20000
-    })
-    // wait until details to change, can take some time to update show page
-    await browser.waitUntil(
-      async() => {
-        return (
-          (await (
-            await this.getShownAssessmentDetails(assessmentKey, recurrence)
-          )[0].getText()) === detail0ToWaitFor
-        )
-      },
-      {
-        timeout: 20000,
-        timeoutMsg: "Expected change after save"
-      }
+    return super.saveAssessmentAndWaitForModalClose(
+      await this.getSaveAssessmentButton(),
+      () => this.getAssessmentModalForm(),
+      () => this.getShownAssessmentDetails(assessmentKey, recurrence),
+      0,
+      detail0ToWaitFor
     )
   }
 

--- a/client/tests/webdriver/pages/showTask.page.js
+++ b/client/tests/webdriver/pages/showTask.page.js
@@ -95,30 +95,21 @@ class ShowTask extends Page {
   }
 
   async fillAssessmentQuestion(valuesArr, prevTextToClear) {
-    // NOTE: assuming assessment content, 2 questions
-    // first focus on the text editor input
-    await (
-      await (
-        await this.getAssessmentModalForm()
-      ).$(".editor-container > .editable")
-    ).click()
-    // Wait for the editor to be focused
-    await browser.pause(300)
-    if (prevTextToClear) {
-      await this.deleteText(prevTextToClear)
-      // Wait for the previous value to be deleted
-      await browser.pause(300)
-    }
-    await browser.keys(valuesArr[0])
+    // NOTE: assuming assessment content, 2 questions; process them in order
 
-    const button = await (await this.getAssessmentModalForm())
-      .$(".btn-group")
-      .$(`label[for="entityAssessment.status_${valuesArr[1]}"]`)
-    // wait for a bit, clicks and do double click, sometimes it does not go through
-    await browser.pause(300)
-    await button.click({ x: 10, y: 10 })
-    await button.click({ x: 10, y: 10 })
-    await browser.pause(300)
+    // Select text editor input
+    await this.fillRichTextInput(
+      await this.getAssessmentModalForm(),
+      "div[id='fg-entityAssessment.issues'] .editor-container > .editable",
+      valuesArr[0],
+      prevTextToClear
+    )
+
+    // Select button group
+    await this.clickButton(
+      await this.getAssessmentModalForm(),
+      `div[id='fg-entityAssessment.status'] label[for="entityAssessment.status_${valuesArr[1]}"]`
+    )
   }
 
   async saveAssessmentAndWaitForModalClose(
@@ -126,28 +117,12 @@ class ShowTask extends Page {
     recurrence,
     detail0ToWaitFor
   ) {
-    await (await this.getSaveAssessmentButton()).click()
-    await browser.pause(300) // wait for modal animation to finish
-
-    await (
-      await this.getAssessmentModalForm()
-    ).waitForExist({
-      reverse: true,
-      timeout: 20000
-    })
-    // wait until details to change, can take some time to update show page
-    await browser.waitUntil(
-      async() => {
-        return (
-          (await (
-            await this.getShownAssessmentDetails(assessmentKey, recurrence)
-          )[0].getText()) === detail0ToWaitFor
-        )
-      },
-      {
-        timeout: 5000,
-        timeoutMsg: "Expected change after save"
-      }
+    return super.saveAssessmentAndWaitForModalClose(
+      await this.getSaveAssessmentButton(),
+      () => this.getAssessmentModalForm(),
+      () => this.getShownAssessmentDetails(assessmentKey, recurrence),
+      0,
+      detail0ToWaitFor
     )
   }
 


### PR DESCRIPTION
Some minor fixes and improvements to ANET.

#### User changes
- The section with additional information for organizations and tasks is now shown more towards the top of the page.

#### Superuser changes
- None

#### Admin changes
- None

#### System admin changes
- Assessments sections can now be left out of the dictionary if there are no assessments.
- Some fields (like an organization's description) are now allowed to be `NULL` in the database.
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [x] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here