### PR TITLE
Move fieldset with custom fields to the top of the page

### DIFF
--- a/client/src/pages/locations/Show.js
+++ b/client/src/pages/locations/Show.js
@@ -178,7 +178,6 @@ const LocationShow = ({ pageDispatchers }) => {
                 )}
               </Fieldset>
 
-              <Leaflet markers={[marker]} />
               {Settings.fields.location.customFields && (
                 <Fieldset title="Location information" id="custom-fields">
                   <ReadonlyCustomFields
@@ -187,6 +186,8 @@ const LocationShow = ({ pageDispatchers }) => {
                   />
                 </Fieldset>
               )}
+
+              <Leaflet markers={[marker]} />
             </Form>
 
             <Approvals relatedObject={location} />

--- a/client/src/pages/positions/Show.js
+++ b/client/src/pages/positions/Show.js
@@ -256,6 +256,15 @@ const PositionShow = ({ pageDispatchers }) => {
                 />
               </Fieldset>
 
+              {Settings.fields.position.customFields && (
+                <Fieldset title="Position information" id="custom-fields">
+                  <ReadonlyCustomFields
+                    fieldsConfig={Settings.fields.position.customFields}
+                    values={values}
+                  />
+                </Fieldset>
+              )}
+
               <Fieldset
                 title="Current assigned person"
                 id="assigned-advisor"
@@ -398,14 +407,6 @@ const PositionShow = ({ pageDispatchers }) => {
                     showModal={showOrganizationsAdministratedModal}
                     onCancel={() => hideOrganizationsAdministratedModal(false)}
                     onSuccess={() => hideOrganizationsAdministratedModal(true)}
-                  />
-                </Fieldset>
-              )}
-              {Settings.fields.position.customFields && (
-                <Fieldset title="Position information" id="custom-fields">
-                  <ReadonlyCustomFields
-                    fieldsConfig={Settings.fields.position.customFields}
-                    values={values}
                   />
                 </Fieldset>
               )}


### PR DESCRIPTION
The Information section for Positions and Locations is now more towards the top of the page.

Closes [AB#952](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/952)

#### User changes
- Users can now see the Information section for Positions and Locations more towards the top of the page.

#### Superuser changes
- None

#### Admin changes
- None

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
