### PR TITLE
Restrict access for unverified accounts

### DIFF
--- a/anet-dictionary.yml
+++ b/anet-dictionary.yml
@@ -1886,6 +1886,7 @@ imagery:
         layers: GEBCO_LATEST
         format: "image/png"
 
+automaticallyAllowAllNewUsers: true
 automaticallyInactivateUsers:
   emailRemindersDaysPrior: [15, 30, 45]
   ignoredDomainNames: []

--- a/client/src/components/EditHistory.js
+++ b/client/src/components/EditHistory.js
@@ -643,6 +643,7 @@ function getSingleSelectParameters(historyEntityType, parentEntityType) {
   if (historyEntityType === "person") {
     const personSearchQuery = {
       status: Model.STATUS.ACTIVE,
+      pendingVerification: false,
       role:
         parentEntityType === Position.TYPE.PRINCIPAL
           ? Person.ROLE.PRINCIPAL

--- a/client/src/components/SearchFilters.js
+++ b/client/src/components/SearchFilters.js
@@ -140,13 +140,13 @@ export const searchFilters = function() {
   const authorWidgetFilters = {
     all: {
       label: "All",
-      queryVars: { role: Person.ROLE.ADVISOR }
+      queryVars: { role: Person.ROLE.ADVISOR, pendingVerification: false }
     }
   }
   const attendeeWidgetFilters = {
     all: {
       label: "All",
-      queryVars: {}
+      queryVars: { pendingVerification: false }
     }
   }
   const pendingApprovalOfWidgetFilters = authorWidgetFilters

--- a/client/src/components/advancedSelectWidget/MultiTypeAdvancedSelectComponent.js
+++ b/client/src/components/advancedSelectWidget/MultiTypeAdvancedSelectComponent.js
@@ -32,11 +32,15 @@ const entityFilters = {
 const peopleFilters = {
   allEntities: {
     label: "All",
-    queryVars: { matchPositionName: true }
+    queryVars: { matchPositionName: true, pendingVerification: false }
   },
   activeAdvisors: {
     label: "All advisors",
-    queryVars: { role: Models.Person.ROLE.ADVISOR, matchPositionName: true }
+    queryVars: {
+      role: Models.Person.ROLE.ADVISOR,
+      matchPositionName: true,
+      pendingVerification: false
+    }
   },
   activePrincipals: {
     label: "All principals",

--- a/client/src/pages/App.js
+++ b/client/src/pages/App.js
@@ -200,7 +200,7 @@ const App = ({ pageDispatchers, pageProps }) => {
     appState.currentUser.isPendingVerification() &&
     !routerLocation.pathname.startsWith("/onboarding")
   ) {
-    return <Navigate replace to="/onboarding" />
+    return <Navigate replace to="/onboarding/new" />
   }
   return (
     <AppContext.Provider

--- a/client/src/pages/Routing.js
+++ b/client/src/pages/Routing.js
@@ -9,6 +9,7 @@ import MergePeople from "pages/admin/merge/MergePeople"
 import MergePositions from "pages/admin/merge/MergePositions"
 import UserActivitiesOverTime from "pages/admin/useractivities/UserActivitiesOverTime"
 import UserActivitiesPerPeriod from "pages/admin/useractivities/UserActivitiesPerPeriod"
+import UsersPendingVerification from "pages/admin/UsersPendingVerification"
 import AttachmentEdit from "pages/attachments/Edit"
 import AttachmentShow from "pages/attachments/Show"
 import BoardDashboard from "pages/dashboards/BoardDashboard"
@@ -136,6 +137,12 @@ const Routing = () => {
       {currentUser.isAdmin() && (
         <Route path={PAGE_URLS.ADMIN}>
           <Route index element={<AdminIndex />} />
+          {!Settings.automaticallyAllowAllNewUsers && (
+            <Route
+              path="usersPendingVerification"
+              element={<UsersPendingVerification />}
+            />
+          )}
           <Route path="merge">
             <Route path="people" element={<MergePeople />} />
             <Route path="positions" element={<MergePositions />} />

--- a/client/src/pages/Routing.js
+++ b/client/src/pages/Routing.js
@@ -22,6 +22,7 @@ import LocationEdit from "pages/locations/Edit"
 import LocationNew from "pages/locations/New"
 import LocationShow from "pages/locations/Show"
 import OnboardingEdit from "pages/onboarding/Edit"
+import OnboardingNew from "pages/onboarding/New"
 import OnboardingShow from "pages/onboarding/Show"
 import OrganizationEdit from "pages/organizations/Edit"
 import OrganizationNew from "pages/organizations/New"
@@ -172,8 +173,9 @@ const Routing = () => {
       <Route path={PAGE_URLS.ONBOARDING}>
         {currentUser.isPendingVerification() ? (
           <>
-            <Route index element={<OnboardingShow />} />
+            <Route index path="new" element={<OnboardingNew />} />
             <Route path="edit" element={<OnboardingEdit />} />
+            <Route path="show" element={<OnboardingShow />} />
           </>
         ) : (
           // Replace with home if user account exists already.

--- a/client/src/pages/admin/UsersPendingVerification.js
+++ b/client/src/pages/admin/UsersPendingVerification.js
@@ -1,0 +1,148 @@
+import { gql } from "@apollo/client"
+import { DEFAULT_PAGE_PROPS, DEFAULT_SEARCH_PROPS } from "actions"
+import API from "api"
+import Fieldset from "components/Fieldset"
+import LinkTo from "components/LinkTo"
+import Messages from "components/Messages"
+import {
+  jumpToTop,
+  mapPageDispatchersToProps,
+  PageDispatchersPropType,
+  useBoilerplate,
+  usePageTitle
+} from "components/Page"
+import UltimatePaginationTopDown from "components/UltimatePaginationTopDown"
+import React, { useState } from "react"
+import { Button, Table } from "react-bootstrap"
+import { connect } from "react-redux"
+
+const GQL_GET_USERS_PENDING_VERIFICATION = gql`
+  query ($personQuery: PersonSearchQueryInput) {
+    personList(query: $personQuery) {
+      pageNum
+      pageSize
+      totalCount
+      list {
+        uuid
+        name
+        rank
+        role
+        avatarUuid
+        emailAddress
+        pendingVerification
+      }
+    }
+  }
+`
+const GQL_APPROVE_USER = gql`
+  mutation ($uuid: String!) {
+    approvePerson(uuid: $uuid)
+  }
+`
+const GQL_DELETE_USER = gql`
+  mutation ($uuid: String!) {
+    deletePerson(uuid: $uuid)
+  }
+`
+
+const UsersPendingVerification = ({ pageDispatchers }) => {
+  const [pageNum, setPageNum] = useState(0)
+  const [stateSuccess, setStateSuccess] = useState(null)
+  const [stateError, setStateError] = useState(null)
+  const { loading, error, data, refetch } = API.useApiQuery(
+    GQL_GET_USERS_PENDING_VERIFICATION,
+    {
+      personQuery: { pageNum, pageSize: 25, pendingVerification: true }
+    }
+  )
+  const { done, result } = useBoilerplate({
+    loading,
+    error,
+    pageProps: DEFAULT_PAGE_PROPS,
+    searchProps: DEFAULT_SEARCH_PROPS,
+    pageDispatchers
+  })
+  usePageTitle("Users Pending Verification")
+  if (done) {
+    return result
+  }
+
+  const { pageSize, totalCount, list } = data.personList
+  return (
+    <Fieldset title="Users Pending Verification">
+      <Messages success={stateSuccess} error={stateError} />
+      {totalCount <= 0 ? (
+        <em>No users pending verification</em>
+      ) : (
+        <UltimatePaginationTopDown
+          componentClassName="searchPagination"
+          className="float-end"
+          pageNum={pageNum}
+          pageSize={pageSize}
+          totalCount={totalCount}
+          goToPage={setPageNum}
+        >
+          <Table responsive hover striped id="users-pending-verification">
+            <thead>
+              <tr>
+                <th>Name</th>
+                <th>Pending Verification</th>
+              </tr>
+            </thead>
+            <tbody>
+              {list.map(person => (
+                <tr key={person.uuid}>
+                  <td>
+                    <LinkTo modelType="Person" model={person} />
+                  </td>
+                  <td>
+                    <Button
+                      variant="primary"
+                      onClick={() => updateAccess(person.uuid, true)}
+                    >
+                      Allow Access
+                    </Button>
+                    <Button
+                      variant="outline-danger"
+                      className="ms-2"
+                      onClick={() => updateAccess(person.uuid, false)}
+                    >
+                      Deny Access
+                    </Button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </Table>
+        </UltimatePaginationTopDown>
+      )}
+    </Fieldset>
+  )
+
+  function updateAccess(uuid, isApproved) {
+    return API.mutation(isApproved ? GQL_APPROVE_USER : GQL_DELETE_USER, {
+      uuid
+    })
+      .then(data => {
+        setStateSuccess(
+          `Pending user was successfully ${isApproved ? "approved" : "deleted"}`
+        )
+        setStateError(null)
+        refetch()
+      })
+      .catch(error => {
+        setStateSuccess(null)
+        setStateError(error)
+        jumpToTop()
+      })
+  }
+}
+
+UsersPendingVerification.propTypes = {
+  pageDispatchers: PageDispatchersPropType
+}
+
+export default connect(
+  null,
+  mapPageDispatchersToProps
+)(UsersPendingVerification)

--- a/client/src/pages/onboarding/Edit.js
+++ b/client/src/pages/onboarding/Edit.js
@@ -14,14 +14,13 @@ import PersonForm from "pages/people/Form"
 import React, { useContext } from "react"
 import { connect } from "react-redux"
 
-const GQL_GET_PERSON = gql`
-  query ($uuid: String!) {
-    person(uuid: $uuid) {
+const GQL_GET_SELF = gql`
+  query {
+    me {
       uuid
       name
       rank
       role
-      avatarUuid
       status
       emailAddress
       phoneNumber
@@ -33,12 +32,6 @@ const GQL_GET_PERSON = gql`
       domainUsername
       openIdSubject
       code
-      position {
-        uuid
-        name
-        type
-        role
-      }
     }
   }
 `
@@ -47,9 +40,7 @@ const OnboardingEdit = ({ pageDispatchers }) => {
   const {
     currentUser: { uuid }
   } = useContext(AppContext)
-  const { loading, error, data } = API.useApiQuery(GQL_GET_PERSON, {
-    uuid
-  })
+  const { loading, error, data } = API.useApiQuery(GQL_GET_SELF)
   const { done, result } = useBoilerplate({
     loading,
     error,
@@ -59,14 +50,14 @@ const OnboardingEdit = ({ pageDispatchers }) => {
     searchProps: DEFAULT_SEARCH_PROPS,
     pageDispatchers
   })
-  usePageTitle("Create your account")
+  usePageTitle("Fill in your profile")
   if (done) {
     return result
   }
 
-  const person = new Person(data ? data.person : {})
+  const person = new Person(data ? data.me : {})
 
-  if (data.person.endOfTourDate) {
+  if (person.endOfTourDate) {
     person.endOfTourDate = moment(person.endOfTourDate).format()
   }
   const parsedFullName = Person.parseFullName(person.name)
@@ -78,8 +69,9 @@ const OnboardingEdit = ({ pageDispatchers }) => {
       <PersonForm
         initialValues={person}
         edit
-        title="Create your account"
-        saveText="Create profile"
+        forOnboarding
+        title="Fill in your profile"
+        saveText="Save"
       />
     </div>
   )

--- a/client/src/pages/onboarding/New.js
+++ b/client/src/pages/onboarding/New.js
@@ -1,0 +1,49 @@
+import { DEFAULT_SEARCH_PROPS, PAGE_PROPS_MIN_HEAD } from "actions"
+import {
+  mapPageDispatchersToProps,
+  PageDispatchersPropType,
+  useBoilerplate,
+  usePageTitle
+} from "components/Page"
+import React from "react"
+import { Button } from "react-bootstrap"
+import { connect } from "react-redux"
+import { useNavigate } from "react-router-dom"
+import Settings from "settings"
+
+const OnboardingNew = ({ pageDispatchers }) => {
+  useBoilerplate({
+    pageProps: PAGE_PROPS_MIN_HEAD,
+    searchProps: DEFAULT_SEARCH_PROPS,
+    pageDispatchers
+  })
+  usePageTitle("Welcome to ANET")
+  const navigate = useNavigate()
+  const approvalMsg = Settings.automaticallyAllowAllNewUsers
+    ? "Let's create a new account for you. We'll grab your basic information and help your superuser get you set up."
+    : "Your access to ANET has been requested. While your approval is pending, please take a moment to fill in your profile."
+
+  return (
+    <div className="onboarding-new">
+      <h1>Welcome to ANET</h1>
+      <p>
+        ANET is a training system for reporting TAA engagements, and learning
+        about past engagements and people.
+      </p>
+      <p>{approvalMsg}</p>
+      <div className="create-account-button-wrapper">
+        <Button variant="primary" onClick={onCreateAccountClick}>
+          Fill in your profile
+        </Button>
+      </div>
+    </div>
+  )
+
+  function onCreateAccountClick() {
+    navigate("/onboarding/edit")
+  }
+}
+
+OnboardingNew.propTypes = { pageDispatchers: PageDispatchersPropType }
+
+export default connect(null, mapPageDispatchersToProps)(OnboardingNew)

--- a/client/src/pages/onboarding/Show.js
+++ b/client/src/pages/onboarding/Show.js
@@ -1,48 +1,201 @@
+import { gql } from "@apollo/client"
 import { DEFAULT_SEARCH_PROPS, PAGE_PROPS_MIN_HEAD } from "actions"
+import API from "api"
+import AppContext from "components/AppContext"
+import * as FieldHelper from "components/FieldHelper"
+import Fieldset from "components/Fieldset"
+import Messages from "components/Messages"
 import {
   mapPageDispatchersToProps,
   PageDispatchersPropType,
   useBoilerplate,
   usePageTitle
 } from "components/Page"
-import React from "react"
-import { Button } from "react-bootstrap"
+import RichTextEditor from "components/RichTextEditor"
+import { Field, Form, Formik } from "formik"
+import DictionaryField from "HOC/DictionaryField"
+import { Person } from "models"
+import moment from "moment"
+import React, { useContext } from "react"
+import { Alert, Col, Container, Row } from "react-bootstrap"
 import { connect } from "react-redux"
-import { useNavigate } from "react-router-dom"
+import { Link, useLocation } from "react-router-dom"
+import Settings from "settings"
+import PersonAvatar from "../people/Avatar"
+
+const GQL_GET_SELF = gql`
+  query {
+    me {
+      uuid
+      name
+      rank
+      role
+      status
+      emailAddress
+      phoneNumber
+      pendingVerification
+      biography
+      country
+      gender
+      endOfTourDate
+      domainUsername
+      openIdSubject
+      code
+    }
+  }
+`
 
 const OnboardingShow = ({ pageDispatchers }) => {
-  useBoilerplate({
+  const {
+    currentUser: { uuid }
+  } = useContext(AppContext)
+  const routerLocation = useLocation()
+  const stateSuccess = routerLocation.state?.success
+  const stateError = routerLocation.state?.error
+  const { loading, error, data } = API.useApiQuery(GQL_GET_SELF)
+  const { done, result } = useBoilerplate({
+    loading,
+    error,
+    modelName: "User",
+    uuid,
     pageProps: PAGE_PROPS_MIN_HEAD,
     searchProps: DEFAULT_SEARCH_PROPS,
     pageDispatchers
   })
-  usePageTitle("Welcome to ANET")
-  const navigate = useNavigate()
-
-  return (
-    <div className="onboarding-new">
-      <h1>Welcome to ANET</h1>
-      <p>
-        ANET is a training system for reporting TAA engagements, and learning
-        about past engagements and people.
-      </p>
-      <p>
-        Let's create a new account for you. We'll grab your basic information
-        and help your superuser get you set up.
-      </p>
-      <div className="create-account-button-wrapper">
-        <Button variant="primary" onClick={onCreateAccountClick}>
-          Create your account
-        </Button>
-      </div>
-    </div>
+  usePageTitle("Your profile")
+  if (done) {
+    return result
+  }
+  const person = new Person(data ? data.me : {})
+  const availableKeys = Object.keys(data.me)
+  const action = (
+    <Link to="/onboarding/edit" className="btn btn-primary">
+      Edit
+    </Link>
+  )
+  const emailHumanValue = (
+    <a href={`mailto:${person.emailAddress}`}>{person.emailAddress}</a>
   )
 
-  function onCreateAccountClick() {
-    navigate("/onboarding/edit")
+  // Keys of fields which should span over 2 columns
+  const fullWidthFieldKeys = person.getFullWidthFields()
+  const fullWidthFields = []
+  const orderedFields = orderPersonFields()
+    .filter(([el, key]) => {
+      if (fullWidthFieldKeys.includes(key)) {
+        fullWidthFields.push(cloneField([el, key], 2))
+        return false
+      }
+      return true
+    })
+    .map(field => cloneField(field, 4))
+
+  const numberOfFieldsUnderAvatar = 1 // person.getNumberOfFieldsInLeftColumn() || 6
+  const leftColumnUnderAvatar = orderedFields.slice(
+    0,
+    numberOfFieldsUnderAvatar
+  )
+  const rightColumn = orderedFields.slice(numberOfFieldsUnderAvatar)
+
+  return (
+    <Formik enableReinitialize initialValues={person}>
+      <div>
+        <Alert variant="warning">Your account is pending approval</Alert>
+        <Messages error={stateError} success={stateSuccess} />
+        <Form className="form-horizontal" method="post">
+          <Fieldset title={`${person.rank} ${person.name}`} action={action} />
+          <Fieldset>
+            <Container fluid>
+              <Row>
+                <Col md={6}>
+                  <PersonAvatar />
+                  {leftColumnUnderAvatar}
+                </Col>
+                <Col md={6}>{rightColumn}</Col>
+              </Row>
+              <Row>
+                <Col md={12}>{fullWidthFields}</Col>
+              </Row>
+            </Container>
+          </Fieldset>
+        </Form>
+      </div>
+    </Formik>
+  )
+
+  function orderPersonFields() {
+    const mappedNonCustomFields = mapNonCustomFields()
+    // map fields that have privileged access check to the condition
+    const privilegedAccessedFields = {
+      domainUsername: {
+        accessCond: false
+      },
+      openIdSubject: {
+        accessCond: false
+      }
+    }
+
+    return (
+      person
+        .getShowPageFieldsOrdered()
+        // Filter on keys actually retrieved
+        .filter(key => availableKeys.includes(key))
+        // Then filter if there is privileged accessed fields and its access condition is true
+        .filter(key =>
+          privilegedAccessedFields[key]
+            ? privilegedAccessedFields[key].accessCond
+            : true
+        )
+        // Also filter if somehow there is no field
+        .filter(key => mappedNonCustomFields[key])
+        // Then map it to components and keys, keys used for React list rendering
+        .map(key => [mappedNonCustomFields[key], key])
+    )
+  }
+
+  function cloneField([el, key], columnWidth) {
+    return React.cloneElement(el, {
+      key,
+      labelColumnWidth: columnWidth
+    })
+  }
+
+  function mapNonCustomFields() {
+    const classNameExceptions = {
+      biography: "biography"
+    }
+
+    // map fields that have specific human value
+    const humanValuesExceptions = {
+      biography: <RichTextEditor readOnly value={person.biography} />,
+      emailAddress: emailHumanValue,
+      endOfTourDate:
+        person.endOfTourDate &&
+        moment(person.endOfTourDate).format(
+          Settings.dateFormats.forms.displayShort.date
+        ),
+      role: Person.humanNameOfRole(person.role),
+      status: Person.humanNameOfStatus(person.status)
+    }
+    return person.getNormalFieldsOrdered().reduce((accum, key) => {
+      const DictField = DictionaryField(Field)
+      accum[key] = (
+        <DictField
+          dictProps={Settings.fields.person[key]}
+          name={key}
+          component={FieldHelper.ReadonlyField}
+          humanValue={humanValuesExceptions[key]}
+          className={classNameExceptions[key]}
+        />
+      )
+
+      return accum
+    }, {})
   }
 }
 
-OnboardingShow.propTypes = { pageDispatchers: PageDispatchersPropType }
+OnboardingShow.propTypes = {
+  pageDispatchers: PageDispatchersPropType
+}
 
 export default connect(null, mapPageDispatchersToProps)(OnboardingShow)

--- a/client/src/pages/reports/Form.js
+++ b/client/src/pages/reports/Form.js
@@ -326,11 +326,15 @@ const ReportForm = ({
         const reportPeopleFilters = {
           all: {
             label: "All",
-            queryVars: { matchPositionName: true }
+            queryVars: { matchPositionName: true, pendingVerification: false }
           },
           activeAdvisors: {
             label: "All advisors",
-            queryVars: { role: Person.ROLE.ADVISOR, matchPositionName: true }
+            queryVars: {
+              role: Person.ROLE.ADVISOR,
+              matchPositionName: true,
+              pendingVerification: false
+            }
           },
           activePrincipals: {
             label: "All principals",
@@ -343,6 +347,7 @@ const ReportForm = ({
             queryVars: {
               role: Person.ROLE.ADVISOR,
               matchPositionName: true,
+              pendingVerification: false,
               orgUuid: currentOrg.uuid
             }
           }

--- a/client/tests/webdriver/baseSpecs/newUserUtils.js
+++ b/client/tests/webdriver/baseSpecs/newUserUtils.js
@@ -42,6 +42,4 @@ export async function createOnboardingNewPerson(
 
   await CreatePerson.submitForm()
   await Home.waitForAlertWarningToLoad()
-  await (await Home.getOnboardingPopover()).waitForExist()
-  await (await Home.getOnboardingPopover()).waitForDisplayed()
 }

--- a/client/tests/webdriver/baseSpecs/onboardNewUser.spec.js
+++ b/client/tests/webdriver/baseSpecs/onboardNewUser.spec.js
@@ -89,8 +89,6 @@ describe("Onboard new user login", () => {
     await OnboardPage.submitForm()
 
     await OnboardPage.waitForAlertWarningToLoad()
-    await (await OnboardPage.getOnboardingPopover()).waitForExist()
-    await (await OnboardPage.getOnboardingPopover()).waitForDisplayed()
     await OnboardPage.logout()
   })
 })

--- a/client/tests/webdriver/pages/onboard.page.js
+++ b/client/tests/webdriver/pages/onboard.page.js
@@ -5,10 +5,6 @@ class Onboard extends CreatePerson {
     return browser.$(".onboarding-new h1")
   }
 
-  async getOnboardingPopover() {
-    return browser.$(".hopscotch-bubble-container")
-  }
-
   async getCreateYourAccountBtn() {
     return browser.$(".create-account-button-wrapper .btn-primary")
   }

--- a/src/main/java/mil/dds/anet/AnetApplication.java
+++ b/src/main/java/mil/dds/anet/AnetApplication.java
@@ -278,8 +278,8 @@ public class AnetApplication extends Application<AnetConfiguration> {
             combinedName.append(mn);
           }
         }
-        // Fall back to just the name
-        if (combinedName.length() == 0) {
+        if (combinedName.isEmpty() && !Utils.isEmptyOrNull(token.getName())) {
+          // Fall back to just the name
           combinedName.append(token.getName());
         }
         return combinedName.toString();

--- a/src/main/java/mil/dds/anet/beans/AdminSetting.java
+++ b/src/main/java/mil/dds/anet/beans/AdminSetting.java
@@ -5,6 +5,7 @@ import io.leangen.graphql.annotations.GraphQLIgnore;
 import io.leangen.graphql.annotations.GraphQLInputField;
 import io.leangen.graphql.annotations.GraphQLQuery;
 import javax.ws.rs.WebApplicationException;
+import mil.dds.anet.graphql.AllowUnverifiedUsers;
 import mil.dds.anet.views.AbstractAnetBean;
 
 public class AdminSetting extends AbstractAnetBean {
@@ -28,6 +29,7 @@ public class AdminSetting extends AbstractAnetBean {
     // just ignore
   }
 
+  @AllowUnverifiedUsers
   public String getKey() {
     return key;
   }
@@ -36,6 +38,7 @@ public class AdminSetting extends AbstractAnetBean {
     this.key = key;
   }
 
+  @AllowUnverifiedUsers
   public String getValue() {
     return value;
   }

--- a/src/main/java/mil/dds/anet/beans/Person.java
+++ b/src/main/java/mil/dds/anet/beans/Person.java
@@ -18,6 +18,7 @@ import mil.dds.anet.AnetObjectEngine;
 import mil.dds.anet.beans.lists.AnetBeanList;
 import mil.dds.anet.beans.recentActivity.Activity;
 import mil.dds.anet.beans.search.ReportSearchQuery;
+import mil.dds.anet.graphql.AllowUnverifiedUsers;
 import mil.dds.anet.utils.DaoUtils;
 import mil.dds.anet.utils.InsertionOrderLinkedList;
 import mil.dds.anet.utils.Utils;
@@ -89,6 +90,13 @@ public class Person extends AbstractCustomizableAnetBean
   private Deque<Activity> recentActivities;
 
   @Override
+  @AllowUnverifiedUsers
+  public String getUuid() {
+    return super.getUuid();
+  }
+
+  @Override
+  @AllowUnverifiedUsers
   public String getName() {
     return name;
   }
@@ -98,6 +106,7 @@ public class Person extends AbstractCustomizableAnetBean
   }
 
   @Override
+  @AllowUnverifiedUsers
   public Status getStatus() {
     return status;
   }
@@ -107,6 +116,7 @@ public class Person extends AbstractCustomizableAnetBean
     this.status = status;
   }
 
+  @AllowUnverifiedUsers
   public Role getRole() {
     return role;
   }
@@ -115,6 +125,7 @@ public class Person extends AbstractCustomizableAnetBean
     this.role = role;
   }
 
+  @AllowUnverifiedUsers
   public Boolean getPendingVerification() {
     return pendingVerification;
   }
@@ -123,6 +134,7 @@ public class Person extends AbstractCustomizableAnetBean
     this.pendingVerification = pendingVerification;
   }
 
+  @AllowUnverifiedUsers
   public String getEmailAddress() {
     return emailAddress;
   }
@@ -131,6 +143,7 @@ public class Person extends AbstractCustomizableAnetBean
     this.emailAddress = Utils.trimStringReturnNull(emailAddress);
   }
 
+  @AllowUnverifiedUsers
   public String getPhoneNumber() {
     return phoneNumber;
   }
@@ -139,6 +152,7 @@ public class Person extends AbstractCustomizableAnetBean
     this.phoneNumber = Utils.trimStringReturnNull(phoneNumber);
   }
 
+  @AllowUnverifiedUsers
   public String getGender() {
     return gender;
   }
@@ -147,6 +161,7 @@ public class Person extends AbstractCustomizableAnetBean
     this.gender = Utils.trimStringReturnNull(gender);
   }
 
+  @AllowUnverifiedUsers
   public String getCountry() {
     return country;
   }
@@ -155,6 +170,7 @@ public class Person extends AbstractCustomizableAnetBean
     this.country = Utils.trimStringReturnNull(country);
   }
 
+  @AllowUnverifiedUsers
   public Instant getEndOfTourDate() {
     return endOfTourDate;
   }
@@ -163,6 +179,7 @@ public class Person extends AbstractCustomizableAnetBean
     this.endOfTourDate = endOfTourDate;
   }
 
+  @AllowUnverifiedUsers
   public String getRank() {
     return rank;
   }
@@ -171,6 +188,7 @@ public class Person extends AbstractCustomizableAnetBean
     this.rank = Utils.trimStringReturnNull(rank);
   }
 
+  @AllowUnverifiedUsers
   public String getBiography() {
     return biography;
   }
@@ -179,6 +197,7 @@ public class Person extends AbstractCustomizableAnetBean
     this.biography = Utils.trimStringReturnNull(biography);
   }
 
+  @AllowUnverifiedUsers
   public String getDomainUsername() {
     return domainUsername;
   }
@@ -187,6 +206,7 @@ public class Person extends AbstractCustomizableAnetBean
     this.domainUsername = domainUsername;
   }
 
+  @AllowUnverifiedUsers
   public String getOpenIdSubject() {
     return openIdSubject;
   }
@@ -291,6 +311,7 @@ public class Person extends AbstractCustomizableAnetBean
     this.avatarUuid = avatarUuid;
   }
 
+  @AllowUnverifiedUsers
   public String getCode() {
     return code;
   }

--- a/src/main/java/mil/dds/anet/graphql/AllowUnverifiedUsers.java
+++ b/src/main/java/mil/dds/anet/graphql/AllowUnverifiedUsers.java
@@ -1,0 +1,11 @@
+package mil.dds.anet.graphql;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.FIELD})
+public @interface AllowUnverifiedUsers {
+}

--- a/src/main/java/mil/dds/anet/resources/AdminResource.java
+++ b/src/main/java/mil/dds/anet/resources/AdminResource.java
@@ -28,6 +28,7 @@ import mil.dds.anet.beans.search.UserActivitySearchQuery;
 import mil.dds.anet.config.AnetConfiguration;
 import mil.dds.anet.database.AdminDao;
 import mil.dds.anet.database.UserActivityDao;
+import mil.dds.anet.graphql.AllowUnverifiedUsers;
 import mil.dds.anet.utils.AnetAuditLogger;
 import mil.dds.anet.utils.AnetConstants;
 import mil.dds.anet.utils.AuthUtils;
@@ -48,6 +49,7 @@ public class AdminResource {
   }
 
   @GraphQLQuery(name = "adminSettings")
+  @AllowUnverifiedUsers
   public List<AdminSetting> getAll() {
     return dao.getAllSettings();
   }
@@ -95,6 +97,7 @@ public class AdminResource {
    * on startup,it is read and set with AnetConfiguration loadVersion method
    */
   @GraphQLQuery(name = "projectVersion")
+  @AllowUnverifiedUsers
   public String getProjectVersion() {
     return config.getVersion();
   }

--- a/src/main/resources/anet-schema.yml
+++ b/src/main/resources/anet-schema.yml
@@ -362,7 +362,21 @@ $defs:
 #########################################################
 type: object
 additionalProperties: false
-required: [keycloakConfiguration, CONNECTION_ERROR_MSG, VERSION_CHANGED_MSG, SUPPORT_EMAIL_ADDR, dateFormats, reportWorkflow, maxTextFieldLength, fields, pinned_ORGs, non_reporting_ORGs, domainNames, activeDomainNames, imagery]
+required:
+  - keycloakConfiguration
+  - CONNECTION_ERROR_MSG
+  - VERSION_CHANGED_MSG
+  - SUPPORT_EMAIL_ADDR
+  - dateFormats
+  - reportWorkflow
+  - maxTextFieldLength
+  - fields
+  - pinned_ORGs
+  - non_reporting_ORGs
+  - domainNames
+  - activeDomainNames
+  - imagery
+  - automaticallyAllowAllNewUsers
 properties:
   keycloakConfiguration:
     type: object
@@ -1180,6 +1194,11 @@ properties:
 
   decisives:
     type: array
+
+  automaticallyAllowAllNewUsers:
+    type: boolean
+    title: Auto account verification.
+    description: Whether newly onboarded users should be automatically verified; when false, admins must explicitly verify new users.
 
   automaticallyInactivateUsers:
     type: object

--- a/src/test/java/mil/dds/anet/test/resources/ReportResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/ReportResourceTest.java
@@ -149,10 +149,18 @@ public class ReportResourceTest extends AbstractResourceTest {
         .withEmailAddress("hunter+testApprover1@example.com").withName("Test Approver 1")
         .withRole(Role.ADVISOR).withStatus(Status.ACTIVE).build();
     approver1 = findOrPutPersonInDb(approver1);
+    if (Boolean.TRUE.equals(approver1.getPendingVerification())) {
+      // Approve newly created user
+      adminMutationExecutor.approvePerson("", approver1.getUuid());
+    }
     Person approver2 = Person.builder().withDomainUsername("testapprover2")
         .withEmailAddress("hunter+testApprover2@example.com").withName("Test Approver 2")
         .withRole(Role.ADVISOR).withStatus(Status.ACTIVE).build();
     approver2 = findOrPutPersonInDb(approver2);
+    if (Boolean.TRUE.equals(approver2.getPendingVerification())) {
+      // Approve newly created user
+      adminMutationExecutor.approvePerson("", approver2.getUuid());
+    }
 
     final PositionInput approver1PosInput = PositionInput.builder()
         .withName("Test Approver 1 Position").withOrganization(getOrganizationInput(advisorOrg))

--- a/src/test/resources/anet.graphql
+++ b/src/test/resources/anet.graphql
@@ -394,6 +394,7 @@ scalar Long
 """Mutation root"""
 type Mutation {
   addComment(comment: CommentInput, uuid: String): Comment
+  approvePerson(uuid: String): Int
   approveReport(comment: CommentInput, uuid: String): Int!
   clearCache: String
   createAttachment(attachment: AttachmentInput): String
@@ -410,6 +411,7 @@ type Mutation {
   deleteAttachment(uuid: String): Int
   deleteNote(uuid: String): Int
   deleteObjectSubscription(uuid: String): Int
+  deletePerson(uuid: String): Int
   deletePersonFromPosition(uuid: String): Int
   deletePosition(uuid: String): Int
   deleteReport(uuid: String): Int

--- a/src/test/resources/anet.graphql
+++ b/src/test/resources/anet.graphql
@@ -431,6 +431,7 @@ type Mutation {
   updateAttachment(attachment: AttachmentInput): String
   updateAuthorizationGroup(authorizationGroup: AuthorizationGroupInput): Int
   updateLocation(location: LocationInput): Int
+  updateMe(person: PersonInput): Int
   updateNote(note: NoteInput): Note
   updateOrganization(organization: OrganizationInput): Int
   updatePerson(person: PersonInput): Int

--- a/testDictionaries/no-custom-fields.yml
+++ b/testDictionaries/no-custom-fields.yml
@@ -1386,6 +1386,7 @@ imagery:
         layers: GEBCO_LATEST
         format: "image/png"
 
+automaticallyAllowAllNewUsers: true
 automaticallyInactivateUsers:
   emailRemindersDaysPrior: [15, 30, 45]
   ignoredDomainNames: []


### PR DESCRIPTION
Access for new users who have not yet been verified is restricted to the onboarding page.
Automatic verification is configurable through the dictionary; when verification is manual, an administrator must explicitly approve a new user.

Closes [AB#904](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/904)

#### User changes
- After onboarding, an administrator will have to approve your account if so configured.

#### Superuser changes
- None.

#### Admin changes
- When so configured in the dictionary, there's a new admin section for approving new users. The Home page for admins will show how many new users are pending verification, and you can click on that link to go to the page for approving them.

#### System admin changes
- [x] anet.yml or anet-dictionary.yml needs change
  Add the following setting to the dictionary:
  ```
  automaticallyAllowAllNewUsers: true
  automaticallyInactivateUsers: […]
  ```
  for backwards-compatibility with previous behaviour.
  Setting `automaticallyAllowAllNewUsers` to `false` means new user accounts will have to be approved explicitly by an admin.
- [ ] db needs migration
- [ ] documentation has changed
- [x] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [x] Added and/or updated unit tests
  - [x] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here