### PR TITLE
Make end of tour date optional

### DIFF
--- a/client/src/components/CustomDateInput.js
+++ b/client/src/components/CustomDateInput.js
@@ -75,7 +75,7 @@ const CustomDateInput = ({
       placeholder={inputFormat}
       maxDate={maxDate}
       minDate={moment().subtract(100, "years").startOf("year").toDate()}
-      canClearSelection={false}
+      canClearSelection
       showActionsBar
       closeOnSelection={!withTime}
       timePickerProps={timePickerProps}
@@ -95,7 +95,8 @@ CustomDateInput.propTypes = {
   value: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.number,
-    PropTypes.instanceOf(Date)
+    PropTypes.instanceOf(Date),
+    PropTypes.oneOf([null])
   ]),
   onChange: PropTypes.func,
   onBlur: PropTypes.func

--- a/client/src/components/CustomDateInput.js
+++ b/client/src/components/CustomDateInput.js
@@ -33,7 +33,8 @@ const CustomDateInput = ({
   withTime,
   value,
   onChange,
-  onBlur
+  onBlur,
+  canClearSelection
 }) => {
   const inputRef = useRef()
   const rightElement = showIcon && CalendarIcon(inputRef.current)
@@ -75,7 +76,7 @@ const CustomDateInput = ({
       placeholder={inputFormat}
       maxDate={maxDate}
       minDate={moment().subtract(100, "years").startOf("year").toDate()}
-      canClearSelection
+      canClearSelection={canClearSelection}
       showActionsBar
       closeOnSelection={!withTime}
       timePickerProps={timePickerProps}
@@ -95,18 +96,19 @@ CustomDateInput.propTypes = {
   value: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.number,
-    PropTypes.instanceOf(Date),
-    PropTypes.oneOf([null])
+    PropTypes.instanceOf(Date)
   ]),
   onChange: PropTypes.func,
-  onBlur: PropTypes.func
+  onBlur: PropTypes.func,
+  canClearSelection: PropTypes.bool
 }
 CustomDateInput.defaultProps = {
   disabled: false,
   showIcon: true,
   maxDate: moment().add(20, "years").endOf("year").toDate(),
   placement: "auto",
-  withTime: false
+  withTime: false,
+  canClearSelection: false
 }
 
 export default CustomDateInput

--- a/client/src/models/Person.js
+++ b/client/src/models/Person.js
@@ -140,9 +140,7 @@ export default class Person extends Model {
             if (Person.isPrincipal({ role })) {
               return schema
             } else {
-              schema = schema.required(
-                `You must provide the ${Settings.fields.person.endOfTourDate}`
-              )
+              // endOfTourDate is not required but if there is, it must be greater than today
               if (Person.isPendingVerification({ pendingVerification })) {
                 schema = schema.test(
                   "end-of-tour-date",

--- a/client/src/pages/people/Form.js
+++ b/client/src/pages/people/Form.js
@@ -590,7 +590,9 @@ const PersonForm = ({
                   value={values.endOfTourDate}
                   onChange={value => setFieldValue("endOfTourDate", value)}
                   onBlur={() => setFieldTouched("endOfTourDate")}
-                  widget={<CustomDateInput id="endOfTourDate" />}
+                  widget={
+                    <CustomDateInput id="endOfTourDate" canClearSelection />
+                  }
                 >
                   {isAdvisor && endOfTourDateInPast && (
                     <Alert variant="warning">

--- a/client/tests/webdriver/baseSpecs/createNewPerson.spec.js
+++ b/client/tests/webdriver/baseSpecs/createNewPerson.spec.js
@@ -168,7 +168,7 @@ describe("Create new Person form page", () => {
       )
       // Don't logout, next test continues…
     })
-    it("Should not save if endOfTourDate is not filled in", async() => {
+    it("Should save even if endOfTourDate is not filled in", async() => {
       // Continue on the same page to prevent "Are you sure you wish to navigate away from the page" warning
       await (
         await CreatePerson.getLastName()
@@ -182,11 +182,6 @@ describe("Create new Person form page", () => {
         await CreatePerson.getEmailAddress()
       ).setValue(VALID_PERSON_ADVISOR.emailAddress)
       await (await CreatePerson.getLastName()).click()
-      let errorMessage = await browser.$(
-        "input#emailAddress + div.invalid-feedback"
-      )
-      // element should *not* be visible!
-      await errorMessage.waitForDisplayed({ timeout: 1000, reverse: true })
       await (
         await CreatePerson.getRank()
       ).selectByAttribute(
@@ -208,17 +203,6 @@ describe("Create new Person form page", () => {
       // This makes sure the help-block is displayed after form submit
       await (await CreatePerson.getEndOfTourDate()).setValue("")
       await (await CreatePerson.getLastName()).click()
-      errorMessage = await (await CreatePerson.getEndOfTourDate())
-        .$("..")
-        .$("..")
-        .$("..")
-        .$("..")
-        .$("div.invalid-feedback")
-      await errorMessage.waitForExist()
-      await errorMessage.waitForDisplayed()
-      expect(await errorMessage.getText()).to.equal(
-        "You must provide the End of tour"
-      )
       // Don't logout, next test continues…
     })
 

--- a/client/tests/webdriver/baseSpecs/createNewPerson.spec.js
+++ b/client/tests/webdriver/baseSpecs/createNewPerson.spec.js
@@ -199,7 +199,6 @@ describe("Create new Person form page", () => {
         "value",
         await CreatePerson.getRandomOption(await CreatePerson.getCountry())
       )
-      // This makes sure the help-block is displayed after form submit
       await (await CreatePerson.getEndOfTourDate()).setValue("")
       await (await CreatePerson.getLastName()).click()
       const errorMessage = await browser.$(

--- a/client/tests/webdriver/baseSpecs/createNewPerson.spec.js
+++ b/client/tests/webdriver/baseSpecs/createNewPerson.spec.js
@@ -181,7 +181,6 @@ describe("Create new Person form page", () => {
       await (
         await CreatePerson.getEmailAddress()
       ).setValue(VALID_PERSON_ADVISOR.emailAddress)
-      await (await CreatePerson.getLastName()).click()
       await (
         await CreatePerson.getRank()
       ).selectByAttribute(
@@ -203,6 +202,11 @@ describe("Create new Person form page", () => {
       // This makes sure the help-block is displayed after form submit
       await (await CreatePerson.getEndOfTourDate()).setValue("")
       await (await CreatePerson.getLastName()).click()
+      const errorMessage = await browser.$(
+        "input#emailAddress + div.invalid-feedback"
+      )
+      // element should *not* be visible!
+      await errorMessage.waitForDisplayed({ timeout: 1000, reverse: true })
       // Don't logout, next test continues…
     })
 


### PR DESCRIPTION
The end of tour date is now optional.

Closes [AB#949](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/949)

#### User changes
- Users can now leave end of tour date empty.

#### Superuser changes
- None

#### Admin changes
- None

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [x] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
