### PR TITLE
Avoid exception when viewing ReportCalendar

### DIFF
--- a/client/src/components/Calendar.js
+++ b/client/src/components/Calendar.js
@@ -46,8 +46,12 @@ const Calendar = ({ events, eventClick, calendarComponentRef }) => (
     }}
     height="auto" // assume a natural height, no scrollbars will be used
     aspectRatio={3} // ratio of width-to-height
+    fixedWeekCount={false}
     ref={calendarComponentRef}
-    dayMaxEvents={2} // workaround for https://github.com/fullcalendar/fullcalendar/issues/5595
+    // set an absolute max; workaround for https://github.com/fullcalendar/fullcalendar/issues/5595
+    dayMaxEvents={2}
+    // assume events are sorted already; workaround for https://github.com/fullcalendar/fullcalendar/issues/7462
+    eventOrder={[]}
     eventMaxStack={3}
     events={events}
     eventOverlap


### PR DESCRIPTION
When the ReportCalendar was showing a _lot_ of engagements, sometimes it would throw an exception; this is now corrected.
Also improve the calendar to show only the relevant weeks for the current month.

Closes [AB#986](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/986)

#### User changes
- No more errors when vieiwing a lot of engagements on the ReportCalendar

#### Superuser changes
- none

#### Admin changes
- none

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
