### PR TITLE
Remove buttons from organization preview

### DIFF
--- a/client/src/components/ApprovalSteps.js
+++ b/client/src/components/ApprovalSteps.js
@@ -14,7 +14,7 @@ function ApprovalSteps({ approvalSteps }) {
     return (
       <div key={idx}>
         <h5>{step.name}</h5>
-        <Table>
+        <Table striped hover responsive>
           <thead>
             <tr>
               <th>Person</th>

--- a/client/src/components/AssociatedPositions.js
+++ b/client/src/components/AssociatedPositions.js
@@ -10,7 +10,7 @@ const ACTION_SIDES = {
 
 const AssociatedPositions = ({ associatedPositions, action, actionSide }) => {
   return (
-    <Table>
+    <Table striped hover responsive>
       <thead>
         <tr>
           {action && actionSide === ACTION_SIDES.LEFT && <th>Action</th>}

--- a/client/src/components/NoPaginationTaskTable.js
+++ b/client/src/components/NoPaginationTaskTable.js
@@ -28,7 +28,7 @@ const NoPaginationTaskTable = ({
               <th>Name</th>
               {showOrganization && <th>Tasked organizations</th>}
               {showDescription && <th>Description</th>}
-              <th />
+              {showDelete && <th />}
             </tr>
           </thead>
           <tbody>

--- a/client/src/components/PositionTable.js
+++ b/client/src/components/PositionTable.js
@@ -140,7 +140,7 @@ const BasePositionTable = ({
               {showOrganizationsAdministrated && <th>Superuser of</th>}
               <th>Current Occupant</th>
               <th>Status</th>
-              <th />
+              {showDelete && <th />}
             </tr>
           </thead>
           <tbody>

--- a/client/src/components/PreviousPositions.js
+++ b/client/src/components/PreviousPositions.js
@@ -10,7 +10,7 @@ function PreviousPositions({ history: previousPositions, action }) {
   return _isEmpty(previousPositions) ? (
     <em>No positions found</em>
   ) : (
-    <Table id="previous-positions">
+    <Table id="previous-positions" striped hover responsive>
       <thead>
         <tr>
           <th>Position</th>

--- a/client/src/components/ReportTable.js
+++ b/client/src/components/ReportTable.js
@@ -138,7 +138,7 @@ const ReportTable = ({
         totalCount={totalCount}
         goToPage={setPage}
       >
-        <Table striped responsive>
+        <Table striped hover responsive>
           <thead>
             <tr>
               <th>Authors</th>

--- a/client/src/components/approvals/Approvals.js
+++ b/client/src/components/approvals/Approvals.js
@@ -25,7 +25,7 @@ const Approvals = ({ restrictedApprovalLabel, relatedObject }) => {
                 readOnly
               />
             )}
-            <Table>
+            <Table striped hover responsive>
               <thead>
                 <tr>
                   <th>Name</th>
@@ -73,7 +73,7 @@ const Approvals = ({ restrictedApprovalLabel, relatedObject }) => {
                 readOnly
               />
             )}
-            <Table>
+            <Table striped hover responsive>
               <thead>
                 <tr>
                   <th>Name</th>

--- a/client/src/components/graphs/OrganizationalChart.js
+++ b/client/src/components/graphs/OrganizationalChart.js
@@ -112,6 +112,7 @@ const getRoleValue = (position, leaderValue, nonLeaderValue) =>
 const OrganizationalChart = ({
   pageDispatchers,
   org,
+  exportTitle,
   width,
   height: initialHeight
 }) => {
@@ -373,7 +374,7 @@ const OrganizationalChart = ({
     <SVGCanvas
       width={width}
       height={height}
-      exportTitle={`${data.organization.shortName} organization chart`}
+      exportTitle={exportTitle}
       zoomFn={increment =>
         setPersonnelDepth(Math.max(0, personnelDepth + increment))}
     >
@@ -388,6 +389,7 @@ const OrganizationalChart = ({
 OrganizationalChart.propTypes = {
   pageDispatchers: PageDispatchersPropType,
   org: PropTypes.object.isRequired,
+  exportTitle: PropTypes.string,
   width: PropTypes.number.isRequired,
   height: PropTypes.number.isRequired
 }

--- a/client/src/components/previews/OrganizationPreview.js
+++ b/client/src/components/previews/OrganizationPreview.js
@@ -211,7 +211,11 @@ const OrganizationPreview = ({ className, uuid }) => {
         )}
       </div>
 
-      <OrganizationLaydown organization={organization} refetch={refetch} />
+      <OrganizationLaydown
+        organization={organization}
+        refetch={refetch}
+        readOnly
+      />
       {organization.isTaskEnabled() && (
         <OrganizationTasks
           organization={organization}

--- a/client/src/components/previews/PersonPreview.js
+++ b/client/src/components/previews/PersonPreview.js
@@ -237,11 +237,11 @@ const PersonPreview = ({ className, uuid }) => {
       position.type === Position.TYPE.PRINCIPAL ? "Is advised by" : "Advises"
     return (
       <Form.Group controlId="counterparts">
-        <Col sm={1} as={Form.Text}>
-          {assocTitle}
+        <Col sm={4}>
+          <Form.Label>{assocTitle}</Form.Label>
         </Col>
-        <Col sm={9}>
-          <Table>
+        <Col sm={12}>
+          <Table striped hover responsive>
             <thead>
               <tr>
                 <th>Name</th>

--- a/client/src/components/previews/PositionPreview.js
+++ b/client/src/components/previews/PositionPreview.js
@@ -163,7 +163,7 @@ const PositionPreview = ({ className, uuid }) => {
 
       <h4>{`Assigned ${assignedRole}`}</h4>
       <div className="preview-section">
-        <Table>
+        <Table striped hover responsive>
           <thead>
             <tr>
               <th>Name</th>
@@ -186,7 +186,7 @@ const PositionPreview = ({ className, uuid }) => {
 
       <h4>Previous position holders</h4>
       <div className="preview-section">
-        <Table>
+        <Table striped hover responsive>
           <thead>
             <tr>
               <th>Name</th>

--- a/client/src/pages/organizations/Laydown.js
+++ b/client/src/pages/organizations/Laydown.js
@@ -32,7 +32,7 @@ function getAllAdministratingPositions(organization) {
   )
 }
 
-const OrganizationLaydown = ({ organization, refetch }) => {
+const OrganizationLaydown = ({ organization, refetch, readOnly }) => {
   const { currentUser } = useContext(AppContext)
   const [showInactivePositions, setShowInactivePositions] = useState(false)
   const [
@@ -41,6 +41,7 @@ const OrganizationLaydown = ({ organization, refetch }) => {
   ] = useState(false)
   const isAdmin = currentUser && currentUser.isAdmin()
   const canAdministrateOrg =
+    !readOnly &&
     currentUser &&
     currentUser.hasAdministrativePermissionsForOrganization(organization)
   const isPrincipalOrg = organization.type === Organization.TYPE.PRINCIPAL_ORG
@@ -78,7 +79,9 @@ const OrganizationLaydown = ({ organization, refetch }) => {
               {({ width, height }) => (
                 <OrganizationalChart
                   org={organization}
-                  exportTitle={`Organization diagram for ${organization}`}
+                  exportTitle={
+                    readOnly ? null : `Organization diagram for ${organization}`
+                  }
                   width={width}
                   height={height}
                 />
@@ -137,6 +140,7 @@ const OrganizationLaydown = ({ organization, refetch }) => {
         id="administratingPositions"
         title={utils.sentenceCase(orgSettings.administratingPositions.label)}
         action={
+          !readOnly &&
           isAdmin && (
             <Button
               onClick={() => setShowAdministratingPositionsModal(true)}
@@ -305,7 +309,8 @@ const OrganizationLaydown = ({ organization, refetch }) => {
 
 OrganizationLaydown.propTypes = {
   organization: PropTypes.instanceOf(Organization).isRequired,
-  refetch: PropTypes.func.isRequired
+  refetch: PropTypes.func.isRequired,
+  readOnly: PropTypes.bool
 }
 
 export default OrganizationLaydown

--- a/client/src/pages/organizations/Laydown.js
+++ b/client/src/pages/organizations/Laydown.js
@@ -177,7 +177,7 @@ const OrganizationLaydown = ({ organization, refetch }) => {
       posPersonHeader = Settings.fields.principal.person.name
     }
     return (
-      <Table responsive>
+      <Table striped hover responsive>
         <thead>
           <tr>
             <th>{posNameHeader}</th>

--- a/client/src/pages/organizations/OrganizationTasks.js
+++ b/client/src/pages/organizations/OrganizationTasks.js
@@ -91,7 +91,7 @@ const OrganizationTasks = ({ pageDispatchers, queryParams, organization }) => {
         totalCount={totalCount}
         goToPage={setPageNum}
       >
-        <Table>
+        <Table striped hover responsive>
           <thead>
             <tr>
               <th>Name</th>

--- a/client/src/pages/people/Show.js
+++ b/client/src/pages/people/Show.js
@@ -626,11 +626,11 @@ const PersonShow = ({ pageDispatchers }) => {
       position.type === Position.TYPE.PRINCIPAL ? "Is advised by" : "Advises"
     return (
       <FormGroup controlId="counterparts">
-        <Col sm={2} as={FormLabel}>
-          {assocTitle}
+        <Col sm={4}>
+          <FormLabel>{assocTitle}</FormLabel>
         </Col>
-        <Col sm={10}>
-          <Table>
+        <Col sm={12}>
+          <Table striped hover responsive>
             <thead>
               <tr>
                 <th>Name</th>

--- a/client/src/pages/positions/OrganizationsAdministrated.js
+++ b/client/src/pages/positions/OrganizationsAdministrated.js
@@ -5,7 +5,7 @@ import { Table } from "react-bootstrap"
 
 const OrganizationsAdministrated = ({ organizations }) => {
   return (
-    <Table>
+    <Table striped hover responsive>
       <thead>
         <tr>
           <th>Name</th>

--- a/client/src/pages/positions/PreviousPeople.js
+++ b/client/src/pages/positions/PreviousPeople.js
@@ -7,7 +7,7 @@ import Settings from "settings"
 
 function PreviousPeople({ history: previousPeople, action }) {
   return (
-    <Table>
+    <Table striped hover responsive>
       <thead>
         <tr>
           <th>Name</th>


### PR DESCRIPTION
In the OrganizationPreview, don't show any action buttons.

Also improve the layout of various tables.

Closes [AB#982](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/982)

#### User changes
- Tables have a more consistent layout.

#### Superuser changes
- In OrganizationPreview, there is no longer an action button to create new positions.

#### Admin changes
- In OrganizationPreview, there is no longer an action button to create new superusers.

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
