### PR TITLE
Allow links in the rich-text editor to be updated

### DIFF
--- a/client/src/components/advancedSelectWidget/MultiTypeAdvancedSelectComponent.js
+++ b/client/src/components/advancedSelectWidget/MultiTypeAdvancedSelectComponent.js
@@ -149,6 +149,7 @@ const MultiTypeAdvancedSelectComponent = ({
   objectType,
   entityTypes,
   value,
+  valueKey,
   isMultiSelect,
   filters,
   className
@@ -175,7 +176,9 @@ const MultiTypeAdvancedSelectComponent = ({
   const SelectComponent = isMultiSelect
     ? AdvancedMultiSelect
     : AdvancedSingleSelect
-  const extraSelectProps = isMultiSelect ? {} : { showRemoveButton: false }
+  const extraSelectProps = isMultiSelect
+    ? {}
+    : { valueKey, showRemoveButton: false }
   const filterDefs =
     typeof advancedSelectProps.filterDefs === "function"
       ? advancedSelectProps.filterDefs(filters[0]?.[entityType])
@@ -235,6 +238,7 @@ MultiTypeAdvancedSelectComponent.propTypes = {
   objectType: PropTypes.string,
   entityTypes: PropTypes.arrayOf(PropTypes.string).isRequired,
   value: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
+  valueKey: PropTypes.string,
   isMultiSelect: PropTypes.bool.isRequired,
   filters: PropTypes.array,
   className: PropTypes.string

--- a/client/src/components/editor/Toolbar.js
+++ b/client/src/components/editor/Toolbar.js
@@ -1,7 +1,7 @@
 import { Icon } from "@blueprintjs/core"
 import { Tooltip2 } from "@blueprintjs/popover2"
 import PropTypes from "prop-types"
-import React, { useRef } from "react"
+import React from "react"
 import { Editor, Transforms } from "slate"
 import { useSlate } from "slate-react"
 import { ANET_LINK, EXTERNAL_LINK } from "utils_links"
@@ -27,7 +27,6 @@ const Toolbar = ({
   toolbarRef
 }) => {
   const editor = useSlate()
-  const selectionRef = useRef(editor.selection)
 
   return (
     <>
@@ -110,7 +109,6 @@ const Toolbar = ({
           text="ANET Link"
           showModal={showAnetLinksModal}
           setShowModal={setShowAnetLinksModal}
-          selectionRef={selectionRef}
           tooltipText="ANET link (Ctrl + ⇧ + k)"
         />
         <EditorToggleButton
@@ -120,7 +118,6 @@ const Toolbar = ({
           icon="link"
           showModal={showExternalLinksModal}
           setShowModal={setShowExternalLinksModal}
-          selectionRef={selectionRef}
           tooltipText="External link (Ctrl + ⇧ + a)"
         />
         <EditorToggleButton
@@ -150,13 +147,11 @@ const Toolbar = ({
         editor={editor}
         showModal={showAnetLinksModal}
         setShowModal={setShowAnetLinksModal}
-        selection={selectionRef.current}
       />
       <LinkSourceAnet
         editor={editor}
         showModal={showExternalLinksModal}
         setShowModal={setShowExternalLinksModal}
-        selection={selectionRef.current}
         external
       />
     </>
@@ -216,6 +211,12 @@ function isMarkActive(editor, format) {
   return marks && marks[format] === true
 }
 
+function isModalActive(editor, format, showModal) {
+  const selectedParent =
+    editor.selection && Editor.parent(editor, editor.selection)?.[0]
+  return showModal || selectedParent?.type === format
+}
+
 const EditorToggleButton = ({
   type,
   editor,
@@ -225,7 +226,6 @@ const EditorToggleButton = ({
   tooltipText,
   showModal,
   setShowModal,
-  selectionRef,
   onClick,
   showFullSize,
   setShowFullSize
@@ -242,13 +242,13 @@ const EditorToggleButton = ({
       onMouseDown = () => toggleBlock(editor, format)
       break
     case BUTTON_TYPES.MODAL:
-      isActive = showModal
+      isActive = isModalActive(editor, format, showModal)
       onMouseDown = () => {
-        selectionRef.current = editor.selection
         setShowModal(true)
       }
       break
     case BUTTON_TYPES.FULLSCREEN:
+      isActive = showFullSize
       onMouseDown = () => setShowFullSize(!showFullSize)
       break
     default:
@@ -287,7 +287,6 @@ EditorToggleButton.propTypes = {
   tooltipText: PropTypes.string,
   showModal: PropTypes.bool,
   setShowModal: PropTypes.func,
-  selectionRef: PropTypes.object,
   onClick: PropTypes.func,
   showFullSize: PropTypes.bool,
   setShowFullSize: PropTypes.func


### PR DESCRIPTION
Links to ANET objects and external links in the ANET rich-text editor can now be updated, by selecting them and then clicking on the corresponding button in the RTE toolbar.

Closes [AB#910](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/910)

#### User changes
- Links in the rich-text editor can be updated.

#### Superuser changes
- None

#### Admin changes
- None

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here