### PR TITLE
Make ANET init more robust

### DIFF
--- a/.github/workflows/build-gradle.yml
+++ b/.github/workflows/build-gradle.yml
@@ -29,6 +29,47 @@ jobs:
     - run: ./gradlew yarn_run_lint
     - run: ./gradlew jar
 
+  test-init:
+    needs: build
+    name: Test ANET init
+    runs-on: ubuntu-latest
+
+    env:
+      ANET_ADMIN_ORG_NAME: "ACME Administrators Inc."
+      ANET_ADMIN_POS_NAME: "The ANET admin"
+      ANET_ADMIN_FULL_NAME: "DOE, John"
+      ANET_ADMIN_DOMAIN_USERNAME: "johndoe"
+      ANET_CONFIG: "anet-test.yml"
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: ./.github/actions/build-cache
+      - run: ./gradlew -PtestEnv dockerCreateDB dockerStartDB
+      - run: |
+          echo "testMode: true" |
+          cat - anet.yml > ${ANET_CONFIG}
+      - run: ./gradlew -PtestEnv dbWait
+      # This step should fail:
+      - name: Run ANET init on empty database
+        id: init-on-empty-db
+        run: ./gradlew -PtestEnv dbInit
+        continue-on-error: true
+      - run: exit 1
+        if: ${{ steps.init-on-empty-db.outcome != 'failure' }}
+      # This step should succeed:
+      - name: Run ANET init on clean database
+        id: init-on-clean-db
+        run: ./gradlew -PtestEnv dbMigrate dbInit
+      # This step should fail:
+      - name: Run ANET init on filled database
+        id: init-on-filled-db
+        run: ./gradlew -PtestEnv dbInit
+        continue-on-error: true
+      - run: exit 1
+        if: ${{ steps.init-on-filled-db.outcome != 'failure' }}
+
   test-server:
     needs: build
     name: Server tests; ${{ matrix.dictionary }}

--- a/anet.yml
+++ b/anet.yml
@@ -131,6 +131,9 @@ anetDictionaryName: ${ANET_DICTIONARY_NAME}
 logging:
   level: INFO
   loggers:
+    "com.google.inject.internal.ProxyFactory": ERROR
+    "io.dropwizard.assets.AssetsBundle": TRACE
+    "io.dropwizard.assets.*": TRACE
     "io.dropwizard.jersey.jackson.JsonProcessingExceptionMapper": TRACE
     "mil.dds.anet.resources.LoggingResource":
       level: TRACE
@@ -149,8 +152,6 @@ logging:
           archivedLogFilenamePattern: ./logs/dbLog-%d.log.zip
           archivedFileCount: 2
           logFormat: '%d{yyyy-MM-dd HH:mm:ss.SSS,UTC}\t%p\t%m%n'
-    "io.dropwizard.assets.AssetsBundle": TRACE
-    "io.dropwizard.assets.*": TRACE
     "mil.dds.anet": DEBUG
     "mil.dds.anet.utils.AnetAuditLogger":
       level: INFO

--- a/build.gradle
+++ b/build.gradle
@@ -63,6 +63,7 @@ run.environment("ANET_SMTP_SSLTRUST", run.environment["ANET_SMTP_SSLTRUST"] ?: r
 run.environment("ANET_SMTP_HTTP_PORT", run.environment["ANET_SMTP_HTTP_PORT"] ?: isTestEnv ? 1180 : 1080)
 run.environment("ANET_DICTIONARY_NAME", run.environment["ANET_DICTIONARY_NAME"] ?: "anet-dictionary.yml")
 
+String anetConfig = run.environment["ANET_CONFIG"] ?: "anet.yml"
 String adminOrgName = run.environment["ANET_ADMIN_ORG_NAME"] ?: "ANET Administrators"
 String adminPosName = run.environment["ANET_ADMIN_POS_NAME"] ?: "ANET Administrator"
 String adminFullName = run.environment["ANET_ADMIN_FULL_NAME"] ?: "DMIN, Arthur"
@@ -246,8 +247,6 @@ application {
   applicationDefaultJvmArgs = ["-Djava.library.path=MY_APP_HOME/lib"]
 }
 
-String anetConfig = "anet.yml"
-
 String dbLoc = run.environment['ANET_DB_SERVER']
 if (run.environment['ANET_DB_EXPOSED_PORT']) {
 	dbLoc = dbLoc + ":" + run.environment['ANET_DB_EXPOSED_PORT'].toString()
@@ -307,6 +306,7 @@ dbWait.mustRunAfter('dockerStartDB')
 //       ANET_ADMIN_POS_NAME="The ANET admin" \
 //       ANET_ADMIN_FULL_NAME="DOE, John" \
 //       ANET_ADMIN_DOMAIN_USERNAME="johndoe" \
+//       ANET_CONFIG="anet.yml" \
 //       ./gradlew dbInit
 // To see all options, run:
 //   ./gradlew dbInit -Pargs="--help"
@@ -325,10 +325,10 @@ task dbInit(dependsOn: 'compileJava', type: JavaExec) {
 			"--adminOrgName", adminOrgName,
 			"--adminPosName", adminPosName,
 			"--adminFullName", adminFullName,
-			"--adminDomainUsername", adminDomainUsername
+			"--adminDomainUsername", adminDomainUsername,
+                        anetConfig
 		])
 	}
-	cmdline << anetConfig
 	args cmdline
 }
 

--- a/src/main/java/mil/dds/anet/InitializationCommand.java
+++ b/src/main/java/mil/dds/anet/InitializationCommand.java
@@ -13,7 +13,9 @@ import mil.dds.anet.beans.Person;
 import mil.dds.anet.beans.Person.Role;
 import mil.dds.anet.beans.Position;
 import mil.dds.anet.beans.Position.PositionType;
+import mil.dds.anet.beans.search.OrganizationSearchQuery;
 import mil.dds.anet.beans.search.PersonSearchQuery;
+import mil.dds.anet.beans.search.PositionSearchQuery;
 import mil.dds.anet.config.AnetConfiguration;
 import mil.dds.anet.database.AdminDao.AdminSettingKeys;
 import net.sourceforge.argparse4j.impl.Arguments;
@@ -45,21 +47,98 @@ public class InitializationCommand extends EnvironmentCommand<AnetConfiguration>
       throws Exception {
     final AnetObjectEngine engine = AnetObjectEngine.getInstance();
 
-    final PersonSearchQuery psq = new PersonSearchQuery();
-    final List<Person> currPeople = engine.getPersonDao().search(psq).getList();
+    checkPreconditions(engine);
+    final String defaultApprovalOrgUuid = createInitialAdministrator(namespace, engine);
+    saveAdminSettings(engine, defaultApprovalOrgUuid);
+
+    System.exit(0);
+  }
+
+  private void checkPreconditions(final AnetObjectEngine engine) {
+    try {
+      checkOrganizations(engine);
+      checkPositions(engine);
+      checkPeople(engine);
+    } catch (Exception e) {
+      exitWithError("ERROR: Could not query database: " + e.getMessage(),
+          "\tDid you run all migrations?");
+    }
+  }
+
+  private void checkOrganizations(final AnetObjectEngine engine) {
+    if (!engine.getOrganizationDao().search(new OrganizationSearchQuery()).getList().isEmpty()) {
+      exitWithError("ERROR: Existing organizations detected in database",
+          "\tThis task can only be run on an otherwise empty database");
+    }
+  }
+
+  private void checkPositions(final AnetObjectEngine engine) {
+    if (!engine.getPositionDao().search(new PositionSearchQuery()).getList().isEmpty()) {
+      exitWithError("ERROR: Existing positions detected in database",
+          "\tThis task can only be run on an otherwise empty database");
+    }
+  }
+
+  private void checkPeople(final AnetObjectEngine engine) {
+    final List<Person> currPeople = engine.getPersonDao().search(new PersonSearchQuery()).getList();
     if (currPeople.isEmpty()) {
-      System.err.println("ERROR: ANET Importer missing from database");
-      System.err.println("\tYou should run all migrations first");
-      System.exit(1);
-      return;
+      exitWithError("ERROR: ANET Importer missing from database",
+          "\tYou should run all migrations first");
     }
     // Only person should be "ANET Importer"
     if (currPeople.size() != 1 || !"ANET Importer".equals(currPeople.get(0).getName())) {
-      System.err.println("ERROR: Other people besides ANET Importer detected in database");
-      System.err.println("\tThis task can only be run on an otherwise empty database");
-      System.exit(1);
-      return;
+      exitWithError("ERROR: Other people besides ANET Importer detected in database",
+          "\tThis task can only be run on an otherwise empty database");
     }
+  }
+
+  private void exitWithError(final String errorMessage, final String userHint) {
+    System.err.println(errorMessage);
+    System.err.println(userHint);
+    System.exit(1);
+  }
+
+  private String createInitialAdministrator(Namespace namespace, AnetObjectEngine engine) {
+    // Create admin organization
+    Organization adminOrg = new Organization();
+    adminOrg.setType(OrganizationType.ADVISOR_ORG);
+    adminOrg.setShortName(namespace.getString("adminOrgName"));
+    adminOrg.setStatus(Organization.Status.ACTIVE);
+    adminOrg = engine.getOrganizationDao().insert(adminOrg);
+
+    // Create admin position
+    Position adminPos = new Position();
+    adminPos.setType(PositionType.ADMINISTRATOR);
+    adminPos.setOrganizationUuid(adminOrg.getUuid());
+    adminPos.setName(namespace.getString("adminPosName"));
+    adminPos.setStatus(Position.Status.ACTIVE);
+    adminPos.setRole(Position.PositionRole.MEMBER);
+    adminPos = engine.getPositionDao().insert(adminPos);
+
+    // Create admin user
+    Person admin = new Person();
+    admin.setName(namespace.getString("adminFullName"));
+    admin.setDomainUsername(namespace.getString("adminDomainUsername"));
+    admin.setRole(Role.ADVISOR);
+    admin = engine.getPersonDao().insert(admin);
+    engine.getPositionDao().setPersonInPosition(admin.getUuid(), adminPos.getUuid());
+
+    // Create default approval workflow
+    final ApprovalStep defaultStep = new ApprovalStep();
+    defaultStep.setName("Default Approver");
+    defaultStep.setType(ApprovalStepType.REPORT_APPROVAL);
+    defaultStep.setRelatedObjectUuid(adminOrg.getUuid());
+    defaultStep.setApprovers(List.of(adminPos));
+    engine.getApprovalStepDao().insert(defaultStep);
+
+    return adminOrg.getUuid();
+  }
+
+  private void saveAdminSettings(final AnetObjectEngine engine,
+      final String defaultApprovalOrgUuid) {
+    // Set Default Approval Chain.
+    saveAdminSetting(engine, AdminSettingKeys.DEFAULT_APPROVAL_ORGANIZATION,
+        defaultApprovalOrgUuid);
 
     // Set Classification String as default
     saveAdminSetting(engine, AdminSettingKeys.SECURITY_BANNER_CLASSIFICATION, "NATO UNCLASSIFIED");
@@ -91,45 +170,9 @@ public class InitializationCommand extends EnvironmentCommand<AnetConfiguration>
 
     // Set daily rollup max report age days as default
     saveAdminSetting(engine, AdminSettingKeys.DAILY_ROLLUP_MAX_REPORT_AGE_DAYS, "14");
-
-    // Create admin organization
-    Organization adminOrg = new Organization();
-    adminOrg.setType(OrganizationType.ADVISOR_ORG);
-    adminOrg.setShortName(namespace.getString("adminOrgName"));
-    adminOrg.setStatus(Organization.Status.ACTIVE);
-    adminOrg = engine.getOrganizationDao().insert(adminOrg);
-
-    // Create admin position
-    Position adminPos = new Position();
-    adminPos.setType(PositionType.ADMINISTRATOR);
-    adminPos.setOrganizationUuid(adminOrg.getUuid());
-    adminPos.setName(namespace.getString("adminPosName"));
-    adminPos.setStatus(Position.Status.ACTIVE);
-    adminPos.setRole(Position.PositionRole.MEMBER);
-    adminPos = engine.getPositionDao().insert(adminPos);
-
-    // Create admin user
-    Person admin = new Person();
-    admin.setName(namespace.getString("adminFullName"));
-    admin.setDomainUsername(namespace.getString("adminDomainUsername"));
-    admin.setRole(Role.ADVISOR);
-    admin = engine.getPersonDao().insert(admin);
-    engine.getPositionDao().setPersonInPosition(admin.getUuid(), adminPos.getUuid());
-
-    // Set Default Approval Chain.
-    saveAdminSetting(engine, AdminSettingKeys.DEFAULT_APPROVAL_ORGANIZATION, adminOrg.getUuid());
-
-    final ApprovalStep defaultStep = new ApprovalStep();
-    defaultStep.setName("Default Approver");
-    defaultStep.setType(ApprovalStepType.REPORT_APPROVAL);
-    defaultStep.setRelatedObjectUuid(adminOrg.getUuid());
-    defaultStep.setApprovers(List.of(adminPos));
-    engine.getApprovalStepDao().insert(defaultStep);
-
-    System.exit(0);
   }
 
-  private static void saveAdminSetting(final AnetObjectEngine engine, final AdminSettingKeys key,
+  private void saveAdminSetting(final AnetObjectEngine engine, final AdminSettingKeys key,
       final String value) {
     final AdminSetting adminSetting = new AdminSetting();
     adminSetting.setKey(key.name());


### PR DESCRIPTION
Make the ANET init  command more robust by adding some additional checks. Add tests during the build that check the correct behaviour. Also reduce the amount of uninteresting logging.

Closes [AB#966](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/966), [AB#968](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/968), [AB#970](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/970)

#### User changes
- none

#### Superuser changes
- none

#### Admin changes
- none

#### System admin changes
-  `anet init` now better checks whether it can run successfully
- [x] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [x] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here