### PR TITLE
Check related objects permissions when creating/updating/deleting attachments

### DIFF
--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1131,7 +1131,7 @@ header.searchPagination {
 }
 
 .rich-text-modal, .wide-assessment-modal {
-  width: 650px;
+  width: 700px;
   max-width: 100%;
 }
 

--- a/src/main/java/mil/dds/anet/database/ApprovalStepDao.java
+++ b/src/main/java/mil/dds/anet/database/ApprovalStepDao.java
@@ -177,7 +177,7 @@ public class ApprovalStepDao extends AnetBaseDao<ApprovalStep, AbstractSearchQue
     // ensure there is nothing currently on this step
     if (isStepInUse(uuid)) {
       throw new WebApplicationException("Reports are currently pending at this step",
-          Status.NOT_ACCEPTABLE);
+          Status.BAD_REQUEST);
     }
 
     // fix up the linked list.

--- a/src/main/java/mil/dds/anet/database/AttachmentDao.java
+++ b/src/main/java/mil/dds/anet/database/AttachmentDao.java
@@ -21,6 +21,7 @@ import mil.dds.anet.database.mappers.AttachmentMapper;
 import mil.dds.anet.database.mappers.GenericRelatedObjectMapper;
 import mil.dds.anet.utils.DaoUtils;
 import mil.dds.anet.utils.FkDataLoaderKey;
+import mil.dds.anet.utils.Utils;
 import mil.dds.anet.views.ForeignKeyFetcher;
 import org.apache.commons.io.IOUtils;
 import org.eclipse.jetty.io.EofException;
@@ -78,8 +79,7 @@ public class AttachmentDao extends AnetBaseDao<Attachment, AbstractSearchQuery<?
         .bindBean(obj).bind("createdAt", DaoUtils.asLocalDateTime(obj.getCreatedAt()))
         .bind("updatedAt", DaoUtils.asLocalDateTime(obj.getUpdatedAt()))
         .bind("authorUuid", obj.getAuthorUuid()).execute();
-    if (obj.getAttachmentRelatedObjects().get(0).getRelatedObjectUuid() != null)
-      insertAttachmentRelatedObjects(DaoUtils.getUuid(obj), obj.getAttachmentRelatedObjects());
+    insertAttachmentRelatedObjects(DaoUtils.getUuid(obj), obj.getAttachmentRelatedObjects());
     return obj;
   }
 
@@ -195,8 +195,10 @@ public class AttachmentDao extends AnetBaseDao<Attachment, AbstractSearchQuery<?
 
   private void insertAttachmentRelatedObjects(String uuid,
       List<GenericRelatedObject> attachmentRelatedObjects) {
-    final AttachmentBatch ab = getDbHandle().attach(AttachmentBatch.class);
-    ab.insertAttachmentRelatedObjects(uuid, attachmentRelatedObjects);
+    if (!Utils.isEmptyOrNull(attachmentRelatedObjects)) {
+      final AttachmentBatch ab = getDbHandle().attach(AttachmentBatch.class);
+      ab.insertAttachmentRelatedObjects(uuid, attachmentRelatedObjects);
+    }
   }
 
   private void deleteAttachmentRelatedObjects(String attachmentUuid) {

--- a/src/main/java/mil/dds/anet/resources/AttachmentResource.java
+++ b/src/main/java/mil/dds/anet/resources/AttachmentResource.java
@@ -30,11 +30,16 @@ import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.StreamingOutput;
 import mil.dds.anet.AnetObjectEngine;
 import mil.dds.anet.beans.Attachment;
+import mil.dds.anet.beans.GenericRelatedObject;
 import mil.dds.anet.beans.Person;
 import mil.dds.anet.database.AttachmentDao;
+import mil.dds.anet.database.LocationDao;
+import mil.dds.anet.database.OrganizationDao;
+import mil.dds.anet.database.ReportDao;
 import mil.dds.anet.utils.AnetAuditLogger;
 import mil.dds.anet.utils.AuthUtils;
 import mil.dds.anet.utils.DaoUtils;
+import mil.dds.anet.utils.Utils;
 import org.apache.tika.Tika;
 import org.apache.tika.io.TikaInputStream;
 import org.glassfish.jersey.media.multipart.FormDataParam;
@@ -76,10 +81,10 @@ public class AttachmentResource {
     if (!hasAttachmentPermission(user, null)) {
       throw new WebApplicationException("You don't have permission to upload attachments",
           Status.FORBIDDEN);
-
     }
     assertAllowedMimeType(attachment.getMimeType());
     assertAllowedClassification(attachment.getClassification());
+    assertAllowedRelatedObjects(user, attachment.getAttachmentRelatedObjects());
 
     attachment.setAuthorUuid(DaoUtils.getUuid(user));
     attachment = dao.insert(attachment);
@@ -129,10 +134,12 @@ public class AttachmentResource {
     if (!hasAttachmentPermission(user, existing)) {
       throw new WebApplicationException("You don't have permission to update this attachment",
           Status.FORBIDDEN);
-
     }
     assertAllowedMimeType(attachment.getMimeType());
     assertAllowedClassification(attachment.getClassification());
+    assertAllowedRelatedObjects(user,
+        existing.loadAttachmentRelatedObjects(AnetObjectEngine.getInstance().getContext()).join());
+    assertAllowedRelatedObjects(user, attachment.getAttachmentRelatedObjects());
 
     final int numRows = dao.update(attachment);
     if (numRows == 0) {
@@ -151,6 +158,8 @@ public class AttachmentResource {
       throw new WebApplicationException("You don't have permission to delete this attachment",
           Status.FORBIDDEN);
     }
+    assertAllowedRelatedObjects(user,
+        existing.loadAttachmentRelatedObjects(AnetObjectEngine.getInstance().getContext()).join());
 
     final int numRows = dao.delete(attachmentUuid);
     if (numRows == 0) {
@@ -214,9 +223,35 @@ public class AttachmentResource {
         || Objects.equals(existingAttachment.getAuthorUuid(), DaoUtils.getUuid(user));
   }
 
+  private void assertAllowedRelatedObjects(final Person user,
+      final List<GenericRelatedObject> relatedObjects) {
+    if (Utils.isEmptyOrNull(relatedObjects)) {
+      return;
+    }
+    if (!relatedObjects.stream().allMatch(aro -> isAllowedRelatedObject(user, aro))) {
+      throw new WebApplicationException(
+          "You are not allowed to link/unlink the attachment to/from one of the requested objects",
+          Status.BAD_REQUEST);
+    }
+  }
+
+  private boolean isAllowedRelatedObject(final Person user,
+      final GenericRelatedObject relatedObject) {
+    // Check whether the user is allowed to link to the attachmentRelatedObjects!
+    return switch (relatedObject.getRelatedObjectType()) {
+      case LocationDao.TABLE_NAME ->
+        LocationResource.hasPermission(user, relatedObject.getRelatedObjectUuid());
+      case OrganizationDao.TABLE_NAME ->
+        OrganizationResource.hasPermission(user, relatedObject.getRelatedObjectUuid());
+      case ReportDao.TABLE_NAME ->
+        ReportResource.hasPermission(user, relatedObject.getRelatedObjectUuid());
+      // TODO: add other object types if and when attachments to them are allowed
+      default -> false;
+    };
+  }
+
   private void assertAllowedMimeType(final String mimeType) {
-    final Map<String, Object> attachmentSettings = getAttachmentSettings();
-    final var allowedMimeTypes = (List<String>) attachmentSettings.get("mimeTypes");
+    final var allowedMimeTypes = getAllowedMimeTypes();
     if (!allowedMimeTypes.contains(mimeType)) {
       throw new WebApplicationException(
           String.format("Files of type \"%s\" are not allowed", mimeType), Status.BAD_REQUEST);
@@ -226,7 +261,7 @@ public class AttachmentResource {
   private void assertAllowedClassification(final String classificationKey) {
     if (classificationKey != null) {
       // if the classification is set, check if it is valid
-      final Map<String, String> allowedClassifications = getAllowedClassifications();
+      final var allowedClassifications = getAllowedClassifications();
       if (!allowedClassifications.containsKey(classificationKey)) {
         throw new WebApplicationException("Classification is not allowed", Status.BAD_REQUEST);
       }
@@ -234,23 +269,27 @@ public class AttachmentResource {
   }
 
   private void assertAttachmentEnabled() {
-    final Map<String, Object> attachmentSettings = getAttachmentSettings();
+    final var attachmentSettings = getAttachmentSettings();
     final Boolean attachmentDisabled = (Boolean) attachmentSettings.get("featureDisabled");
-
-    if (attachmentDisabled) {
+    if (Boolean.TRUE.equals(attachmentDisabled)) {
       throw new WebApplicationException("Attachment feature is disabled", Status.FORBIDDEN);
     }
   }
 
+  @SuppressWarnings("unchecked")
   public static Map<String, Object> getAttachmentSettings() {
     return (Map<String, Object>) AnetObjectEngine.getConfiguration()
         .getDictionaryEntry("fields.attachment");
   }
 
+  @SuppressWarnings("unchecked")
   public static Map<String, String> getAllowedClassifications() {
-    final Map<String, Object> attachmentSettings = getAttachmentSettings();
-    final Map<String, Object> classification =
-        (Map<String, Object>) attachmentSettings.get("classification");
+    final var classification = (Map<String, Object>) getAttachmentSettings().get("classification");
     return (Map<String, String>) classification.get("choices");
+  }
+
+  @SuppressWarnings("unchecked")
+  public static List<String> getAllowedMimeTypes() {
+    return (List<String>) getAttachmentSettings().get("mimeTypes");
   }
 }

--- a/src/main/java/mil/dds/anet/resources/AttachmentResource.java
+++ b/src/main/java/mil/dds/anet/resources/AttachmentResource.java
@@ -219,7 +219,7 @@ public class AttachmentResource {
     final var allowedMimeTypes = (List<String>) attachmentSettings.get("mimeTypes");
     if (!allowedMimeTypes.contains(mimeType)) {
       throw new WebApplicationException(
-          String.format("Files of type \"%s\" are not allowed", mimeType), Status.NOT_ACCEPTABLE);
+          String.format("Files of type \"%s\" are not allowed", mimeType), Status.BAD_REQUEST);
     }
   }
 

--- a/src/main/java/mil/dds/anet/resources/PersonResource.java
+++ b/src/main/java/mil/dds/anet/resources/PersonResource.java
@@ -245,8 +245,7 @@ public class PersonResource {
 
     final String winnerUuid = DaoUtils.getUuid(winner);
     if (loserUuid.equals(winnerUuid)) {
-      throw new WebApplicationException("You selected the same person twice",
-          Status.NOT_ACCEPTABLE);
+      throw new WebApplicationException("You selected the same person twice", Status.BAD_REQUEST);
     }
 
     final Person existingWinner = dao.getByUuid(winnerUuid);

--- a/src/main/java/mil/dds/anet/utils/AuthUtils.java
+++ b/src/main/java/mil/dds/anet/utils/AuthUtils.java
@@ -19,7 +19,9 @@ public class AuthUtils {
   private static final Logger logger =
       LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
-  public static String UNAUTH_MESSAGE = "You do not have permissions to do this";
+  public static final String UNAUTH_MESSAGE = "You do not have permissions to do this";
+
+  private AuthUtils() {}
 
   public static void assertAdministrator(Person user) {
     logger.debug("Asserting admin status for {}", user);
@@ -80,12 +82,15 @@ public class AuthUtils {
 
   public static void assertSuperuser(Person user) {
     logger.debug("Asserting superuser position for {}", user);
-    Position position = DaoUtils.getPosition(user);
-    if (position != null && (position.getType() == PositionType.SUPERUSER
-        || position.getType() == PositionType.ADMINISTRATOR)) {
-      return;
+    if (!isSuperuser(user)) {
+      throw new WebApplicationException(UNAUTH_MESSAGE, Status.FORBIDDEN);
     }
-    throw new WebApplicationException(UNAUTH_MESSAGE, Status.FORBIDDEN);
+  }
+
+  public static boolean isSuperuser(Person user) {
+    Position position = DaoUtils.getPosition(user);
+    return position != null && (position.getType() == PositionType.SUPERUSER
+        || position.getType() == PositionType.ADMINISTRATOR);
   }
 
   public static boolean isAdmin(Person user) {

--- a/src/test/java/mil/dds/anet/test/resources/ReportResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/ReportResourceTest.java
@@ -1487,7 +1487,7 @@ public class ReportResourceTest extends AbstractResourceTest {
             .withDescription("a test attachment created by testDeleteAttachment")
             .withAttachmentRelatedObjects(Collections.singletonList(testAroInput)).build();
     final String createdAttachmentUuid =
-        adminMutationExecutor.createAttachment("", testAttachmentInput);
+        elizabethMutationExecutor.createAttachment("", testAttachmentInput);
     assertThat(createdAttachmentUuid).isNotNull();
 
     final Report updatedReport = adminQueryExecutor.report(FIELDS, r.getUuid());


### PR DESCRIPTION
When creating/updating/deleting attachments, make sure we check whether the user is allowed to link to the related objects.

Closes [AB#981](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/981)

#### User changes
- Permissions for creating/updating/deleting attachments by regular users are now a lot stricter.

#### Superuser changes
- Permissions for creating/updating/deleting attachments by superusers are now a lot stricter.

#### Admin changes
- Permissions for creating/updating/deleting attachments by admins are now stricter.

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [x] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here