### PR TITLE
Show past and planned engagements separately in the Daily Rollup

### DIFF
--- a/client/src/components/DailyRollupChart.js
+++ b/client/src/components/DailyRollupChart.js
@@ -32,7 +32,7 @@ const DailyRollupChart = ({
     let chart = d3.select(node.current)
     const xLabels = [].concat.apply(
       [],
-      data.map(d => d.published + d.cancelled)
+      data.map(d => d.published + d.planned + d.cancelled)
     )
     const yLabels = {}
     const yDomain = data.map(d => {
@@ -144,21 +144,42 @@ const DailyRollupChart = ({
       .attr("dy", ".35em")
       .style("text-anchor", "end")
       .text(d => d.published || "")
+      .attr("fill", utils.getContrastYIQ(barColors.published))
 
     bar
       .append("rect")
       .attr("x", d => d.published && xScale(d.published))
+      .attr("width", d => d.planned && xScale(d.planned))
+      .attr("height", BAR_HEIGHT)
+      .attr("fill", barColors.planned)
+
+    bar
+      .append("text")
+      .attr("x", d => xScale(d.published + d.planned) - 6)
+      .attr("y", BAR_HEIGHT / 2)
+      .attr("dy", ".35em")
+      .style("text-anchor", "end")
+      .text(d => d.planned || "")
+      .attr("fill", utils.getContrastYIQ(barColors.planned))
+
+    bar
+      .append("rect")
+      .attr(
+        "x",
+        d => (d.published || d.planned) && xScale(d.published + d.planned)
+      )
       .attr("width", d => d.cancelled && xScale(d.cancelled))
       .attr("height", BAR_HEIGHT)
       .attr("fill", barColors.cancelled)
 
     bar
       .append("text")
-      .attr("x", d => xScale(d.published) + xScale(d.cancelled) - 6)
+      .attr("x", d => xScale(d.published + d.planned + d.cancelled) - 6)
       .attr("y", BAR_HEIGHT / 2)
       .attr("dy", ".35em")
       .style("text-anchor", "end")
       .text(d => d.cancelled || "")
+      .attr("fill", utils.getContrastYIQ(barColors.cancelled))
   }, [node, width, height, data, onBarClick, tooltip, barColors])
 
   return <svg id={chartId} ref={node} width={width} height={height} />
@@ -173,7 +194,8 @@ DailyRollupChart.propTypes = {
   tooltip: PropTypes.func,
   barColors: PropTypes.shape({
     cancelled: PropTypes.string.isRequired,
-    published: PropTypes.string.isRequired
+    published: PropTypes.string.isRequired,
+    planned: PropTypes.string.isRequired
   }).isRequired
 }
 


### PR DESCRIPTION
The Daily Rollup now shows a clear distinction between published reports for past engagements and planned engagements.

Closes [AB#1008](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1008)

#### User changes
- It's easier to see which parts in the Daily Rollup chart are about past or planned engagements

#### Superuser changes
- None

#### Admin changes
- None

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
