### PR TITLE
Rename Babel config for Jest

### DIFF
--- a/client/babel.config.js
+++ b/client/babel.config.js
@@ -1,4 +1,9 @@
 module.exports = {
+  env: {
+    test: {
+      plugins: ["@babel/plugin-transform-modules-commonjs"]
+    }
+  },
   presets: ["react-app"],
   plugins: [
     [

--- a/client/jest.config.js
+++ b/client/jest.config.js
@@ -1,16 +1,13 @@
 module.exports = {
   moduleDirectories: ["platform/node", "src", "node_modules"],
-  moduleFileExtensions: ["jsx", "js", "json"],
   moduleNameMapper: {
     "^d3$": "<rootDir>/node_modules/d3/dist/d3.min.js",
-    "^jsonpath-plus$":
-      "<rootDir>/node_modules/jsonpath-plus/dist/index-node-cjs.cjs",
     "^.+\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$":
       "<rootDir>/config/jest/FileStub.js",
     "^.+\\.css$": "<rootDir>/config/jest/CSSStub.js"
   },
   setupFiles: ["<rootDir>/config/polyfills.js"],
   setupFilesAfterEnv: ["<rootDir>/jest-setup.js"],
-  testPathIgnorePatterns: ["<rootDir>/(build|docs|node_modules)/"],
-  testEnvironment: "jsdom"
+  testEnvironment: "jsdom",
+  transformIgnorePatterns: ["<rootDir>/node_modules/(?!(jsonpath-plus)/)"]
 }

--- a/client/package.json
+++ b/client/package.json
@@ -22,6 +22,7 @@
     "@babel/plugin-proposal-throw-expressions": "7.22.5",
     "@babel/plugin-syntax-dynamic-import": "7.8.3",
     "@babel/plugin-syntax-import-meta": "7.10.4",
+    "@babel/plugin-transform-modules-commonjs": "7.23.0",
     "@babel/plugin-transform-proto-to-assign": "7.22.5",
     "@babel/preset-react": "7.22.15",
     "@babel/register": "7.22.15",

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -243,6 +243,17 @@
     "@babel/helper-split-export-declaration" "^7.22.6"
     "@babel/helper-validator-identifier" "^7.22.20"
 
+"@babel/helper-module-transforms@^7.23.0":
+  version "7.23.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.23.0.tgz#3ec246457f6c842c0aee62a01f60739906f7047e"
+  integrity sha512-WhDWw1tdrlT0gMgUJSlX0IQvoO1eN279zrAUbVB+KpV2c3Tylz8+GnKOLllCS6Z/iZQEyVYxhZVUdPTqs2YYPw==
+  dependencies:
+    "@babel/helper-environment-visitor" "^7.22.20"
+    "@babel/helper-module-imports" "^7.22.15"
+    "@babel/helper-simple-access" "^7.22.5"
+    "@babel/helper-split-export-declaration" "^7.22.6"
+    "@babel/helper-validator-identifier" "^7.22.20"
+
 "@babel/helper-optimise-call-expression@^7.22.5":
   version "7.22.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.22.5.tgz#f21531a9ccbff644fdd156b4077c16ff0c3f609e"
@@ -884,6 +895,15 @@
   dependencies:
     "@babel/helper-module-transforms" "^7.22.5"
     "@babel/helper-plugin-utils" "^7.22.5"
+
+"@babel/plugin-transform-modules-commonjs@7.23.0":
+  version "7.23.0"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.23.0.tgz#b3dba4757133b2762c00f4f94590cf6d52602481"
+  integrity sha512-32Xzss14/UVc7k9g775yMIvkVK8xwKE0DPdP5JTapr3+Z9w4tzeOuLNY6BXDQR6BdnzIlXnCGAzsk/ICHBLVWQ==
+  dependencies:
+    "@babel/helper-module-transforms" "^7.23.0"
+    "@babel/helper-plugin-utils" "^7.22.5"
+    "@babel/helper-simple-access" "^7.22.5"
 
 "@babel/plugin-transform-modules-commonjs@^7.0.0", "@babel/plugin-transform-modules-commonjs@^7.13.8", "@babel/plugin-transform-modules-commonjs@^7.22.5":
   version "7.22.5"


### PR DESCRIPTION
In preparation for some pure ESM modules (like the major updates of title-case and change-case), we need to rename our Babel config so it gets picked up by Jest, and adapt the config a bit.