### PR TITLE
Make end-of-tour date inclusive

### DIFF
--- a/client/src/pages/people/Form.js
+++ b/client/src/pages/people/Form.js
@@ -30,6 +30,7 @@ import { FastField, Field, Form, Formik } from "formik"
 import _isEmpty from "lodash/isEmpty"
 import _isEqual from "lodash/isEqual"
 import { Person } from "models"
+import moment from "moment"
 import pluralize from "pluralize"
 import PropTypes from "prop-types"
 import React, { useContext, useRef, useState } from "react"
@@ -683,7 +684,11 @@ const PersonForm = ({
                   name="endOfTourDate"
                   component={FieldHelper.SpecialField}
                   value={values.endOfTourDate}
-                  onChange={value => setFieldValue("endOfTourDate", value)}
+                  onChange={value =>
+                    setFieldValue(
+                      "endOfTourDate",
+                      moment(value).endOf("day").format()
+                    )}
                   onBlur={() => setFieldTouched("endOfTourDate")}
                   widget={
                     <CustomDateInput id="endOfTourDate" canClearSelection />

--- a/src/test/java/mil/dds/anet/test/emails/AccountDeactivationWorkerTest.java
+++ b/src/test/java/mil/dds/anet/test/emails/AccountDeactivationWorkerTest.java
@@ -120,7 +120,7 @@ public class AccountDeactivationWorkerTest {
   public void testDeactivation() throws Exception {
 
     // Configure
-    final Person testPersonEotActive = createDummyPerson(Instant.now().minus(1, ChronoUnit.DAYS),
+    final Person testPersonEotActive = createDummyPerson(Instant.now().minus(1, ChronoUnit.HOURS),
         "test1_eot_acive@test.com", Person.Status.ACTIVE);
 
     final Person testPersonEotInactive = createDummyPerson(Instant.now().minus(1, ChronoUnit.DAYS),


### PR DESCRIPTION
The current de-activation of accounts based on end of tour date kicks before the end of the last day at work. This happens because the custom date picker used in the "Person" form rounds down the date to the start of the day. The new implementation will round up this date to the end of the day instead, so users are able to use ANET on their last day at the job.

Closes [AB#1038](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1038)

#### User changes
- As described above.

#### Superuser changes
- None.

#### Admin changes
- None.

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [x] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
