### PR TITLE
Move atmospherics to engagement details section

### DIFF
--- a/client/src/pages/reports/Form.js
+++ b/client/src/pages/reports/Form.js
@@ -634,36 +634,6 @@ const ReportForm = ({
                     }
                   />
                 )}
-
-                {!isFutureEngagement && !values.cancelled && (
-                  <>
-                    <DictFastField
-                      dictProps={Settings.fields.report.atmosphere}
-                      name="atmosphere"
-                      component={FieldHelper.RadioButtonToggleGroupField}
-                      enableClear={Settings.fields.report.atmosphere?.optional}
-                      buttons={atmosphereButtons}
-                      onChange={value =>
-                        setFieldValue("atmosphere", value, true)}
-                      className="atmosphere-form-group"
-                    />
-                    <DictField
-                      dictProps={Settings.fields.report.atmosphereDetails}
-                      name="atmosphereDetails"
-                      component={FieldHelper.InputField}
-                      onChange={event => {
-                        setFieldTouched("atmosphereDetails", true, false)
-                        setFieldValue(
-                          "atmosphereDetails",
-                          event.target.value,
-                          false
-                        )
-                        validateFieldDebounced("atmosphereDetails")
-                      }}
-                      className="atmosphere-details"
-                    />
-                  </>
-                )}
               </Fieldset>
 
               <Fieldset
@@ -832,6 +802,36 @@ const ReportForm = ({
               )}
 
               <Fieldset title="Engagement details" id="meeting-details">
+                {!isFutureEngagement && !values.cancelled && (
+                  <>
+                    <DictFastField
+                      dictProps={Settings.fields.report.atmosphere}
+                      name="atmosphere"
+                      component={FieldHelper.RadioButtonToggleGroupField}
+                      enableClear={Settings.fields.report.atmosphere?.optional}
+                      buttons={atmosphereButtons}
+                      onChange={value =>
+                        setFieldValue("atmosphere", value, true)}
+                      className="atmosphere-form-group"
+                    />
+                    <DictField
+                      dictProps={Settings.fields.report.atmosphereDetails}
+                      name="atmosphereDetails"
+                      component={FieldHelper.InputField}
+                      onChange={event => {
+                        setFieldTouched("atmosphereDetails", true, false)
+                        setFieldValue(
+                          "atmosphereDetails",
+                          event.target.value,
+                          false
+                        )
+                        validateFieldDebounced("atmosphereDetails")
+                      }}
+                      className="atmosphere-details"
+                    />
+                  </>
+                )}
+
                 {Settings.fields.report.keyOutcomes &&
                   !isFutureEngagement &&
                   !values.cancelled && (


### PR DESCRIPTION
Move the atmospherics input in the report form down to the engagement details section.

Closes [AB#987](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/987) 

#### User changes
- In the report form, atmospherics are now in the engagement details section

#### Superuser changes
- None

#### Admin changes
- None

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
