### PR TITLE
Warn the user when the default approval workflow has not been defined

### DIFF
--- a/src/main/java/mil/dds/anet/beans/Report.java
+++ b/src/main/java/mil/dds/anet/beans/Report.java
@@ -15,7 +15,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
-import javax.ws.rs.WebApplicationException;
 import mil.dds.anet.AnetObjectEngine;
 import mil.dds.anet.beans.Person.Role;
 import mil.dds.anet.utils.DaoUtils;
@@ -682,24 +681,9 @@ public class Report extends AbstractCustomizableAnetBean
 
   private CompletableFuture<List<ApprovalStep>> getDefaultOrganizationWorkflow(
       Map<String, Object> context, AnetObjectEngine engine, String defaultOrgUuid) {
-    return isFutureEngagement() ? getDefaultPlanningWorkflow(context, engine, defaultOrgUuid)
-        : getDefaultWorkflow(context, engine, defaultOrgUuid);
-  }
-
-  private CompletableFuture<List<ApprovalStep>> getDefaultPlanningWorkflow(
-      Map<String, Object> context, AnetObjectEngine engine, String defaultOrgUuid) {
-    if (defaultOrgUuid == null) {
-      throw new WebApplicationException("Missing the DEFAULT_APPROVAL_ORGANIZATION admin setting");
-    }
-    return getPlanningWorkflowForRelatedObject(context, engine, defaultOrgUuid);
-  }
-
-  private CompletableFuture<List<ApprovalStep>> getDefaultWorkflow(Map<String, Object> context,
-      AnetObjectEngine engine, String defaultOrgUuid) {
-    if (defaultOrgUuid == null) {
-      throw new WebApplicationException("Missing the DEFAULT_APPROVAL_ORGANIZATION admin setting");
-    }
-    return getWorkflowForRelatedObject(context, engine, defaultOrgUuid);
+    return isFutureEngagement()
+        ? getPlanningWorkflowForRelatedObject(context, engine, defaultOrgUuid)
+        : getWorkflowForRelatedObject(context, engine, defaultOrgUuid);
   }
 
   private CompletableFuture<List<ApprovalStep>> getTaskWorkflow(Map<String, Object> context,
@@ -723,7 +707,7 @@ public class Report extends AbstractCustomizableAnetBean
       AnetObjectEngine engine, String locationUuid) {
     return isFutureEngagement() ? getPlanningWorkflowForRelatedObject(context, engine, locationUuid)
         : getWorkflowForRelatedObject(context, engine, locationUuid);
-  };
+  }
 
   @GraphQLQuery(name = "reportSensitiveInformation")
   public CompletableFuture<ReportSensitiveInformation> loadReportSensitiveInformation(

--- a/src/main/java/mil/dds/anet/database/ReportDao.java
+++ b/src/main/java/mil/dds/anet/database/ReportDao.java
@@ -830,6 +830,20 @@ public class ReportDao extends AnetSubscribableObjectDao<Report, ReportSearchQue
       approval.setPlanned(true); // so the FutureEngagementWorker can find this
       engine.getReportActionDao().insert(approval);
       r.setState(ReportState.APPROVED);
+    } else if (Utils.isEmptyOrNull(steps)) {
+      // Approval workflow has not been defined!
+      final String msg;
+      final String defaultOrgUuid = engine.getDefaultOrgUuid();
+      if (Utils.isEmptyOrNull(defaultOrgUuid)) {
+        msg = "The default approval organization is undefined";
+      } else {
+        final Organization defaultOrg = engine.getOrganizationDao().getByUuid(defaultOrgUuid);
+        msg = defaultOrg == null
+            ? "The default approval organization with uuid '" + defaultOrgUuid + "' does not exist"
+            : "The default approval organization " + defaultOrg
+                + " is missing an approval workflow";
+      }
+      throw new WebApplicationException(msg + "; please contact your administrator!");
     } else {
       // Push the report into the first step of this workflow
       r.setApprovalStep(steps.get(0));


### PR DESCRIPTION
When a user tries to submit a report but no approval workflow has been defined for the primary advisor organization of the report, the workflow of the default approval organization is used. But if the default approval organization has no workflow defined, un unclear exception would be thrown. ANET now shows a clear message instead.

Closes [AB#974](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/974) 

#### User changes
- A clear message is shown if a report can't be submitted because of the lack of a defined approval workflow.

#### Superuser changes
- none

#### Admin changes
- none

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
