### PR TITLE
Make attending authors and primary attendees configurable

### DIFF
--- a/anet-dictionary.yml
+++ b/anet-dictionary.yml
@@ -379,6 +379,8 @@ fields:
       label: Location
       placeholder: Search for the engagement location…
       filter: [POINT_LOCATION, VIRTUAL_LOCATION]
+    reportPeople:
+      optionalAttendingAuthor: false
     customFields:
       relatedReport:
         type: anet_object

--- a/anet-dictionary.yml
+++ b/anet-dictionary.yml
@@ -381,6 +381,8 @@ fields:
       filter: [POINT_LOCATION, VIRTUAL_LOCATION]
     reportPeople:
       optionalAttendingAuthor: false
+      optionalPrimaryAdvisor: false
+      optionalPrimaryPrincipal: true
     customFields:
       relatedReport:
         type: anet_object

--- a/anet-dictionary.yml
+++ b/anet-dictionary.yml
@@ -383,6 +383,10 @@ fields:
       optionalAttendingAuthor: false
       optionalPrimaryAdvisor: false
       optionalPrimaryPrincipal: true
+      attendeeGroups:
+        - label: Linguists
+          filter:
+            orgUuid: 70193ee9-05b4-4aac-80b5-75609825db9f
     customFields:
       relatedReport:
         type: anet_object
@@ -512,10 +516,6 @@ fields:
             typeError: Qty must be a number
             label: Qty
         visibleWhen: $[?(@ && @.multipleButtons && (@.multipleButtons.indexOf('assist') != -1 || @.multipleButtons.indexOf('other') != -1))]
-    attendeeGroups:
-      - label: Linguists
-        filter:
-          orgUuid: 70193ee9-05b4-4aac-80b5-75609825db9f
 
   person:
     status:

--- a/client/src/models/Report.js
+++ b/client/src/models/Report.js
@@ -426,8 +426,11 @@ export default class Report extends Model {
   }
 
   static checkAttendingAuthor(reportPeople) {
-    if (!reportPeople?.some(rp => rp.author && rp.attendee)) {
-      return "You must provide at least 1 attending author"
+    const optionalAttendingAuthor =
+      Settings.fields.report.reportPeople?.optionalAttendingAuthor
+    const attendingAuthor = reportPeople?.some(rp => rp.author && rp.attendee)
+    if (!attendingAuthor && !optionalAttendingAuthor) {
+      return "You must provide at least 1 attending author(s)"
     }
   }
 

--- a/client/src/pages/reports/Form.js
+++ b/client/src/pages/reports/Form.js
@@ -366,7 +366,8 @@ const ReportForm = ({
         }
 
         // Add attendee groups defined in the dictionary
-        const attendeeGroups = Settings.fields.report.attendeeGroups ?? []
+        const attendeeGroups =
+          Settings.fields.report.reportPeople?.attendeeGroups ?? []
         attendeeGroups.forEach(({ label, filter: queryVars }) => {
           reportPeopleFilters[label] = { label, queryVars }
         })

--- a/src/main/java/mil/dds/anet/resources/ReportResource.java
+++ b/src/main/java/mil/dds/anet/resources/ReportResource.java
@@ -398,15 +398,26 @@ public class ReportResource {
 
     if (r.getAdvisorOrgUuid() == null) {
       final ReportPerson advisor = r.loadPrimaryAdvisor(engine.getContext()).join();
+      final Boolean optionalPrimaryAdvisor =
+          (Boolean) config.getDictionaryEntry("fields.report.reportPeople.optionalPrimaryAdvisor");
       if (advisor == null) {
-        throw new WebApplicationException("Report missing primary advisor", Status.BAD_REQUEST);
+        if (!Boolean.TRUE.equals(optionalPrimaryAdvisor)) {
+          throw new WebApplicationException("Report missing primary advisor", Status.BAD_REQUEST);
+        }
+      } else {
+        r.setAdvisorOrg(
+            engine.getOrganizationForPerson(engine.getContext(), advisor.getUuid()).join());
       }
-      r.setAdvisorOrg(
-          engine.getOrganizationForPerson(engine.getContext(), advisor.getUuid()).join());
     }
     if (r.getPrincipalOrgUuid() == null) {
       final ReportPerson principal = r.loadPrimaryPrincipal(engine.getContext()).join();
-      if (principal != null) {
+      final Boolean optionalPrimaryPrincipal = (Boolean) config
+          .getDictionaryEntry("fields.report.reportPeople.optionalPrimaryPrincipal");
+      if (principal == null) {
+        if (!Boolean.TRUE.equals(optionalPrimaryPrincipal)) {
+          throw new WebApplicationException("Report missing primary principal", Status.BAD_REQUEST);
+        }
+      } else {
         r.setPrincipalOrg(
             engine.getOrganizationForPerson(engine.getContext(), principal.getUuid()).join());
       }

--- a/src/main/resources/anet-schema.yml
+++ b/src/main/resources/anet-schema.yml
@@ -640,6 +640,13 @@ properties:
                     type: string
                     enum:
                       [VIRTUAL_LOCATION, PHYSICAL_LOCATION, GEOGRAPHICAL_AREA, POINT_LOCATION, ADVISOR_LOCATION, PRINCIPAL_LOCATION]
+          reportPeople:
+            required: [optionalAttendingAuthor]
+            properties:
+              optionalAttendingAuthor:
+                type: boolean
+                default: false
+                description: Defines if having an attending author for a report is optional
           customFields:
             type: object
             additionalProperties:

--- a/src/main/resources/anet-schema.yml
+++ b/src/main/resources/anet-schema.yml
@@ -655,29 +655,29 @@ properties:
                 type: boolean
                 default: false
                 description: Defines if having a primary principal for a report is optional
+              attendeeGroups:
+                type: array
+                uniqueItems: true
+                items:
+                  type: object
+                  additionalProperties: false
+                  title: Attendee-group
+                  required: [label, filter]
+                  properties:
+                    label:
+                      type: string
+                      title: The label of the attendee group
+                    filter:
+                      type: object
+                      title: Attendee group filters
+                      properties:
+                        orgUuid:
+                          type: string
+                          title: UUID of organisation membership to form
           customFields:
             type: object
             additionalProperties:
               "$ref": "#/$defs/customField"
-          attendeeGroups:
-            type: array
-            uniqueItems: true
-            items:
-              type: object
-              additionalProperties: false
-              title: Attendee-group
-              required: [label, filter]
-              properties:
-                label:
-                  type: string
-                  title: The label of the attendee group
-                filter:
-                  type: object
-                  title: Attendee group filters
-                  properties:
-                    orgUuid:
-                      type: string
-                      title: UUID of organisation membership to form
 
       person:
         type: object

--- a/src/main/resources/anet-schema.yml
+++ b/src/main/resources/anet-schema.yml
@@ -641,12 +641,20 @@ properties:
                     enum:
                       [VIRTUAL_LOCATION, PHYSICAL_LOCATION, GEOGRAPHICAL_AREA, POINT_LOCATION, ADVISOR_LOCATION, PRINCIPAL_LOCATION]
           reportPeople:
-            required: [optionalAttendingAuthor]
+            required: [optionalAttendingAuthor, optionalPrimaryAdvisor, optionalPrimaryPrincipal]
             properties:
               optionalAttendingAuthor:
                 type: boolean
                 default: false
                 description: Defines if having an attending author for a report is optional
+              optionalPrimaryAdvisor:
+                type: boolean
+                default: false
+                description: Defines if having a primary advisor for a report is optional
+              optionalPrimaryPrincipal:
+                type: boolean
+                default: false
+                description: Defines if having a primary principal for a report is optional
           customFields:
             type: object
             additionalProperties:

--- a/testDictionaries/no-custom-fields.yml
+++ b/testDictionaries/no-custom-fields.yml
@@ -367,10 +367,10 @@ fields:
       optionalAttendingAuthor: false
       optionalPrimaryAdvisor: false
       optionalPrimaryPrincipal: true
-    attendeeGroups:
-      - label: Linguists
-        filter:
-          orgUuid: 70193ee9-05b4-4aac-80b5-75609825db9f
+      attendeeGroups:
+        - label: Linguists
+          filter:
+            orgUuid: 70193ee9-05b4-4aac-80b5-75609825db9f
 
   person:
     status:

--- a/testDictionaries/no-custom-fields.yml
+++ b/testDictionaries/no-custom-fields.yml
@@ -365,6 +365,8 @@ fields:
       filter: [POINT_LOCATION, VIRTUAL_LOCATION]
     reportPeople:
       optionalAttendingAuthor: false
+      optionalPrimaryAdvisor: false
+      optionalPrimaryPrincipal: true
     attendeeGroups:
       - label: Linguists
         filter:

--- a/testDictionaries/no-custom-fields.yml
+++ b/testDictionaries/no-custom-fields.yml
@@ -363,6 +363,8 @@ fields:
       label: Location
       placeholder: Search for the engagement location…
       filter: [POINT_LOCATION, VIRTUAL_LOCATION]
+    reportPeople:
+      optionalAttendingAuthor: false
     attendeeGroups:
       - label: Linguists
         filter:


### PR DESCRIPTION
Whether attending authors or primary attendees are required can now be configured through the dictionary.

Closes [AB#988](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/988)

#### User changes
- Depending on dictionary settings, attending authors or primary attendees may now no longer be required.

#### Superuser changes
- None

#### Admin changes
- None

#### System admin changes
- [x] anet.yml or anet-dictionary.yml needs change
  Add something like the following under `fields.reports` in the dictionary:
  ```
    reportPeople:
      optionalAttendingAuthor: false
      optionalPrimaryAdvisor: false
      optionalPrimaryPrincipal: true
      attendeeGroups:
        - label: Linguists
          filter:
            orgUuid: 70193ee9-05b4-4aac-80b5-75609825db9f
  ```
  (note that the pre-existing `attendeeGroups` setting has moved to be under the new `reportPeople` settings)
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
