### PR TITLE
Add all standard fields to the dictionary

### DIFF
--- a/anet-dictionary.yml
+++ b/anet-dictionary.yml
@@ -39,24 +39,28 @@ maxTextFieldLength: 250
 fields:
 
   task:
+    status:
+      label: Status
     shortLabel: Objective / Effort
     shortName:
       label: Objective / Effort number
-      placeholder: Enter an objective / effort name, example....
+      placeholder: Enter an objective / effort name, example …
     longLabel: Objectives and Efforts
     longName:
       label: Objective / Effort long name
-      placeholder: Enter an objective / effort long name, example ....
-    description: Objective / Effort description
+      placeholder: Enter an objective / effort long name, example …
+    description:
+      label: Objective / Effort description
+      placeholder: Fill in the description of this objective / effort
     topLevel:
       shortLabel: Objective
       shortName:
         label: Name of this Objective
-        placeholder: Enter a Name for this Objective name, example ....
+        placeholder: Enter a Name for this Objective name, example …
       longLabel: Objectives
       longName:
         label: Long Name of this Objective
-        placeholder: Enter a long name for this Objective, example ....
+        placeholder: Enter a long name for this Objective, example …
       assessments:
         topTaskOnceReport:
           label: Engagement assessment of objective
@@ -133,11 +137,11 @@ fields:
       shortLabel: Effort
       shortName:
         label: Effort name
-        placeholder: Enter an effort name, example....
+        placeholder: Enter an effort name, example …
       longLabel: Efforts
       longName:
         label: Effort Long Name
-        placeholder: Enter an effort Long Name, example ....
+        placeholder: Enter an effort Long Name, example …
       assessments:
         subTaskMonthly:
           label: Monthly assessment of effort
@@ -275,16 +279,21 @@ fields:
                 - type: required
                   params: [You must provide the answer to subTask11COnceReport.questionForNegative]
 
+    projectedCompletion:
+      label: Projected Completion
+    plannedCompletion:
+      label: Planned Completion
     parentTask:
       label: Parent objective / effort
       placeholder: Start typing to search for a higher level objective / effort
-    childrenTasks: Sub efforts
+    childrenTasks:
+      label: Sub efforts
     taskedOrganizations:
       label: Tasked organizations
-      placeholder: Search for an organization...
+      placeholder: Search for an organization…
     responsiblePositions:
       label: Responsible positions
-      placeholder: Search for a position...
+      placeholder: Search for a position…
     customFields:
       projectStatus:
         type: enum
@@ -304,11 +313,14 @@ fields:
   attachment:
     featureDisabled: false
     restrictToAdmins: false
-    fileName: Filename
+    fileName:
+      label: Filename
     caption:
       label: Caption
-      placeholder: Enter a caption, example....
-    description: Description
+      placeholder: Enter a caption
+    description:
+      label: Description
+      placeholder: Enter a description of this attachment
     classification:
       type: enum
       label: Security Marking
@@ -328,16 +340,35 @@ fields:
 
   report:
     canUnpublishReports: true
-    intent: Engagement purpose
-    atmosphere: Atmospherics
-    atmosphereDetails: Atmospherics details
-    cancelled: ''
+    intent:
+      label: Engagement purpose
+      placeholder: What is the engagement supposed to achieve?
+    engagementDate:
+      label: Engagement date
+    duration:
+      label: Duration (minutes)
+    atmosphere:
+      label: Atmospherics
+    atmosphereDetails:
+      label: Atmospherics details
+      placeholder: Describe the atmosphere
+    cancelled:
+      label: ''
+    cancelledReason:
+      label: due to
     nextSteps:
       label: Next steps
-      maxTextFieldLength: 1000
-    keyOutcomes: Key outcomes
-    reportText: Key details
+      placeholder: Fill in the next steps after this engagement
+      maxLength: 1000
+    keyOutcomes:
+      label: Key outcomes
+      placeholder: Fill in the key outcomes of this engagement
+    reportText:
+      label: Key details
+      placeholder: Fill in a detailed report of the engagement
     location:
+      label: Location
+      placeholder: Search for the engagement location…
       filter: [POINT_LOCATION, VIRTUAL_LOCATION]
     customFields:
       relatedReport:
@@ -474,19 +505,34 @@ fields:
           orgUuid: 70193ee9-05b4-4aac-80b5-75609825db9f
 
   person:
-    firstName: First name
-    lastName: Last name
-    domainUsername: Domain username
-    openIdSubject: OpenID subject
-    position: Current Position
-    prevPositions: Previous Positions
+    status:
+      label: Status
+    firstName:
+      label: First name
+      placeholder: First name(s) - Lower-case except for the first letter of each name
+    lastName:
+      label: Last name
+      placeholder: LAST NAME
+    domainUsername:
+      label: Domain username
+    openIdSubject:
+      label: OpenID subject
+    position:
+      label: Current Position
+      placeholder: Fill in the person's current position
+    prevPositions:
+      label: Previous Positions
     emailAddress:
       label: Email
       placeholder: Only the following email domain names are allowed. ( example.com, cmil.mil, mission.ita, nato.int, *.isaf.nato.int )
-    phoneNumber: Phone
-    country: Nationality
-    code: ID card number
-    rank: Rank
+    phoneNumber:
+      label: Phone
+    country:
+      label: Nationality
+    code:
+      label: ID card number
+    rank:
+      label: Rank
     ranks:
       - value: CIV
         description: the rank of CIV
@@ -547,9 +593,13 @@ fields:
       - value: OF-9
         description: the rank of OF-9
         app6Modifier: K
-    gender: Gender
-    endOfTourDate: End of tour
-    biography: Biography
+    gender:
+      label: Gender
+    endOfTourDate:
+      label: End of tour
+    biography:
+      label: Biography
+      placeholder: Fill in the biography of this person
     customFields:
       placeOfBirth:
         type: anet_object
@@ -675,6 +725,16 @@ fields:
             color: 'skyblue'
 
   location:
+    status:
+      label: Status
+    name:
+      label: Name
+      placeholder: Fill in the name of this location
+    type:
+      label: Type
+    description:
+      label: Description
+      placeholder: Fill in the description of this location
     superuserTypeOptions: [POINT_LOCATION]
     format: LAT_LON
     customFields:
@@ -757,7 +817,22 @@ fields:
             visibleWhen: $[?(@ && @.colourOptions === 'GREEN')]
 
   position:
-    name: Position Name
+    status:
+      label: Status
+    name:
+      label: Position Name
+      placeholder: Name/Description of Position
+    type:
+      label: Type
+    code:
+      label: Position code
+      placeholder: The official code for this position
+    organization:
+      label: Organization
+      placeholder: Search the organization for this position…
+    location:
+      label: Location
+      placeholder: Search for the location where this Position will operate from…
     role:
       label: Position Role
       types:
@@ -845,9 +920,30 @@ fields:
             visibleWhen: $[?(@ && @.colourOptions === 'GREEN')]
 
   organization:
-    shortName: Name
-    parentOrg: Parent Organization
-    profile: Profile
+    status:
+      label: Status
+    shortName:
+      label: Name
+      placeholder: e.g. EF1.1
+    longName:
+      label: Description
+      placeholder: e.g. Force Sustainment
+    identificationCode:
+      label: UIC
+      placeholder: the six character code
+    type:
+      label: Type
+    parentOrg:
+      label: Parent Organization
+      placeholder: Search for a higher level organization…
+    childrenOrgs:
+      label: Sub Organizations
+    location:
+      label: Location
+      placeholder: Search for the location where this Organization will operate from…
+    profile:
+      label: Profile
+      placeholder: Fill in the profile of this organization
     assessments:
       organizationAnnually:
         label: Interaction Plan
@@ -1456,29 +1552,20 @@ fields:
     position:
       name: NATO Billet
       type: ANET User
-      code:
-        label: CE Post Number
-        placeholder: the CE post number for this position
       location:
         filter: [POINT_LOCATION]
       organizationsAdministrated:
         label: Organizations administrated
-        placeholder: Search for an organization...
+        placeholder: Search for an organization…
 
     org:
       name: Advisor Organization
       allOrgName: Advisor Organizations
-      longName:
-        label: Description
-        placeholder: e.g. Force Sustainment
-      identificationCode:
-        label: UIC
-        placeholder: the six character code
       location:
         filter: [ADVISOR_LOCATION]
       administratingPositions:
         label: Assigned Superusers
-        placeholder: Search for a position...
+        placeholder: Search for a position…
 
   principal:
     person:
@@ -1719,26 +1806,17 @@ fields:
     position:
       name: Afghan Tashkil
       type: Afghan Partner
-      code:
-        label: Tashkil
-        placeholder: the Afghan taskhil ID for this position
       location:
         filter: [POINT_LOCATION]
 
     org:
       name: Afghan Government Organization
       allOrgName: Principal Organizations
-      longName:
-        label: Official Organization Name
-        placeholder: e.g. Afghan Ministry of Defense
-      identificationCode:
-        label: UIC
-        placeholder: the six character code
       location:
         filter: [PRINCIPAL_LOCATION]
       administratingPositions:
         label: Assigned Superusers
-        placeholder: Search for a position...
+        placeholder: Search for a position…
 
   superuser:
 

--- a/anet-dictionary.yml
+++ b/anet-dictionary.yml
@@ -281,8 +281,10 @@ fields:
 
     projectedCompletion:
       label: Projected Completion
+      exclude: true
     plannedCompletion:
       label: Planned Completion
+      exclude: true
     parentTask:
       label: Parent objective / effort
       placeholder: Start typing to search for a higher level objective / effort
@@ -349,9 +351,11 @@ fields:
       label: Duration (minutes)
     atmosphere:
       label: Atmospherics
+      exclude: false
     atmosphereDetails:
       label: Atmospherics details
       placeholder: Describe the atmosphere
+      exclude: false
     cancelled:
       label: ''
     cancelledReason:
@@ -360,9 +364,11 @@ fields:
       label: Next steps
       placeholder: Fill in the next steps after this engagement
       maxLength: 1000
+      exclude: false
     keyOutcomes:
       label: Key outcomes
       placeholder: Fill in the key outcomes of this engagement
+      exclude: false
     reportText:
       label: Key details
       placeholder: Fill in a detailed report of the engagement
@@ -531,6 +537,7 @@ fields:
       label: Nationality
     code:
       label: ID card number
+      exclude: true
     rank:
       label: Rank
     ranks:
@@ -595,8 +602,10 @@ fields:
         app6Modifier: K
     gender:
       label: Gender
+      exclude: false
     endOfTourDate:
       label: End of tour
+      exclude: false
     biography:
       label: Biography
       placeholder: Fill in the biography of this person
@@ -827,6 +836,7 @@ fields:
     code:
       label: Position code
       placeholder: The official code for this position
+      exclude: true
     organization:
       label: Organization
       placeholder: Search the organization for this position…
@@ -931,6 +941,7 @@ fields:
     identificationCode:
       label: UIC
       placeholder: the six character code
+      exclude: true
     type:
       label: Type
     parentOrg:
@@ -1117,7 +1128,6 @@ fields:
         - country
         - colourOptions
         - textareaFieldName
-        - code
         - rank
         - numberFieldName
         - nlt
@@ -1791,7 +1801,6 @@ fields:
         - emailAddress
         - multipleButtons
         - inputFieldName
-        - code
         - politicalPosition
         - rank
         - numberFieldName

--- a/anet-dictionary.yml
+++ b/anet-dictionary.yml
@@ -352,6 +352,7 @@ fields:
     atmosphere:
       label: Atmospherics
       exclude: false
+      optional: false
     atmosphereDetails:
       label: Atmospherics details
       placeholder: Describe the atmosphere
@@ -365,10 +366,12 @@ fields:
       placeholder: Fill in the next steps after this engagement
       maxLength: 1000
       exclude: false
+      optional: false
     keyOutcomes:
       label: Key outcomes
       placeholder: Fill in the key outcomes of this engagement
       exclude: false
+      optional: false
     reportText:
       label: Key details
       placeholder: Fill in a detailed report of the engagement
@@ -531,10 +534,12 @@ fields:
     emailAddress:
       label: Email
       placeholder: Only the following email domain names are allowed. ( example.com, cmil.mil, mission.ita, nato.int, *.isaf.nato.int )
+      optional: false
     phoneNumber:
       label: Phone
     country:
       label: Nationality
+      optional: false
     code:
       label: ID card number
       exclude: true
@@ -603,9 +608,11 @@ fields:
     gender:
       label: Gender
       exclude: false
+      optional: false
     endOfTourDate:
       label: End of tour
       exclude: false
+      optional: false
     biography:
       label: Biography
       placeholder: Fill in the biography of this person
@@ -843,6 +850,7 @@ fields:
     location:
       label: Location
       placeholder: Search for the location where this Position will operate from…
+      optional: false
     role:
       label: Position Role
       types:

--- a/client/src/HOC/DictionaryField.js
+++ b/client/src/HOC/DictionaryField.js
@@ -5,10 +5,15 @@ import React from "react"
 const DictionaryField = WrappedComponent => {
   const Wrapper = ({ dictProps, ...otherProps }) => {
     // Only display field if the dictProps are defined
-    if (_isEmpty(dictProps)) {
+    if (_isEmpty(dictProps) || dictProps?.exclude) {
       return null
     } else {
-      return <WrappedComponent {...Object.assign({}, dictProps, otherProps)} />
+      return (
+        <WrappedComponent
+          {...Object.without(dictProps, "exclude")}
+          {...otherProps}
+        />
+      )
     }
   }
   Wrapper.propTypes = {

--- a/client/src/HOC/DictionaryField.js
+++ b/client/src/HOC/DictionaryField.js
@@ -5,10 +5,10 @@ import React from "react"
 const DictionaryField = WrappedComponent => {
   const Wrapper = ({ dictProps, ...otherProps }) => {
     // Only display field if the dictProps are defined
-    if (!_isEmpty(dictProps)) {
-      return <WrappedComponent {...Object.assign({}, dictProps, otherProps)} />
-    } else {
+    if (_isEmpty(dictProps)) {
       return null
+    } else {
+      return <WrappedComponent {...Object.assign({}, dictProps, otherProps)} />
     }
   }
   Wrapper.propTypes = {

--- a/client/src/HOC/DictionaryField.js
+++ b/client/src/HOC/DictionaryField.js
@@ -10,7 +10,7 @@ const DictionaryField = WrappedComponent => {
     } else {
       return (
         <WrappedComponent
-          {...Object.without(dictProps, "exclude")}
+          {...Object.without(dictProps, "exclude", "optional")}
           {...otherProps}
         />
       )

--- a/client/src/components/AdvancedSearch.js
+++ b/client/src/components/AdvancedSearch.js
@@ -83,7 +83,7 @@ const AdvancedSearch = ({
           ? DictionaryField(Dropdown.Item)
           : Dropdown.Item
         const additionalProps = dictProps ? { dictProps } : {}
-        return (
+        return dictProps?.exclude ? null : (
           <ChildComponent
             disabled={existingKeys.includes(filterKey)}
             key={filterKey}
@@ -348,7 +348,7 @@ const SearchFilter = ({
   const additionalProps = dictProps ? { dictProps } : {}
   const { queryKey } = element.props || undefined
 
-  return (
+  return dictProps?.exclude ? null : (
     <FormGroup controlId={queryKey} className="form-group">
       <Row>
         <Col xs={12} sm={3} lg={2} className="label-align">

--- a/client/src/components/AdvancedSearch.js
+++ b/client/src/components/AdvancedSearch.js
@@ -10,6 +10,7 @@ import {
   SearchQueryPropType
 } from "components/SearchFilters"
 import { Form, Formik } from "formik"
+import DictionaryField from "HOC/DictionaryField"
 import _cloneDeep from "lodash/cloneDeep"
 import { Organization, Position } from "models"
 import PropTypes from "prop-types"
@@ -75,16 +76,25 @@ const AdvancedSearch = ({
 
   const advancedSearchMenuContent = (
     <Dropdown style={{ maxHeight: "400px", overflowY: "auto" }}>
-      {Object.keys(filterDefs).map(filterKey => (
-        <Dropdown.Item
-          disabled={existingKeys.includes(filterKey)}
-          key={filterKey}
-          onClick={() => addFilter(filterKey)}
-          // shouldDismissPopover={false}
-        >
-          {filterKey}
-        </Dropdown.Item>
-      ))}
+      {Object.entries(filterDefs).map(([filterKey, filterDef]) => {
+        const dictProps = filterDef.dictProps
+        const label = dictProps?.label || filterKey
+        const ChildComponent = dictProps
+          ? DictionaryField(Dropdown.Item)
+          : Dropdown.Item
+        const additionalProps = dictProps ? { dictProps } : {}
+        return (
+          <ChildComponent
+            disabled={existingKeys.includes(filterKey)}
+            key={filterKey}
+            onClick={() => addFilter(filterKey)}
+            {...additionalProps}
+            // shouldDismissPopover={false}
+          >
+            {label}
+          </ChildComponent>
+        )
+      })}
     </Dropdown>
   )
 
@@ -330,8 +340,12 @@ const SearchFilter = ({
   orgFilterQueryParams,
   updateOrgFilterQueryParams
 }) => {
-  const label = filter.key
-  const ChildComponent = element.component
+  const dictProps = element.dictProps
+  const label = dictProps?.label || filter.key
+  const ChildComponent = dictProps
+    ? DictionaryField(element.component)
+    : element.component
+  const additionalProps = dictProps ? { dictProps } : {}
   const { queryKey } = element.props || undefined
 
   return (
@@ -346,6 +360,7 @@ const SearchFilter = ({
               value={filter.value || ""}
               onChange={onChange}
               orgFilterQueryParams={orgFilterQueryParams}
+              {...additionalProps}
               {...element.props}
             />
           </div>
@@ -376,6 +391,7 @@ SearchFilter.propTypes = {
   updateOrgFilterQueryParams: PropTypes.func,
   element: PropTypes.shape({
     component: PropTypes.func.isRequired,
+    dictProps: PropTypes.object,
     props: PropTypes.object
   })
 }

--- a/client/src/components/EditAdministratingPositionsModal.js
+++ b/client/src/components/EditAdministratingPositionsModal.js
@@ -37,7 +37,7 @@ const EditAdministratingPositionsModal = ({
         ?.administratingPositions) ??
     []
 
-  const AdministratingPositionsMultiSelect = DictionaryField(FastField)
+  const DictFastField = DictionaryField(FastField)
   const positionsFilters = {
     allAdvisorPositions: {
       label: "All advisor positions",
@@ -74,10 +74,10 @@ const EditAdministratingPositionsModal = ({
                 <Container fluid>
                   <Row>
                     <Col md={12}>
-                      <AdministratingPositionsMultiSelect
+                      <DictFastField
+                        dictProps={orgSettings.administratingPositions}
                         name="administratingPositions"
                         component={FieldHelper.SpecialField}
-                        dictProps={orgSettings.administratingPositions}
                         onChange={value => {
                           // validation will be done by setFieldValue
                           value = value.map(position =>

--- a/client/src/components/EditOrganizationsAdministratedModal.js
+++ b/client/src/components/EditOrganizationsAdministratedModal.js
@@ -31,7 +31,7 @@ const EditOrganizationsAdministratedModal = ({
 }) => {
   const [error, setError] = useState(null)
 
-  const OrganizationsAdministratedMultiSelect = DictionaryField(FastField)
+  const DictFastField = DictionaryField(FastField)
   const organizationsFilters = {
     allOrganizations: {
       label: "All organizations",
@@ -65,10 +65,10 @@ const EditOrganizationsAdministratedModal = ({
                 <Container fluid>
                   <Row>
                     <Col md={12}>
-                      <OrganizationsAdministratedMultiSelect
+                      <DictFastField
+                        dictProps={organizationsAdministratedSettings}
                         name="organizationsAdministrated"
                         component={FieldHelper.SpecialField}
-                        dictProps={organizationsAdministratedSettings}
                         onChange={value => {
                           // validation will be done by setFieldValue
                           value = value.map(organization =>

--- a/client/src/components/FieldHelper.js
+++ b/client/src/components/FieldHelper.js
@@ -85,7 +85,8 @@ const Field = ({
   isCompact,
   extraAddon,
   labelColumnWidth,
-  className
+  className,
+  style
 }) => {
   const id = getFieldId(field)
   const widget = useMemo(
@@ -139,7 +140,7 @@ const Field = ({
           {children}
         </>
       ) : (
-        <Row style={{ marginBottom: "1rem" }}>
+        <Row style={{ marginBottom: "1rem", ...style }}>
           {label !== null && (
             <Col sm={labelColumnWidth} as={Form.Label}>
               {label}
@@ -170,7 +171,8 @@ Field.propTypes = {
   extraAddon: PropTypes.object,
   isCompact: PropTypes.bool,
   labelColumnWidth: PropTypes.number,
-  className: PropTypes.string
+  className: PropTypes.string,
+  style: PropTypes.object
 }
 Field.defaultProps = {
   vertical: false, // default direction of label and input = horizontal
@@ -276,7 +278,7 @@ export const ReadonlyField = ({
   isCompact,
   ...otherProps
 }) => {
-  const { className } = otherProps
+  const { className, style } = otherProps
   const widgetElem = useMemo(
     () => (
       <FormControl as="div" plaintext {...field} {...otherProps}>
@@ -297,6 +299,7 @@ export const ReadonlyField = ({
       vertical={vertical}
       isCompact={isCompact}
       className={className}
+      style={style}
     >
       {children}
     </Field>

--- a/client/src/components/FieldHelper.js
+++ b/client/src/components/FieldHelper.js
@@ -482,7 +482,7 @@ const ButtonToggleGroupField = ({
         {!_isEmpty(buttons) && enableClear && (
           <RemoveButton
             title="Clear choice"
-            onClick={() => form.setFieldValue(field.name, "", true)}
+            onClick={() => form.setFieldValue(field.name, null, true)}
           />
         )}
       </>

--- a/client/src/components/Nav.js
+++ b/client/src/components/Nav.js
@@ -201,11 +201,11 @@ const Navigation = ({
                 handleOnClick={resetPages}
               >
                 {`My ${pluralize(taskShortLabel)}`}
-                {notifications?.tasksWithPendingAssessments?.length ? (
+                {!!notifications?.tasksWithPendingAssessments?.length && (
                   <NotificationBadge>
                     {notifications.tasksWithPendingAssessments.length}
                   </NotificationBadge>
-                ) : null}
+                )}
               </SidebarLink>
               <SidebarLink
                 id="my-counterparts-nav"
@@ -213,11 +213,12 @@ const Navigation = ({
                 handleOnClick={resetPages}
               >
                 My Counterparts
-                {notifications?.counterpartsWithPendingAssessments?.length ? (
+                {!!notifications?.counterpartsWithPendingAssessments
+                  ?.length && (
                   <NotificationBadge>
                     {notifications.counterpartsWithPendingAssessments.length}
                   </NotificationBadge>
-                ) : null}
+                )}
               </SidebarLink>
             </>
           )}

--- a/client/src/components/ReportStatistics.js
+++ b/client/src/components/ReportStatistics.js
@@ -69,7 +69,7 @@ const REPORT_FIELDS_FOR_STATISTICS = {
   },
   atmosphere: {
     type: CUSTOM_FIELD_TYPE.ENUM,
-    label: Settings.fields.report.atmosphere,
+    label: Settings.fields.report.atmosphere?.label,
     choices: choicesFactory(Report.ATMOSPHERE, Report.ATMOSPHERE_LABELS)
   }
 }

--- a/client/src/components/ReportSummary.js
+++ b/client/src/components/ReportSummary.js
@@ -292,7 +292,7 @@ const ReportSummaryRow = ({ report }) => {
         <Row>
           <Col md={12}>
             <span>
-              <strong>Location: </strong>
+              <strong>{Settings.fields.report.location?.label}: </strong>
               <LinkTo modelType="Location" model={report.location} />
               {"  "}
               <Badge bg="secondary">
@@ -306,7 +306,8 @@ const ReportSummaryRow = ({ report }) => {
         <Col md={12}>
           {report.intent && (
             <span>
-              <strong>{Settings.fields.report.intent}:</strong> {report.intent}
+              <strong>{Settings.fields.report.intent?.label}:</strong>{" "}
+              {report.intent}
             </span>
           )}
         </Col>
@@ -315,7 +316,7 @@ const ReportSummaryRow = ({ report }) => {
         <Col md={12}>
           {report.keyOutcomes && (
             <span>
-              <strong>{Settings.fields.report.keyOutcomes}:</strong>{" "}
+              <strong>{Settings.fields.report.keyOutcomes?.label}:</strong>{" "}
               {report.keyOutcomes}
             </span>
           )}
@@ -325,7 +326,7 @@ const ReportSummaryRow = ({ report }) => {
         <Col md={12}>
           {report.nextSteps && (
             <span>
-              <strong>{Settings.fields.report.nextSteps.label}:</strong>{" "}
+              <strong>{Settings.fields.report.nextSteps?.label}:</strong>{" "}
               {report.nextSteps}
             </span>
           )}
@@ -335,7 +336,7 @@ const ReportSummaryRow = ({ report }) => {
         <Col md={12}>
           {report.atmosphere && (
             <span>
-              <strong>{Settings.fields.report.atmosphere}:</strong>{" "}
+              <strong>{Settings.fields.report.atmosphere?.label}:</strong>{" "}
               {utils.sentenceCase(report.atmosphere)}
               {report.atmosphereDetails && ` – ${report.atmosphereDetails}`}
             </span>

--- a/client/src/components/RichTextEditor.js
+++ b/client/src/components/RichTextEditor.js
@@ -86,6 +86,7 @@ const ELEMENT_TAGS = {
 
 const RichTextEditor = ({
   value,
+  placeholder,
   onChange,
   onHandleBlur,
   className,
@@ -184,6 +185,7 @@ const RichTextEditor = ({
             />
           )}
           <Editable
+            placeholder={placeholder}
             renderElement={renderElement}
             renderLeaf={renderLeaf}
             onBlur={onHandleBlur}
@@ -210,6 +212,7 @@ const RichTextEditor = ({
 
 RichTextEditor.propTypes = {
   value: PropTypes.string,
+  placeholder: PropTypes.string,
   onChange: PropTypes.func,
   onHandleBlur: PropTypes.func,
   className: PropTypes.string,

--- a/client/src/components/SearchFilters.js
+++ b/client/src/components/SearchFilters.js
@@ -605,7 +605,7 @@ const SearchFilterDisplay = ({ filter, element, showSeparator }) => {
     : element.component
   const additionalProps = dictProps ? { dictProps } : {}
   const sep = showSeparator ? ", " : ""
-  return (
+  return dictProps?.exclude ? null : (
     <>
       <b>{label}</b>:{" "}
       <em>

--- a/client/src/components/SearchFilters.js
+++ b/client/src/components/SearchFilters.js
@@ -31,6 +31,7 @@ import {
 } from "components/advancedSelectWidget/AdvancedSelectOverlayRow"
 import { getBreadcrumbTrailAsText } from "components/BreadcrumbTrail"
 import Model from "components/Model"
+import DictionaryField from "HOC/DictionaryField"
 import _isEmpty from "lodash/isEmpty"
 import _pickBy from "lodash/pickBy"
 import { Location, Organization, Person, Position, Report, Task } from "models"
@@ -92,52 +93,6 @@ const SubscriptionFilter = {
     queryKey: "subscribed",
     msg: "By me"
   }
-}
-
-const taskFilters = () => {
-  const taskShortLabel = Settings.fields.task.shortLabel
-  const taskFiltersObj = {
-    "Within Organization": {
-      component: OrganizationFilter,
-      deserializer: deserializeOrganizationFilter,
-      props: {
-        queryKey: "taskedOrgUuid",
-        queryRecurseStrategyKey: "orgRecurseStrategy",
-        fixedRecurseStrategy: RECURSE_STRATEGY.CHILDREN
-      }
-    },
-    [`Within ${taskShortLabel}`]: {
-      component: TaskFilter,
-      deserializer: deserializeTaskFilter,
-      props: {
-        queryKey: "parentTaskUuid",
-        queryRecurseStrategyKey: "parentTaskRecurseStrategy",
-        fixedRecurseStrategy: RECURSE_STRATEGY.CHILDREN
-      }
-    }
-  }
-  const projectedCompletion = Settings.fields.task.projectedCompletion
-  if (projectedCompletion) {
-    taskFiltersObj[projectedCompletion.label] = {
-      component: DateRangeFilter,
-      deserializer: deserializeDateRangeFilter,
-      props: {
-        queryKey: "projectedCompletion"
-      }
-    }
-  }
-  const plannedCompletion = Settings.fields.task.plannedCompletion
-  if (plannedCompletion) {
-    taskFiltersObj[plannedCompletion.label] = {
-      component: DateRangeFilter,
-      deserializer: deserializeDateRangeFilter,
-      props: {
-        queryKey: "plannedCompletion"
-      }
-    }
-  }
-
-  return taskFiltersObj
 }
 
 const advancedSelectFilterPersonProps = {
@@ -285,6 +240,7 @@ export const searchFilters = function() {
       },
       "Engagement Date": {
         component: DateRangeFilter,
+        dictProps: Settings.fields.report.engagementDate,
         deserializer: deserializeDateRangeFilter,
         props: {
           queryKey: "engagementDate"
@@ -313,6 +269,7 @@ export const searchFilters = function() {
       },
       Location: {
         component: AdvancedSelectFilter,
+        dictProps: Settings.fields.report.location,
         deserializer: deserializeAdvancedSelectFilter,
         props: Object.assign({}, advancedSelectFilterLocationProps, {
           filterDefs: locationWidgetFilters,
@@ -339,8 +296,9 @@ export const searchFilters = function() {
           ]
         }
       },
-      [Settings.fields.report.atmosphere]: {
+      Atmospherics: {
         component: SelectFilter,
+        dictProps: Settings.fields.report.atmosphere,
         deserializer: deserializeSelectFilter,
         props: {
           queryKey: "atmosphere",
@@ -386,6 +344,7 @@ export const searchFilters = function() {
       },
       Role: {
         component: SelectFilter,
+        dictProps: Settings.fields.person.role,
         deserializer: deserializeSelectFilter,
         props: {
           queryKey: "role",
@@ -407,6 +366,7 @@ export const searchFilters = function() {
       },
       Rank: {
         component: SelectFilter,
+        dictProps: Settings.fields.person.rank,
         deserializer: deserializeSelectFilter,
         props: {
           queryKey: "rank",
@@ -416,6 +376,7 @@ export const searchFilters = function() {
       },
       Nationality: {
         component: SelectFilter,
+        dictProps: Settings.fields.person.country,
         deserializer: deserializeSelectFilter,
         props: {
           queryKey: "country",
@@ -450,6 +411,7 @@ export const searchFilters = function() {
     filters: {
       "Organization Type": {
         component: SelectFilter,
+        dictProps: Settings.fields.organization.type,
         deserializer: deserializeSelectFilter,
         props: {
           queryKey: "type",
@@ -474,6 +436,7 @@ export const searchFilters = function() {
       },
       Location: {
         component: AdvancedSelectFilter,
+        dictProps: Settings.fields.organization.location,
         deserializer: deserializeAdvancedSelectFilter,
         props: Object.assign({}, advancedSelectFilterLocationProps, {
           filterDefs: locationWidgetFilters,
@@ -497,6 +460,7 @@ export const searchFilters = function() {
     filters: {
       [POSITION_POSITION_TYPE_FILTER_KEY]: {
         component: SelectFilter,
+        dictProps: Settings.fields.position.type,
         deserializer: deserializeSelectFilter,
         props: {
           queryKey: "type",
@@ -526,6 +490,7 @@ export const searchFilters = function() {
       },
       Location: {
         component: AdvancedSelectFilter,
+        dictProps: Settings.fields.position.location,
         deserializer: deserializeAdvancedSelectFilter,
         props: Object.assign({}, advancedSelectFilterLocationProps, {
           filterDefs: locationWidgetFilters,
@@ -564,6 +529,7 @@ export const searchFilters = function() {
     filters: {
       "Location Type": {
         component: SelectFilter,
+        dictProps: Settings.fields.location.type,
         deserializer: deserializeSelectFilter,
         props: {
           queryKey: "type",
@@ -574,9 +540,43 @@ export const searchFilters = function() {
     }
   }
 
-  // Task filters
   filters[SEARCH_OBJECT_TYPES.TASKS] = {
-    filters: taskFilters()
+    filters: {
+      "Within Organization": {
+        component: OrganizationFilter,
+        deserializer: deserializeOrganizationFilter,
+        props: {
+          queryKey: "taskedOrgUuid",
+          queryRecurseStrategyKey: "orgRecurseStrategy",
+          fixedRecurseStrategy: RECURSE_STRATEGY.CHILDREN
+        }
+      },
+      [`Within ${Settings.fields.task.shortLabel}`]: {
+        component: TaskFilter,
+        deserializer: deserializeTaskFilter,
+        props: {
+          queryKey: "parentTaskUuid",
+          queryRecurseStrategyKey: "parentTaskRecurseStrategy",
+          fixedRecurseStrategy: RECURSE_STRATEGY.CHILDREN
+        }
+      },
+      "Projected Completion": {
+        component: DateRangeFilter,
+        dictProps: Settings.fields.task.projectedCompletion,
+        deserializer: deserializeDateRangeFilter,
+        props: {
+          queryKey: "projectedCompletion"
+        }
+      },
+      "Planned Completion": {
+        component: DateRangeFilter,
+        dictProps: Settings.fields.task.plannedCompletion,
+        deserializer: deserializeDateRangeFilter,
+        props: {
+          queryKey: "plannedCompletion"
+        }
+      }
+    }
   }
 
   for (const filtersForType of Object.values(filters)) {
@@ -598,8 +598,12 @@ const extraFilters = function() {
 }
 
 const SearchFilterDisplay = ({ filter, element, showSeparator }) => {
-  const label = filter.key
-  const ChildComponent = element.component
+  const dictProps = element.dictProps
+  const label = dictProps?.label || filter.key
+  const ChildComponent = dictProps
+    ? DictionaryField(element.component)
+    : element.component
+  const additionalProps = dictProps ? { dictProps } : {}
   const sep = showSeparator ? ", " : ""
   return (
     <>
@@ -608,6 +612,7 @@ const SearchFilterDisplay = ({ filter, element, showSeparator }) => {
         <ChildComponent
           value={filter.value || ""}
           asFormField={false}
+          {...additionalProps}
           {...element.props}
         />
       </em>
@@ -620,6 +625,7 @@ SearchFilterDisplay.propTypes = {
   filter: PropTypes.object,
   element: PropTypes.shape({
     component: PropTypes.func.isRequired,
+    dictProps: PropTypes.object,
     props: PropTypes.object
   }),
   showSeparator: PropTypes.bool
@@ -637,31 +643,30 @@ export const SearchDescription = ({ searchQuery, showPlaceholders }) => {
   const filters = searchQuery.filters
   return (
     <span className="asLink">
-      <>
-        <b>
-          {searchQuery.objectType
-            ? SEARCH_OBJECT_LABELS[searchQuery.objectType]
-            : "Everything"}
-        </b>
-        {filters.length > 0 ? (
-          <>
-            <> filtered on </>
-            {filters.map(
-              (filter, i) =>
-                filterDefs[filter.key] && (
-                  <SearchFilterDisplay
-                    key={filter.key}
-                    filter={filter}
-                    element={filterDefs[filter.key]}
-                    showSeparator={i !== filters.length - 1}
-                  />
-                )
-            )}
-          </>
-        ) : (
-          showPlaceholders && " - add filters"
-        )}
-      </>
+      <b>
+        {searchQuery.objectType
+          ? SEARCH_OBJECT_LABELS[searchQuery.objectType]
+          : "Everything"}
+      </b>
+      {filters.length > 0 ? (
+        <>
+          {" "}
+          filtered on{" "}
+          {filters.map(
+            (filter, i) =>
+              filterDefs[filter.key] && (
+                <SearchFilterDisplay
+                  key={filter.key}
+                  filter={filter}
+                  element={filterDefs[filter.key]}
+                  showSeparator={i !== filters.length - 1}
+                />
+              )
+          )}
+        </>
+      ) : (
+        showPlaceholders && " - add filters"
+      )}
     </span>
   )
 }

--- a/client/src/components/previews/AttachmentPreview.js
+++ b/client/src/components/previews/AttachmentPreview.js
@@ -3,6 +3,7 @@ import API from "api"
 import { PreviewField } from "components/FieldHelper"
 import LinkTo from "components/LinkTo"
 import RichTextEditor from "components/RichTextEditor"
+import DictionaryField from "HOC/DictionaryField"
 import { Attachment } from "models"
 import PropTypes from "prop-types"
 import React from "react"
@@ -39,6 +40,7 @@ const AttachmentPreview = ({ className, uuid }) => {
 
   const attachment = new Attachment(data.attachment ? data.attachment : {})
   const { backgroundImage } = utils.getAttachmentIconDetails(attachment)
+  const DictPreviewField = DictionaryField(PreviewField)
 
   return (
     <div className={`${className} preview-content-scroll`}>
@@ -55,8 +57,8 @@ const AttachmentPreview = ({ className, uuid }) => {
                 style={{ width: "100%", borderRadius: "5px" }}
               />
             </Col>
-            <PreviewField
-              label={Settings.fields.attachment.fileName}
+            <DictPreviewField
+              dictProps={Settings.fields.attachment.fileName}
               value={attachment.fileName}
             />
             <PreviewField
@@ -68,8 +70,8 @@ const AttachmentPreview = ({ className, uuid }) => {
               label="Content length"
               value={utils.humanReadableFileSize(attachment.contentLength)}
             />
-            <PreviewField
-              label={Settings.fields.attachment.classification.label}
+            <DictPreviewField
+              dictProps={Settings.fields.attachment.classification}
               value={Attachment.humanNameOfStatus(
                 attachment.classification
               ).toUpperCase()}
@@ -78,7 +80,7 @@ const AttachmentPreview = ({ className, uuid }) => {
         </Row>
 
         <div className="preview-field-label">
-          {Settings.fields.attachment.description}
+          {Settings.fields.attachment.description?.label}
         </div>
         <div className="preview-field-value">
           <RichTextEditor readOnly value={attachment.description} />

--- a/client/src/components/previews/LocationPreview.js
+++ b/client/src/components/previews/LocationPreview.js
@@ -5,10 +5,12 @@ import GeoLocation from "components/GeoLocation"
 import Leaflet from "components/Leaflet"
 import RichTextEditor from "components/RichTextEditor"
 import { convertLatLngToMGRS } from "geoUtils"
+import DictionaryField from "HOC/DictionaryField"
 import _escape from "lodash/escape"
 import { Location } from "models"
 import PropTypes from "prop-types"
 import React from "react"
+import Settings from "settings"
 
 const GQL_GET_LOCATION = gql`
   query ($uuid: String!) {
@@ -38,6 +40,7 @@ const LocationPreview = ({ className, uuid }) => {
 
   const location = new Location(data.location ? data.location : {})
   const label = Location.LOCATION_FORMAT_LABELS[Location.locationFormat]
+  const DictPreviewField = DictionaryField(PreviewField)
 
   const marker = {
     id: location.uuid || 0,
@@ -56,8 +59,8 @@ const LocationPreview = ({ className, uuid }) => {
         <h4>{`Location ${location.name}`}</h4>
       </div>
       <div className="preview-section">
-        <PreviewField
-          label="Type"
+        <DictPreviewField
+          dictProps={Settings.fields.location.type}
           value={Location.humanNameOfType(location.type)}
         />
 
@@ -77,14 +80,14 @@ const LocationPreview = ({ className, uuid }) => {
           }
         />
 
-        <PreviewField
-          label="Status"
+        <DictPreviewField
+          dictProps={Settings.fields.location.status}
           value={Location.humanNameOfStatus(location.status)}
         />
 
         {location.description && (
-          <PreviewField
-            label="Description"
+          <DictPreviewField
+            dictProps={Settings.fields.location.description}
             value={<RichTextEditor readOnly value={location.description} />}
           />
         )}

--- a/client/src/components/previews/OrganizationPreview.js
+++ b/client/src/components/previews/OrganizationPreview.js
@@ -4,6 +4,7 @@ import { PreviewField } from "components/FieldHelper"
 import LinkTo from "components/LinkTo"
 import Model from "components/Model"
 import RichTextEditor from "components/RichTextEditor"
+import DictionaryField from "HOC/DictionaryField"
 import _isEmpty from "lodash/isEmpty"
 import { Location, Organization } from "models"
 import { PositionRole } from "models/Position"
@@ -121,11 +122,7 @@ const OrganizationPreview = ({ className, uuid }) => {
   const organization = new Organization(
     data.organization ? data.organization : {}
   )
-
-  const isPrincipalOrg = organization.type === Organization.TYPE.PRINCIPAL_ORG
-  const orgSettings = isPrincipalOrg
-    ? Settings.fields.principal.org
-    : Settings.fields.advisor.org
+  const DictPreviewField = DictionaryField(PreviewField)
 
   return (
     <div className={`${className} preview-content-scroll`}>
@@ -133,19 +130,19 @@ const OrganizationPreview = ({ className, uuid }) => {
         <h4>{`Organization ${organization.shortName}`}</h4>
       </div>
       <div className="preview-section">
-        <PreviewField
-          label={orgSettings.longName.label}
+        <DictPreviewField
+          dictProps={Settings.fields.organization.longName}
           value={organization.longName}
         />
 
-        <PreviewField
-          label="Type"
+        <DictPreviewField
+          dictProps={Settings.fields.organization.type}
           value={Organization.humanNameOfType(organization.type)}
         />
 
         {organization?.parentOrg?.uuid && (
-          <PreviewField
-            label={Settings.fields.organization.parentOrg}
+          <DictPreviewField
+            dictProps={Settings.fields.organization.parentOrg}
             value={
               <LinkTo modelType="Organization" model={organization.parentOrg} />
             }
@@ -153,8 +150,8 @@ const OrganizationPreview = ({ className, uuid }) => {
         )}
 
         {organization?.childrenOrgs?.length > 0 && (
-          <PreviewField
-            label="Sub organizations"
+          <DictPreviewField
+            dictProps={Settings.fields.organization.childrenOrgs}
             value={
               <ListGroup>
                 {organization.childrenOrgs.map(childOrg => (
@@ -179,13 +176,13 @@ const OrganizationPreview = ({ className, uuid }) => {
           pluralize(utils.titleCase(PositionRole.DEPUTY.humanNameOfRole()))
         )}
 
-        <PreviewField
-          label={orgSettings.identificationCode?.label}
+        <DictPreviewField
+          dictProps={Settings.fields.organization.identificationCode}
           value={organization.identificationCode}
         />
 
-        <PreviewField
-          label="Location"
+        <DictPreviewField
+          dictProps={Settings.fields.organization.location}
           value={
             organization.location && (
               <>
@@ -198,14 +195,14 @@ const OrganizationPreview = ({ className, uuid }) => {
           }
         />
 
-        <PreviewField
-          label="Status"
+        <DictPreviewField
+          dictProps={Settings.fields.organization.status}
           value={Organization.humanNameOfStatus(organization.status)}
         />
 
         {organization.profile && (
-          <PreviewField
-            label={Settings.fields.organization.profile}
+          <DictPreviewField
+            dictProps={Settings.fields.organization.profile}
             value={<RichTextEditor readOnly value={organization.profile} />}
           />
         )}

--- a/client/src/components/previews/PersonPreview.js
+++ b/client/src/components/previews/PersonPreview.js
@@ -7,6 +7,7 @@ import LinkTo from "components/LinkTo"
 import { DEFAULT_CUSTOM_FIELDS_PARENT } from "components/Model"
 import PreviousPositions from "components/PreviousPositions"
 import RichTextEditor from "components/RichTextEditor"
+import DictionaryField from "HOC/DictionaryField"
 import { Person, Position } from "models"
 import moment from "moment"
 import PropTypes from "prop-types"
@@ -96,6 +97,8 @@ const PersonPreview = ({ className, uuid }) => {
   )
 
   const person = new Person(data.person ? data.person : {})
+  const DictPreviewField = DictionaryField(PreviewField)
+
   // The position for this person's counterparts
   const position = person.position
   const assignedRole =
@@ -124,56 +127,56 @@ const PersonPreview = ({ className, uuid }) => {
               />
             </div>
 
-            <PreviewField
-              label={Settings.fields.person.rank}
+            <DictPreviewField
+              dictProps={Settings.fields.person.rank}
               value={person.rank}
             />
 
-            <PreviewField
-              label="Role"
+            <DictPreviewField
+              dictProps={Settings.fields.person.role}
               value={Person.humanNameOfRole(person.role)}
             />
 
             {isAdmin && (
-              <PreviewField
-                label={Settings.fields.person.domainUsername}
+              <DictPreviewField
+                dictProps={Settings.fields.person.domainUsername}
                 value={person.domainUsername}
               />
             )}
 
-            <PreviewField
-              label="Status"
+            <DictPreviewField
+              dictProps={Settings.fields.person.status}
               value={Person.humanNameOfStatus(person.status)}
             />
           </Col>
           <Col>
-            <PreviewField
-              label={Settings.fields.person.phoneNumber}
+            <DictPreviewField
+              dictProps={Settings.fields.person.phoneNumber}
               value={person.phoneNumber}
             />
 
-            <PreviewField
-              label={Settings.fields.person.emailAddress.label}
+            <DictPreviewField
+              dictProps={Settings.fields.person.emailAddress}
               value={person.emailAddress}
             />
 
-            <PreviewField
-              label={Settings.fields.person.country}
+            <DictPreviewField
+              dictProps={Settings.fields.person.country}
               value={person.country}
             />
 
-            <PreviewField
-              label={Settings.fields.person.code}
+            <DictPreviewField
+              dictProps={Settings.fields.person.code}
               value={person.code}
             />
 
-            <PreviewField
-              label={Settings.fields.person.gender}
+            <DictPreviewField
+              dictProps={Settings.fields.person.gender}
               value={person.gender}
             />
 
-            <PreviewField
-              label={Settings.fields.person.endOfTourDate}
+            <DictPreviewField
+              dictProps={Settings.fields.person.endOfTourDate}
               value={
                 person.endOfTourDate &&
                 moment(person.endOfTourDate).format(
@@ -184,16 +187,17 @@ const PersonPreview = ({ className, uuid }) => {
           </Col>
         </Row>
 
-        <div className="preview-field-label">Biography</div>
+        <div className="preview-field-label">
+          {Settings.fields.person.biography?.label}
+        </div>
         <div className="preview-field-value">
           <RichTextEditor readOnly value={person.biography} />
         </div>
       </div>
       <br />
-      <h4>Position</h4>
+      <h4>{Settings.fields.person.position?.label}</h4>
       <div className="preview-section">
         <div
-          title="Current Position"
           id="current-position"
           className={!position || !position.uuid ? "warning" : undefined}
         >
@@ -209,7 +213,7 @@ const PersonPreview = ({ className, uuid }) => {
         )}
       </div>
       <br />
-      <h4>Previous positions</h4>
+      <h4>{Settings.fields.person.prevPositions?.label}</h4>
       <div className="preview-section">
         <PreviousPositions history={person.previousPositions} />
       </div>

--- a/client/src/components/previews/PositionPreview.js
+++ b/client/src/components/previews/PositionPreview.js
@@ -2,6 +2,7 @@ import { gql } from "@apollo/client"
 import API from "api"
 import { PreviewField } from "components/FieldHelper"
 import LinkTo from "components/LinkTo"
+import DictionaryField from "HOC/DictionaryField"
 import { Location, Position } from "models"
 import moment from "moment"
 import PropTypes from "prop-types"
@@ -84,14 +85,12 @@ const PositionPreview = ({ className, uuid }) => {
   }
 
   const position = new Position(data.position ? data.position : {})
+  const DictPreviewField = DictionaryField(PreviewField)
 
   const isPrincipal = position.type === Position.TYPE.PRINCIPAL
   const assignedRole = isPrincipal
     ? Settings.fields.advisor.person.name
     : Settings.fields.principal.person.name
-  const positionSettings = isPrincipal
-    ? Settings.fields.principal.position
-    : Settings.fields.advisor.position
 
   return (
     <div className={`${className} preview-content-scroll`}>
@@ -99,22 +98,22 @@ const PositionPreview = ({ className, uuid }) => {
         <h4>{`Position ${position.name}`}</h4>
       </div>
       <div className="preview-section">
-        <PreviewField
-          label="Type"
+        <DictPreviewField
+          dictProps={Settings.fields.position.type}
           value={Position.humanNameOfType(position.type)}
         />
 
         {position.organization && (
-          <PreviewField
-            label="Organization"
+          <DictPreviewField
+            dictProps={Settings.fields.position.organization}
             value={
               <LinkTo modelType="Organization" model={position.organization} />
             }
           />
         )}
 
-        <PreviewField
-          label="Location"
+        <DictPreviewField
+          dictProps={Settings.fields.position.location}
           value={
             position.location && (
               <>
@@ -127,18 +126,18 @@ const PositionPreview = ({ className, uuid }) => {
           }
         />
 
-        <PreviewField
-          label={positionSettings.code.label}
+        <DictPreviewField
+          dictProps={Settings.fields.position.code}
           value={position.code}
         />
 
-        <PreviewField
-          label="Status"
+        <DictPreviewField
+          dictProps={Settings.fields.position.status}
           value={Position.humanNameOfStatus(position.status)}
         />
 
-        <PreviewField
-          label={Settings.fields.position.role.label}
+        <DictPreviewField
+          dictProps={Settings.fields.position.role}
           value={Position.humanNameOfRole(position.role)}
         />
       </div>

--- a/client/src/components/previews/ReportPreview.js
+++ b/client/src/components/previews/ReportPreview.js
@@ -5,6 +5,7 @@ import LinkTo from "components/LinkTo"
 import NoPaginationTaskTable from "components/NoPaginationTaskTable"
 import PlanningConflictForReport from "components/PlanningConflictForReport"
 import RichTextEditor from "components/RichTextEditor"
+import DictionaryField from "HOC/DictionaryField"
 import { Person, Report, Task } from "models"
 import moment from "moment"
 import ReportPeople from "pages/reports/ReportPeople"
@@ -122,6 +123,7 @@ const ReportPreview = ({ className, uuid }) => {
   report = new Report(data.report)
   const reportType = report.isFuture() ? "planned engagement" : "report"
   const tasksLabel = pluralize(Settings.fields.task.subLevel.shortLabel)
+  const DictPreviewField = DictionaryField(PreviewField)
 
   // Get initial tasks/people instant assessments values
   const hasAssessments = report.engagementDate && !report.isFuture()
@@ -174,32 +176,29 @@ const ReportPreview = ({ className, uuid }) => {
           extraColForValue
           label="Summary"
           value={
-            <div id="intent" className="form-control-static">
-              <p>
-                <strong>{Settings.fields.report.intent}:</strong>{" "}
-                {report.intent}
-              </p>
-              {report.keyOutcomes && (
-                <p>
-                  <span>
-                    <strong>
-                      {Settings.fields.report.keyOutcomes || "Key outcomes"}:
-                    </strong>{" "}
-                    {report.keyOutcomes}&nbsp;
-                  </span>
-                </p>
-              )}
-              <p>
-                <strong>{Settings.fields.report.nextSteps.label}:</strong>{" "}
-                {report.nextSteps}
-              </p>
+            <div id="report-summary">
+              <DictPreviewField
+                dictProps={Settings.fields.report.intent}
+                name="intent"
+                style={{ marginBottom: 0 }}
+              />
+              <DictPreviewField
+                dictProps={Settings.fields.report.keyOutcomes}
+                name="keyOutcomes"
+                style={{ marginBottom: 0 }}
+              />
+              <DictPreviewField
+                dictProps={Settings.fields.report.nextSteps}
+                name="nextSteps"
+                style={{ marginBottom: 0 }}
+              />
             </div>
           }
         />
 
-        <PreviewField
+        <DictPreviewField
+          dictProps={Settings.fields.report.engagementDate}
           extraColForValue
-          label="Engagement date"
           value={
             <>
               <>
@@ -214,9 +213,9 @@ const ReportPreview = ({ className, uuid }) => {
         />
 
         {Settings.engagementsIncludeTimeAndDuration && report.duration && (
-          <PreviewField
+          <DictPreviewField
+            dictProps={Settings.fields.report.duration}
             extraColForValue
-            label="Duration (minutes)"
             value={report.duration}
           />
         )}
@@ -246,9 +245,9 @@ const ReportPreview = ({ className, uuid }) => {
           }
         />
 
-        <PreviewField
+        <DictPreviewField
+          dictProps={Settings.fields.report.location}
           extraColForValue
-          label="Location"
           value={
             report.location && (
               <LinkTo modelType="Location" model={report.location} />
@@ -257,24 +256,26 @@ const ReportPreview = ({ className, uuid }) => {
         />
 
         {report.cancelled && (
-          <PreviewField
+          <DictPreviewField
+            dictProps={Settings.fields.report.cancelledReason}
             extraColForValue
-            label="Cancelled Reason"
             value={utils.sentenceCase(report.cancelledReason)}
           />
         )}
 
         {!report.cancelled && (
-          <PreviewField
-            extraColForValue
-            label={Settings.fields.report.atmosphere}
-            value={
-              <>
-                {utils.sentenceCase(report.atmosphere)}
-                {report.atmosphereDetails && ` – ${report.atmosphereDetails}`}
-              </>
-            }
-          />
+          <>
+            <DictPreviewField
+              dictProps={Settings.fields.report.atmosphere}
+              extraColForValue
+              value={utils.sentenceCase(report.atmosphere)}
+            />
+            <DictPreviewField
+              dictProps={Settings.fields.report.atmosphereDetails}
+              extraColForValue
+              value={report.atmosphereDetails}
+            />
+          </>
         )}
       </div>
       <h4>
@@ -287,7 +288,7 @@ const ReportPreview = ({ className, uuid }) => {
       </div>
       {report.reportText && (
         <>
-          <h4>{Settings.fields.report.reportText}</h4>
+          <h4>{Settings.fields.report.reportText.label}</h4>
           <div className="preview-section">
             <RichTextEditor readOnly value={report.reportText} />
           </div>

--- a/client/src/components/previews/TaskPreview.js
+++ b/client/src/components/previews/TaskPreview.js
@@ -6,6 +6,7 @@ import LinkTo from "components/LinkTo"
 import Model from "components/Model"
 import PositionTable from "components/PositionTable"
 import RichTextEditor from "components/RichTextEditor"
+import DictionaryField from "HOC/DictionaryField"
 import { Task } from "models"
 import moment from "moment"
 import PropTypes from "prop-types"
@@ -125,6 +126,7 @@ const TaskPreview = ({ className, uuid }) => {
     Model.populateCustomFields(data.task)
   }
   const task = new Task(data.task ? data.task : {})
+  const DictPreviewField = DictionaryField(PreviewField)
 
   const fieldSettings = task.fieldSettings()
   return (
@@ -133,12 +135,12 @@ const TaskPreview = ({ className, uuid }) => {
         <h4>{`${fieldSettings.shortLabel} ${task.shortName}`}</h4>
       </div>
       <div className="preview-section">
-        <PreviewField
-          label={fieldSettings.longName.label}
+        <DictPreviewField
+          dictProps={fieldSettings.longName}
           value={task.longName}
         />
-        <PreviewField
-          label={Settings.fields.task.taskedOrganizations.label}
+        <DictPreviewField
+          dictProps={Settings.fields.task.taskedOrganizations}
           value={
             task.taskedOrganizations && (
               <>
@@ -155,8 +157,8 @@ const TaskPreview = ({ className, uuid }) => {
         />
 
         {Settings.fields.task.parentTask && task.parentTask?.uuid && (
-          <PreviewField
-            label={Settings.fields.task.parentTask.label}
+          <DictPreviewField
+            dictProps={Settings.fields.task.parentTask}
             value={
               task.parentTask && (
                 <BreadcrumbTrail
@@ -172,8 +174,8 @@ const TaskPreview = ({ className, uuid }) => {
 
         {Settings.fields.task.childrenTasks &&
           task.childrenTasks?.length > 0 && (
-            <PreviewField
-              label={Settings.fields.task.childrenTasks}
+            <DictPreviewField
+              dictProps={Settings.fields.task.childrenTasks}
               name="subEfforts"
               value={
                 <ListGroup>
@@ -188,8 +190,8 @@ const TaskPreview = ({ className, uuid }) => {
         )}
 
         {Settings.fields.task.plannedCompletion && (
-          <PreviewField
-            label={Settings.fields.task.plannedCompletion.label}
+          <DictPreviewField
+            dictProps={Settings.fields.task.plannedCompletion}
             value={
               task.plannedCompletion &&
               moment(task.plannedCompletion).format(
@@ -200,8 +202,8 @@ const TaskPreview = ({ className, uuid }) => {
         )}
 
         {Settings.fields.task.projectedCompletion && (
-          <PreviewField
-            label={Settings.fields.task.projectedCompletion.label}
+          <DictPreviewField
+            dictProps={Settings.fields.task.projectedCompletion}
             value={
               task.projectedCompletion &&
               moment(task.projectedCompletion).format(
@@ -211,20 +213,20 @@ const TaskPreview = ({ className, uuid }) => {
           />
         )}
 
-        <PreviewField
-          label="Status"
+        <DictPreviewField
+          dictProps={Settings.fields.task.status}
           value={Task.humanNameOfStatus(task.status)}
         />
 
         {task.description && (
-          <PreviewField
-            label={Settings.fields.task.description}
+          <DictPreviewField
+            dictProps={Settings.fields.task.description}
             value={<RichTextEditor readOnly value={task.description} />}
           />
         )}
       </div>
 
-      <h4>Responsible positions</h4>
+      <h4>{Settings.fields.task.responsiblePositions?.label}</h4>
       <div className="preview-section">
         <PositionTable positions={task.responsiblePositions} />
       </div>

--- a/client/src/models/Organization.js
+++ b/client/src/models/Organization.js
@@ -38,7 +38,7 @@ export default class Organization extends Model {
         .string()
         .required()
         .default("")
-        .label(Settings.fields.organization.shortName),
+        .label(Settings.fields.organization.shortName?.label),
       longName: yup.string().nullable().default(""),
       status: yup
         .string()
@@ -49,12 +49,16 @@ export default class Organization extends Model {
         .string()
         .required()
         .default(() => Organization.TYPE.ADVISOR_ORG),
-      location: yup.object().nullable().default(null).label("Location"),
+      location: yup
+        .object()
+        .nullable()
+        .default(null)
+        .label(Settings.fields.organization.location?.label),
       parentOrg: yup
         .object()
         .nullable()
         .default({})
-        .label(Settings.fields.organization.parentOrg),
+        .label(Settings.fields.organization.parentOrg?.label),
       childrenOrgs: yup.array().nullable().default([]),
       planningApprovalSteps: yup
         .array()

--- a/client/src/models/Organization.js
+++ b/client/src/models/Organization.js
@@ -159,7 +159,12 @@ export default class Organization extends Model {
   }
 
   toString() {
-    return [this.shortName, this.longName, this.identificationCode]
+    return [
+      this.shortName,
+      this.longName,
+      !Settings.fields.organization.identificationCode?.exclude &&
+        this.identificationCode
+    ]
       .filter(Boolean)
       .join(" | ")
   }

--- a/client/src/models/Person.js
+++ b/client/src/models/Person.js
@@ -66,25 +66,27 @@ export default class Person extends Model {
         .when("role", ([role], schema) =>
           Person.isAdvisor({ role })
             ? schema.required(
-              `You must provide the ${Settings.fields.person.firstName}`
+              `You must provide the ${Settings.fields.person.firstName?.label}`
             )
             : schema.nullable()
         )
         .default("")
-        .label(Settings.fields.person.firstName),
+        .label(Settings.fields.person.firstName?.label),
       // not actually in the database, but used for validation
       lastName: yup
         .string()
         .nullable()
         .uppercase()
-        .required(`You must provide the ${Settings.fields.person.lastName}`)
+        .required(
+          `You must provide the ${Settings.fields.person.lastName?.label}`
+        )
         .default("")
-        .label(Settings.fields.person.lastName),
+        .label(Settings.fields.person.lastName?.label),
       domainUsername: yup
         .string()
         .nullable()
         .default("")
-        .label(Settings.fields.person.domainUsername),
+        .label(Settings.fields.person.domainUsername?.label),
       emailAddress: yup
         .string()
         .nullable()
@@ -105,33 +107,37 @@ export default class Person extends Model {
           )
         )
         .default("")
-        .label(Settings.fields.person.emailAddress.label),
+        .label(Settings.fields.person.emailAddress?.label),
       country: yup
         .string()
         .nullable()
-        .required(`You must provide the ${Settings.fields.person.country}`)
+        .required(
+          `You must provide the ${Settings.fields.person.country?.label}`
+        )
         .default("")
-        .label(Settings.fields.person.country),
+        .label(Settings.fields.person.country?.label),
       rank: yup
         .string()
         .nullable()
         .required(
-          `You must provide the ${Settings.fields.person.rank} (Military rank, CIV and CTR values are available)`
+          `You must provide the ${Settings.fields.person.rank?.label} (Military rank, CIV and CTR values are available)`
         )
         .default("")
-        .label(Settings.fields.person.rank),
+        .label(Settings.fields.person.rank?.label),
       avatarUuid: yup.string().nullable().default(null),
       gender: yup
         .string()
         .nullable()
-        .required(`You must provide the ${Settings.fields.person.gender}`)
+        .required(
+          `You must provide the ${Settings.fields.person.gender?.label}`
+        )
         .default("")
-        .label(Settings.fields.person.gender),
+        .label(Settings.fields.person.gender?.label),
       phoneNumber: yup
         .string()
         .nullable()
         .default("")
-        .label(Settings.fields.person.phoneNumber),
+        .label(Settings.fields.person.phoneNumber?.label),
       code: yup.string().nullable().default(""),
       endOfTourDate: yupDate
         .nullable()
@@ -145,7 +151,7 @@ export default class Person extends Model {
               if (Person.isPendingVerification({ pendingVerification })) {
                 schema = schema.test(
                   "end-of-tour-date",
-                  `The ${Settings.fields.person.endOfTourDate} date must be in the future`,
+                  `The ${Settings.fields.person.endOfTourDate?.label} date must be in the future`,
                   endOfTourDate => endOfTourDate > Date.now()
                 )
               }
@@ -154,7 +160,7 @@ export default class Person extends Model {
           }
         )
         .default(null)
-        .label(Settings.fields.person.endOfTourDate),
+        .label(Settings.fields.person.endOfTourDate?.label),
       biography: yup.string().nullable().default(""),
       position: yup.object().nullable().default({}),
       pendingVerification: yup.boolean().default(false),

--- a/client/src/models/Person.js
+++ b/client/src/models/Person.js
@@ -128,8 +128,12 @@ export default class Person extends Model {
       gender: yup
         .string()
         .nullable()
-        .required(
-          `You must provide the ${Settings.fields.person.gender?.label}`
+        .when([], (_, schema) =>
+          Settings.fields.person.gender?.exclude
+            ? schema
+            : schema.required(
+              `You must provide the ${Settings.fields.person.gender?.label}`
+            )
         )
         .default("")
         .label(Settings.fields.person.gender?.label),
@@ -144,7 +148,10 @@ export default class Person extends Model {
         .when(
           ["role", "pendingVerification"],
           ([role, pendingVerification], schema) => {
-            if (Person.isPrincipal({ role })) {
+            if (
+              Settings.fields.person.endOfTourDate?.exclude ||
+              Person.isPrincipal({ role })
+            ) {
               return schema
             } else {
               // endOfTourDate is not required but if there is, it must be greater than today

--- a/client/src/models/Position.js
+++ b/client/src/models/Position.js
@@ -61,7 +61,7 @@ export default class Position extends Model {
         .string()
         .required("Position name is required")
         .default("")
-        .label(Settings.fields.position.name),
+        .label(Settings.fields.position.name?.label),
       type: yup
         .string()
         .required()
@@ -81,7 +81,7 @@ export default class Position extends Model {
         .object()
         .nullable()
         .default(null)
-        .label("Organization")
+        .label(Settings.fields.position.organization?.label)
         .test(
           "required-object",
           // eslint-disable-next-line no-template-curly-in-string
@@ -93,7 +93,7 @@ export default class Position extends Model {
         .object()
         .nullable()
         .default(null)
-        .label("Location")
+        .label(Settings.fields.position.location?.label)
         .when("type", ([type], schema) =>
           [
             Position.TYPE.ADVISOR,

--- a/client/src/models/Position.js
+++ b/client/src/models/Position.js
@@ -95,15 +95,12 @@ export default class Position extends Model {
         .default(null)
         .label(Settings.fields.position.location?.label)
         .when("type", ([type], schema) =>
-          [
-            Position.TYPE.ADVISOR,
-            Position.TYPE.SUPERUSER,
-            Position.TYPE.ADMINISTRATOR
-          ].includes(type)
-            ? schema.required(
+          Settings.fields.position.location?.optional ||
+          type === Position.TYPE.PRINCIPAL
+            ? schema
+            : schema.required(
               `Location is required for ${advisorPosition.name}`
             )
-            : schema.nullable()
         )
     })
 

--- a/client/src/models/Report.js
+++ b/client/src/models/Report.js
@@ -131,32 +131,19 @@ export default class Report extends Model {
         .when(
           ["cancelled", "engagementDate"],
           ([cancelled, engagementDate], schema) =>
-            cancelled
-              ? schema.nullable()
-              : !Report.isFuture(engagementDate)
-                ? schema.required(
-                  `You must provide the overall ${Settings.fields.report.atmosphere?.label} of the engagement`
-                )
-                : schema.nullable()
+            Settings.fields.report.atmosphere?.exclude ||
+            cancelled ||
+            Report.isFuture(engagementDate)
+              ? schema
+              : schema.required(
+                `You must provide the overall ${Settings.fields.report.atmosphere?.label} of the engagement`
+              )
         )
         .default(null)
         .label(Settings.fields.report.atmosphere?.label),
       atmosphereDetails: yup
         .string()
         .nullable()
-        .when(
-          ["cancelled", "atmosphere", "engagementDate"],
-          ([cancelled, atmosphere, engagementDate], schema) =>
-            cancelled
-              ? schema.nullable()
-              : !Report.isFuture(engagementDate)
-                ? atmosphere === Report.ATMOSPHERE.POSITIVE
-                  ? schema.nullable()
-                  : schema.required(
-                    `You must provide ${Settings.fields.report.atmosphereDetails?.label} if the engagement was not Positive`
-                  )
-                : schema.nullable()
-        )
         .default("")
         .label(Settings.fields.report.atmosphereDetails?.label),
       location: yup
@@ -251,11 +238,12 @@ export default class Report extends Model {
         .string()
         .nullable()
         .when("engagementDate", ([engagementDate], schema) =>
-          !Report.isFuture(engagementDate)
-            ? schema.required(
+          Settings.fields.report.nextSteps?.exclude ||
+          Report.isFuture(engagementDate)
+            ? schema
+            : schema.required(
               `You must provide a brief summary of the ${Settings.fields.report.nextSteps?.label}`
             )
-            : schema.nullable()
         )
         .default("")
         .label(Settings.fields.report.nextSteps?.label),
@@ -265,14 +253,13 @@ export default class Report extends Model {
         .when(
           ["cancelled", "engagementDate"],
           ([cancelled, engagementDate], schema) =>
-            cancelled
-              ? schema.nullable()
-              : Settings.fields.report.keyOutcomes &&
-                !Report.isFuture(engagementDate)
-                ? schema.required(
-                  `You must provide a brief summary of the ${Settings.fields.report.keyOutcomes?.label}`
-                )
-                : schema.nullable()
+            Settings.fields.report.keyOutcomes?.exclude ||
+            cancelled ||
+            Report.isFuture(engagementDate)
+              ? schema
+              : schema.required(
+                `You must provide a brief summary of the ${Settings.fields.report.keyOutcomes?.label}`
+              )
         )
         .default("")
         .label(Settings.fields.report.keyOutcomes?.label),

--- a/client/src/models/Report.js
+++ b/client/src/models/Report.js
@@ -99,19 +99,23 @@ export default class Report extends Model {
       intent: yup
         .string()
         .nullable()
-        .required(`You must provide the ${Settings.fields.report.intent}`)
+        .required(
+          `You must provide the ${Settings.fields.report.intent?.label}`
+        )
         .default("")
-        .label(Settings.fields.report.intent),
+        .label(Settings.fields.report.intent?.label),
       engagementDate: yupDate
         .nullable()
-        .required("You must provide the Date of Engagement")
+        .required(
+          `You must provide the  ${Settings.fields.report.engagementDate?.label}`
+        )
         .default(null),
       duration: yup.number().nullable().default(null),
       // not actually in the database, but used for validation:
       cancelled: yup
         .boolean()
         .default(false)
-        .label(Settings.fields.report.cancelled),
+        .label(Settings.fields.report.cancelled?.label),
       cancelledReason: yup
         .string()
         .nullable()
@@ -131,12 +135,12 @@ export default class Report extends Model {
               ? schema.nullable()
               : !Report.isFuture(engagementDate)
                 ? schema.required(
-                  `You must provide the overall ${Settings.fields.report.atmosphere} of the engagement`
+                  `You must provide the overall ${Settings.fields.report.atmosphere?.label} of the engagement`
                 )
                 : schema.nullable()
         )
         .default(null)
-        .label(Settings.fields.report.atmosphere),
+        .label(Settings.fields.report.atmosphere?.label),
       atmosphereDetails: yup
         .string()
         .nullable()
@@ -149,12 +153,12 @@ export default class Report extends Model {
                 ? atmosphere === Report.ATMOSPHERE.POSITIVE
                   ? schema.nullable()
                   : schema.required(
-                    `You must provide ${Settings.fields.report.atmosphereDetails} if the engagement was not Positive`
+                    `You must provide ${Settings.fields.report.atmosphereDetails?.label} if the engagement was not Positive`
                   )
                 : schema.nullable()
         )
         .default("")
-        .label(Settings.fields.report.atmosphereDetails),
+        .label(Settings.fields.report.atmosphereDetails?.label),
       location: yup
         .object()
         .nullable()
@@ -236,25 +240,25 @@ export default class Report extends Model {
               (reportText, testContext) =>
                 utils.isEmptyHtml(reportText)
                   ? testContext.createError({
-                    message: `You must provide the ${Settings.fields.report.reportText}`
+                    message: `You must provide the ${Settings.fields.report.reportText?.label}`
                   })
                   : true
             )
         )
         .default("")
-        .label(Settings.fields.report.reportText),
+        .label(Settings.fields.report.reportText?.label),
       nextSteps: yup
         .string()
         .nullable()
         .when("engagementDate", ([engagementDate], schema) =>
           !Report.isFuture(engagementDate)
             ? schema.required(
-              `You must provide a brief summary of the ${Settings.fields.report.nextSteps.label}`
+              `You must provide a brief summary of the ${Settings.fields.report.nextSteps?.label}`
             )
             : schema.nullable()
         )
         .default("")
-        .label(Settings.fields.report.nextSteps.label),
+        .label(Settings.fields.report.nextSteps?.label),
       keyOutcomes: yup
         .string()
         .nullable()
@@ -266,12 +270,12 @@ export default class Report extends Model {
               : Settings.fields.report.keyOutcomes &&
                 !Report.isFuture(engagementDate)
                 ? schema.required(
-                  `You must provide a brief summary of the ${Settings.fields.report.keyOutcomes}`
+                  `You must provide a brief summary of the ${Settings.fields.report.keyOutcomes?.label}`
                 )
                 : schema.nullable()
         )
         .default("")
-        .label(Settings.fields.report.keyOutcomes),
+        .label(Settings.fields.report.keyOutcomes?.label),
       reportSensitiveInformation: yup
         .object()
         .nullable()

--- a/client/src/models/Report.js
+++ b/client/src/models/Report.js
@@ -132,6 +132,7 @@ export default class Report extends Model {
           ["cancelled", "engagementDate"],
           ([cancelled, engagementDate], schema) =>
             Settings.fields.report.atmosphere?.exclude ||
+            Settings.fields.report.atmosphere?.optional ||
             cancelled ||
             Report.isFuture(engagementDate)
               ? schema
@@ -239,6 +240,7 @@ export default class Report extends Model {
         .nullable()
         .when("engagementDate", ([engagementDate], schema) =>
           Settings.fields.report.nextSteps?.exclude ||
+          Settings.fields.report.nextSteps?.optional ||
           Report.isFuture(engagementDate)
             ? schema
             : schema.required(
@@ -254,6 +256,7 @@ export default class Report extends Model {
           ["cancelled", "engagementDate"],
           ([cancelled, engagementDate], schema) =>
             Settings.fields.report.keyOutcomes?.exclude ||
+            Settings.fields.report.keyOutcomes?.optional ||
             cancelled ||
             Report.isFuture(engagementDate)
               ? schema

--- a/client/src/models/Task.js
+++ b/client/src/models/Task.js
@@ -48,36 +48,32 @@ export default class Task extends Model {
         .string()
         .required()
         .default("")
-        .label(Settings.fields.task.shortName.label),
+        .label(Settings.fields.task.shortName?.label),
       longName: yup
         .string()
         .nullable()
         .default("")
-        .label(Settings.fields.task.longName.label),
+        .label(Settings.fields.task.longName?.label),
       description: yup
         .string()
         .nullable()
         .default("")
-        .label(Settings.fields.task.description),
+        .label(Settings.fields.task.description?.label),
       category: yup.string().nullable().default(""),
       taskedOrganizations: yup
         .array()
         .nullable()
         .default([])
-        .label(Settings.fields.task.taskedOrganizations.label),
-      parentTask: yup
-        .object()
-        .nullable()
-        .default({})
-        .label(parentTask && parentTask.label),
+        .label(Settings.fields.task.taskedOrganizations?.label),
+      parentTask: yup.object().nullable().default({}).label(parentTask?.label),
       projectedCompletion: yupDate
         .nullable()
         .default(null)
-        .label(projectedCompletion && projectedCompletion.label),
+        .label(projectedCompletion?.label),
       plannedCompletion: yupDate
         .nullable()
         .default(null)
-        .label(plannedCompletion && plannedCompletion.label),
+        .label(plannedCompletion?.label),
       status: yup
         .string()
         .required()
@@ -86,7 +82,7 @@ export default class Task extends Model {
         .array()
         .nullable()
         .default([])
-        .label(responsiblePositions && responsiblePositions.label),
+        .label(responsiblePositions?.label),
       // FIXME: resolve code duplication in yup schema for approval steps
       planningApprovalSteps: yup
         .array()

--- a/client/src/pages/HopscotchTour.js
+++ b/client/src/pages/HopscotchTour.js
@@ -12,8 +12,6 @@ const principalSingular = Settings.fields.principal.person.name
 const principalPlural = pluralize(principalSingular)
 const advisorPositionSingular = Settings.fields.advisor.position.name
 const principalPositionSingular = Settings.fields.principal.position.name
-const advisorPositionCode = Settings.fields.advisor.position.code.label
-const principalPositionCode = Settings.fields.principal.position.code.label
 
 const userTour = (currentUser, navigate) => {
   return {
@@ -192,7 +190,7 @@ const reportTour = (currentUser, navigate) => {
         ]
         : []),
       {
-        title: Settings.fields.report.nextSteps.label,
+        title: Settings.fields.report.nextSteps?.label,
         content:
           "Here, tell readers about the next concrete steps that you'll be taking to build on the progress made in your engagement. This will be displayed in your report's summary, so include information that will explain to leadership what you are doing next, as a result of your meeting's outcomes.",
         target: "#nextSteps",
@@ -249,7 +247,7 @@ const orgTour = (currentUser, navigate) => {
       },
       {
         title: "Supported positions",
-        content: `This section shows positions in your organization that currently have people assigned to them. The ${advisorPositionSingular} column tells you the name and ${advisorPositionCode} of the position. To update this information, click on the position and select the "Edit" option.`,
+        content: `This section shows positions in your organization that currently have people assigned to them. The ${advisorPositionSingular} column tells you the name and ${Settings.fields.position.code.label} of the position. To update this information, click on the position and select the "Edit" option.`,
         target: "#supportedPositions h4",
         placement: "top"
       },
@@ -310,7 +308,7 @@ const positionTour = (currentUser, navigate) => {
     steps: [
       {
         title: "Positions",
-        content: `This section allows you to quickly review this position's detailed information, such as the position's ${advisorPositionCode} or ${principalPositionCode}, status, and organization.`,
+        content: `This section allows you to quickly review this position's detailed information, such as the position's ${Settings.fields.position.code.label} or ${Settings.fields.position.code.label}, status, and organization.`,
         target: ".persistent-tour-launcher",
         placement: "left"
       },

--- a/client/src/pages/admin/merge/MergeLocations.js
+++ b/client/src/pages/admin/merge/MergeLocations.js
@@ -8,7 +8,7 @@ import AdvancedSingleSelect from "components/advancedSelectWidget/AdvancedSingle
 import ApprovalSteps from "components/ApprovalSteps"
 import { customFieldsJSONString } from "components/CustomFields"
 import BaseGeoLocation from "components/GeoLocation"
-import LocationField from "components/MergeField"
+import MergeField from "components/MergeField"
 import Messages from "components/Messages"
 import {
   CUSTOM_FIELD_TYPE_DEFAULTS,
@@ -22,7 +22,9 @@ import {
   useBoilerplate,
   usePageTitle
 } from "components/Page"
+import RichTextEditor from "components/RichTextEditor"
 import { convertLatLngToMGRS } from "geoUtils"
+import DictionaryField from "HOC/DictionaryField"
 import useMergeObjects, {
   ALIGN_OPTIONS,
   areAllSet,
@@ -69,6 +71,7 @@ const MergeLocations = ({ pageDispatchers }) => {
   })
   usePageTitle("Merge Locations")
 
+  const DictMergeField = DictionaryField(MergeField)
   const location1 = mergeState[MERGE_SIDES.LEFT]
   const location2 = mergeState[MERGE_SIDES.RIGHT]
   const mergedLocation = mergeState.merged
@@ -137,27 +140,31 @@ const MergeLocations = ({ pageDispatchers }) => {
           )}
           {areAllSet(location1, location2, mergedLocation) && (
             <fieldset>
-              <LocationField
-                label="Name"
+              <DictMergeField
+                dictProps={Settings.fields.location.name}
                 value={mergedLocation.name}
                 align={ALIGN_OPTIONS.CENTER}
-                action={getInfoButton("Name is required.")}
+                action={getInfoButton(
+                  `${Settings.fields.location.name?.label} is required.`
+                )}
                 fieldName="name"
                 mergeState={mergeState}
                 dispatchMergeActions={dispatchMergeActions}
               />
 
-              <LocationField
-                label="Type"
+              <DictMergeField
+                dictProps={Settings.fields.location.type}
                 value={Location.humanNameOfType(mergedLocation.type)}
                 align={ALIGN_OPTIONS.CENTER}
-                action={getInfoButton("Type is required.")}
+                action={getInfoButton(
+                  `${Settings.fields.location.type?.label} is required.`
+                )}
                 fieldName="type"
                 mergeState={mergeState}
                 dispatchMergeActions={dispatchMergeActions}
               />
 
-              <LocationField
+              <MergeField
                 label={locationFormatLabel}
                 fieldName="displayedCoordinate"
                 value={
@@ -185,8 +192,8 @@ const MergeLocations = ({ pageDispatchers }) => {
                 dispatchMergeActions={dispatchMergeActions}
               />
               {getLeafletMap("merged-location-map", mergedLocation)}
-              <LocationField
-                label="Status"
+              <DictMergeField
+                dictProps={Settings.fields.location.status}
                 fieldName="status"
                 value={mergedLocation.status}
                 align={ALIGN_OPTIONS.CENTER}
@@ -207,7 +214,20 @@ const MergeLocations = ({ pageDispatchers }) => {
                 mergeState={mergeState}
                 dispatchMergeActions={dispatchMergeActions}
               />
-              <LocationField
+              <DictMergeField
+                dictProps={Settings.fields.location.description}
+                value={
+                  <RichTextEditor readOnly value={mergedLocation.description} />
+                }
+                align={ALIGN_OPTIONS.CENTER}
+                action={getClearButton(() =>
+                  dispatchMergeActions(setAMergedField("description", "", null))
+                )}
+                fieldName="description"
+                mergeState={mergeState}
+                dispatchMergeActions={dispatchMergeActions}
+              />
+              <MergeField
                 label="Planning Approval Steps"
                 fieldName="planningApprovalSteps"
                 value={
@@ -219,7 +239,7 @@ const MergeLocations = ({ pageDispatchers }) => {
                 mergeState={mergeState}
                 dispatchMergeActions={dispatchMergeActions}
               />
-              <LocationField
+              <MergeField
                 label="Approval Steps"
                 fieldName="approvalSteps"
                 value={
@@ -237,7 +257,7 @@ const MergeLocations = ({ pageDispatchers }) => {
                         fieldName
                       ]
                     return (
-                      <LocationField
+                      <MergeField
                         key={fieldName}
                         label={fieldConfig.label || fieldName}
                         value={JSON.stringify(fieldValue)}
@@ -334,12 +354,11 @@ const MidColTitle = styled.div`
 `
 
 function getLocationFilters() {
-  const locationFilters = {
+  return {
     activeLocations: {
       label: "All locations"
     }
   }
-  return locationFilters
 }
 
 const LocationColumn = ({
@@ -351,6 +370,7 @@ const LocationColumn = ({
   setLocationFormat,
   locationFormatLabel
 }) => {
+  const DictMergeField = DictionaryField(MergeField)
   const location = mergeState[align]
   const idForLocation = label.replace(/\s+/g, "")
   return (
@@ -388,8 +408,8 @@ const LocationColumn = ({
       </FormGroup>
       {areAllSet(location) && (
         <fieldset>
-          <LocationField
-            label="Name"
+          <DictMergeField
+            dictProps={Settings.fields.location.name}
             fieldName="name"
             value={location.name}
             align={align}
@@ -410,8 +430,8 @@ const LocationColumn = ({
             dispatchMergeActions={dispatchMergeActions}
           />
 
-          <LocationField
-            label="Type"
+          <DictMergeField
+            dictProps={Settings.fields.location.type}
             fieldName="type"
             value={Location.humanNameOfType(location.type)}
             align={align}
@@ -429,7 +449,7 @@ const LocationColumn = ({
             dispatchMergeActions={dispatchMergeActions}
           />
 
-          <LocationField
+          <MergeField
             label={locationFormatLabel}
             fieldName="displayedCoordinate"
             value={
@@ -469,8 +489,8 @@ const LocationColumn = ({
             dispatchMergeActions={dispatchMergeActions}
           />
           {getLeafletMap(`merge-location-map-${align}`, location)}
-          <LocationField
-            label="Status"
+          <DictMergeField
+            dictProps={Settings.fields.location.status}
             fieldName="status"
             value={location.status}
             align={align}
@@ -487,7 +507,25 @@ const LocationColumn = ({
             mergeState={mergeState}
             dispatchMergeActions={dispatchMergeActions}
           />
-          <LocationField
+          <DictMergeField
+            dictProps={Settings.fields.location.description}
+            fieldName="description"
+            value={<RichTextEditor readOnly value={location.description} />}
+            align={align}
+            action={getActionButton(
+              () => {
+                dispatchMergeActions(
+                  setAMergedField("description", location.description, align)
+                )
+              },
+              align,
+              mergeState,
+              "description"
+            )}
+            mergeState={mergeState}
+            dispatchMergeActions={dispatchMergeActions}
+          />
+          <MergeField
             label="Planning Approval Steps"
             fieldName="planningApprovalSteps"
             value={
@@ -510,7 +548,7 @@ const LocationColumn = ({
             mergeState={mergeState}
             dispatchMergeActions={dispatchMergeActions}
           />
-          <LocationField
+          <MergeField
             label="Approval Steps"
             fieldName="approvalSteps"
             value={<ApprovalSteps approvalSteps={location.approvalSteps} />}
@@ -537,11 +575,11 @@ const LocationColumn = ({
                 const fieldValue =
                   location[DEFAULT_CUSTOM_FIELDS_PARENT][fieldName]
                 return (
-                  <LocationField
+                  <MergeField
                     key={fieldName}
                     fieldName={`${DEFAULT_CUSTOM_FIELDS_PARENT}.${fieldName}`}
                     label={fieldConfig.label || fieldName}
-                    // To be able to see arrays and ojects
+                    // To be able to see arrays and objects
                     value={JSON.stringify(fieldValue)}
                     align={align}
                     action={getActionButton(

--- a/client/src/pages/admin/merge/MergePeople.js
+++ b/client/src/pages/admin/merge/MergePeople.js
@@ -9,7 +9,7 @@ import AvatarDisplayComponent from "components/AvatarDisplayComponent"
 import { customFieldsJSONString } from "components/CustomFields"
 import EditHistory from "components/EditHistory"
 import LinkTo from "components/LinkTo"
-import PersonField from "components/MergeField"
+import MergeField from "components/MergeField"
 import Messages from "components/Messages"
 import {
   CUSTOM_FIELD_TYPE_DEFAULTS,
@@ -25,6 +25,7 @@ import {
 } from "components/Page"
 import PreviousPositions from "components/PreviousPositions"
 import RichTextEditor from "components/RichTextEditor"
+import DictionaryField from "HOC/DictionaryField"
 import useMergeObjects, {
   ALIGN_OPTIONS,
   areAllSet,
@@ -72,10 +73,10 @@ const MergePeople = ({ pageDispatchers }) => {
   })
   usePageTitle("Merge People")
 
+  const DictMergeField = DictionaryField(MergeField)
   const person1 = mergeState[MERGE_SIDES.LEFT]
   const person2 = mergeState[MERGE_SIDES.RIGHT]
   const mergedPerson = mergeState.merged
-
   const matchingRoles = person1?.role === person2?.role
 
   return (
@@ -140,22 +141,26 @@ const MergePeople = ({ pageDispatchers }) => {
                   <li>Name</li>
                   <li>Role</li>
                   <li>Status</li>
-                  <li>{Settings.fields.person.rank}</li>
-                  <li>{Settings.fields.person.gender}</li>
-                  <li>{Settings.fields.person.country}</li>
+                  <li>{Settings.fields.person.rank?.label}</li>
+                  {!Settings.fields.person.gender?.exclude && (
+                    <li>{Settings.fields.person.gender?.label}</li>
+                  )}
+                  <li>{Settings.fields.person.country?.label}</li>
                 </ul>
-                If the Merged Person will be an {Person.ROLE.ADVISOR}:
+                - If the Merged Person will be an {Person.ROLE.ADVISOR}, also
+                required are:
                 <ul>
-                  <li>{Settings.fields.person.emailAddress.label}</li>
-                  <li>{Settings.fields.person.endOfTourDate}</li>
+                  <li>{Settings.fields.person.emailAddress?.label}</li>
+                  {!Settings.fields.person.endOfTourDate?.exclude && (
+                    <li>{Settings.fields.person.endOfTourDate?.label}</li>
+                  )}
                 </ul>
-                are also required.
               </Callout>
             </div>
           )}
           {areAllSet(person1, person2, mergedPerson) && (
             <fieldset>
-              <PersonField
+              <MergeField
                 label="Avatar"
                 value={
                   <AvatarDisplayComponent
@@ -182,7 +187,7 @@ const MergePeople = ({ pageDispatchers }) => {
                 mergeState={mergeState}
                 dispatchMergeActions={dispatchMergeActions}
               />
-              <PersonField
+              <MergeField
                 label="Name"
                 value={mergedPerson.name}
                 align={ALIGN_OPTIONS.CENTER}
@@ -191,8 +196,8 @@ const MergePeople = ({ pageDispatchers }) => {
                 mergeState={mergeState}
                 dispatchMergeActions={dispatchMergeActions}
               />
-              <PersonField
-                label="Domain username"
+              <DictMergeField
+                dictProps={Settings.fields.person.domainUsername}
                 value={mergedPerson.domainUsername}
                 align={ALIGN_OPTIONS.CENTER}
                 action={
@@ -207,8 +212,8 @@ const MergePeople = ({ pageDispatchers }) => {
                 mergeState={mergeState}
                 dispatchMergeActions={dispatchMergeActions}
               />
-              <PersonField
-                label="OpenID subject"
+              <DictMergeField
+                dictProps={Settings.fields.person.openIdSubject}
                 value={mergedPerson.openIdSubject}
                 align={ALIGN_OPTIONS.CENTER}
                 action={
@@ -223,7 +228,7 @@ const MergePeople = ({ pageDispatchers }) => {
                 mergeState={mergeState}
                 dispatchMergeActions={dispatchMergeActions}
               />
-              <PersonField
+              <MergeField
                 label="Role"
                 value={mergedPerson.role}
                 align={ALIGN_OPTIONS.CENTER}
@@ -232,8 +237,8 @@ const MergePeople = ({ pageDispatchers }) => {
                 mergeState={mergeState}
                 dispatchMergeActions={dispatchMergeActions}
               />
-              <PersonField
-                label="Position"
+              <DictMergeField
+                dictProps={Settings.fields.person.position}
                 value={
                   <LinkTo modelType="Position" model={mergedPerson.position} />
                 }
@@ -248,8 +253,8 @@ const MergePeople = ({ pageDispatchers }) => {
                 mergeState={mergeState}
                 dispatchMergeActions={dispatchMergeActions}
               />
-              <PersonField
-                label="Previous Positions"
+              <DictMergeField
+                dictProps={Settings.fields.person.prevPositions}
                 value={
                   <>
                     <PreviousPositions
@@ -290,8 +295,8 @@ const MergePeople = ({ pageDispatchers }) => {
                 mergeState={mergeState}
                 dispatchMergeActions={dispatchMergeActions}
               />
-              <PersonField
-                label="Status"
+              <DictMergeField
+                dictProps={Settings.fields.person.status}
                 value={mergedPerson.status}
                 align={ALIGN_OPTIONS.CENTER}
                 action={
@@ -315,14 +320,14 @@ const MergePeople = ({ pageDispatchers }) => {
                 mergeState={mergeState}
                 dispatchMergeActions={dispatchMergeActions}
               />
-              <PersonField
-                label={Settings.fields.person.emailAddress.label}
+              <DictMergeField
+                dictProps={Settings.fields.person.emailAddress}
                 value={mergedPerson.emailAddress}
                 align={ALIGN_OPTIONS.CENTER}
                 action={
                   mergedPerson.role === Person.ROLE.ADVISOR
                     ? getInfoButton(
-                      `${Settings.fields.person.emailAddress.label} is required.`
+                      `${Settings.fields.person.emailAddress?.label} is required.`
                     )
                     : matchingRoles &&
                       getClearButton(() =>
@@ -335,8 +340,8 @@ const MergePeople = ({ pageDispatchers }) => {
                 mergeState={mergeState}
                 dispatchMergeActions={dispatchMergeActions}
               />
-              <PersonField
-                label={Settings.fields.person.phoneNumber}
+              <DictMergeField
+                dictProps={Settings.fields.person.phoneNumber}
                 value={mergedPerson.phoneNumber}
                 align={ALIGN_OPTIONS.CENTER}
                 action={
@@ -351,41 +356,41 @@ const MergePeople = ({ pageDispatchers }) => {
                 mergeState={mergeState}
                 dispatchMergeActions={dispatchMergeActions}
               />
-              <PersonField
-                label={Settings.fields.person.rank}
+              <DictMergeField
+                dictProps={Settings.fields.person.rank}
                 value={mergedPerson.rank}
                 align={ALIGN_OPTIONS.CENTER}
                 action={getInfoButton(
-                  `${Settings.fields.person.rank} is required.`
+                  `${Settings.fields.person.rank?.label} is required.`
                 )}
                 fieldName="rank"
                 mergeState={mergeState}
                 dispatchMergeActions={dispatchMergeActions}
               />
-              <PersonField
-                label={Settings.fields.person.gender}
+              <DictMergeField
+                dictProps={Settings.fields.person.gender}
                 value={mergedPerson.gender}
                 align={ALIGN_OPTIONS.CENTER}
                 action={getInfoButton(
-                  `${Settings.fields.person.gender} is required.`
+                  `${Settings.fields.person.gender?.label} is required.`
                 )}
                 fieldName="gender"
                 mergeState={mergeState}
                 dispatchMergeActions={dispatchMergeActions}
               />
-              <PersonField
-                label={Settings.fields.person.country}
+              <DictMergeField
+                dictProps={Settings.fields.person.country}
                 value={mergedPerson.country}
                 align={ALIGN_OPTIONS.CENTER}
                 action={getInfoButton(
-                  `${Settings.fields.person.country} is required.`
+                  `${Settings.fields.person.country?.label} is required.`
                 )}
                 fieldName="country"
                 mergeState={mergeState}
                 dispatchMergeActions={dispatchMergeActions}
               />
-              <PersonField
-                label={Settings.fields.person.code}
+              <DictMergeField
+                dictProps={Settings.fields.person.code}
                 value={mergedPerson.code}
                 align={ALIGN_OPTIONS.CENTER}
                 action={
@@ -398,8 +403,8 @@ const MergePeople = ({ pageDispatchers }) => {
                 mergeState={mergeState}
                 dispatchMergeActions={dispatchMergeActions}
               />
-              <PersonField
-                label={Settings.fields.person.endOfTourDate}
+              <DictMergeField
+                dictProps={Settings.fields.person.endOfTourDate}
                 value={moment(mergedPerson.endOfTourDate).format(
                   Settings.dateFormats.forms.displayShort.date
                 )}
@@ -407,7 +412,7 @@ const MergePeople = ({ pageDispatchers }) => {
                 action={
                   mergedPerson.role === Person.ROLE.ADVISOR
                     ? getInfoButton(
-                      `${Settings.fields.person.endOfTourDate} is required`
+                      `${Settings.fields.person.endOfTourDate?.label} is required`
                     )
                     : matchingRoles &&
                       getClearButton(() =>
@@ -420,8 +425,8 @@ const MergePeople = ({ pageDispatchers }) => {
                 mergeState={mergeState}
                 dispatchMergeActions={dispatchMergeActions}
               />
-              <PersonField
-                label="Biography"
+              <DictMergeField
+                dictProps={Settings.fields.person.biography}
                 value={
                   <RichTextEditor readOnly value={mergedPerson.biography} />
                 }
@@ -442,7 +447,7 @@ const MergePeople = ({ pageDispatchers }) => {
                     const fieldValue =
                       mergedPerson?.[DEFAULT_CUSTOM_FIELDS_PARENT]?.[fieldName]
                     return (
-                      <PersonField
+                      <MergeField
                         key={fieldName}
                         label={fieldConfig.label || fieldName}
                         value={JSON.stringify(fieldValue)}
@@ -547,6 +552,7 @@ const PersonColumn = ({
   dispatchMergeActions,
   actionButtons
 }) => {
+  const DictMergeField = DictionaryField(MergeField)
   const person = mergeState[align]
   const idForPerson = label.replace(/\s+/g, "")
 
@@ -582,7 +588,7 @@ const PersonColumn = ({
       </Form.Group>
       {areAllSet(person) && (
         <fieldset>
-          <PersonField
+          <MergeField
             label="Avatar"
             fieldName="avatarUuid"
             value={
@@ -614,7 +620,7 @@ const PersonColumn = ({
             mergeState={mergeState}
             dispatchMergeActions={dispatchMergeActions}
           />
-          <PersonField
+          <MergeField
             label="Name"
             fieldName="name"
             value={person.name}
@@ -645,8 +651,8 @@ const PersonColumn = ({
             mergeState={mergeState}
             dispatchMergeActions={dispatchMergeActions}
           />
-          <PersonField
-            label="Domain username"
+          <DictMergeField
+            dictProps={Settings.fields.person.domainUsername}
             fieldName="domainUsername"
             value={person.domainUsername}
             align={align}
@@ -670,8 +676,8 @@ const PersonColumn = ({
             mergeState={mergeState}
             dispatchMergeActions={dispatchMergeActions}
           />
-          <PersonField
-            label="OpenID subject"
+          <DictMergeField
+            dictProps={Settings.fields.person.openIdSubject}
             fieldName="openIdSubject"
             value={person.openIdSubject}
             align={align}
@@ -695,7 +701,7 @@ const PersonColumn = ({
             mergeState={mergeState}
             dispatchMergeActions={dispatchMergeActions}
           />
-          <PersonField
+          <MergeField
             label="Role"
             fieldName="role"
             value={person.role}
@@ -716,8 +722,8 @@ const PersonColumn = ({
             mergeState={mergeState}
             dispatchMergeActions={dispatchMergeActions}
           />
-          <PersonField
-            label="Position"
+          <DictMergeField
+            dictProps={Settings.fields.person.position}
             fieldName="position"
             value={<LinkTo modelType="Position" model={person.position} />}
             align={align}
@@ -737,8 +743,8 @@ const PersonColumn = ({
             mergeState={mergeState}
             dispatchMergeActions={dispatchMergeActions}
           />
-          <PersonField
-            label="Previous Positions"
+          <DictMergeField
+            dictProps={Settings.fields.person.prevPositions}
             fieldName="previousPositions"
             value={<PreviousPositions history={person.previousPositions} />}
             align={align}
@@ -762,8 +768,8 @@ const PersonColumn = ({
             mergeState={mergeState}
             dispatchMergeActions={dispatchMergeActions}
           />
-          <PersonField
-            label="Status"
+          <DictMergeField
+            dictProps={Settings.fields.person.status}
             fieldName="status"
             value={person.status}
             align={align}
@@ -783,8 +789,8 @@ const PersonColumn = ({
             mergeState={mergeState}
             dispatchMergeActions={dispatchMergeActions}
           />
-          <PersonField
-            label={Settings.fields.person.emailAddress.label}
+          <DictMergeField
+            dictProps={Settings.fields.person.emailAddress}
             fieldName="emailAddress"
             value={person.emailAddress}
             align={align}
@@ -804,8 +810,8 @@ const PersonColumn = ({
             mergeState={mergeState}
             dispatchMergeActions={dispatchMergeActions}
           />
-          <PersonField
-            label={Settings.fields.person.phoneNumber}
+          <DictMergeField
+            dictProps={Settings.fields.person.phoneNumber}
             fieldName="phoneNumber"
             value={person.phoneNumber}
             align={align}
@@ -825,8 +831,8 @@ const PersonColumn = ({
             mergeState={mergeState}
             dispatchMergeActions={dispatchMergeActions}
           />
-          <PersonField
-            label={Settings.fields.person.rank}
+          <DictMergeField
+            dictProps={Settings.fields.person.rank}
             fieldName="rank"
             value={person.rank}
             align={align}
@@ -846,8 +852,8 @@ const PersonColumn = ({
             mergeState={mergeState}
             dispatchMergeActions={dispatchMergeActions}
           />
-          <PersonField
-            label={Settings.fields.person.gender}
+          <DictMergeField
+            dictProps={Settings.fields.person.gender}
             fieldName="gender"
             value={person.gender}
             align={align}
@@ -867,8 +873,8 @@ const PersonColumn = ({
             mergeState={mergeState}
             dispatchMergeActions={dispatchMergeActions}
           />
-          <PersonField
-            label={Settings.fields.person.country}
+          <DictMergeField
+            dictProps={Settings.fields.person.country}
             fieldName="country"
             value={person.country}
             align={align}
@@ -888,8 +894,8 @@ const PersonColumn = ({
             mergeState={mergeState}
             dispatchMergeActions={dispatchMergeActions}
           />
-          <PersonField
-            label={Settings.fields.person.code}
+          <DictMergeField
+            dictProps={Settings.fields.person.code}
             fieldName="code"
             value={person.code}
             align={align}
@@ -909,8 +915,8 @@ const PersonColumn = ({
             mergeState={mergeState}
             dispatchMergeActions={dispatchMergeActions}
           />
-          <PersonField
-            label={Settings.fields.person.endOfTourDate}
+          <DictMergeField
+            dictProps={Settings.fields.person.endOfTourDate}
             fieldName="endOfTourDate"
             value={moment(person.endOfTourDate).format(
               Settings.dateFormats.forms.displayShort.date
@@ -936,8 +942,8 @@ const PersonColumn = ({
             mergeState={mergeState}
             dispatchMergeActions={dispatchMergeActions}
           />
-          <PersonField
-            label="Biography"
+          <DictMergeField
+            dictProps={Settings.fields.person.biography}
             fieldName="biography"
             value={<RichTextEditor readOnly value={person.biography} />}
             align={align}
@@ -964,11 +970,11 @@ const PersonColumn = ({
                   person[DEFAULT_CUSTOM_FIELDS_PARENT][fieldName]
 
                 return (
-                  <PersonField
+                  <MergeField
                     key={fieldName}
                     fieldName={`${DEFAULT_CUSTOM_FIELDS_PARENT}.${fieldName}`}
                     label={fieldConfig.label || fieldName}
-                    // To be able to see arrays and ojects
+                    // To be able to see arrays and objects
                     value={JSON.stringify(fieldValue)}
                     align={align}
                     action={

--- a/client/src/pages/admin/merge/MergePositions.js
+++ b/client/src/pages/admin/merge/MergePositions.js
@@ -10,7 +10,7 @@ import { customFieldsJSONString } from "components/CustomFields"
 import EditAssociatedPositions from "components/EditAssociatedPositions"
 import EditHistory from "components/EditHistory"
 import LinkTo from "components/LinkTo"
-import PositionField from "components/MergeField"
+import MergeField from "components/MergeField"
 import Messages from "components/Messages"
 import {
   CUSTOM_FIELD_TYPE_DEFAULTS,
@@ -24,6 +24,7 @@ import {
   useBoilerplate,
   usePageTitle
 } from "components/Page"
+import DictionaryField from "HOC/DictionaryField"
 import useMergeObjects, {
   ALIGN_OPTIONS,
   areAllSet,
@@ -72,6 +73,7 @@ const MergePositions = ({ pageDispatchers }) => {
   })
   usePageTitle("Merge Positions")
 
+  const DictMergeField = DictionaryField(MergeField)
   const position1 = mergeState[MERGE_SIDES.LEFT]
   const position2 = mergeState[MERGE_SIDES.RIGHT]
   const mergedPosition = mergeState.merged
@@ -136,8 +138,8 @@ const MergePositions = ({ pageDispatchers }) => {
           )}
           {areAllSet(position1, position2, mergedPosition) && (
             <fieldset>
-              <PositionField
-                label="Name"
+              <DictMergeField
+                dictProps={Settings.fields.position.name}
                 value={mergedPosition.name}
                 align={ALIGN_OPTIONS.CENTER}
                 action={getInfoButton("Name is required.")}
@@ -145,8 +147,8 @@ const MergePositions = ({ pageDispatchers }) => {
                 mergeState={mergeState}
                 dispatchMergeActions={dispatchMergeActions}
               />
-              <PositionField
-                label="Organization"
+              <DictMergeField
+                dictProps={Settings.fields.position.organization}
                 value={
                   <LinkTo
                     modelType="Organization"
@@ -159,8 +161,8 @@ const MergePositions = ({ pageDispatchers }) => {
                 mergeState={mergeState}
                 dispatchMergeActions={dispatchMergeActions}
               />
-              <PositionField
-                label="Type"
+              <DictMergeField
+                dictProps={Settings.fields.position.type}
                 value={mergedPosition.type}
                 align={ALIGN_OPTIONS.CENTER}
                 action={getInfoButton("Type is required.")}
@@ -168,17 +170,19 @@ const MergePositions = ({ pageDispatchers }) => {
                 mergeState={mergeState}
                 dispatchMergeActions={dispatchMergeActions}
               />
-              <PositionField
-                label={Settings.fields.position.role.label}
+              <DictMergeField
+                dictProps={Settings.fields.position.role}
                 value={Position.humanNameOfRole(mergedPosition.role)}
                 align={ALIGN_OPTIONS.CENTER}
-                action={getInfoButton("Role is required.")}
+                action={getInfoButton(
+                  `${Settings.fields.position.role?.label} is required.`
+                )}
                 fieldName="role"
                 mergeState={mergeState}
                 dispatchMergeActions={dispatchMergeActions}
               />
-              <PositionField
-                label="Code"
+              <DictMergeField
+                dictProps={Settings.fields.position.code}
                 value={mergedPosition.code}
                 align={ALIGN_OPTIONS.CENTER}
                 action={getClearButton(() =>
@@ -188,8 +192,8 @@ const MergePositions = ({ pageDispatchers }) => {
                 mergeState={mergeState}
                 dispatchMergeActions={dispatchMergeActions}
               />
-              <PositionField
-                label="Status"
+              <DictMergeField
+                dictProps={Settings.fields.position.status}
                 value={mergedPosition.status}
                 align={ALIGN_OPTIONS.CENTER}
                 action={getActivationButton(
@@ -210,7 +214,7 @@ const MergePositions = ({ pageDispatchers }) => {
                 mergeState={mergeState}
                 dispatchMergeActions={dispatchMergeActions}
               />
-              <PositionField
+              <MergeField
                 label="Associated Positions"
                 value={
                   <>
@@ -244,7 +248,7 @@ const MergePositions = ({ pageDispatchers }) => {
                 mergeState={mergeState}
                 dispatchMergeActions={dispatchMergeActions}
               />
-              <PositionField
+              <MergeField
                 label="Previous People"
                 value={
                   <>
@@ -279,7 +283,7 @@ const MergePositions = ({ pageDispatchers }) => {
                 mergeState={mergeState}
                 dispatchMergeActions={dispatchMergeActions}
               />
-              <PositionField
+              <MergeField
                 label="Person"
                 value={
                   <LinkTo modelType="Person" model={mergedPosition.person} />
@@ -293,7 +297,7 @@ const MergePositions = ({ pageDispatchers }) => {
                 dispatchMergeActions={dispatchMergeActions}
               />
               {mergeState?.merged?.type === Position.TYPE.SUPERUSER && (
-                <PositionField
+                <MergeField
                   label="Organizations Administrated"
                   fieldName="organizationsAdministrated"
                   value={
@@ -321,7 +325,7 @@ const MergePositions = ({ pageDispatchers }) => {
                         fieldName
                       ]
                     return (
-                      <PositionField
+                      <MergeField
                         key={fieldName}
                         label={fieldConfig.label || fieldName}
                         value={JSON.stringify(fieldValue)}
@@ -342,8 +346,8 @@ const MergePositions = ({ pageDispatchers }) => {
                     )
                   }
                 )}
-              <PositionField
-                label="Location"
+              <DictMergeField
+                dictProps={Settings.fields.position.location}
                 value={
                   <LinkTo
                     modelType="Location"
@@ -445,7 +449,7 @@ const MidColTitle = styled.div`
 `
 
 function getPositionFilters(mergeState, align) {
-  const positionsFilters = {
+  return {
     allAdvisorPositions: {
       label: "All",
       queryVars: {
@@ -455,10 +459,10 @@ function getPositionFilters(mergeState, align) {
       }
     }
   }
-  return positionsFilters
 }
 
 const PositionColumn = ({ align, label, mergeState, dispatchMergeActions }) => {
+  const DictMergeField = DictionaryField(MergeField)
   const position = mergeState[align]
   const idForPosition = label.replace(/\s+/g, "")
   return (
@@ -493,8 +497,8 @@ const PositionColumn = ({ align, label, mergeState, dispatchMergeActions }) => {
       </FormGroup>
       {areAllSet(position) && (
         <fieldset>
-          <PositionField
-            label="Name"
+          <DictMergeField
+            dictProps={Settings.fields.position.name}
             fieldName="name"
             value={position.name}
             align={align}
@@ -517,8 +521,8 @@ const PositionColumn = ({ align, label, mergeState, dispatchMergeActions }) => {
             mergeState={mergeState}
             dispatchMergeActions={dispatchMergeActions}
           />
-          <PositionField
-            label="Organization"
+          <DictMergeField
+            dictProps={Settings.fields.position.organization}
             fieldName="organization"
             value={
               <LinkTo modelType="Organization" model={position.organization} />
@@ -527,16 +531,16 @@ const PositionColumn = ({ align, label, mergeState, dispatchMergeActions }) => {
             mergeState={mergeState}
             dispatchMergeActions={dispatchMergeActions}
           />
-          <PositionField
-            label="Type"
+          <DictMergeField
+            dictProps={Settings.fields.position.type}
             fieldName="type"
             value={position.type}
             align={align}
             mergeState={mergeState}
             dispatchMergeActions={dispatchMergeActions}
           />
-          <PositionField
-            label={Settings.fields.position.role.label}
+          <DictMergeField
+            dictProps={Settings.fields.position.role}
             fieldName="role"
             value={position.humanNameOfRole()}
             align={align}
@@ -552,8 +556,8 @@ const PositionColumn = ({ align, label, mergeState, dispatchMergeActions }) => {
             mergeState={mergeState}
             dispatchMergeActions={dispatchMergeActions}
           />
-          <PositionField
-            label="Code"
+          <DictMergeField
+            dictProps={Settings.fields.position.code}
             fieldName="code"
             value={position.code}
             align={align}
@@ -569,8 +573,8 @@ const PositionColumn = ({ align, label, mergeState, dispatchMergeActions }) => {
             mergeState={mergeState}
             dispatchMergeActions={dispatchMergeActions}
           />
-          <PositionField
-            label="Status"
+          <DictMergeField
+            dictProps={Settings.fields.position.status}
             fieldName="status"
             value={position.status}
             align={align}
@@ -586,7 +590,7 @@ const PositionColumn = ({ align, label, mergeState, dispatchMergeActions }) => {
             mergeState={mergeState}
             dispatchMergeActions={dispatchMergeActions}
           />
-          <PositionField
+          <MergeField
             label="Associated Positions"
             fieldName="associatedPositions"
             value={
@@ -611,7 +615,7 @@ const PositionColumn = ({ align, label, mergeState, dispatchMergeActions }) => {
             mergeState={mergeState}
             dispatchMergeActions={dispatchMergeActions}
           />
-          <PositionField
+          <MergeField
             label="Previous People"
             fieldName="previousPeople"
             value={<PreviousPeople history={position.previousPeople} />}
@@ -632,7 +636,7 @@ const PositionColumn = ({ align, label, mergeState, dispatchMergeActions }) => {
             mergeState={mergeState}
             dispatchMergeActions={dispatchMergeActions}
           />
-          <PositionField
+          <MergeField
             label="Person"
             fieldName="person"
             value={<LinkTo modelType="Person" model={position.person} />}
@@ -655,7 +659,7 @@ const PositionColumn = ({ align, label, mergeState, dispatchMergeActions }) => {
             dispatchMergeActions={dispatchMergeActions}
           />
           {position.type === Position.TYPE.SUPERUSER && (
-            <PositionField
+            <MergeField
               label="Organizations Administrated"
               fieldName="organizationsAdministrated"
               value={
@@ -688,11 +692,11 @@ const PositionColumn = ({ align, label, mergeState, dispatchMergeActions }) => {
                   position[DEFAULT_CUSTOM_FIELDS_PARENT][fieldName]
 
                 return (
-                  <PositionField
+                  <MergeField
                     key={fieldName}
                     fieldName={`${DEFAULT_CUSTOM_FIELDS_PARENT}.${fieldName}`}
                     label={fieldConfig.label || fieldName}
-                    // To be able to see arrays and ojects
+                    // To be able to see arrays and objects
                     value={JSON.stringify(fieldValue)}
                     align={align}
                     action={getActionButton(
@@ -714,8 +718,8 @@ const PositionColumn = ({ align, label, mergeState, dispatchMergeActions }) => {
                 )
               }
             )}
-          <PositionField
-            label="Location"
+          <DictMergeField
+            dictProps={Settings.fields.position.location}
             fieldName="location"
             value={<LinkTo modelType="Location" model={position.location} />}
             align={align}

--- a/client/src/pages/attachments/Form.js
+++ b/client/src/pages/attachments/Form.js
@@ -11,6 +11,7 @@ import NavigationWarning from "components/NavigationWarning"
 import { jumpToTop } from "components/Page"
 import RichTextEditor from "components/RichTextEditor"
 import { FastField, Field, Form, Formik } from "formik"
+import DictionaryField from "HOC/DictionaryField"
 import _isEqual from "lodash/isEqual"
 import { Attachment } from "models"
 import PropTypes from "prop-types"
@@ -49,6 +50,7 @@ const AttachmentForm = ({ edit, title, initialValues }) => {
     value: key,
     label: classifications[key]
   }))
+  const DictFastField = DictionaryField(FastField)
 
   return (
     <Formik
@@ -100,18 +102,15 @@ const AttachmentForm = ({ edit, title, initialValues }) => {
                     />
                   </Col>
                   <Col className="attachment-details" xs={12} sm={3} lg={10}>
-                    <FastField
+                    <DictFastField
+                      dictProps={Settings.fields.attachment.caption}
                       name="caption"
-                      label={Settings.fields.attachment.caption.label}
-                      placeholder={
-                        Settings.fields.attachment.caption.placeholder
-                      }
                       component={FieldHelper.InputField}
                     />
 
-                    <FastField
+                    <DictFastField
+                      dictProps={Settings.fields.attachment.fileName}
                       name="fileName"
-                      label={Settings.fields.attachment.fileName}
                       component={FieldHelper.ReadonlyField}
                     />
 
@@ -129,18 +128,18 @@ const AttachmentForm = ({ edit, title, initialValues }) => {
                     />
 
                     {canEdit ? (
-                      <FastField
+                      <DictFastField
+                        dictProps={Settings.fields.attachment.classification}
                         name="classification"
-                        label={Settings.fields.attachment.classification.label}
                         component={FieldHelper.RadioButtonToggleGroupField}
                         buttons={classificationButtons}
                         onChange={value =>
                           setFieldValue("classification", value)}
                       />
                     ) : (
-                      <Field
+                      <DictFastField
+                        dictProps={Settings.fields.attachment.classification}
                         name="classification"
-                        label={Settings.fields.attachment.classification.label}
                         component={FieldHelper.ReadonlyField}
                       />
                     )}
@@ -157,9 +156,9 @@ const AttachmentForm = ({ edit, title, initialValues }) => {
                       />
                     )}
 
-                    <FastField
+                    <DictFastField
+                      dictProps={Settings.fields.attachment.description}
                       name="description"
-                      label={Settings.fields.attachment.description}
                       component={FieldHelper.SpecialField}
                       onChange={value => {
                         // prevent initial unnecessary render of RichTextEditor
@@ -171,7 +170,14 @@ const AttachmentForm = ({ edit, title, initialValues }) => {
                         // validation will be done by setFieldValue
                         setFieldTouched("description", true, false)
                       }}
-                      widget={<RichTextEditor className="description" />}
+                      widget={
+                        <RichTextEditor
+                          className="description"
+                          placeholder={
+                            Settings.fields.attachment.description?.placeholder
+                          }
+                        />
+                      }
                     />
                   </Col>
                 </div>

--- a/client/src/pages/attachments/Show.js
+++ b/client/src/pages/attachments/Show.js
@@ -17,6 +17,7 @@ import {
 } from "components/Page"
 import RichTextEditor from "components/RichTextEditor"
 import { Field, Form, Formik } from "formik"
+import DictionaryField from "HOC/DictionaryField"
 import { Attachment } from "models"
 import PropTypes from "prop-types"
 import React, { useContext } from "react"
@@ -133,6 +134,8 @@ const AttachmentShow = ({ pageDispatchers }) => {
   }
 
   const attachment = new Attachment(data ? data.attachment : {})
+  const DictField = DictionaryField(Field)
+
   const stateSuccess = routerLocation.state && routerLocation.state.success
   const stateError = routerLocation.state && routerLocation.state.error
   const canEdit =
@@ -195,9 +198,9 @@ const AttachmentShow = ({ pageDispatchers }) => {
                     />
                   </Col>
                   <Col className="attachment-details" xs={12} sm={3} lg={8}>
-                    <Field
+                    <DictField
+                      dictProps={Settings.fields.attachment.fileName}
                       name="fileName"
-                      label={Settings.fields.attachment.fileName}
                       component={FieldHelper.ReadonlyField}
                     />
                     <Field
@@ -218,9 +221,9 @@ const AttachmentShow = ({ pageDispatchers }) => {
                         attachment.contentLength
                       )}
                     />
-                    <Field
+                    <DictField
+                      dictProps={Settings.fields.attachment.classification}
                       name="classification"
-                      label={Settings.fields.attachment.classification.label}
                       component={FieldHelper.ReadonlyField}
                       humanValue={classifications[attachment.classification]}
                     />
@@ -233,9 +236,9 @@ const AttachmentShow = ({ pageDispatchers }) => {
                         />
                       }
                     />
-                    <Field
+                    <DictField
+                      dictProps={Settings.fields.attachment.description}
                       name="description"
-                      label={Settings.fields.attachment.description}
                       component={FieldHelper.ReadonlyField}
                       humanValue={
                         <RichTextEditor readOnly value={values.description} />

--- a/client/src/pages/locations/Form.js
+++ b/client/src/pages/locations/Form.js
@@ -21,6 +21,7 @@ import RichTextEditor from "components/RichTextEditor"
 import SimilarObjectsModal from "components/SimilarObjectsModal"
 import { FastField, Field, Form, Formik } from "formik"
 import { convertLatLngToMGRS, parseCoordinate } from "geoUtils"
+import DictionaryField from "HOC/DictionaryField"
 import _escape from "lodash/escape"
 import _isEqual from "lodash/isEqual"
 import { Location, Position } from "models"
@@ -106,6 +107,8 @@ const LocationForm = ({ edit, title, initialValues, notesComponent }) => {
     }
   }
 
+  const DictFastField = DictionaryField(FastField)
+
   return (
     <Formik
       enableReinitialize
@@ -170,7 +173,8 @@ const LocationForm = ({ edit, title, initialValues, notesComponent }) => {
             <Form className="form-horizontal" method="post">
               <Fieldset title={title} action={action} />
               <Fieldset>
-                <FastField
+                <DictFastField
+                  dictProps={Settings.fields.location.name}
                   name="name"
                   component={FieldHelper.InputField}
                   disabled={!canEditName}
@@ -194,7 +198,8 @@ const LocationForm = ({ edit, title, initialValues, notesComponent }) => {
                   }
                 />
 
-                <FastField
+                <DictFastField
+                  dictProps={Settings.fields.location.type}
                   name="type"
                   component={FieldHelper.SpecialField}
                   disabled={!canEditName}
@@ -226,14 +231,16 @@ const LocationForm = ({ edit, title, initialValues, notesComponent }) => {
                   setFieldTouched={setFieldTouched}
                 />
 
-                <FastField
+                <DictFastField
+                  dictProps={Settings.fields.location.status}
                   name="status"
                   component={FieldHelper.RadioButtonToggleGroupField}
                   buttons={statusButtons}
                   onChange={value => setFieldValue("status", value)}
                 />
 
-                <FastField
+                <DictFastField
+                  dictProps={Settings.fields.location.description}
                   name="description"
                   component={FieldHelper.SpecialField}
                   onChange={value => {
@@ -246,7 +253,14 @@ const LocationForm = ({ edit, title, initialValues, notesComponent }) => {
                     // validation will be done by setFieldValue
                     setFieldTouched("description", true, false)
                   }}
-                  widget={<RichTextEditor className="description" />}
+                  widget={
+                    <RichTextEditor
+                      className="description"
+                      placeholder={
+                        Settings.fields.location.description?.placeholder
+                      }
+                    />
+                  }
                 />
 
                 {edit && attachmentEditEnabled && (

--- a/client/src/pages/locations/Show.js
+++ b/client/src/pages/locations/Show.js
@@ -25,6 +25,7 @@ import ReportCollection from "components/ReportCollection"
 import RichTextEditor from "components/RichTextEditor"
 import { Field, Form, Formik } from "formik"
 import { convertLatLngToMGRS } from "geoUtils"
+import DictionaryField from "HOC/DictionaryField"
 import _escape from "lodash/escape"
 import { Attachment, Location } from "models"
 import React, { useContext, useState } from "react"
@@ -76,6 +77,7 @@ const LocationShow = ({ pageDispatchers }) => {
   const location = new Location(data ? data.location : {})
   const canEdit = currentUser.isSuperuser()
   const attachmentsEnabled = !Settings.fields.attachment.featureDisabled
+  const DictField = DictionaryField(Field)
 
   return (
     <Formik enableReinitialize initialValues={location}>
@@ -146,9 +148,14 @@ const LocationShow = ({ pageDispatchers }) => {
                 action={action}
               />
               <Fieldset>
-                <Field name="name" component={FieldHelper.ReadonlyField} />
+                <DictField
+                  dictProps={Settings.fields.location.name}
+                  name="name"
+                  component={FieldHelper.ReadonlyField}
+                />
 
-                <Field
+                <DictField
+                  dictProps={Settings.fields.location.type}
                   name="type"
                   component={FieldHelper.ReadonlyField}
                   humanValue={Location.humanNameOfType(location.type)}
@@ -166,14 +173,16 @@ const LocationShow = ({ pageDispatchers }) => {
                   displayType={GEO_LOCATION_DISPLAY_TYPE.FORM_FIELD}
                 />
 
-                <Field
+                <DictField
+                  dictProps={Settings.fields.location.status}
                   name="status"
                   component={FieldHelper.ReadonlyField}
                   humanValue={Location.humanNameOfStatus}
                 />
 
                 {values.description && (
-                  <Field
+                  <DictField
+                    dictProps={Settings.fields.location.description}
                     name="description"
                     component={FieldHelper.ReadonlyField}
                     humanValue={

--- a/client/src/pages/organizations/Form.js
+++ b/client/src/pages/organizations/Form.js
@@ -88,8 +88,9 @@ const OrganizationForm = ({ edit, title, initialValues, notesComponent }) => {
       label: Settings.fields.principal.org.name
     }
   ]
-  const IdentificationCodeFieldWithLabel = DictionaryField(FastField)
-  const LongNameWithLabel = DictionaryField(FastField)
+
+  const DictField = DictionaryField(Field)
+  const DictFastField = DictionaryField(FastField)
 
   return (
     <Formik
@@ -119,9 +120,6 @@ const OrganizationForm = ({ edit, title, initialValues, notesComponent }) => {
           ? currentUser &&
             currentUser.hasAdministrativePermissionsForOrganization(values)
           : canAdministrateParentOrg
-        const orgSettings = isAdvisorOrg
-          ? Settings.fields.advisor.org
-          : Settings.fields.principal.org
         const orgSearchQuery = {
           status: Model.STATUS.ACTIVE,
           type: values.type
@@ -211,25 +209,26 @@ const OrganizationForm = ({ edit, title, initialValues, notesComponent }) => {
               <Fieldset>
                 {!canAdministrateOrg ? (
                   <>
-                    <FastField
+                    <DictFastField
+                      dictProps={Settings.fields.organization.shortName}
                       name="shortName"
                       component={FieldHelper.ReadonlyField}
-                      label={Settings.fields.organization.shortName}
                     />
-                    <LongNameWithLabel
-                      dictProps={orgSettings.longName}
+                    <DictField
+                      dictProps={Settings.fields.organization.longName}
                       name="longName"
                       component={FieldHelper.ReadonlyField}
                     />
-                    <FastField
+                    <DictField
+                      dictProps={Settings.fields.organization.type}
                       name="type"
                       component={FieldHelper.ReadonlyField}
                       humanValue={Organization.humanNameOfType}
                     />
-                    <FastField
+                    <DictFastField
+                      dictProps={Settings.fields.organization.parentOrg}
                       name="parentOrg"
                       component={FieldHelper.ReadonlyField}
-                      label={Settings.fields.organization.parentOrg}
                       humanValue={
                         values.parentOrg && (
                           <LinkTo
@@ -239,12 +238,15 @@ const OrganizationForm = ({ edit, title, initialValues, notesComponent }) => {
                         )
                       }
                     />
-                    <IdentificationCodeFieldWithLabel
-                      dictProps={orgSettings.identificationCode}
+                    <DictField
+                      dictProps={
+                        Settings.fields.organization.identificationCode
+                      }
                       name="identificationCode"
                       component={FieldHelper.ReadonlyField}
                     />
-                    <FastField
+                    <DictFastField
+                      dictProps={Settings.fields.organization.location}
                       name="location"
                       component={FieldHelper.ReadonlyField}
                       humanValue={
@@ -261,15 +263,16 @@ const OrganizationForm = ({ edit, title, initialValues, notesComponent }) => {
                         )
                       }
                     />
-                    <FastField
+                    <DictFastField
+                      dictProps={Settings.fields.organization.status}
                       name="status"
                       component={FieldHelper.ReadonlyField}
                       humanValue={Organization.humanNameOfStatus}
                     />
-                    <FastField
+                    <DictFastField
+                      dictProps={Settings.fields.organization.profile}
                       name="profile"
                       component={FieldHelper.ReadonlyField}
-                      label={Settings.fields.organization.profile}
                       humanValue={
                         <RichTextEditor readOnly className="profile" />
                       }
@@ -277,27 +280,27 @@ const OrganizationForm = ({ edit, title, initialValues, notesComponent }) => {
                   </>
                 ) : (
                   <>
-                    <FastField
+                    <DictFastField
+                      dictProps={Settings.fields.organization.shortName}
                       name="shortName"
                       component={FieldHelper.InputField}
-                      label={Settings.fields.organization.shortName}
-                      placeholder="e.g. EF1.1"
                     />
-                    <LongNameWithLabel
-                      dictProps={orgSettings.longName}
+                    <DictField
+                      dictProps={Settings.fields.organization.longName}
                       name="longName"
                       component={FieldHelper.InputField}
                     />
-                    <FastField
+                    <DictField
+                      dictProps={Settings.fields.organization.type}
                       name="type"
                       component={FieldHelper.RadioButtonToggleGroupField}
                       buttons={typeButtons}
                       onChange={value => setFieldValue("type", value)}
                       disabled={!isAdmin}
                     />
-                    <Field
+                    <DictFastField
+                      dictProps={Settings.fields.organization.parentOrg}
                       name="parentOrg"
-                      label={Settings.fields.organization.parentOrg}
                       component={FieldHelper.SpecialField}
                       onChange={value => {
                         // validation will be done by setFieldValue
@@ -308,7 +311,9 @@ const OrganizationForm = ({ edit, title, initialValues, notesComponent }) => {
                       widget={
                         <AdvancedSingleSelect
                           fieldName="parentOrg"
-                          placeholder="Search for a higher level organization..."
+                          placeholder={
+                            Settings.fields.organization.parentOrg.placeholder
+                          }
                           showRemoveButton={isAdmin}
                           value={values.parentOrg}
                           overlayColumns={["Name"]}
@@ -322,14 +327,16 @@ const OrganizationForm = ({ edit, title, initialValues, notesComponent }) => {
                         />
                       }
                     />
-                    <IdentificationCodeFieldWithLabel
-                      dictProps={orgSettings.identificationCode}
+                    <DictField
+                      dictProps={
+                        Settings.fields.organization.identificationCode
+                      }
                       name="identificationCode"
                       component={FieldHelper.InputField}
                     />
-                    <Field
+                    <DictFastField
+                      dictProps={Settings.fields.organization.location}
                       name="location"
-                      label="Location"
                       component={FieldHelper.SpecialField}
                       onChange={value => {
                         // validation will be done by setFieldValue
@@ -339,7 +346,9 @@ const OrganizationForm = ({ edit, title, initialValues, notesComponent }) => {
                       widget={
                         <AdvancedSingleSelect
                           fieldName="location"
-                          placeholder="Search for the location where this Organization will operate from..."
+                          placeholder={
+                            Settings.fields.organization.location.placeholder
+                          }
                           value={values.location}
                           overlayColumns={["Name"]}
                           overlayRenderRow={LocationOverlayRow}
@@ -351,16 +360,17 @@ const OrganizationForm = ({ edit, title, initialValues, notesComponent }) => {
                         />
                       }
                     />
-                    <FastField
+                    <DictFastField
+                      dictProps={Settings.fields.organization.status}
                       name="status"
                       component={FieldHelper.RadioButtonToggleGroupField}
                       buttons={statusButtons}
                       onChange={value => setFieldValue("status", value)}
                     />
-                    <FastField
+                    <DictFastField
+                      dictProps={Settings.fields.organization.profile}
                       name="profile"
                       component={FieldHelper.SpecialField}
-                      label={Settings.fields.organization.profile}
                       onChange={value => {
                         // prevent initial unnecessary render of RichTextEditor
                         if (!_isEqual(values.profile, value)) {
@@ -371,7 +381,14 @@ const OrganizationForm = ({ edit, title, initialValues, notesComponent }) => {
                         // validation will be done by setFieldValue
                         setFieldTouched("profile", true, false)
                       }}
-                      widget={<RichTextEditor className="profile" />}
+                      widget={
+                        <RichTextEditor
+                          className="profile"
+                          placeholder={
+                            Settings.fields.organization.profile?.placeholder
+                          }
+                        />
+                      }
                     />
                   </>
                 )}

--- a/client/src/pages/organizations/Show.js
+++ b/client/src/pages/organizations/Show.js
@@ -205,8 +205,7 @@ const OrganizationShow = ({ pageDispatchers }) => {
     )
   }
   const organization = new Organization(data ? data.organization : {})
-  const IdentificationCodeFieldWithLabel = DictionaryField(Field)
-  const LongNameWithLabel = DictionaryField(Field)
+  const DictField = DictionaryField(Field)
 
   const canAdministrateOrg =
     currentUser &&
@@ -361,23 +360,24 @@ const OrganizationShow = ({ pageDispatchers }) => {
                 action={action}
               />
               <Fieldset id="info">
-                <LongNameWithLabel
-                  dictProps={orgSettings.longName}
+                <DictField
+                  dictProps={Settings.fields.organization.longName}
                   name="longName"
                   component={FieldHelper.ReadonlyField}
                 />
 
-                <Field
+                <DictField
+                  dictProps={Settings.fields.organization.type}
                   name="type"
                   component={FieldHelper.ReadonlyField}
                   humanValue={Organization.humanNameOfType}
                 />
 
                 {organization.parentOrg && organization.parentOrg.uuid && (
-                  <Field
+                  <DictField
+                    dictProps={Settings.fields.organization.parentOrg}
                     name="parentOrg"
                     component={FieldHelper.ReadonlyField}
-                    label={Settings.fields.organization.parentOrg}
                     humanValue={
                       organization.parentOrg && (
                         <LinkTo
@@ -391,10 +391,10 @@ const OrganizationShow = ({ pageDispatchers }) => {
 
                 {organization.childrenOrgs &&
                   organization.childrenOrgs.length > 0 && (
-                    <Field
+                    <DictField
+                      dictProps={Settings.fields.organization.childrenOrgs}
                       name="childrenOrgs"
                       component={FieldHelper.ReadonlyField}
-                      label="Sub organizations"
                       humanValue={
                         <ListGroup>
                           {organization.childrenOrgs.map(childOrg => (
@@ -426,14 +426,15 @@ const OrganizationShow = ({ pageDispatchers }) => {
                   )
                 )}
 
-                <IdentificationCodeFieldWithLabel
-                  dictProps={orgSettings.identificationCode}
+                <DictField
+                  dictProps={Settings.fields.organization.identificationCode}
                   name="identificationCode"
                   component={FieldHelper.ReadonlyField}
                 />
 
                 {organization.location && (
-                  <Field
+                  <DictField
+                    dictProps={Settings.fields.organization.location}
                     name="location"
                     component={FieldHelper.ReadonlyField}
                     humanValue={
@@ -454,16 +455,17 @@ const OrganizationShow = ({ pageDispatchers }) => {
                   />
                 )}
 
-                <Field
+                <DictField
+                  dictProps={Settings.fields.organization.status}
                   name="status"
                   component={FieldHelper.ReadonlyField}
                   humanValue={Organization.humanNameOfStatus}
                 />
 
-                <Field
+                <DictField
+                  dictProps={Settings.fields.organization.profile}
                   name="profile"
                   component={FieldHelper.ReadonlyField}
-                  label={Settings.fields.organization.profile}
                   humanValue={
                     <RichTextEditor readOnly value={organization.profile} />
                   }

--- a/client/src/pages/people/Compact.js
+++ b/client/src/pages/people/Compact.js
@@ -126,9 +126,11 @@ const NORMAL_FIELD_OPTIONS = Object.entries(
     "firstName"
   )
 ).reduce((accum, [k, v]) => {
-  accum[k] = {
-    text: v?.label || v,
-    active: !DEFAULT_FIELD_GROUP_EXCEPTIONS.find(field => field === k)
+  if (!v?.exclude) {
+    accum[k] = {
+      text: v?.label || v,
+      active: !DEFAULT_FIELD_GROUP_EXCEPTIONS.find(field => field === k)
+    }
   }
   return accum
 }, {})

--- a/client/src/pages/people/Compact.js
+++ b/client/src/pages/people/Compact.js
@@ -30,6 +30,7 @@ import { GRAPHQL_NOTES_FIELDS } from "components/RelatedObjectNotes"
 import RichTextEditor from "components/RichTextEditor"
 import SimpleMultiCheckboxDropdown from "components/SimpleMultiCheckboxDropdown"
 import { Field, Formik } from "formik"
+import DictionaryField from "HOC/DictionaryField"
 import _isEmpty from "lodash/isEmpty"
 import { Person } from "models"
 import moment from "moment"
@@ -112,7 +113,7 @@ const DEFAULT_FIELD_GROUP_EXCEPTIONS = [
   "emailAddress",
   "phone",
   "code",
-  "endOfTour"
+  "endOfTourDate"
 ]
 
 const NORMAL_FIELD_OPTIONS = Object.entries(
@@ -398,13 +399,12 @@ const CompactPersonView = ({ pageDispatchers }) => {
       role: Person.humanNameOfRole(person.role),
       status: Person.humanNameOfStatus(person.status)
     }
+    const DictField = DictionaryField(Field)
     return person.getNormalFieldsOrdered().reduce((accum, key) => {
       accum[key] = (
-        <Field
+        <DictField
+          dictProps={Settings.fields.person[key]}
           name={key}
-          label={
-            Settings.fields.person[key]?.label || Settings.fields.person[key]
-          }
           component={FieldHelper.ReadonlyField}
           humanValue={humanValuesExceptions[key]}
           className={classNameExceptions[key]}

--- a/client/src/pages/people/Form.js
+++ b/client/src/pages/people/Form.js
@@ -26,6 +26,7 @@ import RichTextEditor from "components/RichTextEditor"
 import SimilarObjectsModal from "components/SimilarObjectsModal"
 import TriggerableConfirm from "components/TriggerableConfirm"
 import { FastField, Field, Form, Formik } from "formik"
+import DictionaryField from "HOC/DictionaryField"
 import _isEmpty from "lodash/isEmpty"
 import _isEqual from "lodash/isEqual"
 import { Person } from "models"
@@ -152,6 +153,9 @@ const PersonForm = ({
       value: "FEMALE"
     }
   ]
+
+  const DictField = DictionaryField(Field)
+  const DictFastField = DictionaryField(FastField)
 
   return (
     <Formik
@@ -309,22 +313,22 @@ const PersonForm = ({
                         <Col sm={7}>
                           <Row>
                             <Col>
-                              <FastField
+                              <DictFastField
+                                dictProps={Settings.fields.person.lastName}
                                 name="lastName"
                                 component={FieldHelper.InputFieldNoLabel}
                                 display="inline"
-                                placeholder="LAST NAME"
                                 disabled={!canEditName}
                                 onKeyDown={handleLastNameOnKeyDown}
                               />
                             </Col>
                             ,
                             <Col>
-                              <FastField
+                              <DictFastField
+                                dictProps={Settings.fields.person.firstName}
                                 name="firstName"
                                 component={FieldHelper.InputFieldNoLabel}
                                 display="inline"
-                                placeholder="First name(s) - Lower-case except for the first letter of each name"
                                 disabled={!canEditName}
                               />
                             </Col>
@@ -501,7 +505,8 @@ const PersonForm = ({
                     </FormGroup>
 
                     {isAdmin && (
-                      <FastField
+                      <DictFastField
+                        dictProps={Settings.fields.person.domainUsername}
                         name="domainUsername"
                         component={FieldHelper.InputField}
                         extraColElem={
@@ -548,19 +553,22 @@ const PersonForm = ({
                     )}
 
                     {disableStatusChange ? (
-                      <FastField
+                      <DictFastField
+                        dictProps={Settings.fields.person.status}
                         name="status"
                         component={FieldHelper.ReadonlyField}
                         humanValue={Person.humanNameOfStatus(values.status)}
                       />
                     ) : isPendingVerification ? (
-                      <FastField
+                      <DictFastField
+                        dictProps={Settings.fields.person.status}
                         name="status"
                         component={FieldHelper.ReadonlyField}
                         humanValue={Person.humanNameOfStatus(values.status)}
                       />
                     ) : (
-                      <Field
+                      <DictField
+                        dictProps={Settings.fields.person.status}
                         name="status"
                         component={FieldHelper.RadioButtonToggleGroupField}
                         buttons={statusButtons}
@@ -587,32 +595,27 @@ const PersonForm = ({
                             </span>
                           </FormText>
                         )}
-                      </Field>
+                      </DictField>
                     )}
                   </Col>
                 </Row>
               </Fieldset>
 
               <Fieldset title="Additional information">
-                <FastField
+                <DictFastField
+                  dictProps={Settings.fields.person.emailAddress}
                   name="emailAddress"
-                  label={Settings.fields.person.emailAddress.label}
                   type="email"
-                  placeholder={
-                    values.role === Person.ROLE.ADVISOR
-                      ? Settings.fields.person.emailAddress.placeholder
-                      : ""
-                  }
                   component={FieldHelper.InputField}
                 />
-                <FastField
+                <DictFastField
+                  dictProps={Settings.fields.person.phoneNumber}
                   name="phoneNumber"
-                  label={Settings.fields.person.phoneNumber}
                   component={FieldHelper.InputField}
                 />
-                <FastField
+                <DictFastField
+                  dictProps={Settings.fields.person.rank}
                   name="rank"
-                  label={Settings.fields.person.rank}
                   component={FieldHelper.SpecialField}
                   widget={
                     <FormSelect>
@@ -626,9 +629,9 @@ const PersonForm = ({
                     </FormSelect>
                   }
                 />
-                <FastField
+                <DictFastField
+                  dictProps={Settings.fields.person.gender}
                   name="gender"
-                  label={Settings.fields.person.gender}
                   component={FieldHelper.SpecialField}
                   widget={
                     <FormSelect>
@@ -644,9 +647,9 @@ const PersonForm = ({
                     </FormSelect>
                   }
                 />
-                <FastField
+                <DictFastField
+                  dictProps={Settings.fields.person.country}
                   name="country"
-                  label={Settings.fields.person.country}
                   component={FieldHelper.SpecialField}
                   widget={
                     <FormSelect>
@@ -659,15 +662,15 @@ const PersonForm = ({
                     </FormSelect>
                   }
                 />
-                <FastField
+                <DictFastField
+                  dictProps={Settings.fields.person.code}
                   name="code"
-                  label={Settings.fields.person.code}
                   component={FieldHelper.InputField}
                   disabled={!isAdmin}
                 />
-                <FastField
+                <DictFastField
+                  dictProps={Settings.fields.person.endOfTourDate}
                   name="endOfTourDate"
-                  label={Settings.fields.person.endOfTourDate}
                   component={FieldHelper.SpecialField}
                   value={values.endOfTourDate}
                   onChange={value => setFieldValue("endOfTourDate", value)}
@@ -681,8 +684,9 @@ const PersonForm = ({
                       Be aware that the end of tour date is in the past.
                     </Alert>
                   )}
-                </FastField>
-                <FastField
+                </DictFastField>
+                <DictFastField
+                  dictProps={Settings.fields.person.biography}
                   name="biography"
                   component={FieldHelper.SpecialField}
                   value={values.biography}
@@ -696,7 +700,14 @@ const PersonForm = ({
                     // validation will be done by setFieldValue
                     setFieldTouched("biography", true, false)
                   }}
-                  widget={<RichTextEditor className="biography" />}
+                  widget={
+                    <RichTextEditor
+                      className="biography"
+                      placeholder={
+                        Settings.fields.person.biography?.placeholder
+                      }
+                    />
+                  }
                 />
 
                 {edit && attachmentEditEnabled && (

--- a/client/src/pages/people/Show.js
+++ b/client/src/pages/people/Show.js
@@ -35,6 +35,7 @@ import RelatedObjectNotes, {
 import ReportCollection from "components/ReportCollection"
 import RichTextEditor from "components/RichTextEditor"
 import { Field, Form, Formik } from "formik"
+import DictionaryField from "HOC/DictionaryField"
 import _isEmpty from "lodash/isEmpty"
 import { Attachment, Person, Position } from "models"
 import moment from "moment"
@@ -520,12 +521,11 @@ const PersonShow = ({ pageDispatchers }) => {
       status: Person.humanNameOfStatus(person.status)
     }
     return person.getNormalFieldsOrdered().reduce((accum, key) => {
+      const DictField = DictionaryField(Field)
       accum[key] = (
-        <Field
+        <DictField
+          dictProps={Settings.fields.person[key]}
           name={key}
-          label={
-            Settings.fields.person[key]?.label || Settings.fields.person[key]
-          }
           component={FieldHelper.ReadonlyField}
           humanValue={humanValuesExceptions[key]}
           className={classNameExceptions[key]}

--- a/client/src/pages/positions/Form.js
+++ b/client/src/pages/positions/Form.js
@@ -116,7 +116,8 @@ const PositionForm = ({ edit, title, initialValues, notesComponent }) => {
     }
   ])
 
-  const CodeFieldWithLabel = DictionaryField(Field)
+  const DictField = DictionaryField(Field)
+  const DictFastField = DictionaryField(FastField)
 
   // For advisor types of positions, add permissions property.
   // The permissions property allows selecting a
@@ -148,10 +149,6 @@ const PositionForm = ({ edit, title, initialValues, notesComponent }) => {
         submitForm
       }) => {
         const isPrincipal = values.type === Position.TYPE.PRINCIPAL
-        const positionSettings = isPrincipal
-          ? Settings.fields.principal.position
-          : Settings.fields.advisor.position
-
         const isAdmin = currentUser && currentUser.isAdmin()
         const permissionsButtons = isAdmin
           ? adminPermissionsButtons
@@ -210,11 +207,10 @@ const PositionForm = ({ edit, title, initialValues, notesComponent }) => {
             <Form className="form-horizontal" method="post">
               <Fieldset title={title} action={action} />
               <Fieldset>
-                <Field
+                <DictField
+                  dictProps={Settings.fields.position.name}
                   name="name"
                   component={FieldHelper.InputField}
-                  label={Settings.fields.position.name}
-                  placeholder="Name/Description of Position"
                   extraColElem={
                     !edit && values.name.length >= MIN_CHARS_FOR_DUPLICATES ? (
                       <>
@@ -236,13 +232,15 @@ const PositionForm = ({ edit, title, initialValues, notesComponent }) => {
                 />
 
                 {edit ? (
-                  <FastField
+                  <DictField
+                    dictProps={Settings.fields.position.type}
                     name="type"
                     component={FieldHelper.ReadonlyField}
                     humanValue={Position.humanNameOfType}
                   />
                 ) : (
-                  <FastField
+                  <DictField
+                    dictProps={Settings.fields.position.type}
                     name="type"
                     component={FieldHelper.RadioButtonToggleGroupField}
                     buttons={typeButtons}
@@ -259,9 +257,9 @@ const PositionForm = ({ edit, title, initialValues, notesComponent }) => {
                   />
                 )}
 
-                <Field
+                <DictField
+                  dictProps={Settings.fields.position.organization}
                   name="organization"
-                  label="Organization"
                   component={FieldHelper.SpecialField}
                   onChange={value => {
                     // validation will be done by setFieldValue
@@ -271,7 +269,9 @@ const PositionForm = ({ edit, title, initialValues, notesComponent }) => {
                   widget={
                     <AdvancedSingleSelect
                       fieldName="organization"
-                      placeholder="Search the organization for this position..."
+                      placeholder={
+                        Settings.fields.position.organization.placeholder
+                      }
                       value={values.organization}
                       overlayColumns={["Name"]}
                       overlayRenderRow={OrganizationOverlayRow}
@@ -285,9 +285,9 @@ const PositionForm = ({ edit, title, initialValues, notesComponent }) => {
                   }
                 />
 
-                <Field
+                <DictField
+                  dictProps={Settings.fields.position.location}
                   name="location"
-                  label="Location"
                   component={FieldHelper.SpecialField}
                   onChange={value => {
                     // validation will be done by setFieldValue
@@ -297,7 +297,9 @@ const PositionForm = ({ edit, title, initialValues, notesComponent }) => {
                   widget={
                     <AdvancedSingleSelect
                       fieldName="location"
-                      placeholder="Search for the location where this Position will operate from..."
+                      placeholder={
+                        Settings.fields.position.location.placeholder
+                      }
                       value={values.location}
                       overlayColumns={["Name"]}
                       overlayRenderRow={LocationOverlayRow}
@@ -310,13 +312,14 @@ const PositionForm = ({ edit, title, initialValues, notesComponent }) => {
                   }
                 />
 
-                <CodeFieldWithLabel
-                  dictProps={positionSettings.code}
+                <DictField
+                  dictProps={Settings.fields.position.code}
                   name="code"
                   component={FieldHelper.InputField}
                 />
 
-                <FastField
+                <DictFastField
+                  dictProps={Settings.fields.position.status}
                   name="status"
                   component={FieldHelper.RadioButtonToggleGroupField}
                   buttons={statusButtons}
@@ -332,11 +335,11 @@ const PositionForm = ({ edit, title, initialValues, notesComponent }) => {
                       </span>
                     </FormBS.Text>
                   )}
-                </FastField>
+                </DictFastField>
 
-                <FastField
+                <DictField
+                  dictProps={Settings.fields.position.role}
                   name="role"
-                  label={Settings.fields.position.role.label}
                   component={FieldHelper.RadioButtonToggleGroupField}
                   buttons={positionRoleButtons}
                   onChange={value => setFieldValue("role", value)}

--- a/client/src/pages/positions/Show.js
+++ b/client/src/pages/positions/Show.js
@@ -97,7 +97,7 @@ const PositionShow = ({ pageDispatchers }) => {
   }
 
   const position = new Position(data ? data.position : {})
-  const CodeFieldWithLabel = DictionaryField(Field)
+  const DictField = DictionaryField(Field)
 
   const isPrincipal = position.type === Position.TYPE.PRINCIPAL
   const isSuperuser = position.type === Position.TYPE.SUPERUSER
@@ -193,14 +193,16 @@ const PositionShow = ({ pageDispatchers }) => {
                 action={action}
               />
               <Fieldset>
-                <Field
+                <DictField
+                  dictProps={Settings.fields.position.type}
                   name="type"
                   component={FieldHelper.ReadonlyField}
                   humanValue={Position.humanNameOfType}
                 />
 
                 {position.organization && (
-                  <Field
+                  <DictField
+                    dictProps={Settings.fields.position.organization}
                     name="organization"
                     component={FieldHelper.ReadonlyField}
                     humanValue={
@@ -214,7 +216,8 @@ const PositionShow = ({ pageDispatchers }) => {
                   />
                 )}
 
-                <Field
+                <DictField
+                  dictProps={Settings.fields.position.location}
                   name="location"
                   component={FieldHelper.ReadonlyField}
                   humanValue={
@@ -232,21 +235,22 @@ const PositionShow = ({ pageDispatchers }) => {
                   }
                 />
 
-                <CodeFieldWithLabel
-                  dictProps={positionSettings.code}
+                <DictField
+                  dictProps={Settings.fields.position.code}
                   name="code"
                   component={FieldHelper.ReadonlyField}
                 />
 
-                <Field
+                <DictField
+                  dictProps={Settings.fields.position.status}
                   name="status"
                   component={FieldHelper.ReadonlyField}
                   humanValue={Position.humanNameOfStatus}
                 />
 
-                <Field
+                <DictField
+                  dictProps={Settings.fields.position.role}
                   name="role"
-                  label={Settings.fields.position.role.label}
                   component={FieldHelper.ReadonlyField}
                   humanValue={Position.humanNameOfRole}
                 />

--- a/client/src/pages/reports/Compact.js
+++ b/client/src/pages/reports/Compact.js
@@ -32,6 +32,7 @@ import { ActionButton, ActionStatus } from "components/ReportWorkflow"
 import RichTextEditor from "components/RichTextEditor"
 import SimpleMultiCheckboxDropdown from "components/SimpleMultiCheckboxDropdown"
 import { Formik } from "formik"
+import DictionaryField from "HOC/DictionaryField"
 import _isEmpty from "lodash/isEmpty"
 import { Person, Report, Task } from "models"
 import moment from "moment"
@@ -284,6 +285,9 @@ const CompactReportView = ({ pageDispatchers }) => {
       />
     )
   }
+
+  const DictCompactRow = DictionaryField(CompactRow)
+
   // Get initial tasks/attendees instant assessments values
   report = Object.assign(report, report.getTasksEngagementAssessments())
   report = Object.assign(report, report.getAttendeesEngagementAssessments())
@@ -322,43 +326,44 @@ const CompactReportView = ({ pageDispatchers }) => {
                   label={getReportSubTitle()}
                   className="reportField"
                 />
-                <CompactRow
-                  label="purpose"
+                <DictCompactRow
+                  dictProps={Settings.fields.report.intent}
                   content={report.intent}
                   className="reportField"
                 />
-                <CompactRow
-                  label={Settings.fields.report.keyOutcomes || "key outcomes"}
+                <DictCompactRow
+                  dictProps={Settings.fields.report.keyOutcomes}
                   content={report.keyOutcomes}
                   className="reportField"
                 />
-                {!report.cancelled ? (
-                  <CompactRow
-                    label={Settings.fields.report.atmosphere}
-                    content={
-                      <>
-                        {utils.sentenceCase(report.atmosphere)}
-                        {report.atmosphereDetails &&
-                          ` – ${report.atmosphereDetails}`}
-                      </>
-                    }
-                    className="reportField"
-                  />
-                ) : null}
-                <CompactRow
-                  label={Settings.fields.report.nextSteps.label}
+                {!report.cancelled && (
+                  <>
+                    <DictCompactRow
+                      dictProps={Settings.fields.report.atmosphere}
+                      value={utils.sentenceCase(report.atmosphere)}
+                      className="reportField"
+                    />
+                    <DictCompactRow
+                      dictProps={Settings.fields.report.atmosphereDetails}
+                      value={report.atmosphereDetails}
+                      className="reportField"
+                    />
+                  </>
+                )}
+                <DictCompactRow
+                  dictProps={Settings.fields.report.nextSteps}
                   content={report.nextSteps}
                   className="reportField"
                 />
                 <CompactRow
                   id="principals"
-                  label="principals"
+                  label="Principals"
                   content={getAttendeesAndAssessments(Person.ROLE.PRINCIPAL)}
                   className="reportField"
                 />
                 <CompactRow
                   id="advisors"
-                  label="advisors"
+                  label="Advisors"
                   content={getAttendeesAndAssessments(Person.ROLE.ADVISOR)}
                   className="reportField"
                 />
@@ -368,37 +373,37 @@ const CompactReportView = ({ pageDispatchers }) => {
                   content={getTasksAndAssessments()}
                   className="reportField"
                 />
-                {report.cancelled ? (
-                  <CompactRow
-                    label="cancelled reason"
+                {report.cancelled && (
+                  <DictCompactRow
+                    dictProps={Settings.fields.report.cancelledReason}
                     content={utils.sentenceCase(report.cancelledReason)}
                     className="reportField"
                   />
-                ) : null}
-                {optionalFields.workflow.active && report.showWorkflow() ? (
+                )}
+                {optionalFields.workflow.active && report.showWorkflow() && (
                   <CompactRowReportWorkflow
                     workflow={report.workflow}
                     className="reportField"
                     isCompact
                   />
-                ) : null}
-                {report.reportText ? (
-                  <CompactRow
-                    label={Settings.fields.report.reportText}
+                )}
+                {report.reportText && (
+                  <DictCompactRow
+                    dictProps={Settings.fields.report.reportText}
                     content={
                       <RichTextEditor readOnly value={report.reportText} />
                     }
                     className="reportField"
                   />
-                ) : null}
-                {Settings.fields.report.customFields ? (
+                )}
+                {Settings.fields.report.customFields && (
                   <ReadonlyCustomFields
                     fieldsConfig={Settings.fields.report.customFields}
                     values={report}
                     vertical
                     isCompact
                   />
-                ) : null}
+                )}
               </FullColumn>
             </CompactTable>
             <CompactFooterContent object={report} />

--- a/client/src/pages/reports/Form.js
+++ b/client/src/pages/reports/Form.js
@@ -641,6 +641,7 @@ const ReportForm = ({
                       dictProps={Settings.fields.report.atmosphere}
                       name="atmosphere"
                       component={FieldHelper.RadioButtonToggleGroupField}
+                      enableClear={Settings.fields.report.atmosphere?.optional}
                       buttons={atmosphereButtons}
                       onChange={value =>
                         setFieldValue("atmosphere", value, true)}

--- a/client/src/pages/reports/Form.js
+++ b/client/src/pages/reports/Form.js
@@ -830,14 +830,7 @@ const ReportForm = ({
                 </Fieldset>
               )}
 
-              <Fieldset
-                title={
-                  !values.cancelled
-                    ? "Meeting discussion"
-                    : "Next steps and details"
-                }
-                id="meeting-details"
-              >
+              <Fieldset title="Engagement details" id="meeting-details">
                 {Settings.fields.report.keyOutcomes &&
                   !isFutureEngagement &&
                   !values.cancelled && (

--- a/client/src/pages/reports/Form.js
+++ b/client/src/pages/reports/Form.js
@@ -37,6 +37,7 @@ import {
 import { EXCLUDED_ASSESSMENT_FIELDS } from "components/RelatedObjectNotes"
 import RichTextEditor from "components/RichTextEditor"
 import { FastField, Field, Form, Formik } from "formik"
+import DictionaryField from "HOC/DictionaryField"
 import _cloneDeep from "lodash/cloneDeep"
 import _debounce from "lodash/debounce"
 import _isEmpty from "lodash/isEmpty"
@@ -264,6 +265,9 @@ const ReportForm = ({
     }
   }
 
+  const DictField = DictionaryField(Field)
+  const DictFastField = DictionaryField(FastField)
+
   const isAuthor = initialValues.reportPeople?.some(
     a => a.author && Person.isEqual(currentUser, a)
   )
@@ -469,12 +473,11 @@ const ReportForm = ({
             <Form className="form-horizontal" method="post">
               <Fieldset title={title} action={action} />
               <Fieldset>
-                <FastField
+                <DictFastField
+                  dictProps={Settings.fields.report.intent}
                   name="intent"
-                  label={Settings.fields.report.intent}
                   component={FieldHelper.InputField}
                   asA="textarea"
-                  placeholder="What is the engagement supposed to achieve?"
                   maxLength={Settings.maxTextFieldLength}
                   onChange={event => {
                     setFieldTouched("intent", true, false)
@@ -499,7 +502,8 @@ const ReportForm = ({
                   className="meeting-goal"
                 />
 
-                <FastField
+                <DictFastField
+                  dictProps={Settings.fields.report.engagementDate}
                   name="engagementDate"
                   component={FieldHelper.SpecialField}
                   onChange={value => {
@@ -521,12 +525,12 @@ const ReportForm = ({
                       </span>
                     </FormBS.Text>
                   )}
-                </FastField>
+                </DictFastField>
 
                 {Settings.engagementsIncludeTimeAndDuration && (
-                  <FastField
+                  <DictFastField
+                    dictProps={Settings.fields.report.duration}
                     name="duration"
-                    label="Duration (minutes)"
                     component={FieldHelper.InputField}
                     inputType="number"
                     onWheelCapture={event => event.currentTarget.blur()} // Prevent scroll action on number input
@@ -543,7 +547,8 @@ const ReportForm = ({
                   />
                 )}
 
-                <FastField
+                <DictFastField
+                  dictProps={Settings.fields.report.location}
                   name="location"
                   component={FieldHelper.SpecialField}
                   onChange={value => {
@@ -554,7 +559,7 @@ const ReportForm = ({
                   widget={
                     <AdvancedSingleSelect
                       fieldName="location"
-                      placeholder="Search for the engagement location..."
+                      placeholder={Settings.fields.report.location.placeholder}
                       value={values.location}
                       overlayColumns={["Name"]}
                       overlayRenderRow={LocationOverlayRow}
@@ -587,10 +592,10 @@ const ReportForm = ({
                 />
 
                 {!isFutureEngagement && (
-                  <FastField
+                  <DictFastField
+                    dictProps={Settings.fields.report.cancelled}
                     name="cancelled"
                     component={FieldHelper.SpecialField}
-                    label={Settings.fields.report.cancelled}
                     widget={
                       <FormBS.Check
                         type="checkbox"
@@ -611,9 +616,8 @@ const ReportForm = ({
                   />
                 )}
                 {!isFutureEngagement && values.cancelled && (
-                  <FastField
-                    name="cancelledReason"
-                    label="due to"
+                  <DictField
+                    dictProps={Settings.fields.report.cancelledReason}
                     component={FieldHelper.SpecialField}
                     onChange={event => {
                       // validation will be done by setFieldValue
@@ -632,21 +636,19 @@ const ReportForm = ({
                 )}
 
                 {!isFutureEngagement && !values.cancelled && (
-                  <FastField
-                    name="atmosphere"
-                    label={Settings.fields.report.atmosphere}
-                    component={FieldHelper.RadioButtonToggleGroupField}
-                    buttons={atmosphereButtons}
-                    onChange={value => setFieldValue("atmosphere", value, true)}
-                    className="atmosphere-form-group"
-                  />
-                )}
-                {!isFutureEngagement &&
-                  !values.cancelled &&
-                  values.atmosphere && (
-                    <Field
+                  <>
+                    <DictFastField
+                      dictProps={Settings.fields.report.atmosphere}
+                      name="atmosphere"
+                      component={FieldHelper.RadioButtonToggleGroupField}
+                      buttons={atmosphereButtons}
+                      onChange={value =>
+                        setFieldValue("atmosphere", value, true)}
+                      className="atmosphere-form-group"
+                    />
+                    <DictField
+                      dictProps={Settings.fields.report.atmosphereDetails}
                       name="atmosphereDetails"
-                      label={Settings.fields.report.atmosphereDetails}
                       component={FieldHelper.InputField}
                       onChange={event => {
                         setFieldTouched("atmosphereDetails", true, false)
@@ -657,13 +659,9 @@ const ReportForm = ({
                         )
                         validateFieldDebounced("atmosphereDetails")
                       }}
-                      placeholder={`Why was this engagement ${values.atmosphere.toLowerCase()}? ${
-                        values.atmosphere === Report.ATMOSPHERE.POSITIVE
-                          ? "(optional)"
-                          : ""
-                      }`}
                       className="atmosphere-details"
                     />
+                  </>
                 )}
               </Fieldset>
 
@@ -843,9 +841,9 @@ const ReportForm = ({
                 {Settings.fields.report.keyOutcomes &&
                   !isFutureEngagement &&
                   !values.cancelled && (
-                    <FastField
+                    <DictFastField
+                      dictProps={Settings.fields.report.keyOutcomes}
                       name="keyOutcomes"
-                      label={Settings.fields.report.keyOutcomes}
                       component={FieldHelper.InputField}
                       asA="textarea"
                       onChange={event => {
@@ -873,9 +871,9 @@ const ReportForm = ({
                 )}
 
                 {!isFutureEngagement && (
-                  <FastField
+                  <DictFastField
+                    dictProps={Settings.fields.report.nextSteps}
                     name="nextSteps"
-                    label={Settings.fields.report.nextSteps.label}
                     component={FieldHelper.InputField}
                     asA="textarea"
                     onChange={event => {
@@ -907,9 +905,9 @@ const ReportForm = ({
                   />
                 )}
 
-                <FastField
+                <DictFastField
+                  dictProps={Settings.fields.report.reportText}
                   name="reportText"
-                  label={Settings.fields.report.reportText}
                   component={FieldHelper.SpecialField}
                   onChange={value => {
                     // prevent initial unnecessary render of RichTextEditor
@@ -921,7 +919,14 @@ const ReportForm = ({
                     // validation will be done by setFieldValue
                     setFieldTouched("reportText", true, false)
                   }}
-                  widget={<RichTextEditor className="reportTextField" />}
+                  widget={
+                    <RichTextEditor
+                      className="reportTextField"
+                      placeholder={
+                        Settings.fields.report.reportText?.placeholder
+                      }
+                    />
+                  }
                 />
 
                 {attachmentEditEnabled && (

--- a/client/src/pages/reports/ReportPeople.js
+++ b/client/src/pages/reports/ReportPeople.js
@@ -53,7 +53,7 @@ const ReportPeople = ({ report, disabled, onChange, showDelete, onDelete }) => {
               </TableContainer>
             </td>
           </tr>
-          {showNonAttending ? (
+          {showNonAttending && (
             <tr>
               <th>Non-attending</th>
               <td style={{ padding: "0" }}>
@@ -69,7 +69,7 @@ const ReportPeople = ({ report, disabled, onChange, showDelete, onDelete }) => {
                 </TableContainer>
               </td>
             </tr>
-          ) : null}
+          )}
         </tbody>
       </Table>
     </div>

--- a/client/src/pages/reports/Show.js
+++ b/client/src/pages/reports/Show.js
@@ -35,6 +35,7 @@ import RichTextEditor from "components/RichTextEditor"
 import { deserializeQueryParams } from "components/SearchFilters"
 import TriggerableConfirm from "components/TriggerableConfirm"
 import { Field, Form, Formik } from "formik"
+import DictionaryField from "HOC/DictionaryField"
 import _concat from "lodash/concat"
 import _isEmpty from "lodash/isEmpty"
 import _upperFirst from "lodash/upperFirst"
@@ -359,6 +360,7 @@ const ReportShow = ({ setSearchQuery, pageDispatchers }) => {
     Person.isEqual(currentUser, rp)
   )
   const tasksLabel = pluralize(Settings.fields.task.subLevel.shortLabel)
+  const DictField = DictionaryField(Field)
 
   // User can approve if report is pending approval and user is one of the approvers in the current approval step
   const canApprove =
@@ -549,38 +551,35 @@ const ReportShow = ({ setSearchQuery, pageDispatchers }) => {
               />
               <Fieldset className="show-report-overview">
                 <Field
-                  name="intent"
                   label="Summary"
+                  name="summary"
                   component={FieldHelper.SpecialField}
                   widget={
-                    <div id="intent" className="form-control-plaintext">
-                      <p>
-                        <strong>{Settings.fields.report.intent}:</strong>{" "}
-                        {report.intent}
-                      </p>
-                      {report.keyOutcomes && (
-                        <p>
-                          <span>
-                            <strong>
-                              {Settings.fields.report.keyOutcomes ||
-                                "Key outcomes"}
-                              :
-                            </strong>{" "}
-                            {report.keyOutcomes}&nbsp;
-                          </span>
-                        </p>
-                      )}
-                      <p>
-                        <strong>
-                          {Settings.fields.report.nextSteps.label}:
-                        </strong>{" "}
-                        {report.nextSteps}
-                      </p>
+                    <div id="report-summary">
+                      <DictField
+                        dictProps={Settings.fields.report.intent}
+                        name="intent"
+                        component={FieldHelper.ReadonlyField}
+                        style={{ marginBottom: 0 }}
+                      />
+                      <DictField
+                        dictProps={Settings.fields.report.keyOutcomes}
+                        name="keyOutcomes"
+                        component={FieldHelper.ReadonlyField}
+                        style={{ marginBottom: 0 }}
+                      />
+                      <DictField
+                        dictProps={Settings.fields.report.nextSteps}
+                        name="nextSteps"
+                        component={FieldHelper.ReadonlyField}
+                        style={{ marginBottom: 0 }}
+                      />
                     </div>
                   }
                 />
 
-                <Field
+                <DictField
+                  dictProps={Settings.fields.report.engagementDate}
                   name="engagementDate"
                   component={FieldHelper.ReadonlyField}
                   humanValue={
@@ -595,9 +594,9 @@ const ReportShow = ({ setSearchQuery, pageDispatchers }) => {
                 />
 
                 {Settings.engagementsIncludeTimeAndDuration && (
-                  <Field
+                  <DictField
+                    dictProps={Settings.fields.report.duration}
                     name="duration"
-                    label="Duration (minutes)"
                     component={FieldHelper.ReadonlyField}
                   />
                 )}
@@ -637,7 +636,8 @@ const ReportShow = ({ setSearchQuery, pageDispatchers }) => {
                   }
                 />
 
-                <Field
+                <DictField
+                  dictProps={Settings.fields.report.location}
                   name="location"
                   component={FieldHelper.ReadonlyField}
                   humanValue={
@@ -648,27 +648,28 @@ const ReportShow = ({ setSearchQuery, pageDispatchers }) => {
                 />
 
                 {report.cancelled && (
-                  <Field
+                  <DictField
+                    dictProps={Settings.fields.report.cancelledReason}
                     name="cancelledReason"
-                    label="Cancelled Reason"
                     component={FieldHelper.ReadonlyField}
                     humanValue={utils.sentenceCase(report.cancelledReason)}
                   />
                 )}
 
                 {!report.cancelled && (
-                  <Field
-                    name="atmosphere"
-                    label={Settings.fields.report.atmosphere}
-                    component={FieldHelper.ReadonlyField}
-                    humanValue={
-                      <>
-                        {utils.sentenceCase(report.atmosphere)}
-                        {report.atmosphereDetails &&
-                          ` – ${report.atmosphereDetails}`}
-                      </>
-                    }
-                  />
+                  <>
+                    <DictField
+                      dictProps={Settings.fields.report.atmosphere}
+                      name="atmosphere"
+                      component={FieldHelper.ReadonlyField}
+                      humanValue={utils.sentenceCase(report.atmosphere)}
+                    />
+                    <DictField
+                      dictProps={Settings.fields.report.atmosphereDetails}
+                      name="atmosphereDetails"
+                      component={FieldHelper.ReadonlyField}
+                    />
+                  </>
                 )}
 
                 {attachmentsEnabled && (
@@ -706,7 +707,7 @@ const ReportShow = ({ setSearchQuery, pageDispatchers }) => {
               </Fieldset>
               {report.reportText && (
                 <Fieldset
-                  title={Settings.fields.report.reportText}
+                  title={Settings.fields.report.reportText?.label}
                   id="report-text"
                 >
                   <RichTextEditor readOnly value={report.reportText} />

--- a/client/src/pages/tasks/Form.js
+++ b/client/src/pages/tasks/Form.js
@@ -24,6 +24,7 @@ import { jumpToTop } from "components/Page"
 import PositionTable from "components/PositionTable"
 import RichTextEditor from "components/RichTextEditor"
 import { FastField, Field, Form, Formik } from "formik"
+import DictionaryField from "HOC/DictionaryField"
 import _isEqual from "lodash/isEqual"
 import { Organization, Position, Task } from "models"
 import PropTypes from "prop-types"
@@ -35,7 +36,6 @@ import POSITIONS_ICON from "resources/positions.png"
 import TASKS_ICON from "resources/tasks.png"
 import Settings from "settings"
 import utils from "utils"
-import DictionaryField from "../../HOC/DictionaryField"
 
 const GQL_CREATE_TASK = gql`
   mutation ($task: TaskInput!) {
@@ -67,13 +67,8 @@ const TaskForm = ({ edit, title, initialValues, notesComponent }) => {
     }
   ]
 
-  const ShortNameField = DictionaryField(Field)
-  const LongNameField = DictionaryField(Field)
-  const TaskParentTask = DictionaryField(FastField)
-  const PlannedCompletionField = DictionaryField(FastField)
-  const ProjectedCompletionField = DictionaryField(FastField)
-  const TaskedOrganizationsMultiSelect = DictionaryField(FastField)
-  const ResponsiblePositionsMultiSelect = DictionaryField(FastField)
+  const DictField = DictionaryField(Field)
+  const DictFastField = DictionaryField(FastField)
 
   const taskedOrganizationsFilters = {
     allAdvisorOrganizations: {
@@ -170,23 +165,23 @@ const TaskForm = ({ edit, title, initialValues, notesComponent }) => {
             <Form className="form-horizontal" method="post">
               <Fieldset title={title} action={action} />
               <Fieldset>
-                <ShortNameField
+                <DictField
                   dictProps={fieldSettings.shortName}
                   name="shortName"
                   component={FieldHelper.InputField}
                   disabled={disabled}
                 />
 
-                <LongNameField
+                <DictField
                   dictProps={fieldSettings.longName}
                   name="longName"
                   component={FieldHelper.InputField}
                 />
 
-                <TaskedOrganizationsMultiSelect
+                <DictFastField
+                  dictProps={Settings.fields.task.taskedOrganizations}
                   name="taskedOrganizations"
                   component={FieldHelper.SpecialField}
-                  dictProps={Settings.fields.task.taskedOrganizations}
                   onChange={value => {
                     // validation will be done by setFieldValue
                     setFieldTouched("taskedOrganizations", true, false) // onBlur doesn't work when selecting an option
@@ -213,10 +208,10 @@ const TaskForm = ({ edit, title, initialValues, notesComponent }) => {
                 />
 
                 {Settings.fields.task.parentTask && (
-                  <TaskParentTask
+                  <DictFastField
+                    dictProps={Settings.fields.task.parentTask}
                     name="parentTask"
                     component={FieldHelper.SpecialField}
-                    dictProps={Settings.fields.task.parentTask}
                     onChange={value => {
                       // validation will be done by setFieldValue
                       setFieldTouched("parentTask", true, false) // onBlur doesn't work when selecting an option
@@ -244,40 +239,37 @@ const TaskForm = ({ edit, title, initialValues, notesComponent }) => {
                   />
                 )}
 
-                {Settings.fields.task.plannedCompletion && (
-                  <PlannedCompletionField
-                    dictProps={Settings.fields.task.plannedCompletion}
-                    name="plannedCompletion"
-                    component={FieldHelper.SpecialField}
-                    onChange={value =>
-                      setFieldValue("plannedCompletion", value)}
-                    onBlur={() => setFieldTouched("plannedCompletion")}
-                    widget={<CustomDateInput id="plannedCompletion" />}
-                    disabled={disabled}
-                  />
-                )}
+                <DictFastField
+                  dictProps={Settings.fields.task.plannedCompletion}
+                  name="plannedCompletion"
+                  component={FieldHelper.SpecialField}
+                  onChange={value => setFieldValue("plannedCompletion", value)}
+                  onBlur={() => setFieldTouched("plannedCompletion")}
+                  widget={<CustomDateInput id="plannedCompletion" />}
+                  disabled={disabled}
+                />
 
-                {Settings.fields.task.projectedCompletion && (
-                  <ProjectedCompletionField
-                    dictProps={Settings.fields.task.projectedCompletion}
-                    name="projectedCompletion"
-                    component={FieldHelper.SpecialField}
-                    onChange={value =>
-                      setFieldValue("projectedCompletion", value)}
-                    onBlur={() => setFieldTouched("projectedCompletion")}
-                    widget={<CustomDateInput id="projectedCompletion" />}
-                    disabled={disabled}
-                  />
-                )}
+                <DictFastField
+                  dictProps={Settings.fields.task.projectedCompletion}
+                  name="projectedCompletion"
+                  component={FieldHelper.SpecialField}
+                  onChange={value =>
+                    setFieldValue("projectedCompletion", value)}
+                  onBlur={() => setFieldTouched("projectedCompletion")}
+                  widget={<CustomDateInput id="projectedCompletion" />}
+                  disabled={disabled}
+                />
 
                 {disabled ? (
-                  <FastField
+                  <DictFastField
+                    dictProps={Settings.fields.task.status}
                     name="status"
                     component={FieldHelper.ReadonlyField}
                     humanValue={Position.humanNameOfStatus}
                   />
                 ) : (
-                  <FastField
+                  <DictFastField
+                    dictProps={Settings.fields.task.status}
                     name="status"
                     component={FieldHelper.RadioButtonToggleGroupField}
                     buttons={statusButtons}
@@ -285,9 +277,9 @@ const TaskForm = ({ edit, title, initialValues, notesComponent }) => {
                   />
                 )}
 
-                <FastField
+                <DictFastField
+                  dictProps={Settings.fields.task.description}
                   name="description"
-                  label={fieldSettings.description}
                   component={FieldHelper.SpecialField}
                   onChange={value => {
                     // prevent initial unnecessary render of RichTextEditor
@@ -299,15 +291,24 @@ const TaskForm = ({ edit, title, initialValues, notesComponent }) => {
                     // validation will be done by setFieldValue
                     setFieldTouched("description", true, false)
                   }}
-                  widget={<RichTextEditor className="description" />}
+                  widget={
+                    <RichTextEditor
+                      className="description"
+                      placeholder={
+                        Settings.fields.task.description?.placeholder
+                      }
+                    />
+                  }
                 />
               </Fieldset>
 
-              <Fieldset title="Responsible positions">
-                <ResponsiblePositionsMultiSelect
+              <Fieldset
+                title={Settings.fields.task.responsiblePositions?.label}
+              >
+                <DictFastField
+                  dictProps={Settings.fields.task.responsiblePositions}
                   name="responsiblePositions"
                   component={FieldHelper.SpecialField}
-                  dictProps={Settings.fields.task.responsiblePositions}
                   onChange={value => {
                     // validation will be done by setFieldValue
                     value = value.map(position =>

--- a/client/src/pages/tasks/Show.js
+++ b/client/src/pages/tasks/Show.js
@@ -26,6 +26,7 @@ import RelatedObjectNotes, {
 import ReportCollection from "components/ReportCollection"
 import RichTextEditor from "components/RichTextEditor"
 import { Field, Form, Formik } from "formik"
+import DictionaryField from "HOC/DictionaryField"
 import _isEmpty from "lodash/isEmpty"
 import { Task } from "models"
 import moment from "moment"
@@ -34,7 +35,6 @@ import { ListGroup, ListGroupItem } from "react-bootstrap"
 import { connect } from "react-redux"
 import { useLocation, useParams } from "react-router-dom"
 import Settings from "settings"
-import DictionaryField from "../../HOC/DictionaryField"
 
 const GQL_GET_TASK = gql`
   query($uuid: String!) {
@@ -192,10 +192,7 @@ const TaskShow = ({ pageDispatchers }) => {
     : task.descendantTasks?.map(task => new Task(task))
 
   const fieldSettings = task.fieldSettings()
-  const LongNameField = DictionaryField(Field)
-  const TaskParentTask = DictionaryField(Field)
-  const PlannedCompletionField = DictionaryField(Field)
-  const ProjectedCompletionField = DictionaryField(Field)
+  const DictField = DictionaryField(Field)
 
   // Admins can edit tasks or users in positions related to the task
   const isAdmin = currentUser && currentUser.isAdmin()
@@ -270,14 +267,14 @@ const TaskShow = ({ pageDispatchers }) => {
                 }}
               >
                 <Fieldset style={{ flex: "1 1 0" }}>
-                  <LongNameField
+                  <DictField
                     dictProps={fieldSettings.longName}
                     name="longName"
                     component={FieldHelper.ReadonlyField}
                   />
-                  <Field
+                  <DictField
+                    dictProps={Settings.fields.task.taskedOrganizations}
                     name="taskedOrganizations"
-                    label={Settings.fields.task.taskedOrganizations.label}
                     component={FieldHelper.ReadonlyField}
                     humanValue={
                       task.taskedOrganizations && (
@@ -294,7 +291,7 @@ const TaskShow = ({ pageDispatchers }) => {
                     }
                   />
                   {Settings.fields.task.parentTask && task.parentTask?.uuid && (
-                    <TaskParentTask
+                    <DictField
                       dictProps={Settings.fields.task.parentTask}
                       name="parentTask"
                       component={FieldHelper.ReadonlyField}
@@ -312,8 +309,8 @@ const TaskShow = ({ pageDispatchers }) => {
                   )}
                   {Settings.fields.task.childrenTasks &&
                     task.childrenTasks?.length > 0 && (
-                      <Field
-                        label={Settings.fields.task.childrenTasks}
+                      <DictField
+                        dictProps={Settings.fields.task.childrenTasks}
                         name="subEfforts"
                         component={FieldHelper.ReadonlyField}
                         humanValue={
@@ -332,7 +329,7 @@ const TaskShow = ({ pageDispatchers }) => {
                       />
                   )}
                   {Settings.fields.task.plannedCompletion && (
-                    <PlannedCompletionField
+                    <DictField
                       dictProps={Settings.fields.task.plannedCompletion}
                       name="plannedCompletion"
                       component={FieldHelper.ReadonlyField}
@@ -345,7 +342,7 @@ const TaskShow = ({ pageDispatchers }) => {
                     />
                   )}
                   {Settings.fields.task.projectedCompletion && (
-                    <ProjectedCompletionField
+                    <DictField
                       dictProps={Settings.fields.task.projectedCompletion}
                       name="projectedCompletion"
                       component={FieldHelper.ReadonlyField}
@@ -357,15 +354,16 @@ const TaskShow = ({ pageDispatchers }) => {
                       }
                     />
                   )}
-                  <Field
+                  <DictField
+                    dictProps={Settings.fields.task.status}
                     name="status"
                     component={FieldHelper.ReadonlyField}
                     humanValue={Task.humanNameOfStatus}
                   />
-                  <Field
+                  <DictField
+                    dictProps={Settings.fields.task.description}
                     name="description"
                     component={FieldHelper.ReadonlyField}
-                    label={Settings.fields.task.description}
                     humanValue={
                       <RichTextEditor readOnly value={values.description} />
                     }
@@ -386,7 +384,7 @@ const TaskShow = ({ pageDispatchers }) => {
               </Fieldset>
             )}
 
-            <Fieldset title="Responsible positions">
+            <Fieldset title={Settings.fields.task.responsiblePositions?.label}>
               <PositionTable positions={task.responsiblePositions} />
             </Fieldset>
 

--- a/client/src/utils.js
+++ b/client/src/utils.js
@@ -257,7 +257,7 @@ export default {
   },
 
   getMaxTextFieldLength: function(field) {
-    return field?.maxTextFieldLength || Settings.maxTextFieldLength
+    return field?.maxLength || Settings.maxTextFieldLength
   },
 
   pluralizeWord: function(count, word) {

--- a/client/tests/e2e/permissions.js
+++ b/client/tests/e2e/permissions.js
@@ -99,7 +99,7 @@ test.serial("checking superuser permissions", async t => {
   const $principalOrgLink = await getFromSearchResults(
     t,
     "MoD",
-    "MoD | Ministry of Defense | Z12345",
+    "MoD | Ministry of Defense",
     "organizations"
   )
   await $principalOrgLink.click()
@@ -159,16 +159,12 @@ test.serial("checking superuser permissions", async t => {
   const $modLink = await getFromSearchResults(
     t,
     "MoD",
-    "MoD | Ministry of Defense | Z12345",
+    "MoD | Ministry of Defense",
     "organizations"
   )
   await $modLink.click()
   // Check that Bob is (also) superuser of MoD
-  await findSuperuserLink(
-    t,
-    "CIV BOBTOWN, Bob",
-    "MoD | Ministry of Defense | Z12345"
-  )
+  await findSuperuserLink(t, "CIV BOBTOWN, Bob", "MoD | Ministry of Defense")
   await pageHelpers.clickPersonNameFromSupportedPositionsFieldset(
     "CIV KYLESON, Kyle"
   )
@@ -254,7 +250,7 @@ validateUserCannotEditOtherUser(
 )
 
 test.serial("checking admin permissions", async t => {
-  t.plan(15)
+  t.plan(14)
 
   const {
     $,
@@ -310,7 +306,7 @@ test.serial("checking admin permissions", async t => {
   const $principalOrgLink = await getFromSearchResults(
     t,
     "MoD",
-    "MoD | Ministry of Defense | Z12345",
+    "MoD | Ministry of Defense",
     "organizations"
   )
   await $principalOrgLink.click()
@@ -569,11 +565,6 @@ async function validateAdminPrincipalOrgPermissions(t) {
     t,
     "#longName",
     "Field longName of a principal organization should be enabled for admins"
-  )
-  await assertElementEnabled(
-    t,
-    "#identificationCode",
-    "Field identificationCode of a principal organization should be enabled for admins"
   )
 }
 

--- a/client/tests/e2e/report.js
+++ b/client/tests/e2e/report.js
@@ -89,11 +89,7 @@ test.serial("Draft and submit a report", async t => {
     $principalPosition1,
     "Planning Captain, MOD-FO-00004"
   )
-  await assertElementText(
-    t,
-    $principalOrg1,
-    "MoD | Ministry of Defense | Z12345"
-  )
+  await assertElementText(t, $principalOrg1, "MoD | Ministry of Defense")
 
   const $attendeesAdvancedSelect2 =
     await pageHelpers.chooseAdvancedSelectOption(

--- a/client/tests/e2e/report.js
+++ b/client/tests/e2e/report.js
@@ -410,7 +410,7 @@ async function approveReport(t, user) {
   await t.context.logout()
 }
 test.serial("Verify that validations work", async t => {
-  t.plan(27)
+  t.plan(26)
 
   const {
     assertElementText,
@@ -558,34 +558,21 @@ test.serial("Verify that validations work", async t => {
   const $atmosphereDetails = await $("#atmosphereDetails")
   t.is(
     await $atmosphereDetails.getAttribute("placeholder"),
-    "Why was this engagement positive? (optional)"
+    "Describe the atmosphere"
   )
 
   const $neutralAtmosphereButton = await $('label[for="atmosphere_NEUTRAL"]')
   await $neutralAtmosphereButton.click()
   t.is(
-    (await $atmosphereDetails.getAttribute("placeholder")).trim(),
-    "Why was this engagement neutral?"
+    await $atmosphereDetails.getAttribute("placeholder"),
+    "Describe the atmosphere"
   )
 
   const $negativeAtmosphereButton = await $('label[for="atmosphere_NEGATIVE"]')
   await $negativeAtmosphereButton.click()
   t.is(
-    (await $atmosphereDetails.getAttribute("placeholder")).trim(),
-    "Why was this engagement negative?"
-  )
-
-  const $atmosphereDetailsInput = await t.context.driver.findElement(
-    By.css('input[id="atmosphereDetails"]')
-  )
-
-  await $neutralAtmosphereButton.click()
-  // check that parent div.form-group now has a class 'has-error'
-  await verifyFieldIsRequired(
-    $atmosphereDetailsInput,
-    "atmosphereDetails",
-    "input",
-    "Neutral atmospherics details"
+    await $atmosphereDetails.getAttribute("placeholder"),
+    "Describe the atmosphere"
   )
 
   const $reportPeopleFieldsetTitle = await $(

--- a/client/tests/webdriver/baseSpecs/advancedSearch.spec.js
+++ b/client/tests/webdriver/baseSpecs/advancedSearch.spec.js
@@ -10,13 +10,13 @@ const ANET_OBJECT_TYPES = {
     sampleFilter: "Organization"
   },
   Organizations: {
-    sampleFilter: "Organization Type"
+    sampleFilter: "Type"
   },
   Positions: {
-    sampleFilter: "Position Type"
+    sampleFilter: "Type"
   },
   Locations: {
-    sampleFilter: "Location Type"
+    sampleFilter: "Type"
   },
   "Objective / Efforts": {
     sampleFilter: "Organization"

--- a/client/tests/webdriver/baseSpecs/createNewPosition.spec.js
+++ b/client/tests/webdriver/baseSpecs/createNewPosition.spec.js
@@ -6,7 +6,7 @@ const ADMIN_ORG_COMPLETE = "ANET Administrators"
 const ADVISOR_ORG = "EF 2.2"
 const ADVISOR_ORG_COMPLETE = "EF 2.2"
 const PRINCIPAL_ORG = "MoI"
-const PRINCIPAL_ORG_COMPLETE = "MoI | Ministry of Interior | P12345"
+const PRINCIPAL_ORG_COMPLETE = "MoI | Ministry of Interior"
 const SIMILAR_ADVISOR_POSITION_NAME = "EF 1.1 Advisor for Agriculture"
 
 describe("Create position page", () => {

--- a/client/tests/webdriver/baseSpecs/mergePeople.spec.js
+++ b/client/tests/webdriver/baseSpecs/mergePeople.spec.js
@@ -102,7 +102,9 @@ describe("Merge people of the same role", () => {
       await (await MergePeople.getColumnContent("left", "Role")).getText()
     ).to.eq(EXAMPLE_PEOPLE.validLeft.role)
     expect(
-      await (await MergePeople.getColumnContent("left", "Position")).getText()
+      await (
+        await MergePeople.getColumnContent("left", "Current Position")
+      ).getText()
     ).to.eq(EXAMPLE_PEOPLE.validLeft.position)
     expect(await MergePeople.getPreviousPositions("left")).to.eql(
       EXAMPLE_PEOPLE.validLeft.previousPositions
@@ -166,7 +168,9 @@ describe("Merge people of the same role", () => {
       await (await MergePeople.getColumnContent("right", "Role")).getText()
     ).to.eq(EXAMPLE_PEOPLE.validRight.role)
     expect(
-      await (await MergePeople.getColumnContent("right", "Position")).getText()
+      await (
+        await MergePeople.getColumnContent("right", "Current Position")
+      ).getText()
     ).to.eq(EXAMPLE_PEOPLE.validRight.position)
     expect(await MergePeople.getPreviousPositions("right")).to.eql(
       EXAMPLE_PEOPLE.validRight.previousPositions
@@ -211,7 +215,9 @@ describe("Merge people of the same role", () => {
       await (await MergePeople.getColumnContent("mid", "Role")).getText()
     ).to.eq(EXAMPLE_PEOPLE.validLeft.role)
     expect(
-      await (await MergePeople.getColumnContent("mid", "Position")).getText()
+      await (
+        await MergePeople.getColumnContent("mid", "Current Position")
+      ).getText()
     ).to.eq(EXAMPLE_PEOPLE.validLeft.position)
     expect(await MergePeople.getPreviousPositions("mid")).to.eql(
       EXAMPLE_PEOPLE.validLeft.previousPositions
@@ -254,7 +260,9 @@ describe("Merge people of the same role", () => {
       await (await MergePeople.getColumnContent("mid", "Role")).getText()
     ).to.eq(EXAMPLE_PEOPLE.validRight.role)
     expect(
-      await (await MergePeople.getColumnContent("mid", "Position")).getText()
+      await (
+        await MergePeople.getColumnContent("mid", "Current Position")
+      ).getText()
     ).to.eq(EXAMPLE_PEOPLE.validRight.position)
     expect(await MergePeople.getPreviousPositions("mid")).to.eql(
       EXAMPLE_PEOPLE.validRight.previousPositions
@@ -302,14 +310,18 @@ describe("Merge people of the same role", () => {
       await (await MergePeople.getColumnContent("mid", "Role")).getText()
     ).to.equal(EXAMPLE_PEOPLE.validLeft.role)
 
-    await (await MergePeople.getSelectButton("left", "Position")).click()
+    await (
+      await MergePeople.getSelectButton("left", "Current Position")
+    ).click()
     await MergePeople.waitForColumnToChange(
       EXAMPLE_PEOPLE.validLeft.position,
       "mid",
-      "Position"
+      "Current Position"
     )
     expect(
-      await (await MergePeople.getColumnContent("mid", "Position")).getText()
+      await (
+        await MergePeople.getColumnContent("mid", "Current Position")
+      ).getText()
     ).to.equal(EXAMPLE_PEOPLE.validLeft.position)
 
     await (await MergePeople.getSelectButton("left", "Status")).click()
@@ -497,7 +509,9 @@ describe("Merge people of different roles", () => {
       await (await MergePeople.getColumnContent("mid", "Role")).getText()
     ).to.eq(EXAMPLE_PEOPLE.validLeft.role)
     expect(
-      await (await MergePeople.getColumnContent("mid", "Position")).getText()
+      await (
+        await MergePeople.getColumnContent("mid", "Current Position")
+      ).getText()
     ).to.eq(EXAMPLE_PEOPLE.validLeft.position)
     expect(await MergePeople.getPreviousPositions("mid")).to.eql(
       EXAMPLE_PEOPLE.validLeft.previousPositions
@@ -539,7 +553,9 @@ describe("Merge people of different roles", () => {
       await (await MergePeople.getColumnContent("mid", "Role")).getText()
     ).to.eq(EXAMPLE_PEOPLE.advisorRight.role)
     expect(
-      await (await MergePeople.getColumnContent("mid", "Position")).getText()
+      await (
+        await MergePeople.getColumnContent("mid", "Current Position")
+      ).getText()
     ).to.eq(EXAMPLE_PEOPLE.advisorRight.position)
     expect(await MergePeople.getPreviousPositions("mid")).to.eql(
       EXAMPLE_PEOPLE.advisorRight.previousPositions

--- a/client/tests/webdriver/baseSpecs/mergePositions.spec.js
+++ b/client/tests/webdriver/baseSpecs/mergePositions.spec.js
@@ -6,10 +6,9 @@ const EXAMPLE_POSITIONS = {
   validLeft: {
     search: "merge one",
     fullName: "Merge One",
-    organization: "MoD | Ministry of Defense | Z12345",
+    organization: "MoD | Ministry of Defense",
     type: "PRINCIPAL",
     role: "Deputy",
-    code: "MOD-M1-HQ-00001",
     status: "ACTIVE",
     person: "CIV BEMERGED, Myposwill",
     associatedPositions: [
@@ -28,10 +27,9 @@ const EXAMPLE_POSITIONS = {
   validRight: {
     search: "merge two",
     fullName: "Merge Two",
-    organization: "MoD | Ministry of Defense | Z12345",
+    organization: "MoD | Ministry of Defense",
     type: "PRINCIPAL",
     role: "Leader",
-    code: "MOD-M2-HQ-00001",
     status: "ACTIVE",
     person: "Unspecified",
     associatedPositions: [
@@ -89,9 +87,6 @@ describe("Merge positions page", () => {
         await MergePositions.getColumnContent("left", "Position Role")
       ).getText()
     ).to.eq(EXAMPLE_POSITIONS.validLeft.role)
-    expect(
-      await (await MergePositions.getColumnContent("left", "Code")).getText()
-    ).to.eq(EXAMPLE_POSITIONS.validLeft.code)
     expect(
       await (await MergePositions.getColumnContent("left", "Status")).getText()
     ).to.eq(EXAMPLE_POSITIONS.validLeft.status)
@@ -162,9 +157,6 @@ describe("Merge positions page", () => {
       ).getText()
     ).to.eq(EXAMPLE_POSITIONS.validRight.role)
     expect(
-      await (await MergePositions.getColumnContent("right", "Code")).getText()
-    ).to.eq(EXAMPLE_POSITIONS.validRight.code)
-    expect(
       await (await MergePositions.getColumnContent("right", "Status")).getText()
     ).to.eq(EXAMPLE_POSITIONS.validRight.status)
     expect(
@@ -204,9 +196,6 @@ describe("Merge positions page", () => {
         await MergePositions.getColumnContent("mid", "Position Role")
       ).getText()
     ).to.eq(EXAMPLE_POSITIONS.validLeft.role)
-    expect(
-      await (await MergePositions.getColumnContent("mid", "Code")).getText()
-    ).to.eq(EXAMPLE_POSITIONS.validLeft.code)
     expect(
       await (await MergePositions.getColumnContent("mid", "Status")).getText()
     ).to.eq(EXAMPLE_POSITIONS.validLeft.status)
@@ -251,9 +240,6 @@ describe("Merge positions page", () => {
       ).getText()
     ).to.eq(EXAMPLE_POSITIONS.validRight.role)
     expect(
-      await (await MergePositions.getColumnContent("mid", "Code")).getText()
-    ).to.eq(EXAMPLE_POSITIONS.validRight.code)
-    expect(
       await (await MergePositions.getColumnContent("mid", "Status")).getText()
     ).to.eq(EXAMPLE_POSITIONS.validRight.status)
     expect(
@@ -297,16 +283,6 @@ describe("Merge positions page", () => {
         await MergePositions.getColumnContent("mid", "Position Role")
       ).getText()
     ).to.equal(EXAMPLE_POSITIONS.validLeft.role)
-
-    await (await MergePositions.getSelectButton("left", "Code")).click()
-    await MergePositions.waitForColumnToChange(
-      EXAMPLE_POSITIONS.validLeft.code,
-      "mid",
-      "Code"
-    )
-    expect(
-      await (await MergePositions.getColumnContent("mid", "Code")).getText()
-    ).to.equal(EXAMPLE_POSITIONS.validLeft.code)
 
     await (
       await MergePositions.getSelectButton("left", "Associated Positions")

--- a/client/tests/webdriver/baseSpecs/mergePositions.spec.js
+++ b/client/tests/webdriver/baseSpecs/mergePositions.spec.js
@@ -69,10 +69,12 @@ describe("Merge positions page", () => {
     await MergePositions.waitForColumnToChange(
       EXAMPLE_POSITIONS.validLeft.fullName,
       "left",
-      "Name"
+      "Position Name"
     )
     expect(
-      await (await MergePositions.getColumnContent("left", "Name")).getText()
+      await (
+        await MergePositions.getColumnContent("left", "Position Name")
+      ).getText()
     ).to.eq(EXAMPLE_POSITIONS.validLeft.fullName)
     expect(
       await (
@@ -139,10 +141,12 @@ describe("Merge positions page", () => {
     await MergePositions.waitForColumnToChange(
       EXAMPLE_POSITIONS.validRight.fullName,
       "right",
-      "Name"
+      "Position Name"
     )
     expect(
-      await (await MergePositions.getColumnContent("right", "Name")).getText()
+      await (
+        await MergePositions.getColumnContent("right", "Position Name")
+      ).getText()
     ).to.eq(EXAMPLE_POSITIONS.validRight.fullName)
     expect(
       await (
@@ -180,10 +184,12 @@ describe("Merge positions page", () => {
     await MergePositions.waitForColumnToChange(
       EXAMPLE_POSITIONS.validLeft.fullName,
       "mid",
-      "Name"
+      "Position Name"
     )
     expect(
-      await (await MergePositions.getColumnContent("mid", "Name")).getText()
+      await (
+        await MergePositions.getColumnContent("mid", "Position Name")
+      ).getText()
     ).to.eq(EXAMPLE_POSITIONS.validLeft.fullName)
     expect(
       await (
@@ -224,10 +230,12 @@ describe("Merge positions page", () => {
     await MergePositions.waitForColumnToChange(
       EXAMPLE_POSITIONS.validRight.fullName,
       "mid",
-      "Name"
+      "Position Name"
     )
     expect(
-      await (await MergePositions.getColumnContent("mid", "Name")).getText()
+      await (
+        await MergePositions.getColumnContent("mid", "Position Name")
+      ).getText()
     ).to.eq(EXAMPLE_POSITIONS.validRight.fullName)
     expect(
       await (
@@ -262,14 +270,18 @@ describe("Merge positions page", () => {
     ).to.eq(EXAMPLE_POSITIONS.validRight.location)
   })
   it("Should be able to select from both left and right side.", async() => {
-    await (await MergePositions.getSelectButton("left", "Name")).click()
+    await (
+      await MergePositions.getSelectButton("left", "Position Name")
+    ).click()
     await MergePositions.waitForColumnToChange(
       EXAMPLE_POSITIONS.validLeft.fullName,
       "mid",
-      "Name"
+      "Position Name"
     )
     expect(
-      await (await MergePositions.getColumnContent("mid", "Name")).getText()
+      await (
+        await MergePositions.getColumnContent("mid", "Position Name")
+      ).getText()
     ).to.eq(EXAMPLE_POSITIONS.validLeft.fullName)
 
     await (
@@ -316,7 +328,7 @@ describe("Merge positions page", () => {
     await MergePositions.waitForColumnToChange(
       EXAMPLE_POSITIONS.validLeft.fullName,
       "mid",
-      "Name"
+      "Position Name"
     )
     await (await MergePositions.getEditAssociatedPositionsButton()).click()
     await (

--- a/client/tests/webdriver/baseSpecs/printReport.spec.js
+++ b/client/tests/webdriver/baseSpecs/printReport.spec.js
@@ -39,12 +39,13 @@ describe("Show print report page", () => {
     })
     it("We should see the correct report fields", async() => {
       const mustHaveFieldTexts = [
-        "purpose",
+        "Engagement purpose",
         "Key outcomes",
-        "Next steps",
-        "principals",
-        "advisors",
         "Atmospherics",
+        "Atmospherics details",
+        "Next steps",
+        "Principals",
+        "Advisors",
         "Efforts"
       ]
       const fields = await ShowReport.getCompactReportFields()

--- a/client/tests/webdriver/pages/report/showReport.page.js
+++ b/client/tests/webdriver/pages/report/showReport.page.js
@@ -79,9 +79,7 @@ class ShowReport extends Page {
   }
 
   async getIntent() {
-    const text =
-      (await (await browser.$("#intent > p:first-child")).getText()) || ""
-    return text.slice(text.indexOf(": ") + 2)
+    return (await browser.$("#intent")).getText()
   }
 
   async getEngagementDate() {

--- a/src/main/java/mil/dds/anet/database/LocationDao.java
+++ b/src/main/java/mil/dds/anet/database/LocationDao.java
@@ -84,6 +84,9 @@ public class LocationDao extends AnetSubscribableObjectDao<Location, LocationSea
     // Update positions
     updateForMerge("positions", "locationUuid", winnerLocationUuid, loserLocationUuid);
 
+    // Update organizations
+    updateForMerge("organizations", "locationUuid", winnerLocationUuid, loserLocationUuid);
+
     // Update notes
     updateM2mForMerge("noteRelatedObjects", "noteUuid", "relatedObjectUuid", winnerLocationUuid,
         loserLocationUuid);

--- a/src/main/resources/anet-schema.yml
+++ b/src/main/resources/anet-schema.yml
@@ -52,10 +52,26 @@ $defs:
             description: Used for styling this field.
             additionalProperties: true
 
+# properties for input fields that can be excluded
+  excludableInputFieldProperties:
+    properties:
+      exclude:
+        type: boolean
+        default: false
+        title: Whether this input field should be excluded
+        description: Used for excluding input fields that are irrelevant.
+
 # non-extensible definition for fields that allow free-form entry
   inputField:
     unevaluatedProperties: false
     "$ref": "#/$defs/extensibleInputField"
+
+# non-extensible definition for input fields that can be excluded
+  excludableInputField:
+    unevaluatedProperties: false
+    allOf:
+      - "$ref": "#/$defs/extensibleInputField"
+      - "$ref": "#/$defs/excludableInputFieldProperties"
 
 # definition for fields that present a choice to be selected from
   choiceField:
@@ -513,9 +529,9 @@ properties:
           subLevel:
             "$ref": "#/properties/fields/properties/task/properties/topLevel"
           projectedCompletion:
-            "$ref": "#/$defs/inputField"
+            "$ref": "#/$defs/excludableInputField"
           plannedCompletion:
-            "$ref": "#/$defs/inputField"
+            "$ref": "#/$defs/excludableInputField"
           parentTask:
             "$ref": "#/$defs/inputField"
           childrenTasks:
@@ -575,17 +591,17 @@ properties:
           duration:
             "$ref": "#/$defs/inputField"
           atmosphere:
-            "$ref": "#/$defs/inputField"
+            "$ref": "#/$defs/excludableInputField"
           atmosphereDetails:
-            "$ref": "#/$defs/inputField"
+            "$ref": "#/$defs/excludableInputField"
           cancelled:
             "$ref": "#/$defs/inputField"
           cancelledReason:
             "$ref": "#/$defs/inputField"
           nextSteps:
-            "$ref": "#/$defs/inputField"
+            "$ref": "#/$defs/excludableInputField"
           keyOutcomes:
-            "$ref": "#/$defs/inputField"
+            "$ref": "#/$defs/excludableInputField"
           reportText:
             "$ref": "#/$defs/inputField"
           location:
@@ -652,7 +668,7 @@ properties:
           country:
             "$ref": "#/$defs/inputField"
           code:
-            "$ref": "#/$defs/inputField"
+            "$ref": "#/$defs/excludableInputField"
           rank:
             "$ref": "#/$defs/inputField"
           ranks:
@@ -662,9 +678,9 @@ properties:
             items:
               "$ref": "#/$defs/describedValue"
           gender:
-            "$ref": "#/$defs/inputField"
+            "$ref": "#/$defs/excludableInputField"
           endOfTourDate:
-            "$ref": "#/$defs/inputField"
+            "$ref": "#/$defs/excludableInputField"
           biography:
             "$ref": "#/$defs/inputField"
           customFields:
@@ -718,7 +734,7 @@ properties:
           type:
             "$ref": "#/$defs/inputField"
           code:
-            "$ref": "#/$defs/inputField"
+            "$ref": "#/$defs/excludableInputField"
           organization:
             "$ref": "#/$defs/inputField"
           location:
@@ -765,7 +781,7 @@ properties:
           longName:
             "$ref": "#/$defs/inputField"
           identificationCode:
-            "$ref": "#/$defs/inputField"
+            "$ref": "#/$defs/excludableInputField"
           type:
             "$ref": "#/$defs/inputField"
           parentOrg:

--- a/src/main/resources/anet-schema.yml
+++ b/src/main/resources/anet-schema.yml
@@ -19,7 +19,6 @@ $defs:
 # base definition for all Fields. Every field is assumed to have a label
   labeledField:
     type: object
-    required: [label]
     properties:
       label:
         type: string
@@ -30,29 +29,33 @@ $defs:
         title: The color of the label, optional
         description: Used in the UI where a label for the field is shown.
 
-# definition for fields that allow free-form entry
+# extensible definition for fields that allow free-form entry
+  extensibleInputField:
+    allOf:
+      - "$ref": "#/$defs/labeledField"
+      - properties:
+          placeholder:
+            type: string
+            title: The placeholder for this field
+            description: Used in the UI where a placeholder for the field is shown (example input).
+          asA:
+            type: string
+            title: The bootstrap component class
+            description: Used to determine how the user interface of this particular field looks.
+          maxLength:
+            type: integer
+            minimum: 1
+            description: Used in the UI for a text input field's maximum input length.
+          style:
+            type: object
+            title: Optional styling for the bootstrap component class
+            description: Used for styling this field.
+            additionalProperties: true
+
+# non-extensible definition for fields that allow free-form entry
   inputField:
     unevaluatedProperties: false
-    allOf:
-    - "$ref": "#/$defs/labeledField"
-    - properties:
-        placeholder:
-          type: string
-          title: The placeholder for this field
-          description: Used in the UI where a placeholder for the field is shown (example input).
-        asA:
-          type: string
-          title: The bootstrap component class
-          description: Used to determine how the user interface of this particular field looks.
-        maxTextFieldLength:
-          type: integer
-          minimum: 1
-          description: Used in the UI for a text input field's maximum input length.
-        style:
-          type: object
-          title: Optional styling for the bootstrap component class
-          description: Used for styling this field.
-          additionalProperties: true
+    "$ref": "#/$defs/extensibleInputField"
 
 # definition for fields that present a choice to be selected from
   choiceField:
@@ -470,8 +473,12 @@ properties:
       task:
         type: object
         additionalProperties: false
-        required: [shortLabel, shortName, longLabel, longName, description, topLevel, subLevel, taskedOrganizations, responsiblePositions]
+        required: [status, shortLabel, shortName, longLabel, longName, description, topLevel, subLevel,
+                   projectedCompletion, plannedCompletion, parentTask, childrenTasks,
+                   taskedOrganizations, responsiblePositions]
         properties:
+          status:
+            "$ref": "#/$defs/labeledField"
           shortLabel:
             type: string
             title: The short label for this field
@@ -485,9 +492,7 @@ properties:
           longName:
             "$ref": "#/$defs/inputField"
           description:
-            type: string
-            title: The label for a task's description
-            description: Used in the UI where a task's description is shown.
+            "$ref": "#/$defs/inputField"
           topLevel:
             type: object
             additionalProperties: false
@@ -514,9 +519,7 @@ properties:
           parentTask:
             "$ref": "#/$defs/inputField"
           childrenTasks:
-            type: string
-            title: The sub tasks for this field
-            description: Used in the UI where sub tasks for task are shown.
+            "$ref": "#/$defs/labeledField"
           taskedOrganizations:
             "$ref": "#/$defs/inputField"
           responsiblePositions:
@@ -540,26 +543,25 @@ properties:
             title: Whether the attachment functionality is restricted to admins
             description: Used for restricting attachment functionality to admins
           fileName:
-            type: string
-            title: The label for the filename of an attachment
-            description: Used in the UI where an attachment's filename is shown.
+            "$ref": "#/$defs/labeledField"
           caption:
             "$ref": "#/$defs/inputField"
           description:
-            type: string
-            title: The label for a attachment's description
-            description: Used in the UI where an attachment's description is shown.
+            "$ref": "#/$defs/inputField"
           classification:
             "$ref": "#/$defs/customField"
           mimeTypes:
             type: array
+            title: The allowed MIME types for uploading attachments
+            description: Used for restricting the types of attachments that can be uploaded
             uniqueItems: true
             minItems: 1
 
       report:
         type: object
         additionalProperties: false
-        required: [intent, atmosphere, atmosphereDetails, cancelled, nextSteps, reportText]
+        required: [intent, engagementDate, duration, atmosphere, atmosphereDetails, cancelled,
+                   cancelledReason, nextSteps, keyOutcomes, reportText, location]
         properties:
           canUnpublishReports:
             type: boolean
@@ -567,43 +569,37 @@ properties:
             title: Whether reports can be unpublished
             description: Used for reports; if set to `true`, admins can change report state from published to draft
           intent:
-            type: string
-            title: The label for a report's intent
-            description: Used in the UI where a report's intent is shown.
+            "$ref": "#/$defs/inputField"
+          engagementDate:
+            "$ref": "#/$defs/inputField"
+          duration:
+            "$ref": "#/$defs/inputField"
           atmosphere:
-            type: string
-            title: The label for a report's athmosphere
-            description: Used in the UI where a report's athmosphere is shown.
+            "$ref": "#/$defs/inputField"
           atmosphereDetails:
-            type: string
-            title: The label for report's athmosphere details
-            description: Used in the UI where a report's athmosphere details are shown.
+            "$ref": "#/$defs/inputField"
           cancelled:
-            type: string
-            title: The label for a report's cancelled
-            description: Used in the UI where a report's cancelled is shown.
+            "$ref": "#/$defs/inputField"
+          cancelledReason:
+            "$ref": "#/$defs/inputField"
           nextSteps:
             "$ref": "#/$defs/inputField"
           keyOutcomes:
-            type: string
-            title: The label for report's key outcomes
-            description: Used in the UI where report's key outcomes are shown.
+            "$ref": "#/$defs/inputField"
           reportText:
-            type: string
-            title: The label for report's engagement details
-            description: Used in the UI where report's engagement details are shown.
+            "$ref": "#/$defs/inputField"
           location:
-            type: object
-            additionalProperties: false
             required: [filter]
-            properties:
-              filter:
-                type: array
-                uniqueItems: true
-                items:
-                  type: string
-                  enum:
-                    [VIRTUAL_LOCATION, PHYSICAL_LOCATION, GEOGRAPHICAL_AREA, POINT_LOCATION, ADVISOR_LOCATION, PRINCIPAL_LOCATION]
+            allOf:
+            - "$ref": "#/$defs/extensibleInputField"
+            - properties:
+                filter:
+                  type: array
+                  uniqueItems: true
+                  items:
+                    type: string
+                    enum:
+                      [VIRTUAL_LOCATION, PHYSICAL_LOCATION, GEOGRAPHICAL_AREA, POINT_LOCATION, ADVISOR_LOCATION, PRINCIPAL_LOCATION]
           customFields:
             type: object
             additionalProperties:
@@ -631,50 +627,34 @@ properties:
       person:
         type: object
         additionalProperties: false
-        required: [firstName, lastName, domainUsername, openIdSubject, emailAddress, phoneNumber, country, rank, ranks, gender, endOfTourDate, biography, position, prevPositions]
+        required: [status, firstName, lastName, position, prevPositions, domainUsername, openIdSubject,
+                   emailAddress, phoneNumber, country, code, rank, ranks, gender, endOfTourDate,
+                   biography]
         properties:
+          status:
+            "$ref": "#/$defs/labeledField"
           firstName:
-            type: string
-            title: The label for a person's first name
-            description: Used in the UI where a person's first name is shown.
+            "$ref": "#/$defs/inputField"
           lastName:
-            type: string
-            title: The label for a person's last name
-            description: Used in the UI where a person's last name is shown.
+            "$ref": "#/$defs/inputField"
           position:
-            type: string
-            title: The label for person's current position
-            description: Used in Person page UI where a person's position is shown.
+            "$ref": "#/$defs/inputField"
           prevPositions:
-            type: string
-            title: The label for person's previous positions
-            description: Used in Person page UI where a person's previous positions are shown.
+            "$ref": "#/$defs/labeledField"
           domainUsername:
-            type: string
-            title: The label for a person's domain username
-            description: Used in the UI where a person's domain username is shown.
+            "$ref": "#/$defs/inputField"
           openIdSubject:
-            type: string
-            title: The label for a person's OpenID subject
-            description: Used in the UI where a person's OpenID subject is shown.
+            "$ref": "#/$defs/labeledField"
           emailAddress:
             "$ref": "#/$defs/inputField"
           phoneNumber:
-            type: string
-            title: The label for a person's phone number
-            description: Used in the UI where a person's phone number is shown.
+            "$ref": "#/$defs/inputField"
           country:
-            type: string
-            title: The label for a person's country
-            description: Used in the UI where a person's country is shown.
+            "$ref": "#/$defs/inputField"
           code:
-            type: string
-            title: The label for a person's code
-            description: Used in the UI where a person's code is shown.
+            "$ref": "#/$defs/inputField"
           rank:
-            type: string
-            title: The label for a person's rank
-            description: Used in the UI where a person's rank is shown.
+            "$ref": "#/$defs/inputField"
           ranks:
             type: array
             uniqueItems: true
@@ -682,17 +662,11 @@ properties:
             items:
               "$ref": "#/$defs/describedValue"
           gender:
-            type: string
-            title: The label for a person's gender
-            description: Used in the UI where a person's gender is shown.
+            "$ref": "#/$defs/inputField"
           endOfTourDate:
-            type: string
-            title: The label for a person's end of tour date
-            description: Used in the UI where a person's end of tour date is shown.
+            "$ref": "#/$defs/inputField"
           biography:
-            type: string
-            title: The label for a person's biography
-            description: Used in the UI where a person's biography is shown.
+            "$ref": "#/$defs/inputField"
           customFields:
             type: object
             additionalProperties:
@@ -705,8 +679,16 @@ properties:
       location:
         type: object
         additionalProperties: false
-        required: [format]
+        required: [status, name, type, description, superuserTypeOptions, format]
         properties:
+          status:
+            "$ref": "#/$defs/labeledField"
+          name:
+            "$ref": "#/$defs/inputField"
+          type:
+            "$ref": "#/$defs/inputField"
+          description:
+            "$ref": "#/$defs/inputField"
           superuserTypeOptions:
             type: array
             uniqueItems: true
@@ -727,12 +709,20 @@ properties:
       position:
         type: object
         additionalProperties: false
-        required: [name, role]
+        required: [status, name, type, code, organization, role]
         properties:
+          status:
+            "$ref": "#/$defs/labeledField"
           name:
-            type: string
-            title: The label for a position's name
-            description: Used in the UI where a position's name is shown.
+            "$ref": "#/$defs/inputField"
+          type:
+            "$ref": "#/$defs/inputField"
+          code:
+            "$ref": "#/$defs/inputField"
+          organization:
+            "$ref": "#/$defs/inputField"
+          location:
+            "$ref": "#/$defs/inputField"
           role:
             type: object
             additionalProperties: false
@@ -766,20 +756,26 @@ properties:
       organization:
         type: object
         additionalProperties: false
-        required: [shortName, parentOrg, profile]
+        required: [status, shortName, longName, identificationCode, type, parentOrg, childrenOrgs, location, profile]
         properties:
+          status:
+            "$ref": "#/$defs/labeledField"
           shortName:
-            type: string
-            title: The label for an organization's short name
-            description: Used in the UI where an organization's short name is shown.
+            "$ref": "#/$defs/inputField"
+          longName:
+            "$ref": "#/$defs/inputField"
+          identificationCode:
+            "$ref": "#/$defs/inputField"
+          type:
+            "$ref": "#/$defs/inputField"
           parentOrg:
-            type: string
-            title: The label for an organization's parent organization
-            description: Used in the UI where an organization's parent organization is shown.
+            "$ref": "#/$defs/inputField"
+          childrenOrgs:
+            "$ref": "#/$defs/labeledField"
+          location:
+            "$ref": "#/$defs/inputField"
           profile:
-            type: string
-            title: The label for an organization's profile
-            description: Used in the UI where an organization's profile is shown
+            "$ref": "#/$defs/inputField"
           assessments:
             type: object
             additionalProperties:
@@ -838,7 +834,7 @@ properties:
           position:
             type: object
             additionalProperties: false
-            required: [name, type, code]
+            required: [name, type, location, organizationsAdministrated]
             properties:
               name:
                 type: string
@@ -848,8 +844,6 @@ properties:
                 type: string
                 title: The permissions type of this field
                 description: Used in the UI for the type/permissions of an advisor position.
-              code:
-                "$ref": "#/$defs/inputField"
               location:
                 type: object
                 additionalProperties: false
@@ -868,7 +862,7 @@ properties:
           org:
             type: object
             additionalProperties: false
-            required: [name, allOrgName, longName]
+            required: [name, allOrgName, location, administratingPositions]
             properties:
               name:
                 type: string
@@ -878,10 +872,6 @@ properties:
                 type: string
                 title: The name used to represent 'all advisor organizations'
                 description: Used in the UI to refer to all advisor organizations collectively.
-              longName:
-                "$ref": "#/$defs/inputField"
-              identificationCode:
-                "$ref": "#/$defs/inputField"
               location:
                 type: object
                 additionalProperties: false
@@ -945,7 +935,7 @@ properties:
           position:
             type: object
             additionalProperties: false
-            required: [name, type, code]
+            required: [name, type, location]
             properties:
               name:
                 type: string
@@ -955,8 +945,6 @@ properties:
                 type: string
                 title: The permissions type of this field
                 description: Used in the UI for the type/permissions of a principal position.
-              code:
-                "$ref": "#/$defs/inputField"
               location:
                 type: object
                 additionalProperties: false
@@ -973,7 +961,7 @@ properties:
           org:
             type: object
             additionalProperties: false
-            required: [name, allOrgName, longName, administratingPositions]
+            required: [name, allOrgName, location, administratingPositions]
             properties:
               name:
                 type: string
@@ -983,10 +971,6 @@ properties:
                 type: string
                 title: The name used to represent 'all principal organizations'
                 description: Used in the UI to refer to all principal organizations collectively.
-              longName:
-                "$ref": "#/$defs/inputField"
-              identificationCode:
-                "$ref": "#/$defs/inputField"
               location:
                 type: object
                 additionalProperties: false

--- a/src/main/resources/anet-schema.yml
+++ b/src/main/resources/anet-schema.yml
@@ -52,6 +52,15 @@ $defs:
             description: Used for styling this field.
             additionalProperties: true
 
+# properties for input fields that can be made optional
+  optionableInputFieldProperties:
+    properties:
+      optional:
+        type: boolean
+        default: false
+        title: Whether this input field should be optional
+        description: Used for making input fields optional that are by default required.
+
 # properties for input fields that can be excluded
   excludableInputFieldProperties:
     properties:
@@ -66,11 +75,26 @@ $defs:
     unevaluatedProperties: false
     "$ref": "#/$defs/extensibleInputField"
 
+# non-extensible definition for input fields that can be made optional
+  optionableInputField:
+    unevaluatedProperties: false
+    allOf:
+      - "$ref": "#/$defs/extensibleInputField"
+      - "$ref": "#/$defs/optionableInputFieldProperties"
+
 # non-extensible definition for input fields that can be excluded
   excludableInputField:
     unevaluatedProperties: false
     allOf:
       - "$ref": "#/$defs/extensibleInputField"
+      - "$ref": "#/$defs/excludableInputFieldProperties"
+
+# non-extensible definition for input fields that can be made optional or excluded
+  optionableExcludableInputField:
+    unevaluatedProperties: false
+    allOf:
+      - "$ref": "#/$defs/extensibleInputField"
+      - "$ref": "#/$defs/optionableInputFieldProperties"
       - "$ref": "#/$defs/excludableInputFieldProperties"
 
 # definition for fields that present a choice to be selected from
@@ -591,7 +615,7 @@ properties:
           duration:
             "$ref": "#/$defs/inputField"
           atmosphere:
-            "$ref": "#/$defs/excludableInputField"
+            "$ref": "#/$defs/optionableExcludableInputField"
           atmosphereDetails:
             "$ref": "#/$defs/excludableInputField"
           cancelled:
@@ -599,9 +623,9 @@ properties:
           cancelledReason:
             "$ref": "#/$defs/inputField"
           nextSteps:
-            "$ref": "#/$defs/excludableInputField"
+            "$ref": "#/$defs/optionableExcludableInputField"
           keyOutcomes:
-            "$ref": "#/$defs/excludableInputField"
+            "$ref": "#/$defs/optionableExcludableInputField"
           reportText:
             "$ref": "#/$defs/inputField"
           location:
@@ -662,11 +686,11 @@ properties:
           openIdSubject:
             "$ref": "#/$defs/labeledField"
           emailAddress:
-            "$ref": "#/$defs/inputField"
+            "$ref": "#/$defs/optionableInputField"
           phoneNumber:
             "$ref": "#/$defs/inputField"
           country:
-            "$ref": "#/$defs/inputField"
+            "$ref": "#/$defs/optionableInputField"
           code:
             "$ref": "#/$defs/excludableInputField"
           rank:
@@ -678,9 +702,9 @@ properties:
             items:
               "$ref": "#/$defs/describedValue"
           gender:
-            "$ref": "#/$defs/excludableInputField"
+            "$ref": "#/$defs/optionableExcludableInputField"
           endOfTourDate:
-            "$ref": "#/$defs/excludableInputField"
+            "$ref": "#/$defs/optionableExcludableInputField"
           biography:
             "$ref": "#/$defs/inputField"
           customFields:
@@ -738,32 +762,30 @@ properties:
           organization:
             "$ref": "#/$defs/inputField"
           location:
-            "$ref": "#/$defs/inputField"
+            "$ref": "#/$defs/optionableInputField"
           role:
             type: object
-            additionalProperties: false
+            unevaluatedProperties: false
             required: [types]
-            title: The label for a position's role
             description: Used in the UI where a position's roles are displayed as choices
-            properties:
-              label:
-                type: string
-                description: UI label of position-role
-              types:
-                type: object
-                description: Enumeration of position role types
-                required: [member, deputy, leader]
-                additionalProperties: false
-                properties:
-                  member:
-                    type: string
-                    description: UI label of member position
-                  deputy:
-                    type: string
-                    description: UI label of deputy position
-                  leader:
-                    type: string
-                    description: UI label of leader position
+            allOf:
+              - "$ref": "#/$defs/extensibleInputField"
+              - properties:
+                  types:
+                    type: object
+                    description: Enumeration of position role types
+                    required: [member, deputy, leader]
+                    additionalProperties: false
+                    properties:
+                      member:
+                        type: string
+                        description: UI label of member position
+                      deputy:
+                        type: string
+                        description: UI label of deputy position
+                      leader:
+                        type: string
+                        description: UI label of leader position
           customFields:
             type: object
             additionalProperties:

--- a/src/main/resources/emails/approvalNeeded.ftlh
+++ b/src/main/resources/emails/approvalNeeded.ftlh
@@ -100,7 +100,7 @@ Dear ${approvalStepName},
 </div>
 
 <div>
-  <strong>${fields.report.atmosphere}:</strong> ${(report.atmosphere)!}
+  <strong>${fields.report.atmosphere.label!}:</strong> ${(report.atmosphere)!}
   <#if report.atmosphereDetails??>
 	  - ${(report.atmosphereDetails)!}
   </#if>
@@ -129,14 +129,14 @@ Dear ${approvalStepName},
 
 <div class="row">
   <div class="col-md-8">
-    <p><strong>${fields.report.intent}:</strong> ${report.intent}</p>
+    <p><strong>${fields.report.intent.label!}:</strong> ${report.intent}</p>
     <#if report.keyOutcomes??>
       <#if fields.report.keyOutcomes??>
-        <p><strong>${fields.report.keyOutcomes}:</strong> ${(report.keyOutcomes)!}</p>
+        <p><strong>${fields.report.keyOutcomes.label!}:</strong> ${(report.keyOutcomes)!}</p>
       </#if>
     </#if>
     <#if report.nextSteps??>
-      <p><strong>${fields.report.nextSteps.label}:</strong> ${(report.nextSteps)!}</p>
+      <p><strong>${fields.report.nextSteps.label!}:</strong> ${(report.nextSteps)!}</p>
     </#if>
   </div>
 </div>

--- a/src/main/resources/emails/emailReport.ftlh
+++ b/src/main/resources/emails/emailReport.ftlh
@@ -246,17 +246,17 @@ ${sender.name} sent you a report from ANET:
         <div class="col-sm-7">
           <div id="intent" class="form-control-static">
             <p>
-              <strong>${fields.report.intent}:</strong> ${(report.intent)!}
+              <strong>${fields.report.intent.label!}:</strong> ${(report.intent)!}
             </p>
             <#if report.keyOutcomes??>
               <#if fields.report.keyOutcomes??>
                 <p>
-                  <span><strong>${fields.report.keyOutcomes}:</strong> ${(report.keyOutcomes)!}</span>
+                  <span><strong>${fields.report.keyOutcomes.label!}:</strong> ${(report.keyOutcomes)!}</span>
                 </p>
               </#if>
             </#if>
             <p>
-              <strong>${fields.report.nextSteps.label}:</strong> ${(report.nextSteps)!}
+              <strong>${fields.report.nextSteps.label!}:</strong> ${(report.nextSteps)!}
             </p>
           </div>
         </div>
@@ -304,7 +304,7 @@ ${sender.name} sent you a report from ANET:
             </div>
           </div>
         <#else>
-          <label for="atmosphere" class="col-sm-2 control-label">${fields.report.atmosphere}</label>
+          <label for="atmosphere" class="col-sm-2 control-label">${fields.report.atmosphere.label!}</label>
           <div class="col-sm-7">
             <div id="atmosphere" class="form-control-static">
               ${(report.atmosphere)!?capitalize} - ${(report.atmosphereDetails)!}
@@ -461,7 +461,7 @@ ${sender.name} sent you a report from ANET:
   <#if report.reportText??>
     <div>
       <h2 class="legend">
-        <span class="title-text">${fields.report.reportText}</span>
+        <span class="title-text">${fields.report.reportText.label!}</span>
       </h2>
       <fieldset>
         <div>

--- a/src/main/resources/emails/rollup.ftlh
+++ b/src/main/resources/emails/rollup.ftlh
@@ -114,10 +114,10 @@ a {
 
 <#macro renderReport report>
 	<#if report.cancelledReason??>
-	    <p className="report-cancelled" style="border-left:16px solid #DA9795;padding-left:10px;">
-	        <strong>Cancelled:</strong>
-	        ${(report.cancelledReason)!}
-	    </p>
+		<p className="report-cancelled" style="border-left:16px solid #DA9795;padding-left:10px;">
+			<strong>Cancelled:</strong>
+			${(report.cancelledReason)!}
+		</p>
 	</#if>
 
 	<div>
@@ -136,7 +136,7 @@ a {
 	</div>
 
 	<div>
-		<strong>${fields.report.atmosphere}:</strong> ${(report.atmosphere)!}
+		<strong>${fields.report.atmosphere.label!}:</strong> ${(report.atmosphere)!}
 		<#if report.atmosphereDetails??>
 			- ${(report.atmosphereDetails)!}
 		</#if>
@@ -160,17 +160,17 @@ a {
 
     <div class="row">
         <div class="col-md-8">
-            <p><strong>${fields.report.intent}:</strong> ${(report.intent)!}</p>
+            <p><strong>${fields.report.intent.label!}:</strong> ${(report.intent)!}</p>
             <#if report.keyOutcomes??>
-				<#if fields.report.keyOutcomes??>
-                	<p><strong>${fields.report.keyOutcomes}:</strong> ${(report.keyOutcomes)!}</p>
-            	</#if>
+              <#if fields.report.keyOutcomes??>
+                <p><strong>${fields.report.keyOutcomes.label!}:</strong> ${(report.keyOutcomes)!}</p>
+              </#if>
             </#if>
             <#if report.nextSteps??>
-                <p><strong>${fields.report.nextSteps.label}:</strong> ${(report.nextSteps)!}</p>
+                <p><strong>${fields.report.nextSteps.label!}:</strong> ${(report.nextSteps)!}</p>
             </#if>
             <#if showReportText >
-                <p><strong>${fields.report.reportText}</strong> ${(report.reportText)!?no_esc}</p>
+                <p><strong>${fields.report.reportText.label!}</strong> ${(report.reportText)!?no_esc}</p>
             </#if>
         </div>
     </div>

--- a/testDictionaries/no-custom-fields.yml
+++ b/testDictionaries/no-custom-fields.yml
@@ -280,8 +280,10 @@ fields:
 
     projectedCompletion:
       label: Projected Completion
+      exclude: true
     plannedCompletion:
       label: Planned Completion
+      exclude: true
     parentTask:
       label: Parent objective / effort
       placeholder: Start typing to search for a higher level objective / effort
@@ -333,9 +335,11 @@ fields:
       label: Duration (minutes)
     atmosphere:
       label: Atmospherics
+      exclude: false
     atmosphereDetails:
       label: Atmospherics details
       placeholder: Describe the atmosphere
+      exclude: false
     cancelled:
       label: ''
     cancelledReason:
@@ -344,9 +348,11 @@ fields:
       label: Next steps
       placeholder: Fill in the next steps after this engagement
       maxLength: 1000
+      exclude: false
     keyOutcomes:
       label: Key outcomes
       placeholder: Fill in the key outcomes of this engagement
+      exclude: false
     reportText:
       label: Key details
       placeholder: Fill in a detailed report of the engagement
@@ -386,6 +392,7 @@ fields:
       label: Nationality
     code:
       label: ID card number
+      exclude: true
     rank:
       label: Rank
     ranks:
@@ -450,8 +457,10 @@ fields:
         app6Modifier: K
     gender:
       label: Gender
+      exclude: false
     endOfTourDate:
       label: End of tour
+      exclude: false
     biography:
       label: Biography
       placeholder: Fill in the biography of this person
@@ -502,6 +511,7 @@ fields:
     code:
       label: Position code
       placeholder: The official code for this position
+      exclude: true
     organization:
       label: Organization
       placeholder: Search the organization for this position…
@@ -527,6 +537,7 @@ fields:
     identificationCode:
       label: UIC
       placeholder: the six character code
+      exclude: true
     type:
       label: Type
     parentOrg:
@@ -631,7 +642,6 @@ fields:
         - emailAddress
         - phoneNumber
         - country
-        - code
         - rank
         - gender
         - endOfTourDate
@@ -1295,7 +1305,6 @@ fields:
         - domainUsername
         - openIdSubject
         - emailAddress
-        - code
         - politicalPosition
         - rank
         - gender

--- a/testDictionaries/no-custom-fields.yml
+++ b/testDictionaries/no-custom-fields.yml
@@ -38,24 +38,28 @@ maxTextFieldLength: 250
 fields:
 
   task:
+    status:
+      label: Status
     shortLabel: Objective / Effort
     shortName:
       label: Objective / Effort number
-      placeholder: Enter an objective / effort name, example....
+      placeholder: Enter an objective / effort name, example …
     longLabel: Objectives and Efforts
     longName:
       label: Objective / Effort long name
-      placeholder: Enter an objective / effort long name, example ....
-    description: Objective / Effort description
+      placeholder: Enter an objective / effort long name, example …
+    description:
+      label: Objective / Effort description
+      placeholder: Fill in the description of this objective / effort
     topLevel:
       shortLabel: Objective
       shortName:
         label: Name of this Objective
-        placeholder: Enter a Name for this Objective name, example ....
+        placeholder: Enter a Name for this Objective name, example …
       longLabel: Objectives
       longName:
         label: Long Name of this Objective
-        placeholder: Enter a long name for this Objective, example ....
+        placeholder: Enter a long name for this Objective, example …
       assessments:
         topTaskOnceReport:
           label: Engagement assessment of objective
@@ -132,11 +136,11 @@ fields:
       shortLabel: Effort
       shortName:
         label: Effort name
-        placeholder: Enter an effort name, example....
+        placeholder: Enter an effort name, example …
       longLabel: Efforts
       longName:
         label: Effort Long Name
-        placeholder: Enter an effort Long Name, example ....
+        placeholder: Enter an effort Long Name, example …
       assessments:
         subTaskMonthly:
           label: Monthly assessment of effort
@@ -274,25 +278,33 @@ fields:
                 - type: required
                   params: [You must provide the answer to subTask11COnceReport.questionForNegative]
 
+    projectedCompletion:
+      label: Projected Completion
+    plannedCompletion:
+      label: Planned Completion
     parentTask:
       label: Parent objective / effort
       placeholder: Start typing to search for a higher level objective / effort
-    childrenTasks: Sub efforts
+    childrenTasks:
+      label: Sub efforts
     taskedOrganizations:
       label: Tasked organizations
-      placeholder: Search for an organization...
+      placeholder: Search for an organization…
     responsiblePositions:
       label: Responsible positions
-      placeholder: Search for a position...
+      placeholder: Search for a position…
 
   attachment:
     featureDisabled: false
     restrictToAdmins: false
-    fileName: Filename
+    fileName:
+      label: Filename
     caption:
       label: Caption
-      placeholder: Enter a caption, example....
-    description: Description
+      placeholder: Enter a caption
+    description:
+      label: Description
+      placeholder: Enter a description of this attachment
     classification:
       type: enum
       label: Security Marking
@@ -303,6 +315,8 @@ fields:
         NU_rel_EU: NATO UNCLASSIFIED Releasable to EU
     mimeTypes:
       - application/pdf
+      - image/avif
+      - image/gif
       - image/jpeg
       - image/png
       - image/webp
@@ -310,16 +324,35 @@ fields:
 
   report:
     canUnpublishReports: true
-    intent: Engagement purpose
-    atmosphere: Atmospherics
-    atmosphereDetails: Atmospherics details
-    cancelled: ''
+    intent:
+      label: Engagement purpose
+      placeholder: What is the engagement supposed to achieve?
+    engagementDate:
+      label: Engagement date
+    duration:
+      label: Duration (minutes)
+    atmosphere:
+      label: Atmospherics
+    atmosphereDetails:
+      label: Atmospherics details
+      placeholder: Describe the atmosphere
+    cancelled:
+      label: ''
+    cancelledReason:
+      label: due to
     nextSteps:
       label: Next steps
-      maxTextFieldLength: 1000
-    keyOutcomes: Key outcomes
-    reportText: Key details
+      placeholder: Fill in the next steps after this engagement
+      maxLength: 1000
+    keyOutcomes:
+      label: Key outcomes
+      placeholder: Fill in the key outcomes of this engagement
+    reportText:
+      label: Key details
+      placeholder: Fill in a detailed report of the engagement
     location:
+      label: Location
+      placeholder: Search for the engagement location…
       filter: [POINT_LOCATION, VIRTUAL_LOCATION]
     attendeeGroups:
       - label: Linguists
@@ -327,19 +360,34 @@ fields:
           orgUuid: 70193ee9-05b4-4aac-80b5-75609825db9f
 
   person:
-    firstName: First name
-    lastName: Last name
-    domainUsername: Domain username
-    openIdSubject: OpenID subject
-    position: Current Position
-    prevPositions: Previous Positions
+    status:
+      label: Status
+    firstName:
+      label: First name
+      placeholder: First name(s) - Lower-case except for the first letter of each name
+    lastName:
+      label: Last name
+      placeholder: LAST NAME
+    domainUsername:
+      label: Domain username
+    openIdSubject:
+      label: OpenID subject
+    position:
+      label: Current Position
+      placeholder: Fill in the person's current position
+    prevPositions:
+      label: Previous Positions
     emailAddress:
       label: Email
       placeholder: Only the following email domain names are allowed. ( example.com, cmil.mil, mission.ita, nato.int, *.isaf.nato.int )
-    phoneNumber: Phone
-    country: Nationality
-    code: ID card number
-    rank: Rank
+    phoneNumber:
+      label: Phone
+    country:
+      label: Nationality
+    code:
+      label: ID card number
+    rank:
+      label: Rank
     ranks:
       - value: CIV
         description: the rank of CIV
@@ -400,9 +448,13 @@ fields:
       - value: OF-9
         description: the rank of OF-9
         app6Modifier: K
-    gender: Gender
-    endOfTourDate: End of tour
-    biography: Biography
+    gender:
+      label: Gender
+    endOfTourDate:
+      label: End of tour
+    biography:
+      label: Biography
+      placeholder: Fill in the biography of this person
     customSensitiveInformation:
       birthday:
         type: date
@@ -426,11 +478,36 @@ fields:
             color: 'skyblue'
 
   location:
+    status:
+      label: Status
+    name:
+      label: Name
+      placeholder: Fill in the name of this location
+    type:
+      label: Type
+    description:
+      label: Description
+      placeholder: Fill in the description of this location
     superuserTypeOptions: [POINT_LOCATION]
     format: LAT_LON
 
   position:
-    name: Position Name
+    status:
+      label: Status
+    name:
+      label: Position Name
+      placeholder: Name/Description of Position
+    type:
+      label: Type
+    code:
+      label: Position code
+      placeholder: The official code for this position
+    organization:
+      label: Organization
+      placeholder: Search the organization for this position…
+    location:
+      label: Location
+      placeholder: Search for the location where this Position will operate from…
     role:
       label: Position Role
       types:
@@ -439,9 +516,30 @@ fields:
         leader: Leader
 
   organization:
-    shortName: Name
-    parentOrg: Parent Organization
-    profile: Profile
+    status:
+      label: Status
+    shortName:
+      label: Name
+      placeholder: e.g. EF1.1
+    longName:
+      label: Description
+      placeholder: e.g. Force Sustainment
+    identificationCode:
+      label: UIC
+      placeholder: the six character code
+    type:
+      label: Type
+    parentOrg:
+      label: Parent Organization
+      placeholder: Search for a higher level organization…
+    childrenOrgs:
+      label: Sub Organizations
+    location:
+      label: Location
+      placeholder: Search for the location where this Organization will operate from…
+    profile:
+      label: Profile
+      placeholder: Fill in the profile of this organization
     assessments:
       organizationAnnually:
         label: Interaction Plan
@@ -964,29 +1062,20 @@ fields:
     position:
       name: NATO Billet
       type: ANET User
-      code:
-        label: CE Post Number
-        placeholder: the CE post number for this position
       location:
         filter: [POINT_LOCATION]
       organizationsAdministrated:
         label: Organizations administrated
-        placeholder: Search for an organization...
+        placeholder: Search for an organization…
 
     org:
       name: Advisor Organization
       allOrgName: Advisor Organizations
-      longName:
-        label: Description
-        placeholder: e.g. Force Sustainment
-      identificationCode:
-        label: UIC
-        placeholder: the six character code
       location:
         filter: [ADVISOR_LOCATION]
       administratingPositions:
         label: Assigned Superusers
-        placeholder: Search for a position...
+        placeholder: Search for a position…
 
   principal:
     person:
@@ -1137,7 +1226,7 @@ fields:
           label: Screening & Vetting of principal from MoD
           recurrence: ondemand
           test: $.subject.position.organization[?(@property === "shortName" && @.match(/^MoD/i))]
-          onDemandAssessmentExpirationDays: 108
+          onDemandAssessmentExpirationDays: 180
           authorizationGroupUuids:
             read: ['c21e7321-7ec5-4837-8805-a302f9575754']
             write: ['39a78d51-c351-452c-9206-4305ec8dd76d']
@@ -1217,26 +1306,17 @@ fields:
     position:
       name: Afghan Tashkil
       type: Afghan Partner
-      code:
-        label: Tashkil
-        placeholder: the Afghan taskhil ID for this position
       location:
         filter: [POINT_LOCATION]
 
     org:
       name: Afghan Government Organization
       allOrgName: Principal Organizations
-      longName:
-        label: Official Organization Name
-        placeholder: e.g. Afghan Ministry of Defense
-      identificationCode:
-        label: UIC
-        placeholder: the six character code
       location:
         filter: [PRINCIPAL_LOCATION]
       administratingPositions:
         label: Assigned Superusers
-        placeholder: Search for a position...
+        placeholder: Search for a position…
 
   superuser:
 

--- a/testDictionaries/no-custom-fields.yml
+++ b/testDictionaries/no-custom-fields.yml
@@ -336,6 +336,7 @@ fields:
     atmosphere:
       label: Atmospherics
       exclude: false
+      optional: false
     atmosphereDetails:
       label: Atmospherics details
       placeholder: Describe the atmosphere
@@ -349,10 +350,12 @@ fields:
       placeholder: Fill in the next steps after this engagement
       maxLength: 1000
       exclude: false
+      optional: false
     keyOutcomes:
       label: Key outcomes
       placeholder: Fill in the key outcomes of this engagement
       exclude: false
+      optional: false
     reportText:
       label: Key details
       placeholder: Fill in a detailed report of the engagement
@@ -386,10 +389,12 @@ fields:
     emailAddress:
       label: Email
       placeholder: Only the following email domain names are allowed. ( example.com, cmil.mil, mission.ita, nato.int, *.isaf.nato.int )
+      optional: false
     phoneNumber:
       label: Phone
     country:
       label: Nationality
+      optional: false
     code:
       label: ID card number
       exclude: true
@@ -458,9 +463,11 @@ fields:
     gender:
       label: Gender
       exclude: false
+      optional: false
     endOfTourDate:
       label: End of tour
       exclude: false
+      optional: false
     biography:
       label: Biography
       placeholder: Fill in the biography of this person
@@ -518,6 +525,7 @@ fields:
     location:
       label: Location
       placeholder: Search for the location where this Position will operate from…
+      optional: false
     role:
       label: Position Role
       types:


### PR DESCRIPTION
Add definitions for all standard fields to the ANET dictionary. Also allow selected fields to be excluded from the ANET user interface, and provide the option to make selected fields (that are now required under some conditions) to be made fully optional.

Also fix location merge:
- merge the description field that was missing before
- update organizations linking to the location to point to the newly merged location

Closes NCI-Agency/anet#1287, [AB#989](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/989), [AB#1002](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1002)

#### User changes
- Field labels are now more consistent throughout the application

#### Superuser changes
- None

#### Admin changes
- During Location merge you can now also pick the correct description
- Location merge will no longer fail for locations linked to organizations
- Selected fields can be excluded through a dictionary setting
- Selected fields that are by default required can now be made optional through a dictionary setting

#### System admin changes
- [x] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [x] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here