### PR TITLE
Fix modal dialogs with large contents

### DIFF
--- a/client/src/components/RelatedObjectNoteModal.js
+++ b/client/src/components/RelatedObjectNoteModal.js
@@ -49,8 +49,8 @@ const RelatedObjectNoteModal = ({
       centered
       show={showModal}
       onHide={close}
+      size="lg"
       style={{ zIndex: "1300" }}
-      dialogClassName="rich-text-modal"
     >
       <Formik
         enableReinitialize

--- a/client/src/components/assessments/AssessmentModal.js
+++ b/client/src/components/assessments/AssessmentModal.js
@@ -1,8 +1,7 @@
 import API from "api"
 import {
   CustomFieldsContainer,
-  customFieldsJSONString,
-  SPECIAL_WIDGET_TYPES
+  customFieldsJSONString
 } from "components/CustomFields"
 import Messages from "components/Messages"
 import Model, {
@@ -35,12 +34,7 @@ const AssessmentModal = ({
   entity
 }) => {
   const [assessmentError, setAssessmentError] = useState(null)
-  const hasQuestionSets = !_isEmpty(assessmentConfig.questionSets)
   const dictionaryPath = entity.getAssessmentDictionaryPath()
-  const hasRichTextEditor = Object.values(
-    assessmentConfig.questions || {}
-  ).find(question => question.widget === SPECIAL_WIDGET_TYPES.RICH_TEXT_EDITOR)
-  const wideModal = hasQuestionSets || hasRichTextEditor
   const edit = !!note.uuid
   const initialValues = useMemo(
     () =>
@@ -50,92 +44,90 @@ const AssessmentModal = ({
     [assessment, assessmentYupSchema]
   )
   return (
-    <>
-      <Modal
-        centered
-        show={showModal}
-        onHide={closeModal}
-        dialogClassName={wideModal && "wide-assessment-modal"}
-        style={{ zIndex: "1250" }}
+    <Modal
+      centered
+      show={showModal}
+      onHide={closeModal}
+      size="lg"
+      style={{ zIndex: "1250" }}
+    >
+      <Formik
+        enableReinitialize
+        onSubmit={onAssessmentSubmit}
+        validationSchema={assessmentYupSchema}
+        initialValues={initialValues}
       >
-        <Formik
-          enableReinitialize
-          onSubmit={onAssessmentSubmit}
-          validationSchema={assessmentYupSchema}
-          initialValues={initialValues}
-        >
-          {({
-            isSubmitting,
-            isValid,
-            setFieldValue,
-            setFieldTouched,
-            validateForm,
-            values,
-            submitForm
-          }) => {
-            return (
-              <Form>
-                <Modal.Header closeButton>
-                  <Modal.Title>{title}</Modal.Title>
-                </Modal.Header>
-                <Modal.Body>
-                  <div
-                    style={{
-                      display: "flex",
-                      flexDirection: "column",
-                      padding: 5,
-                      height: "100%"
-                    }}
-                  >
-                    <Messages error={assessmentError} />
-                    {!_isEmpty(assessmentConfig.questions) && (
-                      <CustomFieldsContainer
-                        fieldsConfig={assessmentConfig.questions}
-                        parentFieldName={ENTITY_ASSESSMENT_PARENT_FIELD}
-                        formikProps={{
-                          setFieldTouched,
-                          setFieldValue,
-                          values,
-                          validateForm
-                        }}
-                        vertical
-                      />
-                    )}
-                    {!_isEmpty(assessmentConfig.questionSets) && (
-                      <QuestionSet
-                        entity={entity}
-                        questionSets={assessmentConfig.questionSets}
-                        parentFieldName={`${ENTITY_ASSESSMENT_PARENT_FIELD}.questionSets`}
-                        formikProps={{
-                          setFieldTouched,
-                          setFieldValue,
-                          values,
-                          validateForm
-                        }}
-                        readonly={false}
-                        vertical
-                      />
-                    )}
-                  </div>
-                </Modal.Body>
-                <Modal.Footer className="justify-content-between">
-                  <Button onClick={closeModal} variant="outline-secondary">
-                    Cancel
-                  </Button>
-                  <Button
-                    onClick={submitForm}
-                    variant="primary"
-                    disabled={isSubmitting}
-                  >
-                    Save
-                  </Button>
-                </Modal.Footer>
-              </Form>
-            )
-          }}
-        </Formik>
-      </Modal>
-    </>
+        {({
+          isSubmitting,
+          isValid,
+          setFieldValue,
+          setFieldTouched,
+          validateForm,
+          values,
+          submitForm
+        }) => {
+          return (
+            <Form>
+              <Modal.Header closeButton>
+                <Modal.Title>{title}</Modal.Title>
+              </Modal.Header>
+              <Modal.Body>
+                <div
+                  style={{
+                    display: "flex",
+                    flexDirection: "column",
+                    padding: 5,
+                    height: "100%"
+                  }}
+                >
+                  <Messages error={assessmentError} />
+                  {!_isEmpty(assessmentConfig.questions) && (
+                    <CustomFieldsContainer
+                      fieldsConfig={assessmentConfig.questions}
+                      parentFieldName={ENTITY_ASSESSMENT_PARENT_FIELD}
+                      formikProps={{
+                        setFieldTouched,
+                        setFieldValue,
+                        values,
+                        validateForm
+                      }}
+                      vertical
+                    />
+                  )}
+                  {!_isEmpty(assessmentConfig.questionSets) && (
+                    <QuestionSet
+                      entity={entity}
+                      questionSets={assessmentConfig.questionSets}
+                      parentFieldName={`${ENTITY_ASSESSMENT_PARENT_FIELD}.questionSets`}
+                      formikProps={{
+                        setFieldTouched,
+                        setFieldValue,
+                        values,
+                        validateForm
+                      }}
+                      readonly={false}
+                      vertical
+                    />
+                  )}
+                </div>
+              </Modal.Body>
+              <Modal.Footer className="justify-content-between">
+                <Button onClick={closeModal} variant="outline-secondary">
+                  Cancel
+                </Button>
+                <Button
+                  onClick={submitForm}
+                  variant="primary"
+                  disabled={isSubmitting}
+                >
+                  Save
+                </Button>
+              </Modal.Footer>
+            </Form>
+          )
+        }}
+      </Formik>
+    </Modal>
   )
 
   function closeModal() {

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1130,11 +1130,6 @@ header.searchPagination {
   opacity: 1;
 }
 
-.rich-text-modal, .wide-assessment-modal {
-  width: 700px;
-  max-width: 100%;
-}
-
 @page {
   margin: 0;
 }


### PR DESCRIPTION
Make sure modal dialogs with (potentially) large contents, like assessments or related object notes, scroll properly.

Closes [AB#889](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/889)

#### User changes
- Modal dialogs with large contents now scroll properly if the contents don't fit on the screen.

#### Superuser changes
- None

#### Admin changes
- None

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
