### PR TITLE
Fix task name mapping

### DIFF
--- a/client/src/components/TaskTable.js
+++ b/client/src/components/TaskTable.js
@@ -9,10 +9,12 @@ import {
 import UltimatePaginationTopDown from "components/UltimatePaginationTopDown"
 import _get from "lodash/get"
 import { Task } from "models"
+import pluralize from "pluralize"
 import PropTypes from "prop-types"
 import React, { useState } from "react"
 import { Table } from "react-bootstrap"
 import { connect } from "react-redux"
+import Settings from "settings"
 
 const GQL_GET_TASK_LIST = gql`
   query ($taskQuery: TaskSearchQueryInput) {
@@ -96,8 +98,9 @@ const BaseTaskTable = ({
   totalCount,
   goToPage
 }) => {
+  const taskShortLabel = Settings.fields.task.shortLabel
   if (_get(tasks, "length", 0) === 0) {
-    return <em>No tasks found</em>
+    return <em>No {pluralize(taskShortLabel)} found</em>
   }
 
   return (

--- a/client/tests/webdriver/customFieldsSpecs/pendingAssessments.spec.js
+++ b/client/tests/webdriver/customFieldsSpecs/pendingAssessments.spec.js
@@ -152,7 +152,7 @@ describe("In my tasks page", () => {
       await (await MyTasks.getMyPendingTasks()).waitForDisplayed()
       expect(
         await (await MyTasks.getMyPendingTasksContent()).getText()
-      ).to.equal("No tasks found")
+      ).to.equal("No Objective / Efforts found")
       await MyTasks.logout()
     })
   })


### PR DESCRIPTION
Make sure the dictionary settings for tasks are used in the UI.

Closes [AB#1039](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1039)

#### User changes
- When no results are found the resulting message will use the name defined in the dictionary for "tasks"

#### Superuser changes
- None

#### Admin changes
- None

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [X] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [x] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here