### PR TITLE
Add number of results to each entity header in search page

### DIFF
--- a/client/src/pages/searches/Search.js
+++ b/client/src/pages/searches/Search.js
@@ -802,7 +802,19 @@ const Search = ({
         </Alert>
       )}
       {queryTypes.includes(SEARCH_OBJECT_TYPES.ORGANIZATIONS) && (
-        <Fieldset id="organizations" title="Organizations">
+        <Fieldset
+          id="organizations"
+          title={
+            <>
+              Organizations
+              {hasOrganizationsResults && (
+                <Badge pill bg="secondary" className="ms-1">
+                  {numOrganizations}
+                </Badge>
+              )}
+            </>
+          }
+        >
           <Organizations
             pageDispatchers={pageDispatchers}
             queryParams={genericSearchQueryParams}
@@ -814,7 +826,19 @@ const Search = ({
         </Fieldset>
       )}
       {queryTypes.includes(SEARCH_OBJECT_TYPES.PEOPLE) && (
-        <Fieldset id="people" title="People">
+        <Fieldset
+          id="people"
+          title={
+            <>
+              People
+              {hasPeopleResults && (
+                <Badge pill bg="secondary" className="ms-1">
+                  {numPeople}
+                </Badge>
+              )}
+            </>
+          }
+        >
           <People
             pageDispatchers={pageDispatchers}
             queryParams={genericSearchQueryParams}
@@ -826,7 +850,19 @@ const Search = ({
         </Fieldset>
       )}
       {queryTypes.includes(SEARCH_OBJECT_TYPES.POSITIONS) && (
-        <Fieldset id="positions" title="Positions">
+        <Fieldset
+          id="positions"
+          title={
+            <>
+              Positions
+              {hasPositionsResults && (
+                <Badge pill bg="secondary" className="ms-1">
+                  {numPositions}
+                </Badge>
+              )}
+            </>
+          }
+        >
           <Positions
             pageDispatchers={pageDispatchers}
             queryParams={genericSearchQueryParams}
@@ -838,7 +874,19 @@ const Search = ({
         </Fieldset>
       )}
       {queryTypes.includes(SEARCH_OBJECT_TYPES.TASKS) && (
-        <Fieldset id="tasks" title={pluralize(taskShortLabel)}>
+        <Fieldset
+          id="tasks"
+          title={
+            <>
+              {pluralize(taskShortLabel)}
+              {hasTasksResults && (
+                <Badge pill bg="secondary" className="ms-1">
+                  {numTasks}
+                </Badge>
+              )}
+            </>
+          }
+        >
           <Tasks
             pageDispatchers={pageDispatchers}
             queryParams={genericSearchQueryParams}
@@ -850,7 +898,19 @@ const Search = ({
         </Fieldset>
       )}
       {queryTypes.includes(SEARCH_OBJECT_TYPES.LOCATIONS) && (
-        <Fieldset id="locations" title="Locations">
+        <Fieldset
+          id="locations"
+          title={
+            <>
+              Locations
+              {hasLocationsResults && (
+                <Badge pill bg="secondary" className="ms-1">
+                  {numLocations}
+                </Badge>
+              )}
+            </>
+          }
+        >
           <Locations
             pageDispatchers={pageDispatchers}
             queryParams={genericSearchQueryParams}
@@ -862,7 +922,19 @@ const Search = ({
         </Fieldset>
       )}
       {queryTypes.includes(SEARCH_OBJECT_TYPES.REPORTS) && (
-        <Fieldset id="reports" title="Reports">
+        <Fieldset
+          id="reports"
+          title={
+            <>
+              Reports
+              {hasReportsResults && (
+                <Badge pill bg="secondary" className="ms-1">
+                  {numReports}
+                </Badge>
+              )}
+            </>
+          }
+        >
           <ReportCollection
             queryParams={reportsSearchQueryParams}
             setTotalCount={setNumReports}

--- a/client/tests/webdriver/baseSpecs/search.spec.js
+++ b/client/tests/webdriver/baseSpecs/search.spec.js
@@ -1,0 +1,74 @@
+import { expect } from "chai"
+import Home from "../pages/home.page"
+import Search from "../pages/search.page"
+
+describe("When using search", () => {
+  it("Should show results counter and table when searching in all entities and results found", async() => {
+    await Home.openAsSuperuser()
+    await (await Home.getSearchBar()).setValue("")
+    await (await Home.getSubmitSearch()).click()
+    // Reports
+    expect(
+      parseInt(await (await Search.getFoundCounter("reports")).getText())
+    ).to.be.greaterThan(0)
+    await (await Search.getFoundReportTable()).waitForExist({ timeout: 20000 })
+    // People
+    expect(
+      parseInt(await (await Search.getFoundCounter("people")).getText())
+    ).to.be.greaterThan(0)
+    await (await Search.getFoundPeopleTable()).waitForExist({ timeout: 20000 })
+    // Organizations
+    expect(
+      parseInt(await (await Search.getFoundCounter("organizations")).getText())
+    ).to.be.greaterThan(0)
+    await (
+      await Search.getFoundOrganizationTable()
+    ).waitForExist({ timeout: 20000 })
+    // Positions
+    expect(
+      parseInt(await (await Search.getFoundCounter("positions")).getText())
+    ).to.be.greaterThan(0)
+    await (
+      await Search.getFoundPositionTable()
+    ).waitForExist({ timeout: 20000 })
+    // Locations
+    expect(
+      parseInt(await (await Search.getFoundCounter("locations")).getText())
+    ).to.be.greaterThan(0)
+    await (
+      await Search.getFoundLocationTable()
+    ).waitForExist({ timeout: 20000 })
+    // Tasks
+    expect(
+      parseInt(await (await Search.getFoundCounter("tasks")).getText())
+    ).to.be.greaterThan(0)
+    await (await Search.getFoundTaskTable()).waitForExist({ timeout: 20000 })
+  })
+  it("Should not show results counters when searching in all entities and no results found", async() => {
+    await Home.openAsSuperuser()
+    await (await Home.getSearchBar()).setValue("·$%&")
+    await (await Home.getSubmitSearch()).click()
+    expect(await (await Search.getNoResultsFound()).isDisplayed()).to.equal(
+      true
+    )
+    // Reports
+    expect(
+      await (await Search.getFoundCounter("reports")).isDisplayed()
+    ).to.equal(false)
+    expect(
+      await (await Search.getFoundCounter("people")).isDisplayed()
+    ).to.equal(false)
+    expect(
+      await (await Search.getFoundCounter("organizations")).isDisplayed()
+    ).to.equal(false)
+    expect(
+      await (await Search.getFoundCounter("positions")).isDisplayed()
+    ).to.equal(false)
+    expect(
+      await (await Search.getFoundCounter("locations")).isDisplayed()
+    ).to.equal(false)
+    expect(
+      await (await Search.getFoundCounter("tasks")).isDisplayed()
+    ).to.equal(false)
+  })
+})

--- a/client/tests/webdriver/pages/search.page.js
+++ b/client/tests/webdriver/pages/search.page.js
@@ -1,6 +1,18 @@
 import Page from "./page"
 
 class Search extends Page {
+  async getMain() {
+    return browser.$("div#main-viewport")
+  }
+
+  async getNoResultsFound() {
+    return browser.$('//div/b[text()="No search results found!"]')
+  }
+
+  async getFoundCounter(entity) {
+    return browser.$(`div#${entity} span span`)
+  }
+
   async getFoundPeopleTable() {
     return browser.$("div#people #people-search-results")
   }
@@ -15,6 +27,14 @@ class Search extends Page {
 
   async getFoundReportTable() {
     return browser.$("div#reports .report-collection")
+  }
+
+  async getFoundPositionTable() {
+    return browser.$("div#positions #positions-search-results")
+  }
+
+  async getFoundLocationTable() {
+    return browser.$("div#locations #locations-search-results")
   }
 
   async linkOfPersonFound(name) {


### PR DESCRIPTION
When displaying results of a search add a counter of matches next to the entity heading.

Closes [AB#1040](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1040)

#### User changes
- When displaying results of a search add a counter of matches next to the entity heading.

#### Superuser changes
- None

#### Admin changes
- None

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [x] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
