### PR TITLE
Add option to render enums as select dropdown

### DIFF
--- a/anet-dictionary.yml
+++ b/anet-dictionary.yml
@@ -643,6 +643,8 @@ fields:
         type: enumset
         label: Choose one or more of the options
         helpText: Help text for choosing multiple values
+        asA: select
+        htmlSize: 4
         choices:
           opt1:
             label: Option 1
@@ -650,6 +652,12 @@ fields:
             label: Option 2
           opt3:
             label: Option 3
+          opt4:
+            label: Option 4
+          opt5:
+            label: Option 5
+          opt6:
+            label: Option 6
       inputFieldName:
         type: text
         label: Text field

--- a/client/src/components/FieldHelper.js
+++ b/client/src/components/FieldHelper.js
@@ -17,6 +17,7 @@ import {
   Form,
   FormControl,
   FormGroup,
+  FormSelect,
   InputGroup,
   ListGroup,
   Row,
@@ -520,30 +521,135 @@ ButtonToggleGroupField.propTypes = {
 export const RadioButtonToggleGroupField = ({
   field, // { name, value, onChange, onBlur }
   form, // also values, setXXXX, handleXXXX, dirty, isValid, status, etc.
+  asA,
+  enableClear,
   ...props
-}) => (
-  <ButtonToggleGroupField field={field} form={form} type="radio" {...props} />
-)
+}) =>
+  (asA === "select" && (
+    <SelectField field={field} form={form} {...props} />
+  )) || (
+    <ButtonToggleGroupField
+      field={field}
+      form={form}
+      type="radio"
+      enableClear={enableClear}
+      {...props}
+    />
+  )
 RadioButtonToggleGroupField.propTypes = {
   field: PropTypes.object,
-  form: PropTypes.object
+  form: PropTypes.object,
+  asA: PropTypes.string,
+  enableClear: PropTypes.bool
 }
 
 export const CheckboxButtonToggleGroupField = ({
   field, // { name, value, onChange, onBlur }
   form, // also values, setXXXX, handleXXXX, dirty, isValid, status, etc.
+  asA,
+  enableClear,
   ...props
-}) => (
-  <ButtonToggleGroupField
-    field={field}
-    form={form}
-    type="checkbox"
-    {...props}
-  />
-)
+}) =>
+  (asA === "select" && (
+    <SelectField field={field} form={form} multiple {...props} />
+  )) || (
+    <ButtonToggleGroupField
+      field={field}
+      form={form}
+      type="checkbox"
+      enableClear={enableClear}
+      {...props}
+    />
+  )
 CheckboxButtonToggleGroupField.propTypes = {
   field: PropTypes.object,
-  form: PropTypes.object
+  form: PropTypes.object,
+  asA: PropTypes.string,
+  enableClear: PropTypes.bool
+}
+
+export const SelectField = ({
+  field, // { name, value, onChange, onBlur }
+  form, // contains, touched, errors, values, setXXXX, handleXXXX, dirty, isValid, status, etc.
+  label,
+  buttons,
+  multiple,
+  onChange,
+  className,
+  children,
+  extraColElem,
+  addon,
+  vertical,
+  extraAddon,
+  ...otherProps
+}) => {
+  const { validationState } = getFormGroupValidationState(field, form)
+  if (validationState) {
+    className = classNames(className, "is-invalid")
+  }
+  const widgetElem = useMemo(
+    () => (
+      <FormSelect
+        {...field}
+        value={field.value ?? ""}
+        multiple={multiple}
+        isInvalid={validationState}
+        className={className}
+        onChange={e => {
+          let newValue
+          if (!multiple) {
+            // First (empty) option must be the empty string (""); replace with null when selected
+            newValue = e.target.value || null
+          } else {
+            newValue = []
+            for (const opt of e.target.options) {
+              if (opt.selected) {
+                newValue.push(opt.value)
+              }
+            }
+          }
+          onChange(newValue)
+        }}
+        {...otherProps}
+      >
+        {!multiple && <option />}
+        {buttons.map(option => (
+          <option key={`${field.name}_${option.value}`} value={option.value}>
+            {option.label}
+          </option>
+        ))}
+      </FormSelect>
+    ),
+    [field, className, otherProps, buttons, multiple, onChange, validationState]
+  )
+  return (
+    <Field
+      field={field}
+      form={form}
+      label={label}
+      widgetElem={widgetElem}
+      extraColElem={extraColElem}
+      addon={addon}
+      vertical={vertical}
+      extraAddon={extraAddon}
+    >
+      {children}
+    </Field>
+  )
+}
+SelectField.propTypes = {
+  field: PropTypes.object,
+  form: PropTypes.object,
+  label: PropTypes.string,
+  buttons: PropTypes.array.isRequired,
+  multiple: PropTypes.bool,
+  onChange: PropTypes.func.isRequired,
+  className: PropTypes.string,
+  children: PropTypes.any,
+  extraColElem: PropTypes.object,
+  addon: PropTypes.object,
+  vertical: PropTypes.bool,
+  extraAddon: PropTypes.object
 }
 
 export default Field

--- a/src/main/resources/anet-schema.yml
+++ b/src/main/resources/anet-schema.yml
@@ -139,6 +139,8 @@ $defs:
         type: string
       asA:
         type: string
+      htmlSize:
+        type: number
       filters:
         type: array
         uniqueItems: true


### PR DESCRIPTION
When so defined in the dictionary, an enum will be a single select, an enumset will be a multiselect. The number of visible entries in the select can be set with the `htmlSize` property.

Closes [AB#994](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/994)

#### User changes
- None

#### Superuser changes
- None

#### Admin changes
- None

#### System admin changes
- [x] anet.yml or anet-dictionary.yml needs change
  You can now do:
  ```
        someField:
          type: enum
          asA: select
  ```
  to render an enum as a dropdown instead of a row of buttons, or:
  ```
        someField:
          type: enumset
          asA: select
          htmlSize: 4
  ```
  to render an enumset as a multiselect dropdown, with 4 visible choices.
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
