### PR TITLE
Add attachment functionality to organizations

### DIFF
--- a/client/src/components/Attachment/UploadedAttachments.js
+++ b/client/src/components/Attachment/UploadedAttachments.js
@@ -8,12 +8,7 @@ import ShowUploadedAttachments from "./ShowUploadedAttachments"
 const GQL_GET_RELATED_ATTACHMENTS = gql`
   query ($uuid: String!) {
     relatedObjectAttachments(uuid: $uuid) {
-      uuid
-      fileName
-      contentLength
-      mimeType
-      classification
-      description
+      ${Attachment.basicFieldsQuery}
     }
   }
 `

--- a/client/src/components/previews/AttachmentPreview.js
+++ b/client/src/components/previews/AttachmentPreview.js
@@ -13,13 +13,7 @@ import utils from "utils"
 const GQL_GET_ATTACHMENT = gql`
   query ($uuid: String) {
     attachment(uuid: $uuid) {
-      uuid
-      fileName
-      caption
-      contentLength
-      mimeType
-      classification
-      description
+      ${Attachment.basicFieldsQuery}
       author {
         uuid
         name

--- a/client/src/models/Attachment.js
+++ b/client/src/models/Attachment.js
@@ -29,8 +29,10 @@ export default class Attachment extends Model {
     classification: yup.string().nullable().default(null)
   })
 
-  static autocompleteQuery =
-    "uuid fileName caption description classification mimeType"
+  static basicFieldsQuery =
+    "uuid fileName caption description classification mimeType contentLength"
+
+  static autocompleteQuery = Location.basicFieldsQuery
 
   static _resourceOverride = ["attachments"].join("/")
 

--- a/client/src/pages/attachments/Edit.js
+++ b/client/src/pages/attachments/Edit.js
@@ -16,13 +16,7 @@ import AttachmentForm from "./Form"
 const GQL_GET_ATTACHMENT = gql`
   query ($uuid: String) {
     attachment(uuid: $uuid) {
-      uuid
-      fileName
-      caption
-      contentLength
-      mimeType
-      classification
-      description
+      ${Attachment.basicFieldsQuery}
       attachmentRelatedObjects {
         relatedObject {
           ... on AuthorizationGroup {

--- a/client/src/pages/attachments/Show.js
+++ b/client/src/pages/attachments/Show.js
@@ -29,13 +29,7 @@ import utils from "utils"
 const GQL_GET_ATTACHMENT = gql`
   query ($uuid: String) {
     attachment(uuid: $uuid) {
-      uuid
-      fileName
-      caption
-      contentLength
-      mimeType
-      classification
-      description
+      ${Attachment.basicFieldsQuery}
       author {
         uuid
         name

--- a/client/src/pages/locations/Show.js
+++ b/client/src/pages/locations/Show.js
@@ -26,7 +26,7 @@ import RichTextEditor from "components/RichTextEditor"
 import { Field, Form, Formik } from "formik"
 import { convertLatLngToMGRS } from "geoUtils"
 import _escape from "lodash/escape"
-import { Location } from "models"
+import { Attachment, Location } from "models"
 import React, { useContext, useState } from "react"
 import { connect } from "react-redux"
 import { useLocation, useParams } from "react-router-dom"
@@ -36,15 +36,10 @@ import utils from "utils"
 const GQL_GET_LOCATION = gql`
   query($uuid: String!) {
     location(uuid: $uuid) {
-      attachments {
-        uuid
-        fileName
-        contentLength
-        mimeType
-        description
-        classification
-      }
       ${Location.allFieldsQuery}
+      attachments {
+        ${Attachment.basicFieldsQuery}
+      }
     }
   }
 `

--- a/client/src/pages/organizations/Form.js
+++ b/client/src/pages/organizations/Form.js
@@ -9,6 +9,7 @@ import {
 import AdvancedSingleSelect from "components/advancedSelectWidget/AdvancedSingleSelect"
 import AppContext from "components/AppContext"
 import ApprovalsDefinition from "components/approvals/ApprovalsDefinition"
+import UploadAttachment from "components/Attachment/UploadAttachment"
 import {
   CustomFieldsContainer,
   customFieldsJSONString
@@ -23,6 +24,7 @@ import NoPaginationTaskTable from "components/NoPaginationTaskTable"
 import { jumpToTop } from "components/Page"
 import RichTextEditor from "components/RichTextEditor"
 import { FastField, Field, Form, Formik } from "formik"
+import DictionaryField from "HOC/DictionaryField"
 import _isEmpty from "lodash/isEmpty"
 import _isEqual from "lodash/isEqual"
 import { Location, Organization, Position, Task } from "models"
@@ -37,7 +39,6 @@ import TASKS_ICON from "resources/tasks.png"
 import { RECURSE_STRATEGY } from "searchUtils"
 import Settings from "settings"
 import utils from "utils"
-import DictionaryField from "../../HOC/DictionaryField"
 
 const GQL_CREATE_ORGANIZATION = gql`
   mutation ($organization: OrganizationInput!) {
@@ -366,6 +367,24 @@ const OrganizationForm = ({ edit, title, initialValues, notesComponent }) => {
                       widget={<RichTextEditor className="profile" />}
                     />
                   </>
+                )}
+
+                {edit && (
+                  <Field
+                    name="uploadAttachments"
+                    label="Attachments"
+                    component={FieldHelper.SpecialField}
+                    widget={
+                      <UploadAttachment
+                        edit={edit}
+                        relatedObjectType={Organization.relatedObjectType}
+                        relatedObjectUuid={values.uuid}
+                      />
+                    }
+                    onHandleBlur={() => {
+                      setFieldTouched("uploadAttachments", true, false)
+                    }}
+                  />
                 )}
               </Fieldset>
 

--- a/client/src/pages/organizations/Show.js
+++ b/client/src/pages/organizations/Show.js
@@ -4,6 +4,7 @@ import API from "api"
 import AppContext from "components/AppContext"
 import Approvals from "components/approvals/Approvals"
 import AssessmentResultsContainer from "components/assessments/AssessmentResultsContainer"
+import AttachmentCard from "components/Attachment/AttachmentCard"
 import { ReadonlyCustomFields } from "components/CustomFields"
 import * as FieldHelper from "components/FieldHelper"
 import Fieldset from "components/Fieldset"
@@ -27,8 +28,9 @@ import ReportCollection from "components/ReportCollection"
 import RichTextEditor from "components/RichTextEditor"
 import SubNav from "components/SubNav"
 import { Field, Form, Formik } from "formik"
+import DictionaryField from "HOC/DictionaryField"
 import _isEmpty from "lodash/isEmpty"
-import { Location, Organization, Report } from "models"
+import { Attachment, Location, Organization, Report } from "models"
 import { PositionRole } from "models/Position"
 import { orgTour } from "pages/HopscotchTour"
 import pluralize from "pluralize"
@@ -47,7 +49,6 @@ import { useLocation, useParams } from "react-router-dom"
 import { RECURSE_STRATEGY } from "searchUtils"
 import Settings from "settings"
 import utils from "utils"
-import DictionaryField from "../../HOC/DictionaryField"
 import OrganizationLaydown from "./Laydown"
 import OrganizationTasks from "./OrganizationTasks"
 
@@ -154,6 +155,9 @@ const GQL_GET_ORGANIZATION = gql`
             ...personFields
           }
         }
+      }
+      attachments {
+        ${Attachment.basicFieldsQuery}
       }
       customFields
       ${GRAPHQL_NOTES_FIELDS}
@@ -461,6 +465,24 @@ const OrganizationShow = ({ pageDispatchers }) => {
                   label={Settings.fields.organization.profile}
                   humanValue={
                     <RichTextEditor readOnly value={organization.profile} />
+                  }
+                />
+
+                <Field
+                  name="attachments"
+                  label="Attachments"
+                  component={FieldHelper.ReadonlyField}
+                  humanValue={
+                    <div className="attachment-card-list">
+                      {organization.attachments.map((attachment, index) => (
+                        <AttachmentCard
+                          key={index}
+                          attachment={attachment}
+                          index={index}
+                          edit={false}
+                        />
+                      ))}
+                    </div>
                   }
                 />
               </Fieldset>

--- a/client/src/pages/reports/Show.js
+++ b/client/src/pages/reports/Show.js
@@ -38,7 +38,7 @@ import { Field, Form, Formik } from "formik"
 import _concat from "lodash/concat"
 import _isEmpty from "lodash/isEmpty"
 import _upperFirst from "lodash/upperFirst"
-import { Comment, Person, Position, Report, Task } from "models"
+import { Attachment, Comment, Person, Position, Report, Task } from "models"
 import moment from "moment"
 import pluralize from "pluralize"
 import PropTypes from "prop-types"
@@ -235,12 +235,7 @@ const GQL_GET_REPORT = gql`
         description
       }
       attachments {
-        uuid
-        fileName
-        contentLength
-        mimeType
-        classification
-        description
+        ${Attachment.basicFieldsQuery}
       }
       customFields
       ${GRAPHQL_NOTES_FIELDS}

--- a/client/tests/webdriver/baseSpecs/showLocation.spec.js
+++ b/client/tests/webdriver/baseSpecs/showLocation.spec.js
@@ -4,31 +4,22 @@ import ShowLocation from "../pages/location/showLocation.page"
 const LOCATION_UUID = "e5b3a4b9-acf7-4c79-8224-f248b9a7215d"
 
 describe("Show location page", () => {
-  beforeEach("Open the show location page", async() => {
-    await ShowLocation.open(LOCATION_UUID)
-  })
-
   describe("When on the show page of a location with attachment(s)", () => {
     it("We should see a container for Attachment List", async() => {
-      // Attachment container
+      await ShowLocation.open(LOCATION_UUID)
       await (await ShowLocation.getAttachments()).waitForExist()
       await (await ShowLocation.getAttachments()).waitForDisplayed()
     })
     it("We should see a card of Attachment", async() => {
-      // Attachment card list
       await (await ShowLocation.getCard()).waitForExist()
       await (await ShowLocation.getCard()).waitForDisplayed()
-      expect(await await ShowLocation.getFileData()).to.be.equal(
-        "attachL…\n12.0 KB"
-      )
+      expect(await ShowLocation.getFileData()).to.be.equal("attachL…\n12.0 KB")
     })
     it("We can go to the show page of Attachment", async() => {
-      if (await (await ShowLocation.getImageClick()).isClickable()) {
-        await (await ShowLocation.getImageClick()).click()
-        await expect(browser).toHaveUrlContaining(
-          "/attachments/f7cd5b02-ef73-4ee8-814b-c5a7a916685d"
-        )
-      }
+      await (await ShowLocation.getImageClick()).click()
+      await expect(await browser.getUrl()).to.include(
+        "/attachments/f7cd5b02-ef73-4ee8-814b-c5a7a916685d"
+      )
     })
   })
 })

--- a/client/tests/webdriver/baseSpecs/showOrganization.spec.js
+++ b/client/tests/webdriver/baseSpecs/showOrganization.spec.js
@@ -3,6 +3,7 @@ import Home from "../pages/home.page"
 import Search from "../pages/search.page"
 import ShowOrganization from "../pages/showOrganization.page"
 
+const ORGANIZATION_UUID = "ccbee4bb-08b8-42df-8cb5-65e8172f657b" // EF 2.2
 const ORGANIZATION_EF2_SEARCH_STRING = "EF 2"
 const ORGANIZATION_EF22_SEARCH_STRING = "EF 2.2"
 const LEADER_POSITION_TEXT = "EF 2.2 Final Reviewer"
@@ -48,8 +49,12 @@ describe("Show organization page", () => {
       const deputyField = await ShowOrganization.getDeputies()
       // eslint-disable-next-line no-unused-expressions
       expect(await deputyField.isExisting()).to.be.false
+
+      // Log out
+      await ShowOrganization.logout()
     })
   })
+
   describe("As an admin", () => {
     it("Should first search, find and open the organization page", async() => {
       await Home.openAsAdminUser()
@@ -105,6 +110,30 @@ describe("Show organization page", () => {
       expect(
         await (await ShowOrganization.getDeputyPositionPerson()).getText()
       ).to.equal(DEPUTY_PERSON_TEXT)
+
+      // Log out
+      await ShowOrganization.logout()
+    })
+  })
+
+  describe("When on the show page of an organization with attachment(s)", () => {
+    it("We should see a container for Attachment List", async() => {
+      await ShowOrganization.open(ORGANIZATION_UUID)
+      await (await ShowOrganization.getAttachments()).waitForExist()
+      await (await ShowOrganization.getAttachments()).waitForDisplayed()
+    })
+    it("We should see a card of Attachment", async() => {
+      await (await ShowOrganization.getCard()).waitForExist()
+      await (await ShowOrganization.getCard()).waitForDisplayed()
+      expect(await ShowOrganization.getFileData()).to.be.equal(
+        "attachO…\n12.0 KB"
+      )
+    })
+    it("We can go to the show page of Attachment", async() => {
+      await (await ShowOrganization.getImageClick()).click()
+      await expect(await browser.getUrl()).to.include(
+        "/attachments/9ac41246-25ac-457c-b7d6-946c5f625f1f"
+      )
     })
   })
 })

--- a/client/tests/webdriver/baseSpecs/showReport.spec.js
+++ b/client/tests/webdriver/baseSpecs/showReport.spec.js
@@ -41,17 +41,13 @@ describe("Show report page", () => {
       // Attachment card list
       await (await ShowReport.getCard()).waitForExist()
       await (await ShowReport.getCard()).waitForDisplayed()
-      expect(await await ShowReport.getFileData()).to.be.equal(
-        "test_at…\n12.0 KB"
-      )
+      expect(await ShowReport.getFileData()).to.be.equal("test_at…\n12.0 KB")
     })
     it("We can go to the show page of Attachment", async() => {
-      if (await (await ShowReport.getImageClick()).isClickable()) {
-        await (await ShowReport.getImageClick()).click()
-        await expect(browser).toHaveUrlContaining(
-          "/attachments/f076406f-1a9b-4fc9-8ab2-cd2a138ec26d"
-        )
-      }
+      await (await ShowReport.getImageClick()).click()
+      await expect(await browser.getUrl()).to.include(
+        "/attachments/f076406f-1a9b-4fc9-8ab2-cd2a138ec26d"
+      )
     })
   })
 })

--- a/client/tests/webdriver/pages/location/showLocation.page.js
+++ b/client/tests/webdriver/pages/location/showLocation.page.js
@@ -22,21 +22,5 @@ class ShowLocation extends Page {
   async getLngField() {
     return browser.$('div[name="location"] span:nth-child(3)')
   }
-
-  async getAttachments() {
-    return browser.$("#attachments")
-  }
-
-  async getCard() {
-    return browser.$(".card")
-  }
-
-  async getFileData() {
-    return (await browser.$(".info-line")).getText()
-  }
-
-  async getImageClick() {
-    return browser.$(".imagePreview")
-  }
 }
 export default new ShowLocation()

--- a/client/tests/webdriver/pages/page.js
+++ b/client/tests/webdriver/pages/page.js
@@ -27,6 +27,22 @@ class Page {
     return browser.$("#topbar .logo")
   }
 
+  async getAttachments() {
+    return browser.$("#attachments")
+  }
+
+  async getCard() {
+    return browser.$(".card")
+  }
+
+  async getFileData() {
+    return (await browser.$(".info-line")).getText()
+  }
+
+  async getImageClick() {
+    return browser.$(".image-preview")
+  }
+
   async loginFormSubmit() {
     await (await this.getLoginFormSubmitButton()).click()
   }

--- a/client/tests/webdriver/pages/report/showReport.page.js
+++ b/client/tests/webdriver/pages/report/showReport.page.js
@@ -108,22 +108,6 @@ class ShowReport extends Page {
     return (await browser.$("div[name='duration']")).getText()
   }
 
-  async getAttachments() {
-    return browser.$("#attachments")
-  }
-
-  async getCard() {
-    return browser.$(".card")
-  }
-
-  async getFileData() {
-    return (await browser.$(".info-line")).getText()
-  }
-
-  async getImageClick() {
-    return browser.$(".imagePreview")
-  }
-
   async getCurrentUrl() {
     return browser.getCurrentUrl()
   }

--- a/client/tests/webdriver/pages/showOrganization.page.js
+++ b/client/tests/webdriver/pages/showOrganization.page.js
@@ -1,6 +1,12 @@
 import Page from "./page"
 
+const PAGE_URL = "/organizations/:uuid"
+
 class ShowOrganization extends Page {
+  async open(uuid) {
+    await super.open(PAGE_URL.replace(":uuid", uuid))
+  }
+
   async getAlertSuccess() {
     return browser.$(".alert-success")
   }

--- a/insertBaseData-psql.sql
+++ b/insertBaseData-psql.sql
@@ -1155,13 +1155,20 @@ INSERT INTO "attachmentRelatedObjects" ("attachmentUuid", "relatedObjectType", "
   WHERE r.intent = 'A test report from Arthur';
 
 -- Add attachments for locations
-SELECT ('''' || uuid || '''') AS "authorUuid" FROM people WHERE name = 'DMIN, Arthur' \gset
 INSERT INTO attachments (uuid, "authorUuid", "fileName", "caption", "mimeType", content, "contentLength", "description", "classification", "createdAt", "updatedAt")
 	VALUES ('f7cd5b02-ef73-4ee8-814b-c5a7a916685d', :authorUuid, 'attachLocation.png', 'attachLocation', 'image/png', lo_import('/var/tmp/default_avatar.png'), 12316, 'We can add attachments to a location', NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
 INSERT INTO "attachmentRelatedObjects" ("attachmentUuid", "relatedObjectType", "relatedObjectUuid")
   SELECT 'f7cd5b02-ef73-4ee8-814b-c5a7a916685d', 'locations', loc.uuid
   FROM locations loc
   WHERE loc.name = 'Antarctica';
+
+-- Add attachments for organizations
+INSERT INTO attachments (uuid, "authorUuid", "fileName", "caption", "mimeType", content, "contentLength", "description", "classification", "createdAt", "updatedAt")
+	VALUES ('9ac41246-25ac-457c-b7d6-946c5f625f1f', :authorUuid, 'attachOrganization.png', 'attachOrganization', 'image/png', lo_import('/var/tmp/default_avatar.png'), 12316, 'We can add attachments to an organization', NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+INSERT INTO "attachmentRelatedObjects" ("attachmentUuid", "relatedObjectType", "relatedObjectUuid")
+  SELECT '9ac41246-25ac-457c-b7d6-946c5f625f1f', 'organizations', org.uuid
+  FROM organizations org
+  WHERE org."shortName" = 'EF 2.2';
 
 -- Update the full-text indexes
 REFRESH MATERIALIZED VIEW CONCURRENTLY "mv_fts_authorizationGroups";


### PR DESCRIPTION
It is now possible to add attachments to organizations.

Closes [AB#950](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/950)

#### User changes
- User can see organization attachments.

#### Superuser changes
- Superusers can upload attachments to their organizations.

#### Admin changes
- Admins can upload, edit and delete organization attachments.

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [x] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [x] Opened debt issues for anything not resolved here