### PR TITLE
Allow assessments to be in the future

### DIFF
--- a/anet-dictionary.yml
+++ b/anet-dictionary.yml
@@ -61,7 +61,6 @@ fields:
         topTaskOnceReport:
           label: Engagement assessment of objective
           recurrence: once
-          allowFutureAssesments: true
           relatedObjectType: report
           authorizationGroupUuids:
             read: ['c21e7321-7ec5-4837-8805-a302f9575754']
@@ -143,6 +142,7 @@ fields:
         subTaskMonthly:
           label: Monthly assessment of effort
           recurrence: monthly
+          allowFutureAssessments: true
           questions:
             requiredButFilteredOutQuestion:
               test: $.subject[?(@property === "noSuchProperty" && @.match(/^willNeverMatch/i))]

--- a/anet-dictionary.yml
+++ b/anet-dictionary.yml
@@ -61,6 +61,7 @@ fields:
         topTaskOnceReport:
           label: Engagement assessment of objective
           recurrence: once
+          allowFutureAssesments: true
           relatedObjectType: report
           authorizationGroupUuids:
             read: ['c21e7321-7ec5-4837-8805-a302f9575754']

--- a/client/src/components/assessments/instant/InstantAssessmentResultsTable.js
+++ b/client/src/components/assessments/instant/InstantAssessmentResultsTable.js
@@ -107,12 +107,7 @@ const InstantAssessmentResultsTable = ({
     return null
   }
   const { recurrence, numberOfPeriods } = periodsDetails
-  const periodsConfig = getPeriodsConfig(
-    recurrence,
-    numberOfPeriods,
-    offset,
-    true
-  )
+  const periodsConfig = getPeriodsConfig(recurrence, numberOfPeriods, offset)
   if (_isEmpty(periodsConfig?.periods)) {
     return null
   }

--- a/client/src/components/assessments/instant/InstantAssessmentResultsTable.js
+++ b/client/src/components/assessments/instant/InstantAssessmentResultsTable.js
@@ -107,7 +107,12 @@ const InstantAssessmentResultsTable = ({
     return null
   }
   const { recurrence, numberOfPeriods } = periodsDetails
-  const periodsConfig = getPeriodsConfig(recurrence, numberOfPeriods, offset)
+  const periodsConfig = getPeriodsConfig(
+    recurrence,
+    numberOfPeriods,
+    offset,
+    true
+  )
   if (_isEmpty(periodsConfig?.periods)) {
     return null
   }

--- a/client/src/components/assessments/periodic/PeriodicAssessmentResultsTable.js
+++ b/client/src/components/assessments/periodic/PeriodicAssessmentResultsTable.js
@@ -85,12 +85,7 @@ const PeriodicAssessmentResultsTable = ({
     return null
   }
   const { recurrence, numberOfPeriods } = periodsDetails
-  const periodsConfig = getPeriodsConfig(
-    recurrence,
-    numberOfPeriods,
-    offset,
-    true
-  )
+  const periodsConfig = getPeriodsConfig(recurrence, numberOfPeriods, offset)
   if (_isEmpty(periodsConfig?.periods)) {
     return null
   }

--- a/client/src/components/assessments/periodic/PeriodicAssessmentResultsTable.js
+++ b/client/src/components/assessments/periodic/PeriodicAssessmentResultsTable.js
@@ -85,7 +85,12 @@ const PeriodicAssessmentResultsTable = ({
     return null
   }
   const { recurrence, numberOfPeriods } = periodsDetails
-  const periodsConfig = getPeriodsConfig(recurrence, numberOfPeriods, offset)
+  const periodsConfig = getPeriodsConfig(
+    recurrence,
+    numberOfPeriods,
+    offset,
+    true
+  )
   if (_isEmpty(periodsConfig?.periods)) {
     return null
   }

--- a/client/src/components/assessments/periodic/PeriodicAssessmentResultsTable.js
+++ b/client/src/components/assessments/periodic/PeriodicAssessmentResultsTable.js
@@ -84,18 +84,19 @@ const PeriodicAssessmentResultsTable = ({
   if (!entity) {
     return null
   }
+  const entityPeriodicAssessmentConfig =
+    entity.getInstantAssessmentConfig(assessmentKey)
   const { recurrence, numberOfPeriods } = periodsDetails
   const periodsConfig = getPeriodsConfig(
     recurrence,
     numberOfPeriods,
     offset,
-    true
+    true,
+    entityPeriodicAssessmentConfig?.allowFutureAssessments
   )
   if (_isEmpty(periodsConfig?.periods)) {
     return null
   }
-  const entityPeriodicAssessmentConfig =
-    entity.getInstantAssessmentConfig(assessmentKey)
   const subEntitiesPeriodicAssessmentConfig = subEntities
     ?.map(s => s.getInstantAssessmentConfig(assessmentKey))
     .filter(mc => !_isEmpty(mc))

--- a/client/src/periodUtils.js
+++ b/client/src/periodUtils.js
@@ -153,14 +153,21 @@ export const PERIOD_FACTORIES = {
   })
 }
 
-export const getPeriodsConfig = (recurrence, numberOfPeriods, offset) => {
+export const getPeriodsConfig = (
+  recurrence,
+  numberOfPeriods,
+  offset,
+  forAssessments = false
+) => {
   const now = moment()
   const periods = []
   for (let i = numberOfPeriods - 1; i >= 0; i--) {
     const periodDetails = PERIOD_FACTORIES[recurrence](now, offset + i)
 
-    // always allow assessments for all periods
-    periodDetails.allowNewAssessments = true
+    if (forAssessments) {
+      // allow new assessments
+      periodDetails.allowNewAssessments = true
+    }
 
     periods.push(periodDetails)
   }

--- a/client/src/periodUtils.js
+++ b/client/src/periodUtils.js
@@ -153,20 +153,15 @@ export const PERIOD_FACTORIES = {
   })
 }
 
-export const getPeriodsConfig = (
-  recurrence,
-  numberOfPeriods,
-  offset,
-  forAssessments = false
-) => {
+export const getPeriodsConfig = (recurrence, numberOfPeriods, offset) => {
   const now = moment()
   const periods = []
   for (let i = numberOfPeriods - 1; i >= 0; i--) {
     const periodDetails = PERIOD_FACTORIES[recurrence](now, offset + i)
-    if (forAssessments) {
-      // only allow assessments for past periods
-      periodDetails.allowNewAssessments = offset + i > 0
-    }
+
+    // always allow assessments for all periods
+    periodDetails.allowNewAssessments = true
+
     periods.push(periodDetails)
   }
   return {

--- a/client/src/periodUtils.js
+++ b/client/src/periodUtils.js
@@ -157,16 +157,18 @@ export const getPeriodsConfig = (
   recurrence,
   numberOfPeriods,
   offset,
-  forAssessments = false
+  forPeriodicAssessments = false,
+  allowFutureAssessments = false
 ) => {
   const now = moment()
   const periods = []
   for (let i = numberOfPeriods - 1; i >= 0; i--) {
     const periodDetails = PERIOD_FACTORIES[recurrence](now, offset + i)
 
-    if (forAssessments) {
+    if (forPeriodicAssessments) {
       // allow new assessments
-      periodDetails.allowNewAssessments = true
+      periodDetails.allowNewAssessments =
+        allowFutureAssessments || offset + i > 0
     }
 
     periods.push(periodDetails)

--- a/client/tests/webdriver/baseSpecs/assessmentsForTasks.spec.js
+++ b/client/tests/webdriver/baseSpecs/assessmentsForTasks.spec.js
@@ -89,7 +89,7 @@ describe("For the periodic task assessments", () => {
       )
     })
 
-    it("Should allow seeing add button for the assessments in the future", async() => {
+    it("Should see an add button for subTaskMonthly assessments in the future", async() => {
       await (
         await ShowTask.getNextPeriodButton("subTaskMonthly", "monthly")
       ).waitForExist()
@@ -101,6 +101,22 @@ describe("For the periodic task assessments", () => {
       await (
         await ShowTask.getFutureAddAssessmentButton("subTaskMonthly", "monthly")
       ).waitForExist()
+    })
+
+    it("Should not see an add button for subTaskWeekly assessments in the future", async() => {
+      await (
+        await ShowTask.getNextPeriodButton("subTaskWeekly", "weekly")
+      ).waitForExist()
+
+      await (
+        await ShowTask.getNextPeriodButton("subTaskWeekly", "weekly")
+      ).click()
+
+      expect(
+        await (
+          await ShowTask.getFutureAddAssessmentButton("subTaskWeekly", "weekly")
+        ).isExisting()
+      ).to.equal(false)
 
       await ShowTask.logout()
     })

--- a/client/tests/webdriver/baseSpecs/assessmentsForTasks.spec.js
+++ b/client/tests/webdriver/baseSpecs/assessmentsForTasks.spec.js
@@ -87,6 +87,21 @@ describe("For the periodic task assessments", () => {
         "monthly",
         ADVISOR_1_TASK_EDIT_DETAILS
       )
+    })
+
+    it("Should allow seeing add button for the assessments in the future", async() => {
+      await (
+        await ShowTask.getNextPeriodButton("subTaskMonthly", "monthly")
+      ).waitForExist()
+
+      await (
+        await ShowTask.getNextPeriodButton("subTaskMonthly", "monthly")
+      ).click()
+
+      await (
+        await ShowTask.getFutureAddAssessmentButton("subTaskMonthly", "monthly")
+      ).waitForExist()
+
       await ShowTask.logout()
     })
   })

--- a/client/tests/webdriver/pages/showTask.page.js
+++ b/client/tests/webdriver/pages/showTask.page.js
@@ -76,7 +76,7 @@ class ShowTask extends Page {
 
   async getShownAssessmentPanel(assessmentKey, recurrence) {
     return (await this.getAssessmentsTable(assessmentKey, recurrence)).$(
-      "tbody tr:last-child td:first-child .card"
+      "tbody tr:nth-child(2) td:first-child .card"
     )
   }
 

--- a/client/tests/webdriver/pages/showTask.page.js
+++ b/client/tests/webdriver/pages/showTask.page.js
@@ -60,7 +60,7 @@ class ShowTask extends Page {
 
   async getFutureAddAssessmentButton(assessmentKey, recurrence) {
     return (await this.getAssessmentsTable(assessmentKey, recurrence)).$(
-      "tbody tr:last-child td:last-child"
+      "tbody tr:last-child td:last-child button"
     )
   }
 

--- a/client/tests/webdriver/pages/showTask.page.js
+++ b/client/tests/webdriver/pages/showTask.page.js
@@ -52,6 +52,18 @@ class ShowTask extends Page {
     )
   }
 
+  async getNextPeriodButton(assessmentKey, recurrence) {
+    return (await this.getAssessmentResults(assessmentKey, recurrence)).$(
+      "button:last-child"
+    )
+  }
+
+  async getFutureAddAssessmentButton(assessmentKey, recurrence) {
+    return (await this.getAssessmentsTable(assessmentKey, recurrence)).$(
+      "tbody tr:last-child td:last-child"
+    )
+  }
+
   async getEditAssessmentButton(assessmentKey, recurrence) {
     return (await this.getAssessmentsTable(assessmentKey, recurrence)).$(
       'div.card button[title="Edit assessment"]'

--- a/src/main/resources/anet-schema.yml
+++ b/src/main/resources/anet-schema.yml
@@ -238,6 +238,11 @@ $defs:
         type: string
         enum: [once, daily, weekly, biweekly, semimonthly, monthly, quarterly, semiannually, annually, ondemand]
         default: once
+      allowFutureAssesments:
+        type: boolean
+        default: false
+        title: allow assesments to be in the future
+        description: allow assesment dates to be in the future in order to be able to plan future.
       relatedObjectType:
         title: object type context in which the assessment will be made
         type: string

--- a/src/main/resources/anet-schema.yml
+++ b/src/main/resources/anet-schema.yml
@@ -238,11 +238,11 @@ $defs:
         type: string
         enum: [once, daily, weekly, biweekly, semimonthly, monthly, quarterly, semiannually, annually, ondemand]
         default: once
-      allowFutureAssesments:
+      allowFutureAssessments:
         type: boolean
         default: false
-        title: allow assesments to be in the future
-        description: allow assesment dates to be in the future in order to be able to plan future.
+        title: Allow assessments to be in the future
+        description: Allow assessment dates to be in the future for planning purposes.
       relatedObjectType:
         title: object type context in which the assessment will be made
         type: string

--- a/testDictionaries/no-custom-fields.yml
+++ b/testDictionaries/no-custom-fields.yml
@@ -141,6 +141,7 @@ fields:
         subTaskMonthly:
           label: Monthly assessment of effort
           recurrence: monthly
+          allowFutureAssessments: true
           questions:
             requiredButFilteredOutQuestion:
               test: $.subject[?(@property === "noSuchProperty" && @.match(/^willNeverMatch/i))]


### PR DESCRIPTION
ANET now allows assessments to be in the future, which will be quite useful when planning for upcoming dates.

Closes [AB#888](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/888)

#### User changes
- Users were allowed to select past dates only, now they are also able to select future dates.

#### Superuser changes
- None

#### Admin changes
- None

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [x] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [ ] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
