### PR TITLE
Use intent as report title

### DIFF
--- a/client/src/components/Fieldset.js
+++ b/client/src/components/Fieldset.js
@@ -1,3 +1,4 @@
+import classNames from "classnames"
 import { CompactRow } from "components/Compact"
 import _isEmpty from "lodash/isEmpty"
 import PropTypes from "prop-types"
@@ -37,7 +38,13 @@ const Fieldset = ({
     >
       {(title || action) && (
         <h4 className="legend">
-          <span className="title-text">{title}</span>
+          <span
+            className={classNames("title-text", "ellipsized-text", {
+              "limit-title-text": action
+            })}
+          >
+            {title}
+          </span>
           {action && <small className="action-small">{action}</small>}
         </h4>
       )}

--- a/client/src/components/RelatedObjectNotes.js
+++ b/client/src/components/RelatedObjectNotes.js
@@ -105,7 +105,11 @@ const RelatedObjectNotes = ({
 
   return (
     <>
-      <Button onClick={handleShow} title="Show notes">
+      <Button
+        onClick={handleShow}
+        title="Show notes"
+        style={{ display: noNotes ? "inline-block" : "inline-grid" }}
+      >
         {!noNotes && <NotificationBadge>{badgeLabel}</NotificationBadge>}
         <Icon icon={IconNames.COMMENT} />
       </Button>

--- a/client/src/components/ReportWorkflow.css
+++ b/client/src/components/ReportWorkflow.css
@@ -1,7 +1,3 @@
-.report-summary h4.legend {
-  display: none;
-}
-
 .workflow-fieldset .workflow-action {
   position: relative;
   display: inline-block;

--- a/client/src/components/previews/AttachmentPreview.js
+++ b/client/src/components/previews/AttachmentPreview.js
@@ -45,7 +45,7 @@ const AttachmentPreview = ({ className, uuid }) => {
   return (
     <div className={`${className} preview-content-scroll`}>
       <div className="preview-sticky-title">
-        <h4>{`Attachment ${attachment.caption}`}</h4>
+        <h4 className="ellipsized-text">{`Attachment ${attachment.caption}`}</h4>
       </div>
       <div className="preview-section">
         <Row>

--- a/client/src/components/previews/AuthorizationGroupPreview.js
+++ b/client/src/components/previews/AuthorizationGroupPreview.js
@@ -58,7 +58,7 @@ const AuthorizationGroupPreview = ({ className, uuid }) => {
   return (
     <div className={`${className} preview-content-scroll`}>
       <div className="preview-sticky-title">
-        <h4>{`Authorization Group ${authorizationGroup.name}`}</h4>
+        <h4 className="ellipsized-text">{`Authorization Group ${authorizationGroup.name}`}</h4>
       </div>
       <div className="preview-section">
         <PreviewField label="Name" value={authorizationGroup.name} />

--- a/client/src/components/previews/LocationPreview.js
+++ b/client/src/components/previews/LocationPreview.js
@@ -56,7 +56,7 @@ const LocationPreview = ({ className, uuid }) => {
   return (
     <div className={`${className} preview-content-scroll`}>
       <div className="preview-sticky-title">
-        <h4>{`Location ${location.name}`}</h4>
+        <h4 className="ellipsized-text">{`Location ${location.name}`}</h4>
       </div>
       <div className="preview-section">
         <DictPreviewField

--- a/client/src/components/previews/OrganizationPreview.js
+++ b/client/src/components/previews/OrganizationPreview.js
@@ -127,7 +127,7 @@ const OrganizationPreview = ({ className, uuid }) => {
   return (
     <div className={`${className} preview-content-scroll`}>
       <div className="preview-sticky-title">
-        <h4>{`Organization ${organization.shortName}`}</h4>
+        <h4 className="ellipsized-text">{`Organization ${organization.shortName}`}</h4>
       </div>
       <div className="preview-section">
         <DictPreviewField

--- a/client/src/components/previews/PersonPreview.js
+++ b/client/src/components/previews/PersonPreview.js
@@ -115,7 +115,7 @@ const PersonPreview = ({ className, uuid }) => {
   return (
     <div className={`${className} preview-content-scroll`}>
       <div className="preview-sticky-title">
-        <h4>{`${person.rank} ${person.name}`}</h4>
+        <h4 className="ellipsized-text">{`${person.rank} ${person.name}`}</h4>
       </div>
       <div className="preview-section">
         <Row>

--- a/client/src/components/previews/PositionPreview.js
+++ b/client/src/components/previews/PositionPreview.js
@@ -95,7 +95,7 @@ const PositionPreview = ({ className, uuid }) => {
   return (
     <div className={`${className} preview-content-scroll`}>
       <div className="preview-sticky-title">
-        <h4>{`Position ${position.name}`}</h4>
+        <h4 className="ellipsized-text">{`Position ${position.name}`}</h4>
       </div>
       <div className="preview-section">
         <DictPreviewField

--- a/client/src/components/previews/ReportPreview.js
+++ b/client/src/components/previews/ReportPreview.js
@@ -132,6 +132,7 @@ const ReportPreview = ({ className, uuid }) => {
     report = Object.assign(report, report.getAttendeesEngagementAssessments())
   }
 
+  const reportTitle = report.intent || `#${report.uuid}`
   return (
     <div className={`report-preview preview-content-scroll ${className || ""}`}>
       {report.isPublished() && (
@@ -170,7 +171,7 @@ const ReportPreview = ({ className, uuid }) => {
         </div>
       )}
 
-      <h4>Report {uuid}</h4>
+      <h4>Report {reportTitle}</h4>
       <div className="preview-section">
         <PreviewField
           extraColForValue

--- a/client/src/components/previews/ReportPreview.js
+++ b/client/src/components/previews/ReportPreview.js
@@ -171,7 +171,7 @@ const ReportPreview = ({ className, uuid }) => {
         </div>
       )}
 
-      <h4>Report {reportTitle}</h4>
+      <h4 className="ellipsized-text">Report {reportTitle}</h4>
       <div className="preview-section">
         <PreviewField
           extraColForValue

--- a/client/src/components/previews/TaskPreview.js
+++ b/client/src/components/previews/TaskPreview.js
@@ -132,7 +132,7 @@ const TaskPreview = ({ className, uuid }) => {
   return (
     <div className={`${className} preview-content-scroll`}>
       <div className="preview-sticky-title">
-        <h4>{`${fieldSettings.shortLabel} ${task.shortName}`}</h4>
+        <h4 className="ellipsized-text">{`${fieldSettings.shortLabel} ${task.shortName}`}</h4>
       </div>
       <div className="preview-section">
         <DictPreviewField

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -53,35 +53,38 @@ fieldset {
   width: 100%;
 }
 
-.legend {
-  float: left;
+.ellipsized-text {
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+  display: inline-block;
+  max-width: 100%;
+}
+
+h4.legend {
   width: 100%;
   color: #363636;
   border: none;
   font-weight: normal;
-}
-
-h4.legend {
   margin-top: 1rem;
-}
-
-.legend small {
-  float: right;
   display: flex;
-  font-size: 1.2rem;
-  margin: 1rem 0.5rem 0 0;
+  flex-wrap: wrap;
+  row-gap: 0.5rem;
+  column-gap: 0.5rem;
+  justify-content: space-between;
 }
 
-.legend small .btn {
-  margin-top: -2rem;
+h4.legend span.limit-title-text {
+  max-width: calc(100% - 400px);
+  min-width: 20rem;
 }
 
-.legend small .btn.btn-outline-danger.float-end {
-  margin-top: -1.5rem;
-}
-
-.legend small :not(.btn-group) .btn + .btn {
-  margin-left: 1rem;
+h4.legend small.action-small {
+  display: flex;
+  flex-wrap: wrap;
+  row-gap: 0.5rem;
+  column-gap: 0.5rem;
+  margin-right: 0.5rem;
 }
 
 .form-top-submit {
@@ -1204,7 +1207,6 @@ header.searchPagination {
 }
 
 .rollup-date-range-container {
-  padding-bottom: 8px;
   display: flex;
   align-items: center;
 }
@@ -1273,21 +1275,6 @@ div[id*='fg-entityAssessment'] {
   /* hide guide tour on small screen as it is broken */
   .persistent-tour-launcher {
     display: none;
-  }
-
-  .scroll-anchor-container .action-small {
-    display: flex;
-    flex-direction: column;
-    justify-content: flex-start;
-    align-items: flex-end;
-  }
-
-  .scroll-anchor-container .action-small > * {
-    margin: 5px 0 0 0;
-  }
-
-  .legend small .btn {
-    margin: 5px 0 0 0;
   }
 
   fieldset {

--- a/client/src/pages/admin/Index.js
+++ b/client/src/pages/admin/Index.js
@@ -137,15 +137,13 @@ const AdminIndex = ({ pageDispatchers }) => {
       <Formik enableReinitialize onSubmit={onSubmit} initialValues={settings}>
         {({ values, isSubmitting, submitForm }) => {
           const action = (
-            <div>
-              <Button
-                variant="primary"
-                onClick={submitForm}
-                disabled={isSubmitting}
-              >
-                Save settings
-              </Button>
-            </div>
+            <Button
+              variant="primary"
+              onClick={submitForm}
+              disabled={isSubmitting}
+            >
+              Save settings
+            </Button>
           )
           return (
             <Form className="form-horizontal" method="post">
@@ -186,7 +184,7 @@ const AdminIndex = ({ pageDispatchers }) => {
               </Fieldset>
               <div className="submit-buttons">
                 <div />
-                {action}
+                <div>{action}</div>
               </div>
             </Form>
           )

--- a/client/src/pages/admin/authorizationgroup/Form.js
+++ b/client/src/pages/admin/authorizationgroup/Form.js
@@ -57,16 +57,14 @@ const AuthorizationGroupForm = ({ edit, title, initialValues }) => {
     >
       {({ isSubmitting, dirty, setFieldValue, submitForm }) => {
         const action = (
-          <div>
-            <Button
-              key="submit"
-              variant="primary"
-              onClick={submitForm}
-              disabled={isSubmitting}
-            >
-              Save Authorization Group
-            </Button>
-          </div>
+          <Button
+            key="submit"
+            variant="primary"
+            onClick={submitForm}
+            disabled={isSubmitting}
+          >
+            Save Authorization Group
+          </Button>
         )
         return (
           <div>

--- a/client/src/pages/attachments/Form.js
+++ b/client/src/pages/attachments/Form.js
@@ -73,16 +73,14 @@ const AttachmentForm = ({ edit, title, initialValues }) => {
         const { backgroundSize, backgroundImage } =
           utils.getAttachmentIconDetails(values)
         const action = (
-          <div>
-            <Button
-              key="submit"
-              variant="primary"
-              onClick={submitForm}
-              disabled={isSubmitting}
-            >
-              Save Attachment
-            </Button>
-          </div>
+          <Button
+            key="submit"
+            variant="primary"
+            onClick={submitForm}
+            disabled={isSubmitting}
+          >
+            Save Attachment
+          </Button>
         )
         return (
           <div>

--- a/client/src/pages/attachments/Show.js
+++ b/client/src/pages/attachments/Show.js
@@ -149,10 +149,7 @@ const AttachmentShow = ({ pageDispatchers }) => {
       {({ values }) => {
         const action = (
           <>
-            <Button
-              className="d-flex p-0 align-items-center"
-              disabled={contentMissing}
-            >
+            <Button variant="primary" disabled={contentMissing}>
               <a
                 href={`/api/attachment/download/${attachment.uuid}`}
                 style={{

--- a/client/src/pages/locations/Form.js
+++ b/client/src/pages/locations/Form.js
@@ -147,7 +147,7 @@ const LocationForm = ({ edit, title, initialValues, notesComponent }) => {
           })
         }
         const action = (
-          <div>
+          <>
             <Button
               key="submit"
               variant="primary"
@@ -157,7 +157,7 @@ const LocationForm = ({ edit, title, initialValues, notesComponent }) => {
               Save Location
             </Button>
             {notesComponent}
-          </div>
+          </>
         )
 
         const coordinates = {

--- a/client/src/pages/locations/Show.js
+++ b/client/src/pages/locations/Show.js
@@ -95,30 +95,26 @@ const LocationShow = ({ pageDispatchers }) => {
         const action = (
           <>
             {canEdit && (
-              <span style={{ marginLeft: "1rem" }}>
-                <LinkTo
-                  modelType="Location"
-                  model={location}
-                  edit
-                  button="primary"
-                  id="editButton"
-                >
-                  Edit
-                </LinkTo>
-              </span>
+              <LinkTo
+                modelType="Location"
+                model={location}
+                edit
+                button="primary"
+                id="editButton"
+              >
+                Edit
+              </LinkTo>
             )}
-            <span className="ms-3">
-              <RelatedObjectNotes
-                notes={location.notes}
-                relatedObject={
-                  location.uuid && {
-                    relatedObjectType: Location.relatedObjectType,
-                    relatedObjectUuid: location.uuid,
-                    relatedObject: location
-                  }
+            <RelatedObjectNotes
+              notes={location.notes}
+              relatedObject={
+                location.uuid && {
+                  relatedObjectType: Location.relatedObjectType,
+                  relatedObjectUuid: location.uuid,
+                  relatedObject: location
                 }
-              />
-            </span>
+              }
+            />
           </>
         )
         return (

--- a/client/src/pages/organizations/Form.js
+++ b/client/src/pages/organizations/Form.js
@@ -143,7 +143,7 @@ const OrganizationForm = ({ edit, title, initialValues, notesComponent }) => {
           values.parentOrg = {}
         }
         const action = canAdministrateOrg && (
-          <div>
+          <>
             <Button
               key="submit"
               variant="primary"
@@ -153,7 +153,7 @@ const OrganizationForm = ({ edit, title, initialValues, notesComponent }) => {
               Save Organization
             </Button>
             {notesComponent}
-          </div>
+          </>
         )
         const tasksFilters = {
           allTasks: {

--- a/client/src/pages/organizations/Laydown.js
+++ b/client/src/pages/organizations/Laydown.js
@@ -69,11 +69,11 @@ const OrganizationLaydown = ({ organization, refetch, readOnly }) => {
         className="scroll-anchor-container"
       >
         <div style={{ display: "flex", flexDirection: "column" }}>
-          <div>
-            <h4 className="legend">
-              <span className="title-text">Organization Diagram</span>
-            </h4>
-          </div>
+          <h4 className="legend">
+            <span className="title-text ellipsized-text">
+              Organization Diagram
+            </span>
+          </h4>
           <div style={{ backgroundColor: "white" }}>
             <ContainerDimensions>
               {({ width, height }) => (
@@ -95,19 +95,17 @@ const OrganizationLaydown = ({ organization, refetch, readOnly }) => {
         id="supportedPositions"
         title="Supported positions"
         action={
-          <div>
-            {canAdministrateOrg && (
-              <LinkTo
-                modelType="Position"
-                model={Position.pathForNew({
-                  organizationUuid: organization.uuid
-                })}
-                button
-              >
-                Create position
-              </LinkTo>
-            )}
-          </div>
+          canAdministrateOrg && (
+            <LinkTo
+              modelType="Position"
+              model={Position.pathForNew({
+                organizationUuid: organization.uuid
+              })}
+              button
+            >
+              Create position
+            </LinkTo>
+          )
         }
       >
         {renderPositionTable(supportedPositions)}
@@ -120,15 +118,13 @@ const OrganizationLaydown = ({ organization, refetch, readOnly }) => {
         id="vacantPositions"
         title="Vacant positions"
         action={
-          <div>
-            {numInactivePos > 0 && (
-              <Button onClick={toggleShowInactive} variant="outline-secondary">
-                {(showInactivePositions ? "Hide " : "Show ") +
-                  numInactivePos +
-                  " inactive position(s)"}
-              </Button>
-            )}
-          </div>
+          numInactivePos > 0 && (
+            <Button onClick={toggleShowInactive} variant="outline-secondary">
+              {(showInactivePositions ? "Hide " : "Show ") +
+                numInactivePos +
+                " inactive position(s)"}
+            </Button>
+          )
         }
       >
         {renderPositionTable(positionsNeedingAttention)}

--- a/client/src/pages/organizations/Show.js
+++ b/client/src/pages/organizations/Show.js
@@ -273,7 +273,7 @@ const OrganizationShow = ({ pageDispatchers }) => {
     <Formik enableReinitialize initialValues={organization}>
       {({ values }) => {
         const action = (
-          <div>
+          <>
             {canAdministrateOrg && (
               <LinkTo
                 modelType="Organization"
@@ -307,7 +307,7 @@ const OrganizationShow = ({ pageDispatchers }) => {
                 }
               }
             />
-          </div>
+          </>
         )
         return (
           <div>

--- a/client/src/pages/people/Form.js
+++ b/client/src/pages/people/Form.js
@@ -232,7 +232,7 @@ const PersonForm = ({
             ? "Yes, I would like to inactivate my predecessor's account and set up a new one for myself"
             : "Yes, I would like to inactivate this account"
         const action = (
-          <div>
+          <>
             <Button
               key="submit"
               variant="primary"
@@ -242,7 +242,7 @@ const PersonForm = ({
               {saveText}
             </Button>
             {notesComponent}
-          </div>
+          </>
         )
 
         return (

--- a/client/src/pages/people/Show.js
+++ b/client/src/pages/people/Show.js
@@ -209,7 +209,7 @@ const PersonShow = ({ pageDispatchers }) => {
   const attachmentsEnabled = !Settings.fields.attachment.featureDisabled
 
   const action = (
-    <div>
+    <>
       <Button value="compactView" variant="primary" onClick={onCompactClick}>
         Summary / Print
       </Button>
@@ -234,7 +234,7 @@ const PersonShow = ({ pageDispatchers }) => {
           }
         }
       />
-    </div>
+    </>
   )
   const emailHumanValue = (
     <a href={`mailto:${person.emailAddress}`}>{person.emailAddress}</a>

--- a/client/src/pages/positions/Form.js
+++ b/client/src/pages/positions/Form.js
@@ -181,7 +181,7 @@ const PositionForm = ({ edit, title, initialValues, notesComponent }) => {
           values.person &&
           values.person.uuid
         const action = (
-          <div>
+          <>
             <Button
               key="submit"
               variant="primary"
@@ -191,7 +191,7 @@ const PositionForm = ({ edit, title, initialValues, notesComponent }) => {
               Save Position
             </Button>
             {notesComponent}
-          </div>
+          </>
         )
         const organizationFilters = {
           allOrganizations: {

--- a/client/src/pages/positions/Show.js
+++ b/client/src/pages/positions/Show.js
@@ -128,30 +128,26 @@ const PositionShow = ({ pageDispatchers }) => {
         const action = (
           <>
             {canEdit && (
-              <span style={{ marginLeft: "1rem" }}>
-                <LinkTo
-                  modelType="Position"
-                  model={position}
-                  edit
-                  button="primary"
-                  className="edit-position"
-                >
-                  Edit
-                </LinkTo>
-              </span>
+              <LinkTo
+                modelType="Position"
+                model={position}
+                edit
+                button="primary"
+                className="edit-position"
+              >
+                Edit
+              </LinkTo>
             )}
-            <span className="ms-3">
-              <RelatedObjectNotes
-                notes={position.notes}
-                relatedObject={
-                  position.uuid && {
-                    relatedObjectType: Position.relatedObjectType,
-                    relatedObjectUuid: position.uuid,
-                    relatedObject: position
-                  }
+            <RelatedObjectNotes
+              notes={position.notes}
+              relatedObject={
+                position.uuid && {
+                  relatedObjectType: Position.relatedObjectType,
+                  relatedObjectUuid: position.uuid,
+                  relatedObject: position
                 }
-              />
-            </span>
+              }
+            />
           </>
         )
         return (

--- a/client/src/pages/reports/Edit.js
+++ b/client/src/pages/reports/Edit.js
@@ -169,12 +169,13 @@ const ReportEdit = ({ pageDispatchers }) => {
     reportInitialValues.reportPeople
   )
 
+  const reportTitle = report.intent || `#${report.uuid}`
   return (
     <div className="report-edit">
       <ReportForm
         edit
         initialValues={reportInitialValues}
-        title={`Report #${report.uuid}`}
+        title={`Report ${reportTitle}`}
         showSensitiveInfo={!!report.reportSensitiveInformation?.text}
         notesComponent={
           <RelatedObjectNotes

--- a/client/src/pages/reports/Form.js
+++ b/client/src/pages/reports/Form.js
@@ -424,7 +424,7 @@ const ReportForm = ({
           isAuthor
         // Skip validation on save!
         const action = (
-          <div>
+          <>
             <Button
               variant="primary"
               onClick={() => onSubmit(values, { resetForm, setSubmitting })}
@@ -433,7 +433,7 @@ const ReportForm = ({
               {submitText}
             </Button>
             {notesComponent}
-          </div>
+          </>
         )
         const isFutureEngagement = Report.isFuture(values.engagementDate)
         const hasAssessments = values.engagementDate && !isFutureEngagement

--- a/client/src/pages/reports/Show.js
+++ b/client/src/pages/reports/Show.js
@@ -406,7 +406,7 @@ const ReportShow = ({ setSearchQuery, pageDispatchers }) => {
     >
       {({ isValid, setFieldValue, values }) => {
         const action = (
-          <div>
+          <>
             {canEmail && (
               <Button onClick={toggleEmailModal} variant="outline-secondary">
                 Email report
@@ -435,7 +435,7 @@ const ReportShow = ({ setSearchQuery, pageDispatchers }) => {
                 }
               }
             />
-          </div>
+          </>
         )
 
         const reportTitle = report.intent || `#${report.uuid}`

--- a/client/src/pages/reports/Show.js
+++ b/client/src/pages/reports/Show.js
@@ -438,6 +438,7 @@ const ReportShow = ({ setSearchQuery, pageDispatchers }) => {
           </div>
         )
 
+        const reportTitle = report.intent || `#${report.uuid}`
         return (
           <div className="report-show">
             {renderEmailModal(values, setFieldValue)}
@@ -544,7 +545,7 @@ const ReportShow = ({ setSearchQuery, pageDispatchers }) => {
                         persistent
                       />
                     )}{" "}
-                    Report #{report.uuid}
+                    Report {reportTitle}
                   </>
                 }
                 action={action}

--- a/client/src/pages/rollup/Show.js
+++ b/client/src/pages/rollup/Show.js
@@ -439,7 +439,7 @@ const RollupShow = ({ pageDispatchers, searchQuery, setSearchQuery }) => {
           </div>
         }
         action={
-          <span>
+          <>
             <Button
               id="print-rollup"
               href={previewPlaceholderUrl}
@@ -456,7 +456,7 @@ const RollupShow = ({ pageDispatchers, searchQuery, setSearchQuery }) => {
             >
               Email rollup
             </Button>
-          </span>
+          </>
         }
         style={fieldsetStyle}
       >

--- a/client/src/pages/tasks/Form.js
+++ b/client/src/pages/tasks/Form.js
@@ -146,7 +146,7 @@ const TaskForm = ({ edit, title, initialValues, notesComponent }) => {
         const disabled = !isAdmin
         const fieldSettings = values.fieldSettings()
         const action = (
-          <div>
+          <>
             <Button
               key="submit"
               variant="primary"
@@ -156,7 +156,7 @@ const TaskForm = ({ edit, title, initialValues, notesComponent }) => {
               Save {fieldSettings.shortLabel}
             </Button>
             {notesComponent}
-          </div>
+          </>
         )
         return (
           <div>

--- a/client/src/pages/tasks/Show.js
+++ b/client/src/pages/tasks/Show.js
@@ -212,24 +212,20 @@ const TaskShow = ({ pageDispatchers }) => {
         const action = (
           <>
             {canEdit && (
-              <span style={{ marginLeft: "1rem" }}>
-                <LinkTo modelType="Task" model={task} edit button="primary">
-                  Edit
-                </LinkTo>
-              </span>
+              <LinkTo modelType="Task" model={task} edit button="primary">
+                Edit
+              </LinkTo>
             )}
-            <span className="ms-3">
-              <RelatedObjectNotes
-                notes={task.notes}
-                relatedObject={
-                  task.uuid && {
-                    relatedObjectType: Task.relatedObjectType,
-                    relatedObjectUuid: task.uuid,
-                    relatedObject: task
-                  }
+            <RelatedObjectNotes
+              notes={task.notes}
+              relatedObject={
+                task.uuid && {
+                  relatedObjectType: Task.relatedObjectType,
+                  relatedObjectUuid: task.uuid,
+                  relatedObject: task
                 }
-              />
-            </span>
+              }
+            />
           </>
         )
         return (

--- a/client/tests/webdriver/pages/report/showReport.page.js
+++ b/client/tests/webdriver/pages/report/showReport.page.js
@@ -71,11 +71,8 @@ class ShowReport extends Page {
   }
 
   async getUuid() {
-    const title =
-      (await (
-        await browser.$("//span[@class='title-text'][contains(.,'Report #')]")
-      ).getText()) || ""
-    return title.slice(title.lastIndexOf("#") + 1)
+    const url = await browser.getUrl()
+    return url.slice(url.lastIndexOf("/") + 1)
   }
 
   async getIntent() {


### PR DESCRIPTION
Instead of the uuid, the report intent is now used as the title on report pages.
Also the page titles were made more responsive.

Closes [AB#999](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/999)

#### User changes
- Report pages now have a more meaningful title

#### Superuser changes
- None

#### Admin changes
- None

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [x] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here