### PR TITLE
Only return distinct results from the search

### DIFF
--- a/src/main/java/mil/dds/anet/search/AbstractAuthorizationGroupSearcher.java
+++ b/src/main/java/mil/dds/anet/search/AbstractAuthorizationGroupSearcher.java
@@ -29,7 +29,6 @@ public abstract class AbstractAuthorizationGroupSearcher
   @Override
   protected void buildQuery(AuthorizationGroupSearchQuery query) {
     qb.addSelectClause(AuthorizationGroupDao.AUTHORIZATION_GROUP_FIELDS);
-    qb.addTotalCount();
     qb.addFromClause("\"authorizationGroups\"");
 
     if (hasTextQuery(query)) {

--- a/src/main/java/mil/dds/anet/search/AbstractLocationSearcher.java
+++ b/src/main/java/mil/dds/anet/search/AbstractLocationSearcher.java
@@ -27,7 +27,6 @@ public abstract class AbstractLocationSearcher
   @Override
   protected void buildQuery(LocationSearchQuery query) {
     qb.addSelectClause(LocationDao.LOCATION_FIELDS);
-    qb.addTotalCount();
     qb.addFromClause("locations");
     qb.addEnumEqualsClause("status", "locations.status", query.getStatus());
     qb.addLikeClause("type", "locations.type", DaoUtils.getEnumString(query.getType()));

--- a/src/main/java/mil/dds/anet/search/AbstractOrganizationSearcher.java
+++ b/src/main/java/mil/dds/anet/search/AbstractOrganizationSearcher.java
@@ -29,7 +29,6 @@ public abstract class AbstractOrganizationSearcher extends
   @Override
   protected void buildQuery(OrganizationSearchQuery query) {
     qb.addSelectClause(OrganizationDao.ORGANIZATION_FIELDS);
-    qb.addTotalCount();
     qb.addFromClause("organizations");
 
     if (hasTextQuery(query)) {

--- a/src/main/java/mil/dds/anet/search/AbstractPersonSearcher.java
+++ b/src/main/java/mil/dds/anet/search/AbstractPersonSearcher.java
@@ -46,7 +46,6 @@ public abstract class AbstractPersonSearcher extends AbstractSearcher<Person, Pe
 
   protected void buildQuery(Set<String> subFields, PersonSearchQuery query) {
     qb.addSelectClause(getTableFields(subFields));
-    qb.addTotalCount();
     qb.addFromClause("people");
 
     if (query.getOrgUuid() != null || query.getLocationUuid() != null

--- a/src/main/java/mil/dds/anet/search/AbstractPositionSearcher.java
+++ b/src/main/java/mil/dds/anet/search/AbstractPositionSearcher.java
@@ -58,7 +58,6 @@ public abstract class AbstractPositionSearcher
   @Override
   protected void buildQuery(PositionSearchQuery query) {
     qb.addSelectClause(PositionDao.POSITION_FIELDS);
-    qb.addTotalCount();
     qb.addFromClause("positions");
 
     if (query.getMatchPersonName()) {

--- a/src/main/java/mil/dds/anet/search/AbstractSearchQueryBuilder.java
+++ b/src/main/java/mil/dds/anet/search/AbstractSearchQueryBuilder.java
@@ -94,10 +94,6 @@ public abstract class AbstractSearchQueryBuilder<B, T extends AbstractSearchQuer
     selectClauses.add(clause);
   }
 
-  public void addTotalCount() {
-    addSelectClause("COUNT(*) OVER() AS \"totalCount\"");
-  }
-
   public void addFromClause(String clause) {
     fromClauses.add(clause);
   }
@@ -297,6 +293,8 @@ public abstract class AbstractSearchQueryBuilder<B, T extends AbstractSearchQuer
     addAdditionalFromClauses();
     addWhereClauses();
     addGroupByClauses();
+    sql.insert(0, "SELECT *, COUNT(*) OVER() AS \"totalCount\" FROM (");
+    sql.append(") AS results");
     addOrderByClauses();
     return sql.toString();
   }
@@ -315,7 +313,7 @@ public abstract class AbstractSearchQueryBuilder<B, T extends AbstractSearchQuer
 
   protected void addSelectClauses() {
     if (!selectClauses.isEmpty()) {
-      sql.append(" SELECT ");
+      sql.append(" SELECT DISTINCT ");
       sql.append(Joiner.on(", ").join(selectClauses));
     }
   }
@@ -350,8 +348,7 @@ public abstract class AbstractSearchQueryBuilder<B, T extends AbstractSearchQuer
 
   protected void addOrderByClauses() {
     if (!orderByClauses.isEmpty()) {
-      sql.insert(0, "SELECT * FROM (");
-      sql.append(") AS results ORDER BY ");
+      sql.append(" ORDER BY ");
       sql.append(Joiner.on(", ").join(orderByClauses));
     }
   }

--- a/src/main/java/mil/dds/anet/search/AbstractSubscriptionSearcher.java
+++ b/src/main/java/mil/dds/anet/search/AbstractSubscriptionSearcher.java
@@ -33,7 +33,6 @@ public abstract class AbstractSubscriptionSearcher extends
 
   protected void buildQuery(SubscriptionSearchQuery query, Person user) {
     qb.addSelectClause(SubscriptionDao.SUBSCRIPTION_FIELDS);
-    qb.addTotalCount();
     qb.addFromClause("subscriptions");
     final Position position = DaoUtils.getPosition(user);
     qb.addStringEqualsClause("positionUuid", "subscriptions.\"subscriberUuid\"",

--- a/src/main/java/mil/dds/anet/search/AbstractSubscriptionUpdateSearcher.java
+++ b/src/main/java/mil/dds/anet/search/AbstractSubscriptionUpdateSearcher.java
@@ -35,7 +35,6 @@ public abstract class AbstractSubscriptionUpdateSearcher
 
   protected void buildQuery(SubscriptionUpdateSearchQuery query, Person user) {
     qb.addSelectClause(SubscriptionUpdateDao.SUBSCRIPTION_UPDATE_FIELDS);
-    qb.addTotalCount();
     qb.addFromClause("\"subscriptionUpdates\"");
     final Position position = DaoUtils.getPosition(user);
     qb.addWhereClause(

--- a/src/main/java/mil/dds/anet/search/AbstractTaskSearcher.java
+++ b/src/main/java/mil/dds/anet/search/AbstractTaskSearcher.java
@@ -30,7 +30,6 @@ public abstract class AbstractTaskSearcher extends AbstractSearcher<Task, TaskSe
   @Override
   protected void buildQuery(TaskSearchQuery query) {
     qb.addSelectClause(TaskDao.TASK_FIELDS);
-    qb.addTotalCount();
     qb.addFromClause("tasks");
 
     if (hasTextQuery(query)) {

--- a/src/main/java/mil/dds/anet/search/AbstractUserActivitySearcher.java
+++ b/src/main/java/mil/dds/anet/search/AbstractUserActivitySearcher.java
@@ -36,7 +36,6 @@ public abstract class AbstractUserActivitySearcher extends
         break;
     }
     qb.addSelectClause("count");
-    qb.addTotalCount();
     qb.addFromClause(WITH_CLAUSE_NAME);
     addOrderByClauses(qb, query);
   }

--- a/src/main/java/mil/dds/anet/search/pg/PostgresqlReportSearcher.java
+++ b/src/main/java/mil/dds/anet/search/pg/PostgresqlReportSearcher.java
@@ -34,7 +34,6 @@ public class PostgresqlReportSearcher extends AbstractReportSearcher {
   @Override
   protected void buildQuery(Set<String> subFields, ReportSearchQuery query) {
     qb.addSelectClause(getTableFields(subFields));
-    qb.addTotalCount();
     qb.addFromClause("reports");
     super.buildQuery(subFields, query);
   }


### PR DESCRIPTION
Make sure the totalCount is still correct, by adding it to the outer query. Since it was always added to any search query anyway, add it unconditionally.

Closes [AB#977](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/977)

#### User changes
- Tasks that have been assigned to organizations in the same hierarchy now no longer show up twice.

#### Superuser changes
- none

#### Admin changes
- none

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here