### PR TITLE
Make some basic report fields & requirements optional

### DIFF
--- a/client/src/pages/reports/Form.js
+++ b/client/src/pages/reports/Form.js
@@ -631,18 +631,22 @@ const ReportForm = ({
                   />
                 )}
 
-                {!isFutureEngagement && !values.cancelled && (
-                  <FastField
-                    name="atmosphere"
-                    label={Settings.fields.report.atmosphere}
-                    component={FieldHelper.RadioButtonToggleGroupField}
-                    buttons={atmosphereButtons}
-                    onChange={value => setFieldValue("atmosphere", value, true)}
-                    className="atmosphere-form-group"
-                  />
+                {!isFutureEngagement &&
+                  !values.cancelled &&
+                  Settings.fields.report.atmosphere && (
+                    <FastField
+                      name="atmosphere"
+                      label={Settings.fields.report.atmosphere}
+                      component={FieldHelper.RadioButtonToggleGroupField}
+                      buttons={atmosphereButtons}
+                      onChange={value =>
+                        setFieldValue("atmosphere", value, true)}
+                      className="atmosphere-form-group"
+                    />
                 )}
                 {!isFutureEngagement &&
                   !values.cancelled &&
+                  Settings.fields.report.atmosphere &&
                   values.atmosphere && (
                     <Field
                       name="atmosphereDetails"
@@ -872,7 +876,7 @@ const ReportForm = ({
                     />
                 )}
 
-                {!isFutureEngagement && (
+                {!isFutureEngagement && Settings.fields.report.nextSteps && (
                   <FastField
                     name="nextSteps"
                     label={Settings.fields.report.nextSteps.label}

--- a/client/src/pages/reports/Show.js
+++ b/client/src/pages/reports/Show.js
@@ -656,7 +656,7 @@ const ReportShow = ({ setSearchQuery, pageDispatchers }) => {
                   />
                 )}
 
-                {!report.cancelled && (
+                {!report.cancelled && Settings.fields.report.atmosphere && (
                   <Field
                     name="atmosphere"
                     label={Settings.fields.report.atmosphere}

--- a/src/main/resources/anet-schema.yml
+++ b/src/main/resources/anet-schema.yml
@@ -53,6 +53,10 @@ $defs:
           title: Optional styling for the bootstrap component class
           description: Used for styling this field.
           additionalProperties: true
+        exclude:
+          type: boolean
+          default: no
+          description: Set to true to exclude to input field
 
 # definition for fields that present a choice to be selected from
   choiceField:
@@ -559,7 +563,7 @@ properties:
       report:
         type: object
         additionalProperties: false
-        required: [intent, atmosphere, atmosphereDetails, cancelled, nextSteps, reportText]
+        required: [intent, atmosphere, cancelled, nextSteps, reportText]
         properties:
           canUnpublishReports:
             type: boolean
@@ -571,19 +575,21 @@ properties:
             title: The label for a report's intent
             description: Used in the UI where a report's intent is shown.
           atmosphere:
-            type: string
-            title: The label for a report's athmosphere
-            description: Used in the UI where a report's athmosphere is shown.
+            type: [string, boolean]
+            title: The label for a report's atmosphere
+            description: Used in the UI where a report's atmosphere is shown.
           atmosphereDetails:
             type: string
-            title: The label for report's athmosphere details
-            description: Used in the UI where a report's athmosphere details are shown.
+            title: The label for report's atmosphere details
+            description: Used in the UI where a report's atmosphere details are shown.
           cancelled:
             type: string
             title: The label for a report's cancelled
             description: Used in the UI where a report's cancelled is shown.
           nextSteps:
-            "$ref": "#/$defs/inputField"
+            oneOf:
+             - type: boolean
+             - "$ref": "#/$defs/inputField"
           keyOutcomes:
             type: string
             title: The label for report's key outcomes
@@ -604,6 +610,17 @@ properties:
                   type: string
                   enum:
                     [VIRTUAL_LOCATION, PHYSICAL_LOCATION, GEOGRAPHICAL_AREA, POINT_LOCATION, ADVISOR_LOCATION, PRINCIPAL_LOCATION]
+          requirements:
+            type: object
+            properties:
+              primaryAttendee:
+                type: boolean
+                description: Require at least 1 attending advisor
+                default: yes
+              attendingAuthor:
+                type: boolean
+                description: Require the author to attend the meeting
+                default: yes
           customFields:
             type: object
             additionalProperties:


### PR DESCRIPTION
Exclude basic engagement report requirement for LMT event report usage:
- Be able to exclude `atmosphere` & `atmosphereDetails` field
- Be able to exclude `nextSteps` field
- Possiblity to disable the following publication requirements:
  - Requirement to fill in keyOutcomes from report submission requirements
  - Requirement to have at least 1 attending advisor
  - Requirement to the author to have attended the meeting
- Other:
  - Correct typo's in `anet-schema.yml`

Resolves [AB#988](https://dev.azure.com/ncia-anet/ANET/_workitems/edit/988)

To exclude `atmosphere` & `atmosphereDetails` field:

```yaml
fields:
  report:
   
   # Disable atmosphere & atmosphereDetails:
   atmosphere: no
   # atmosphereDetails
   
   # Disable nextSteps:
   nextSteps: no
   
    # Disable publication requirements: 
    requirements: 
      primaryAttendee: no
      attendingAuthor: no
      keyOutcomes: no
```

All changes to the `anet-dictionary.yml` are optional.

#### User changes
- 

#### Superuser changes
-

#### Admin changes
-

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [ ] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [ ] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
