### PR TITLE
Add dictionary settings to make report approval workflow optional

### DIFF
--- a/anet-dictionary.yml
+++ b/anet-dictionary.yml
@@ -31,6 +31,8 @@ printOptions:
   sensitiveInformationTooltipText: Releasability Information
 
 reportWorkflow:
+  optionalApprovalWorkflow: false
+  optionalPlanningApprovalWorkflow: true
   nbOfHoursQuarantineApproved: 24
   nbOfHoursApprovalTimeout: 48
 

--- a/src/main/resources/anet-schema.yml
+++ b/src/main/resources/anet-schema.yml
@@ -485,8 +485,18 @@ properties:
   reportWorkflow:
     type: object
     additionalProperties: false
-    required: [nbOfHoursQuarantineApproved, nbOfHoursApprovalTimeout]
+    required: [optionalApprovalWorkflow, optionalPlanningApprovalWorkflow, nbOfHoursQuarantineApproved, nbOfHoursApprovalTimeout]
     properties:
+      optionalApprovalWorkflow:
+        type: boolean
+        title: Whether having a report approval workflow (including the default workflow) is optional
+        description: Used in the report approval logic to automatically approve an engagement report
+                     if the workflow is optional and there is no defined workflow.
+      optionalPlanningApprovalWorkflow:
+        type: boolean
+        title: Whether having a report planning approval workflow (including the default workflow) is optional
+        description: Used in the report approval logic to automatically approve a planned engagement report
+                     if the workflow is optional and there is no defined planning workflow.
       nbOfHoursQuarantineApproved:
         type: integer
         minimum: 0

--- a/testDictionaries/no-custom-fields.yml
+++ b/testDictionaries/no-custom-fields.yml
@@ -30,6 +30,8 @@ printOptions:
   sensitiveInformationTooltipText: Releasability Information
 
 reportWorkflow:
+  optionalApprovalWorkflow: false
+  optionalPlanningApprovalWorkflow: true
   nbOfHoursQuarantineApproved: 24
   nbOfHoursApprovalTimeout: 48
 


### PR DESCRIPTION
When so defined in the dictionary, the report approval workflow and/or report planning approval workflow can be made optional.

Closes [AB#997](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/997)

#### User changes
- None

#### Superuser changes
- None

#### Admin changes
- None

#### System admin changes
- [x] anet.yml or anet-dictionary.yml needs change
  Add a dictionary entry like this:
  ```
  reportWorkflow:
    optionalApprovalWorkflow: false
    optionalPlanningApprovalWorkflow: true
  ```
  for backwards-compatibility with previous behaviour.
  Setting `optionalApprovalWorkflow` to `true` makes the report approval workflow optional; this means that you don't have to set a default approval organization in the admin settings, or (when set) that you don't have to define an approval workflow for the default approval organization.
  Setting `optionalPlanningApprovalWorkflow` to `false` makes the planning approval workflow required.
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
