### PR TITLE
Add missing initialization of position role to init command

### DIFF
--- a/src/main/java/mil/dds/anet/InitializationCommand.java
+++ b/src/main/java/mil/dds/anet/InitializationCommand.java
@@ -105,6 +105,7 @@ public class InitializationCommand extends EnvironmentCommand<AnetConfiguration>
     adminPos.setOrganizationUuid(adminOrg.getUuid());
     adminPos.setName(namespace.getString("adminPosName"));
     adminPos.setStatus(Position.Status.ACTIVE);
+    adminPos.setRole(Position.PositionRole.MEMBER);
     adminPos = engine.getPositionDao().insert(adminPos);
 
     // Create admin user


### PR DESCRIPTION
This fixes the `anet init` method.

Resolves [AB#967](https://dev.azure.com/ncia-anet/ANET/_workitems/edit/967)

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here