### PR TITLE
Allow a person gender to be 'Not Specified'

### DIFF
--- a/client/src/pages/people/Form.js
+++ b/client/src/pages/people/Form.js
@@ -118,6 +118,20 @@ const PersonForm = ({
       label: Settings.fields.principal.person.name
     }
   ]
+  const genderOptions = [
+    {
+      label: "Not Specified",
+      value: "NOT SPECIFIED"
+    },
+    {
+      label: "Male",
+      value: "MALE"
+    },
+    {
+      label: "Female",
+      value: "FEMALE"
+    }
+  ]
 
   return (
     <Formik
@@ -556,9 +570,14 @@ const PersonForm = ({
                   component={FieldHelper.SpecialField}
                   widget={
                     <FormSelect>
-                      <option />
-                      <option value="MALE">Male</option>
-                      <option value="FEMALE">Female</option>
+                      {genderOptions.map(genderOption => (
+                        <option
+                          key={genderOption.value}
+                          value={genderOption.value}
+                        >
+                          {genderOption.label}
+                        </option>
+                      ))}
                     </FormSelect>
                   }
                 />


### PR DESCRIPTION
ANET now allows selecting gender as "Not Specified" in addition to "Male" and "Female" options for the people who don't want to specify their gender.

Closes [AB#948](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/948)

#### User changes
- Users now have a third, "Not Specified", option when selecting their gender. 

#### Superuser changes
- None

#### Admin changes
- None

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [ ] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
