### PR TITLE
Remove clickable buttons from organisation preview

### DIFF
--- a/client/src/pages/organizations/Laydown.js
+++ b/client/src/pages/organizations/Laydown.js
@@ -1,4 +1,3 @@
-import AppContext from "components/AppContext"
 import EditAdministratingPositionsModal from "components/EditAdministratingPositionsModal"
 import Fieldset from "components/Fieldset"
 import OrganizationalChart from "components/graphs/OrganizationalChart"
@@ -7,7 +6,7 @@ import Model from "components/Model"
 import PositionTable from "components/PositionTable"
 import { Organization, Person, Position } from "models"
 import PropTypes from "prop-types"
-import React, { useContext, useState } from "react"
+import React, { useState } from "react"
 import { Button, Table } from "react-bootstrap"
 import ContainerDimensions from "react-container-dimensions"
 import { Element } from "react-scroll"
@@ -33,16 +32,11 @@ function getAllAdministratingPositions(organization) {
 }
 
 const OrganizationLaydown = ({ organization, refetch }) => {
-  const { currentUser } = useContext(AppContext)
   const [showInactivePositions, setShowInactivePositions] = useState(false)
   const [
     showAdministratingPositionsModal,
     setShowAdministratingPositionsModal
   ] = useState(false)
-  const isAdmin = currentUser && currentUser.isAdmin()
-  const canAdministrateOrg =
-    currentUser &&
-    currentUser.hasAdministrativePermissionsForOrganization(organization)
   const isPrincipalOrg = organization.type === Organization.TYPE.PRINCIPAL_ORG
   const numInactivePos = organization.positions.filter(
     p => p.status === Model.STATUS.INACTIVE
@@ -88,25 +82,7 @@ const OrganizationLaydown = ({ organization, refetch }) => {
         </div>
       </Element>
 
-      <Fieldset
-        id="supportedPositions"
-        title="Supported positions"
-        action={
-          <div>
-            {canAdministrateOrg && (
-              <LinkTo
-                modelType="Position"
-                model={Position.pathForNew({
-                  organizationUuid: organization.uuid
-                })}
-                button
-              >
-                Create position
-              </LinkTo>
-            )}
-          </div>
-        }
-      >
+      <Fieldset id="supportedPositions" title="Supported positions">
         {renderPositionTable(supportedPositions)}
         {supportedPositions.length === 0 && (
           <em>There are no occupied positions</em>
@@ -136,16 +112,6 @@ const OrganizationLaydown = ({ organization, refetch }) => {
       <Fieldset
         id="administratingPositions"
         title={utils.sentenceCase(orgSettings.administratingPositions.label)}
-        action={
-          isAdmin && (
-            <Button
-              onClick={() => setShowAdministratingPositionsModal(true)}
-              variant="outline-secondary"
-            >
-              Edit {utils.noCase(orgSettings.administratingPositions.label)}
-            </Button>
-          )
-        }
       >
         <PositionTable
           id="superuser-table"


### PR DESCRIPTION
The Organisation Preview had buttons that you can click to create a position or to edit assigned superusers. Previews should not contain clickable buttons.

Closes [AB#982](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/982)

#### User changes
- None

#### Superuser changes
- None

#### Admin changes
- Organisation Preview do not have clickable buttons anymore which Admins were able to click earlier.

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [ ] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
