### PR TITLE
Allow admins to edit published reports

### DIFF
--- a/client/src/pages/reports/Show.js
+++ b/client/src/pages/reports/Show.js
@@ -362,23 +362,26 @@ const ReportShow = ({ setSearchQuery, pageDispatchers }) => {
   const tasksLabel = pluralize(Settings.fields.task.subLevel.shortLabel)
   const DictField = DictionaryField(Field)
 
-  // User can approve if report is pending approval and user is one of the approvers in the current approval step
+  // User can approve when admin,
+  // or if report is pending approval and user is one of the approvers in the current approval step
   const canApprove =
-    report.isPending() &&
-    report.approvalStep?.approvers?.some(member =>
-      Position.isEqual(member, currentUser?.position)
-    )
-  const canRequestChanges = canApprove || (report.isApproved() && isAdmin)
+    isAdmin ||
+    (report.isPending() &&
+      report.approvalStep?.approvers?.some(member =>
+        Position.isEqual(member, currentUser?.position)
+      ))
   // Approved reports may be published by an admin user
   const canPublish = report.isApproved() && isAdmin
-  // Warn admins when they try to approve their own report
+  // Approvers and publishers can request changes
+  const canRequestChanges = canApprove || canPublish
+  // Warn authors when they try to approve their own report
   const warnApproveOwnReport = canApprove && isAuthor
 
   // Attending authors can edit if report is not published
   // Non-attending authors can only edit if it is future
   let canEdit =
     isAuthor && !report.isPublished() && (report.isFuture() || isAttending)
-  // Approvers can edit
+  // Approvers can also edit
   canEdit = canEdit || canApprove
   // Authors and approvers can always read assessments
   const canReadAssessments = isAuthor || canApprove


### PR DESCRIPTION
Admins can edit published reports, and also always approve reports (regardless of the workflow).

Closes [AB#991](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/991)

#### User changes
- None

#### Superuser changes
- None

#### Admin changes
- Admins can edit published reports, and also always approve reports (regardless of the workflow)

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
