### PR TITLE
Improve MIME type checks

### DIFF
--- a/src/main/java/mil/dds/anet/database/AttachmentDao.java
+++ b/src/main/java/mil/dds/anet/database/AttachmentDao.java
@@ -92,8 +92,7 @@ public class AttachmentDao extends AnetBaseDao<Attachment, AbstractSearchQuery<?
             + "UPDATE \"attachments\" SET \"mimeType\" = :mimeType, \"fileName\" = :fileName, "
             + "\"description\" = :description, \"classification\" = :classification, "
             + "\"caption\" = :caption, \"updatedAt\" = :updatedAt WHERE uuid = :uuid")
-        .bindBean(obj).bind("updatedAt", DaoUtils.asLocalDateTime(obj.getUpdatedAt()))
-        .bind("updatedAt", DaoUtils.asLocalDateTime(obj.getUpdatedAt())).execute();
+        .bindBean(obj).bind("updatedAt", DaoUtils.asLocalDateTime(obj.getUpdatedAt())).execute();
   }
 
   @Override
@@ -103,6 +102,14 @@ public class AttachmentDao extends AnetBaseDao<Attachment, AbstractSearchQuery<?
         .createQuery("/* deleteAttachment */ DELETE FROM attachments WHERE uuid = :uuid"
             + " RETURNING CASE WHEN content IS NULL THEN 1 ELSE lo_unlink(content) END")
         .bind("uuid", uuid).mapTo(Integer.class).one();
+  }
+
+  @InTransaction
+  public int updateMimeType(Attachment obj) {
+    return getDbHandle()
+        .createUpdate("/* updateAttachmentMimeType */ "
+            + "UPDATE \"attachments\" SET \"mimeType\" = :mimeType WHERE uuid = :uuid")
+        .bindBean(obj).execute();
   }
 
   public interface AttachmentContent {

--- a/src/main/java/mil/dds/anet/resources/AttachmentResource.java
+++ b/src/main/java/mil/dds/anet/resources/AttachmentResource.java
@@ -105,13 +105,23 @@ public class AttachmentResource {
       return attachmentContent;
     }
     if (!detectedMimeType.equals(attachment.getMimeType())) {
-      logger.error(
-          "Attachment content upload rejected for attachment {} (\"{}\"): "
-              + "stated mimeType \"{}\" differs from detected mimeType \"{}\"",
-          attachment.getUuid(), attachment.getFileName(), attachment.getMimeType(),
-          detectedMimeType);
-      throw new WebApplicationException("Attachment content does not match the MIME type",
-          Status.BAD_REQUEST);
+      if (getAllowedMimeTypes().contains(detectedMimeType)) {
+        logger.info(
+            "Attachment content upload for attachment {} (\"{}\"): "
+                + "updated stated mimeType \"{}\" to detected mimeType \"{}\"",
+            attachment.getUuid(), attachment.getFileName(), attachment.getMimeType(),
+            detectedMimeType);
+        attachment.setMimeType(detectedMimeType);
+        dao.updateMimeType(attachment);
+      } else {
+        logger.error(
+            "Attachment content upload rejected for attachment {} (\"{}\"): "
+                + "stated mimeType \"{}\" differs from detected mimeType \"{}\"",
+            attachment.getUuid(), attachment.getFileName(), attachment.getMimeType(),
+            detectedMimeType);
+        throw new WebApplicationException("Attachment content does not match the MIME type",
+            Status.BAD_REQUEST);
+      }
     }
     return tikaInputStream;
   }


### PR DESCRIPTION
If the MIME type suggested by the browser when creating an attachment differs from the detected MIME type based on the uploaded attachment contents, update the MIME type if the detected MIME type is also allowed. This helps with container formats like HEIC/HEIF, where the browser may not be able to accurately guess the actual format based on just the filename extension.

Closes [AB#1005](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1005)

#### User changes
- Attachment upload will not fail if the actual MIME type of the uploaded contents is allowed but different from what the user's browser inferred.

#### Superuser changes
- None

#### Admin changes
- None

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
