### PR TITLE
By default, search only for Published reports

### DIFF
--- a/client/src/components/AdvancedSearch.js
+++ b/client/src/components/AdvancedSearch.js
@@ -2,6 +2,7 @@ import { Popover2, Popover2InteractionKind } from "@blueprintjs/popover2"
 import "@blueprintjs/popover2/lib/css/blueprint-popover2.css"
 import styled from "@emotion/styled"
 import { resetPagination, SEARCH_OBJECT_LABELS, setSearchQuery } from "actions"
+import AppContext from "components/AppContext"
 import ButtonToggleGroup from "components/ButtonToggleGroup"
 import DictionaryField from "components/DictionaryField"
 import RemoveButton from "components/RemoveButton"
@@ -14,7 +15,7 @@ import { Form, Formik } from "formik"
 import _cloneDeep from "lodash/cloneDeep"
 import { Organization, Position } from "models"
 import PropTypes from "prop-types"
-import React, { useState } from "react"
+import React, { useContext, useState } from "react"
 import {
   Button,
   Col,
@@ -53,6 +54,7 @@ const AdvancedSearch = ({
   searchObjectTypes,
   text
 }) => {
+  const { currentUser } = useContext(AppContext)
   const navigate = useNavigate()
   const [objectType, setObjectType] = useState(searchQuery.objectType)
   const [filters, setFilters] = useState(
@@ -62,7 +64,7 @@ const AdvancedSearch = ({
   const [orgFilterQueryParams, setOrgFilterQueryParams] = useState(
     getOrgQueryParams(null)
   )
-  const ALL_FILTERS = searchFilters()
+  const ALL_FILTERS = searchFilters(currentUser?.isAdmin())
   const commonFiltersForAllObjectTypes = findCommonFiltersForAllObjectTypes(
     searchObjectTypes,
     ALL_FILTERS
@@ -352,7 +354,7 @@ const SearchFilter = ({
     <FormGroup controlId={queryKey} className="form-group">
       <Row>
         <Col xs={12} sm={3} lg={2} className="label-align">
-          <FormLabel>{label}</FormLabel>
+          <FormLabel className={element.labelClass}>{label}</FormLabel>
         </Col>
         <Col xs={10} sm={8} lg={9}>
           <div>
@@ -392,6 +394,7 @@ SearchFilter.propTypes = {
   element: PropTypes.shape({
     component: PropTypes.func.isRequired,
     dictProps: PropTypes.object,
+    labelClass: PropTypes.string,
     props: PropTypes.object
   })
 }

--- a/client/src/components/PlanningConflictForPerson.js
+++ b/client/src/components/PlanningConflictForPerson.js
@@ -38,6 +38,7 @@ const BasePlanningConflictForPerson = ({ person, report, iconOnly }) => {
   const { loading, error, data } = API.useApiQuery(GET_PERSON_WITH_REPORTS, {
     uuid: person.uuid,
     attendedReportsQuery: {
+      state: Object.values(Report.STATE),
       engagementDateStart: moment(report.engagementDate)
         .startOf("day")
         .valueOf(),

--- a/client/src/components/PlanningConflictForReport.js
+++ b/client/src/components/PlanningConflictForReport.js
@@ -37,6 +37,7 @@ const PlanningConflictForReport = ({ report, text, largeIcon }) => {
     {
       uuid: report.uuid,
       attendedReportsQuery: {
+        state: Object.values(Report.STATE),
         engagementDateStart: moment(report.engagementDate)
           .startOf("day")
           .valueOf(),

--- a/client/src/components/SearchFilters.js
+++ b/client/src/components/SearchFilters.js
@@ -282,6 +282,7 @@ export const searchFilters = function(includeAdminFilters) {
       State: {
         component: ReportStateFilter,
         deserializer: deserializeReportStateFilter,
+        isDefault: true,
         props: {
           queryKey: "state"
         }

--- a/client/src/components/SearchFilters.js
+++ b/client/src/components/SearchFilters.js
@@ -29,6 +29,7 @@ import {
   PositionOverlayRow,
   TaskOverlayRow
 } from "components/advancedSelectWidget/AdvancedSelectOverlayRow"
+import AppContext from "components/AppContext"
 import { getBreadcrumbTrailAsText } from "components/BreadcrumbTrail"
 import DictionaryField from "components/DictionaryField"
 import Model from "components/Model"
@@ -36,7 +37,7 @@ import _isEmpty from "lodash/isEmpty"
 import _pickBy from "lodash/pickBy"
 import { Location, Organization, Person, Position, Report, Task } from "models"
 import PropTypes from "prop-types"
-import React from "react"
+import React, { useContext } from "react"
 import LOCATIONS_ICON from "resources/locations.png"
 import PEOPLE_ICON from "resources/people.png"
 import POSITIONS_ICON from "resources/positions.png"
@@ -89,6 +90,7 @@ const StatusFilter = {
 const SubscriptionFilter = {
   component: CheckboxFilter,
   deserializer: deserializeCheckboxFilter,
+  labelClass: "pt-0",
   props: {
     queryKey: "subscribed",
     msg: "By me"
@@ -133,7 +135,7 @@ const advancedSelectFilterTaskProps = {
   addon: TASKS_ICON
 }
 
-export const searchFilters = function() {
+export const searchFilters = function(includeAdminFilters) {
   const filters = {}
 
   const taskShortLabel = Settings.fields.task.shortLabel
@@ -283,48 +285,67 @@ export const searchFilters = function() {
         props: {
           queryKey: "state"
         }
-      },
-      "Engagement Status": {
-        component: SelectFilter,
-        deserializer: deserializeSelectFilter,
-        props: {
-          queryKey: "engagementStatus",
-          options: [
-            Report.ENGAGEMENT_STATUS.HAPPENED,
-            Report.ENGAGEMENT_STATUS.FUTURE,
-            Report.ENGAGEMENT_STATUS.CANCELLED
-          ]
-        }
-      },
-      Atmospherics: {
-        component: SelectFilter,
-        dictProps: Settings.fields.report.atmosphere,
-        deserializer: deserializeSelectFilter,
-        props: {
-          queryKey: "atmosphere",
-          options: [
-            Report.ATMOSPHERE.POSITIVE,
-            Report.ATMOSPHERE.NEUTRAL,
-            Report.ATMOSPHERE.NEGATIVE
-          ]
-        }
-      },
-      "Sensitive Info": {
-        component: CheckboxFilter,
-        deserializer: deserializeCheckboxFilter,
-        props: {
-          queryKey: "sensitiveInfo"
-        }
-      },
-      [taskShortLabel]: {
-        component: AdvancedSelectFilter,
-        deserializer: deserializeAdvancedSelectFilter,
-        props: Object.assign({}, advancedSelectFilterTaskProps, {
-          filterDefs: taskWidgetFilters,
-          placeholder: `Filter reports by ${taskShortLabel}...`,
-          queryKey: "taskUuid"
-        })
       }
+    }
+  }
+  if (includeAdminFilters) {
+    filters[SEARCH_OBJECT_TYPES.REPORTS].filters = {
+      ...filters[SEARCH_OBJECT_TYPES.REPORTS].filters,
+      "Include all Drafts?": {
+        component: RadioButtonFilter,
+        deserializer: deserializeRadioButtonFilter,
+        labelClass: "pt-0",
+        props: {
+          queryKey: "includeAllDrafts",
+          options: [true, false],
+          labels: ["Yes", "No"]
+        }
+      }
+    }
+  }
+  filters[SEARCH_OBJECT_TYPES.REPORTS].filters = {
+    ...filters[SEARCH_OBJECT_TYPES.REPORTS].filters,
+    "Engagement Status": {
+      component: SelectFilter,
+      deserializer: deserializeSelectFilter,
+      props: {
+        queryKey: "engagementStatus",
+        options: [
+          Report.ENGAGEMENT_STATUS.HAPPENED,
+          Report.ENGAGEMENT_STATUS.FUTURE,
+          Report.ENGAGEMENT_STATUS.CANCELLED
+        ]
+      }
+    },
+    Atmospherics: {
+      component: SelectFilter,
+      dictProps: Settings.fields.report.atmosphere,
+      deserializer: deserializeSelectFilter,
+      props: {
+        queryKey: "atmosphere",
+        options: [
+          Report.ATMOSPHERE.POSITIVE,
+          Report.ATMOSPHERE.NEUTRAL,
+          Report.ATMOSPHERE.NEGATIVE
+        ]
+      }
+    },
+    "Sensitive Info": {
+      component: CheckboxFilter,
+      deserializer: deserializeCheckboxFilter,
+      labelClass: "pt-0",
+      props: {
+        queryKey: "sensitiveInfo"
+      }
+    },
+    [taskShortLabel]: {
+      component: AdvancedSelectFilter,
+      deserializer: deserializeAdvancedSelectFilter,
+      props: Object.assign({}, advancedSelectFilterTaskProps, {
+        filterDefs: taskWidgetFilters,
+        placeholder: `Filter reports by ${taskShortLabel}...`,
+        queryKey: "taskUuid"
+      })
     }
   }
 
@@ -387,6 +408,7 @@ export const searchFilters = function() {
       "Has Biography?": {
         component: RadioButtonFilter,
         deserializer: deserializeSelectFilter,
+        labelClass: "pt-0",
         props: {
           queryKey: "hasBiography",
           options: [true, false],
@@ -396,6 +418,7 @@ export const searchFilters = function() {
       "Pending Verification": {
         component: RadioButtonFilter,
         deserializer: deserializeSelectFilter,
+        labelClass: "pt-0",
         isDefault: true,
         props: {
           queryKey: "pendingVerification",
@@ -447,6 +470,7 @@ export const searchFilters = function() {
       [`Has ${Settings.fields.organization.profile?.label}?`]: {
         component: RadioButtonFilter,
         deserializer: deserializeSelectFilter,
+        labelClass: "pt-0",
         props: {
           queryKey: "hasProfile",
           options: [true, false],
@@ -501,6 +525,7 @@ export const searchFilters = function() {
       "Is Filled?": {
         component: RadioButtonFilter,
         deserializer: deserializeRadioButtonFilter,
+        labelClass: "pt-0",
         props: {
           queryKey: "isFilled",
           options: [true, false],
@@ -510,6 +535,7 @@ export const searchFilters = function() {
       "Has Pending Assessments": {
         component: CheckboxFilter,
         deserializer: deserializeCheckboxFilter,
+        labelClass: "pt-0",
         props: {
           queryKey: "hasPendingAssessments",
           msg: "Yes"
@@ -632,7 +658,8 @@ SearchFilterDisplay.propTypes = {
 }
 
 export const SearchDescription = ({ searchQuery, showPlaceholders }) => {
-  const ALL_FILTERS = searchFilters()
+  const { currentUser } = useContext(AppContext)
+  const ALL_FILTERS = searchFilters(currentUser?.isAdmin())
   const filterDefs =
     searchQuery.objectType && SEARCH_OBJECT_TYPES[searchQuery.objectType]
       ? ALL_FILTERS[SEARCH_OBJECT_TYPES[searchQuery.objectType]].filters
@@ -704,7 +731,7 @@ export const deserializeQueryParams = (
       }
       return null
     })
-    const ALL_FILTERS = searchFilters()
+    const ALL_FILTERS = searchFilters(true)
     const filterDefs = ALL_FILTERS[objType].filters
     Object.entries(filterDefs).map(([filterKey, filterDef]) => {
       const deser = filterDef.deserializer(

--- a/client/src/components/advancedSearch/ReportStateFilter.js
+++ b/client/src/components/advancedSearch/ReportStateFilter.js
@@ -30,7 +30,7 @@ const ReportStateFilter = ({
     return val.state.length === 1 && val.state[0] === Report.STATE.CANCELLED
   }
   const defaultValue = {
-    state: inputValue.state || [Report.STATE.DRAFT],
+    state: inputValue.state || [Report.STATE.PUBLISHED],
     cancelledReason: inputValue.cancelledReason || ""
   }
   const toQuery = val => {

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -130,7 +130,7 @@ fieldset.danger {
 
 #daily-rollup fieldset,
 #advisor-reports fieldset,
-#cancelled-reports fieldset,
+#cancelled-engagement-reports fieldset,
 #future-engagements-by-location fieldset,
 #not-approved-reports fieldset,
 #pending-assessments-by-position fieldset,

--- a/client/src/pages/Home.js
+++ b/client/src/pages/Home.js
@@ -137,7 +137,7 @@ const HomeTiles = ({ currentUser, setSearchQuery, pageDispatchers }) => {
 
   function adminQueries(currentUser) {
     return [
-      allDraft(),
+      myDraft(currentUser),
       allPending(),
       pendingMe(currentUser),
       allPlanned(),
@@ -164,13 +164,6 @@ const HomeTiles = ({ currentUser, setSearchQuery, pageDispatchers }) => {
       myOrgFuture(currentUser),
       mySensitiveInfo()
     ]
-  }
-
-  function allDraft() {
-    return {
-      title: "All draft reports",
-      query: { state: [Report.STATE.DRAFT, Report.STATE.REJECTED] }
-    }
   }
 
   function myDraft(currentUser) {

--- a/client/src/pages/insights/Show.js
+++ b/client/src/pages/insights/Show.js
@@ -34,7 +34,7 @@ import { RECURSE_STRATEGY } from "searchUtils"
 import Settings from "settings"
 
 export const NOT_APPROVED_REPORTS = "not-approved-reports"
-export const CANCELLED_REPORTS = "cancelled-reports"
+export const CANCELLED_REPORTS = "cancelled-engagement-reports"
 export const REPORTS_BY_TASK = "reports-by-task"
 export const REPORTS_BY_DAY_OF_WEEK = "reports-by-day-of-week"
 export const FUTURE_ENGAGEMENTS_BY_LOCATION = "future-engagements-by-location"

--- a/client/tests/webdriver/baseSpecs/homeTiles.spec.js
+++ b/client/tests/webdriver/baseSpecs/homeTiles.spec.js
@@ -28,11 +28,20 @@ describe("When checking the home page tiles", () => {
       await Home.openAsAdminUser()
       await (await Home.getHomeTilesContainer()).waitForExist()
       await (await Home.getHomeTilesContainer()).waitForDisplayed()
-      // We should at least see Arthur's and Erin's own drafts (might be more if tests have run)
-      const draft = await (await Home.getAllDraftReportsCount()).getText()
-      expect(parseInt(draft, 10)).to.be.at.least(2)
+      // We should at least see Arthur's own draft (might be more if tests have run)
+      const draft = await (await Home.getMyDraftReportsCount()).getText()
+      expect(parseInt(draft, 10)).to.be.at.least(1)
       // Load drafts
-      await (await Home.getAllDraftReports()).click()
+      await (await Home.getMyDraftReports()).click()
+      await Search.selectReportTable()
+      await browser.pause(500)
+      // Arthur's draft report should be there
+      // eslint-disable-next-line no-unused-expressions
+      expect(
+        await (
+          await Search.linkOfReportFound(ARTHURS_DRAFT_REPORT)
+        ).isExisting()
+      ).to.be.true
       // Search for Erin's draft report
       await (await Home.getSearchBar()).setValue(ERINS_DRAFT_REPORT)
       await (await Home.getSubmitSearch()).click()
@@ -41,7 +50,7 @@ describe("When checking the home page tiles", () => {
       // eslint-disable-next-line no-unused-expressions
       expect(
         await (await Search.linkOfReportFound(ERINS_DRAFT_REPORT)).isExisting()
-      ).to.be.true
+      ).to.be.false
     })
   })
 

--- a/client/tests/webdriver/pages/home.page.js
+++ b/client/tests/webdriver/pages/home.page.js
@@ -76,14 +76,6 @@ class Home extends Page {
     return (await this.getMyTasksLink()).$("span.badge")
   }
 
-  async getAllDraftReports() {
-    return browser.$('//button[contains(text(), "All draft reports")]')
-  }
-
-  async getAllDraftReportsCount() {
-    return (await this.getAllDraftReports()).$("h1")
-  }
-
   async getMyDraftReports() {
     return browser.$('//button[contains(text(), "My draft reports")]')
   }

--- a/src/main/java/mil/dds/anet/beans/search/ReportSearchQuery.java
+++ b/src/main/java/mil/dds/anet/beans/search/ReportSearchQuery.java
@@ -91,6 +91,9 @@ public class ReportSearchQuery extends SubscribableObjectSearchQuery<ReportSearc
   List<ReportState> state;
   @GraphQLQuery
   @GraphQLInputField
+  private Boolean includeAllDrafts;
+  @GraphQLQuery
+  @GraphQLInputField
   List<EngagementStatus> engagementStatus;
   @GraphQLQuery
   @GraphQLInputField
@@ -300,6 +303,14 @@ public class ReportSearchQuery extends SubscribableObjectSearchQuery<ReportSearc
     this.state = state;
   }
 
+  public Boolean getIncludeAllDrafts() {
+    return includeAllDrafts;
+  }
+
+  public void setIncludeAllDrafts(Boolean includeAllDrafts) {
+    this.includeAllDrafts = includeAllDrafts;
+  }
+
   public List<EngagementStatus> getEngagementStatus() {
     return engagementStatus;
   }
@@ -363,8 +374,8 @@ public class ReportSearchQuery extends SubscribableObjectSearchQuery<ReportSearc
         updatedAtStart, updatedAtEnd, releasedAtStart, releasedAtEnd, attendeeUuid, atmosphere,
         advisorOrgUuid, includeAdvisorOrgChildren, principalOrgUuid, includePrincipalOrgChildren,
         orgUuid, orgRecurseStrategy, locationUuid, taskUuid, pendingApprovalOf, state,
-        engagementStatus, cancelledReason, authorPositionUuid, attendeePositionUuid,
-        authorizationGroupUuid, sensitiveInfo, systemSearch);
+        includeAllDrafts, engagementStatus, cancelledReason, authorPositionUuid,
+        attendeePositionUuid, authorizationGroupUuid, sensitiveInfo, systemSearch);
   }
 
   @Override
@@ -396,6 +407,7 @@ public class ReportSearchQuery extends SubscribableObjectSearchQuery<ReportSearc
         && Objects.equals(getTaskUuid(), other.getTaskUuid())
         && Objects.equals(getPendingApprovalOf(), other.getPendingApprovalOf())
         && Objects.equals(getState(), other.getState())
+        && Objects.equals(getIncludeAllDrafts(), other.getIncludeAllDrafts())
         && Objects.equals(getEngagementStatus(), other.getEngagementStatus())
         && Objects.equals(getCancelledReason(), other.getCancelledReason())
         && Objects.equals(getAuthorPositionUuid(), other.getAuthorPositionUuid())

--- a/src/test/java/mil/dds/anet/test/resources/ReportResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/ReportResourceTest.java
@@ -1119,8 +1119,9 @@ public class ReportResourceTest extends AbstractResourceTest {
     final Person jack = getJackJackson();
     final Person steve = getSteveSteveson();
 
-    // Search based on report Text body
-    ReportSearchQueryInput query = ReportSearchQueryInput.builder().withText("spreadsheet").build();
+    // Search based on report Text body, for any report State
+    ReportSearchQueryInput query = ReportSearchQueryInput.builder()
+        .withState(List.of(ReportState.values())).withText("spreadsheet").build();
     AnetBeanList_Report searchResults = jackQueryExecutor.reportList(getListFields(FIELDS), query);
     assertThat(searchResults.getList()).isNotEmpty();
 
@@ -1250,7 +1251,8 @@ public class ReportResourceTest extends AbstractResourceTest {
     assertThat(locSearchResults.getList()).isNotEmpty();
     Location cabot = locSearchResults.getList().get(0);
 
-    query = ReportSearchQueryInput.builder().withLocationUuid(cabot.getUuid()).build();
+    query = ReportSearchQueryInput.builder().withState(List.of(ReportState.values()))
+        .withLocationUuid(cabot.getUuid()).build();
     searchResults = jackQueryExecutor.reportList(getListFields(FIELDS), query);
     assertThat(searchResults.getList()).isNotEmpty();
     assertThat(searchResults.getList().stream()

--- a/src/test/java/mil/dds/anet/test/resources/ReportResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/ReportResourceTest.java
@@ -3,8 +3,6 @@ package mil.dds.anet.test.resources;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
 import com.graphql_java_generator.exception.GraphQLRequestExecutionException;
 import com.graphql_java_generator.exception.GraphQLRequestPreparationException;
 import java.lang.invoke.MethodHandles;
@@ -209,14 +207,14 @@ public class ReportResourceTest extends AbstractResourceTest {
     final ApprovalStepInput approvalStepInput =
         ApprovalStepInput.builder().withName("Test Group for Approving")
             .withType(ApprovalStepType.REPORT_APPROVAL).withRelatedObjectUuid(advisorOrg.getUuid())
-            .withApprovers(ImmutableList.of(getPositionInput(approver1Pos))).build();
+            .withApprovers(List.of(getPositionInput(approver1Pos))).build();
     approvalStepsInput.add(approvalStepInput);
 
     // Adding a new approval step to an AO automatically puts it at the end of the approval process.
     final ApprovalStepInput releaseApprovalStepInput =
         ApprovalStepInput.builder().withName("Test Group of Releasers")
             .withType(ApprovalStepType.REPORT_APPROVAL).withRelatedObjectUuid(advisorOrg.getUuid())
-            .withApprovers(ImmutableList.of(getPositionInput(approver2Pos))).build();
+            .withApprovers(List.of(getPositionInput(approver2Pos))).build();
     approvalStepsInput.add(releaseApprovalStepInput);
     final OrganizationInput advisorOrgInput = getOrganizationInput(advisorOrg);
     advisorOrgInput.setApprovalSteps(approvalStepsInput);
@@ -259,11 +257,11 @@ public class ReportResourceTest extends AbstractResourceTest {
     // Write a Report
     final ReportPerson nonAttendingAuthor = personToReportAuthor(getElizabethElizawell());
     nonAttendingAuthor.setAttendee(false);
-    final ArrayList<ReportPerson> reportPeople =
-        Lists.newArrayList(principal, personToReportAuthor(author), nonAttendingAuthor);
+    final List<ReportPerson> reportPeople =
+        List.of(principal, personToReportAuthor(author), nonAttendingAuthor);
     final ReportInput rInput = ReportInput.builder().withEngagementDate(Instant.now())
         .withDuration(120).withReportPeople(getReportPeopleInput(reportPeople))
-        .withTasks(Lists.newArrayList(getTaskInput(action))).withLocation(getLocationInput(loc))
+        .withTasks(List.of(getTaskInput(action))).withLocation(getLocationInput(loc))
         .withAtmosphere(Atmosphere.POSITIVE).withAtmosphereDetails("Everybody was super nice!")
         .withIntent("A testing report to test that reporting reports")
         // set HTML of report text
@@ -490,7 +488,7 @@ public class ReportResourceTest extends AbstractResourceTest {
         .contains(loc.getUuid());
 
     // Go and delete the entire approval chain!
-    advisorOrg.setApprovalSteps(ImmutableList.of());
+    advisorOrg.setApprovalSteps(List.of());
     nrUpdated = adminMutationExecutor.updateOrganization("", getOrganizationInput(advisorOrg));
     assertThat(nrUpdated).isEqualTo(1);
 
@@ -584,14 +582,14 @@ public class ReportResourceTest extends AbstractResourceTest {
     final ApprovalStepInput approvalStepInput =
         ApprovalStepInput.builder().withName("Test Group for Approving")
             .withType(ApprovalStepType.REPORT_APPROVAL).withRelatedObjectUuid(advisorOrg.getUuid())
-            .withApprovers(ImmutableList.of(getPositionInput(approver1Pos))).build();
+            .withApprovers(List.of(getPositionInput(approver1Pos))).build();
     approvalStepsInput.add(approvalStepInput);
 
     // Adding a new approval step to an AO automatically puts it at the end of the approval process.
     final ApprovalStepInput releaseApprovalStepInput =
         ApprovalStepInput.builder().withName("Test Group of Releasers")
             .withType(ApprovalStepType.REPORT_APPROVAL).withRelatedObjectUuid(advisorOrg.getUuid())
-            .withApprovers(ImmutableList.of(getPositionInput(approver2Pos))).build();
+            .withApprovers(List.of(getPositionInput(approver2Pos))).build();
     approvalStepsInput.add(releaseApprovalStepInput);
     final OrganizationInput advisorOrgInput = getOrganizationInput(advisorOrg);
     advisorOrgInput.setApprovalSteps(approvalStepsInput);
@@ -632,21 +630,21 @@ public class ReportResourceTest extends AbstractResourceTest {
     assertThat(loc.getUuid()).isNotNull();
 
     // Write a Report
-    final ReportInput rInput = ReportInput.builder().withEngagementDate(Instant.now())
-        .withDuration(120)
-        .withReportPeople(
-            getReportPeopleInput(Lists.newArrayList(reportAttendee, personToReportAuthor(author))))
-        .withTasks(Lists.newArrayList(getTaskInput(action))).withLocation(getLocationInput(loc))
-        .withAtmosphere(Atmosphere.POSITIVE).withAtmosphereDetails("Everybody was super nice!")
-        .withIntent("A testing report to test that reporting reports")
-        // set HTML of report text
-        .withReportText(UtilsTest.getCombinedHtmlTestCase().getInput())
-        // set JSON of customFields
-        .withCustomFields(UtilsTest.getCombinedJsonTestCase().getInput())
-        .withNextSteps("This is the next steps on a report")
-        .withKeyOutcomes("These are the key outcomes of this engagement")
-        .withAdvisorOrg(getOrganizationInput(advisorOrg))
-        .withPrincipalOrg(getOrganizationInput(reportAttendeeOrg)).build();
+    final ReportInput rInput =
+        ReportInput.builder().withEngagementDate(Instant.now()).withDuration(120)
+            .withReportPeople(
+                getReportPeopleInput(List.of(reportAttendee, personToReportAuthor(author))))
+            .withTasks(List.of(getTaskInput(action))).withLocation(getLocationInput(loc))
+            .withAtmosphere(Atmosphere.POSITIVE).withAtmosphereDetails("Everybody was super nice!")
+            .withIntent("A testing report to test that reporting reports")
+            // set HTML of report text
+            .withReportText(UtilsTest.getCombinedHtmlTestCase().getInput())
+            // set JSON of customFields
+            .withCustomFields(UtilsTest.getCombinedJsonTestCase().getInput())
+            .withNextSteps("This is the next steps on a report")
+            .withKeyOutcomes("These are the key outcomes of this engagement")
+            .withAdvisorOrg(getOrganizationInput(advisorOrg))
+            .withPrincipalOrg(getOrganizationInput(reportAttendeeOrg)).build();
     final Report created = authorMutationExecutor.createReport(FIELDS, rInput);
     assertThat(created).isNotNull();
     assertThat(created.getUuid()).isNotNull();
@@ -859,7 +857,7 @@ public class ReportResourceTest extends AbstractResourceTest {
         .contains(loc.getUuid());
 
     // Go and delete the entire approval chain!
-    advisorOrg.setApprovalSteps(ImmutableList.of());
+    advisorOrg.setApprovalSteps(List.of());
     nrUpdated = adminMutationExecutor.updateOrganization("", getOrganizationInput(advisorOrg));
     assertThat(nrUpdated).isEqualTo(1);
 
@@ -886,7 +884,7 @@ public class ReportResourceTest extends AbstractResourceTest {
     final MutationExecutor authorMutationExecutor = getMutationExecutor(author.getDomainUsername());
 
     final List<ReportPersonInput> reportPeopleInput =
-        getReportPeopleInput(ImmutableList.of(personToPrimaryReportPerson(roger),
+        getReportPeopleInput(List.of(personToPrimaryReportPerson(roger),
             personToPrimaryReportPerson(jack), personToReportAuthor(author)));
 
     // Write a report as that person
@@ -975,9 +973,8 @@ public class ReportResourceTest extends AbstractResourceTest {
     assertThat(nrUpdated).isEqualTo(1);
 
     // Change primary advisor of the report to someone in EF 1.1
-    returned.setReportPeople(
-        ImmutableList.of(personToPrimaryReportPerson(roger), personToReportPerson(jack),
-            personToPrimaryReportPerson(bob), personToReportAuthor(author)));
+    returned.setReportPeople(List.of(personToPrimaryReportPerson(roger), personToReportPerson(jack),
+        personToPrimaryReportPerson(bob), personToReportAuthor(author)));
     final Report updated =
         authorMutationExecutor.updateReport(FIELDS, getReportInput(returned), true);
     assertThat(updated).isNotNull();
@@ -1046,8 +1043,8 @@ public class ReportResourceTest extends AbstractResourceTest {
         .withNextSteps("These are the next steps summarized")
         .withReportText("This report was generated by ReportsResourceTest#reportEditTest")
         .withReportPeople(getReportPeopleInput(
-            ImmutableList.of(personToPrimaryReportPerson(roger), personToReportAuthor(elizabeth))))
-        .withTasks(ImmutableList.of(getTaskInput(taskSearchResults.getList().get(0)))).build();
+            List.of(personToPrimaryReportPerson(roger), personToReportAuthor(elizabeth))))
+        .withTasks(List.of(getTaskInput(taskSearchResults.getList().get(0)))).build();
     Report returned = elizabethMutationExecutor.createReport(FIELDS, rInput);
     assertThat(returned).isNotNull();
     assertThat(returned.getUuid()).isNotNull();
@@ -1058,9 +1055,9 @@ public class ReportResourceTest extends AbstractResourceTest {
     returned.setReportText(UtilsTest.getCombinedHtmlTestCase().getInput());
     // u[date JSON of customFields
     returned.setCustomFields(UtilsTest.getCombinedJsonTestCase().getInput());
-    returned.setReportPeople(ImmutableList.of(personToPrimaryReportPerson(roger),
-        personToReportPerson(nick), personToPrimaryReportAuthor(elizabeth)));
-    returned.setTasks(ImmutableList.of());
+    returned.setReportPeople(List.of(personToPrimaryReportPerson(roger), personToReportPerson(nick),
+        personToPrimaryReportAuthor(elizabeth)));
+    returned.setTasks(List.of());
     Report updated = elizabethMutationExecutor.updateReport(FIELDS, getReportInput(returned), true);
     assertThat(updated).isNotNull();
 
@@ -1097,10 +1094,10 @@ public class ReportResourceTest extends AbstractResourceTest {
 
     // Bob edits the report (change reportText, remove Person, add a Task)
     returned3.setReportText(rInput.getReportText() + ", edited by Bob!!");
-    returned3.setReportPeople(ImmutableList.of(personToPrimaryReportPerson(nick),
-        personToPrimaryReportAuthor(elizabeth)));
-    returned3.setTasks(
-        ImmutableList.of(taskSearchResults.getList().get(1), taskSearchResults.getList().get(2)));
+    returned3.setReportPeople(
+        List.of(personToPrimaryReportPerson(nick), personToPrimaryReportAuthor(elizabeth)));
+    returned3
+        .setTasks(List.of(taskSearchResults.getList().get(1), taskSearchResults.getList().get(2)));
     updated = getMutationExecutor("bob").updateReport(FIELDS, getReportInput(returned3), true);
     assertThat(updated).isNotNull();
 
@@ -1262,12 +1259,12 @@ public class ReportResourceTest extends AbstractResourceTest {
 
     // Search by Status.
     query.setLocationUuid(null);
-    query.setState(ImmutableList.of(ReportState.CANCELLED));
+    query.setState(List.of(ReportState.CANCELLED));
     searchResults = jackQueryExecutor.reportList(getListFields(FIELDS), query);
     assertThat(searchResults.getList()).isNotEmpty();
     final int numCancelled = searchResults.getTotalCount();
 
-    query.setState(ImmutableList.of(ReportState.CANCELLED, ReportState.PUBLISHED));
+    query.setState(List.of(ReportState.CANCELLED, ReportState.PUBLISHED));
     searchResults = jackQueryExecutor.reportList(getListFields(FIELDS), query);
     assertThat(searchResults.getList()).isNotEmpty();
     assertThat(searchResults.getTotalCount()).isGreaterThan(numCancelled);
@@ -1470,8 +1467,8 @@ public class ReportResourceTest extends AbstractResourceTest {
     final Person jack = getJackJackson();
     final Person roger = getRogerRogwell();
     final List<ReportPersonInput> reportPeopleInput =
-        getReportPeopleInput(ImmutableList.of(personToPrimaryReportPerson(roger),
-            personToReportPerson(jack), personToPrimaryReportAuthor(elizabeth)));
+        getReportPeopleInput(List.of(personToPrimaryReportPerson(roger), personToReportPerson(jack),
+            personToPrimaryReportAuthor(elizabeth)));
 
     // Write a report as that person
     final ReportInput rInput = ReportInput.builder()
@@ -1543,12 +1540,12 @@ public class ReportResourceTest extends AbstractResourceTest {
 
     // Liz was supposed to meet with Steve, but he cancelled.
 
-    final ReportInput rInput =
-        ReportInput.builder().withIntent("Meet with Steve about a thing we never got to talk about")
-            .withEngagementDate(Instant.now()).withDuration(45)
-            .withReportPeople(getReportPeopleInput(ImmutableList
-                .of(personToPrimaryReportAuthor(elizabeth), personToPrimaryReportPerson(steve))))
-            .withCancelledReason(ReportCancelledReason.CANCELLED_BY_PRINCIPAL).build();
+    final ReportInput rInput = ReportInput.builder()
+        .withIntent("Meet with Steve about a thing we never got to talk about")
+        .withEngagementDate(Instant.now()).withDuration(45)
+        .withReportPeople(getReportPeopleInput(
+            List.of(personToPrimaryReportAuthor(elizabeth), personToPrimaryReportPerson(steve))))
+        .withCancelledReason(ReportCancelledReason.CANCELLED_BY_PRINCIPAL).build();
 
     final Report saved = elizabethMutationExecutor.createReport(FIELDS, rInput);
     assertThat(saved).isNotNull();
@@ -1590,13 +1587,12 @@ public class ReportResourceTest extends AbstractResourceTest {
       throws GraphQLRequestExecutionException, GraphQLRequestPreparationException {
     final Person steve = getSteveSteveson();
 
-    final ReportInput rInput =
-        ReportInput.builder().withIntent("Test the Daily rollup graph")
-            .withNextSteps("Check for a change in the rollup graph")
-            .withKeyOutcomes("Foobar the bazbiz")
-            .withReportPeople(getReportPeopleInput(ImmutableList
-                .of(personToPrimaryReportAuthor(admin), personToPrimaryReportPerson(steve))))
-            .build();
+    final ReportInput rInput = ReportInput.builder().withIntent("Test the Daily rollup graph")
+        .withNextSteps("Check for a change in the rollup graph")
+        .withKeyOutcomes("Foobar the bazbiz")
+        .withReportPeople(getReportPeopleInput(
+            List.of(personToPrimaryReportAuthor(admin), personToPrimaryReportPerson(steve))))
+        .build();
     Report r = adminMutationExecutor.createReport(FIELDS, rInput);
     assertThat(r).isNotNull();
     assertThat(r.getUuid()).isNotNull();
@@ -1675,8 +1671,8 @@ public class ReportResourceTest extends AbstractResourceTest {
     final ReportInput rInput = ReportInput.builder().withIntent("Test the Daily rollup graph")
         .withNextSteps("Check for a change in the rollup graph")
         .withKeyOutcomes("Foobar the bazbiz")
-        .withReportPeople(getReportPeopleInput(ImmutableList
-            .of(personToPrimaryReportAuthor(elizabeth), personToPrimaryReportPerson(steve))))
+        .withReportPeople(getReportPeopleInput(
+            List.of(personToPrimaryReportAuthor(elizabeth), personToPrimaryReportPerson(steve))))
         .build();
     Report r = elizabethMutationExecutor.createReport(FIELDS, rInput);
     assertThat(r).isNotNull();
@@ -1755,8 +1751,7 @@ public class ReportResourceTest extends AbstractResourceTest {
         // set HTML of report sensitive information
         .withText(UtilsTest.getCombinedHtmlTestCase().getInput()).build();
     final ReportInput rInput = ReportInput.builder()
-        .withReportPeople(
-            getReportPeopleInput(ImmutableList.of(personToPrimaryReportAuthor(elizabeth))))
+        .withReportPeople(getReportPeopleInput(List.of(personToPrimaryReportAuthor(elizabeth))))
         .withReportText(
             "This reportTest was generated by ReportsResourceTest#testSensitiveInformation")
         .withReportSensitiveInformation(rsiInput).build();
@@ -1861,7 +1856,7 @@ public class ReportResourceTest extends AbstractResourceTest {
   }
 
   private ReportSearchQueryInput.Builder setupQueryEngagementDayOfWeek() {
-    return ReportSearchQueryInput.builder().withState(ImmutableList.of(ReportState.PUBLISHED));
+    return ReportSearchQueryInput.builder().withState(List.of(ReportState.PUBLISHED));
   }
 
   private AnetBeanList_Report runSearchQuery(ReportSearchQueryInput query)
@@ -1975,7 +1970,7 @@ public class ReportResourceTest extends AbstractResourceTest {
         .withNextSteps("Retrieve the advisor reports insight")
         .withLocation(getLocationInput(getLocation(author, "General Hospital")))
         .withEngagementDate(engagementDate)
-        .withReportPeople(getReportPeopleInput(Lists.newArrayList(reportPerson)))
+        .withReportPeople(getReportPeopleInput(List.of(reportPerson)))
         .withAdvisorOrg(getOrganizationInput(advisorOrganization)).build();
     final Report created = adminMutationExecutor.createReport(FIELDS, rInput);
     assertThat(created).isNotNull();
@@ -2004,7 +1999,7 @@ public class ReportResourceTest extends AbstractResourceTest {
     final Instant engagementDate =
         Instant.now().atZone(DaoUtils.getServerNativeZoneId()).minusWeeks(2).toInstant();
     final ReportInput rInput = ReportInput.builder()
-        .withReportPeople(getReportPeopleInput(ImmutableList.of(
+        .withReportPeople(getReportPeopleInput(List.of(
             personToPrimaryReportPerson(getSteveSteveson()),
             personToPrimaryReportPerson(getElizabethElizawell()), personToReportAuthor(author))))
         .withState(ReportState.DRAFT).withAtmosphere(Atmosphere.POSITIVE)
@@ -2024,7 +2019,7 @@ public class ReportResourceTest extends AbstractResourceTest {
     assertThat(searchResults).isNotEmpty();
     final Task t11a =
         searchResults.stream().filter(t -> t.getShortName().equals("1.1.A")).findFirst().get();
-    rInput.setTasks(ImmutableList.of(getTaskInput(t11a)));
+    rInput.setTasks(List.of(getTaskInput(t11a)));
 
     // Create the report
     final Report created = authorMutationExecutor.createReport(FIELDS, rInput);
@@ -2108,7 +2103,7 @@ public class ReportResourceTest extends AbstractResourceTest {
     final Person author = getJackJackson();
     final MutationExecutor authorMutationExecutor = getMutationExecutor(author.getDomainUsername());
     final ReportInput rInput = ReportInput.builder()
-        .withReportPeople(getReportPeopleInput(ImmutableList.of(personToReportAuthor(author))))
+        .withReportPeople(getReportPeopleInput(List.of(personToReportAuthor(author))))
         .withState(ReportState.DRAFT).withAtmosphere(Atmosphere.POSITIVE)
         .withIntent("Testing report authors").withEngagementDate(Instant.now()).build();
     final Report reportFirstAuthor = authorMutationExecutor.createReport(FIELDS, rInput);
@@ -2129,7 +2124,7 @@ public class ReportResourceTest extends AbstractResourceTest {
     // Add a second author
     final Person liz = getElizabethElizawell();
     reportFirstAuthor
-        .setReportPeople(ImmutableList.of(personToReportAuthor(author), personToReportAuthor(liz)));
+        .setReportPeople(List.of(personToReportAuthor(author), personToReportAuthor(liz)));
     final Report reportTwoAuthors =
         authorMutationExecutor.updateReport(FIELDS, getReportInput(reportFirstAuthor), true);
     assertThat(reportTwoAuthors.getReportPeople())
@@ -2138,7 +2133,7 @@ public class ReportResourceTest extends AbstractResourceTest {
         .anyMatch(rp -> Objects.equals(rp.getUuid(), liz.getUuid()) && rp.getAuthor());
 
     // Remove the first author
-    reportTwoAuthors.setReportPeople(ImmutableList.of(personToReportAuthor(liz)));
+    reportTwoAuthors.setReportPeople(List.of(personToReportAuthor(liz)));
     final Report reportSecondAuthor =
         authorMutationExecutor.updateReport(FIELDS, getReportInput(reportTwoAuthors), true);
     assertThat(reportSecondAuthor.getReportPeople())
@@ -2156,7 +2151,7 @@ public class ReportResourceTest extends AbstractResourceTest {
 
     // Try to add first author again, should fail
     reportSecondAuthor
-        .setReportPeople(ImmutableList.of(personToReportAuthor(author), personToReportAuthor(liz)));
+        .setReportPeople(List.of(personToReportAuthor(author), personToReportAuthor(liz)));
     try {
       authorMutationExecutor.updateReport(FIELDS, getReportInput(reportSecondAuthor), true);
       fail("Expected ForbiddenException");
@@ -2198,7 +2193,7 @@ public class ReportResourceTest extends AbstractResourceTest {
     final Instant engagementDate = Instant.now().atZone(DaoUtils.getServerNativeZoneId())
         .minusWeeks(isFuture ? -2 : 2).toInstant();
     final ReportInput rInput = ReportInput.builder()
-        .withReportPeople(getReportPeopleInput(ImmutableList.of(
+        .withReportPeople(getReportPeopleInput(List.of(
             personToPrimaryReportPerson(getSteveSteveson()), personToPrimaryReportAuthor(author))))
         .withState(ReportState.DRAFT).withAtmosphere(Atmosphere.POSITIVE)
         .withIntent("Testing unpublishing").withKeyOutcomes("Unpublishing works")
@@ -2216,7 +2211,7 @@ public class ReportResourceTest extends AbstractResourceTest {
     assertThat(searchResults).isNotEmpty();
     final Task t11a =
         searchResults.stream().filter(t -> t.getShortName().equals("EF7")).findFirst().get();
-    rInput.setTasks(ImmutableList.of(getTaskInput(t11a)));
+    rInput.setTasks(List.of(getTaskInput(t11a)));
 
     // Create the report
     final Report created = authorMutationExecutor.createReport(FIELDS, rInput);

--- a/src/test/resources/anet.graphql
+++ b/src/test/resources/anet.graphql
@@ -985,6 +985,7 @@ input ReportSearchQueryInput {
   engagementStatus: [EngagementStatus]
   inMyReports: Boolean
   includeAdvisorOrgChildren: Boolean
+  includeAllDrafts: Boolean
   includeEngagementDayOfWeek: Boolean
   includePrincipalOrgChildren: Boolean
   locationUuid: String


### PR DESCRIPTION
See below for detailed changes.

Closes [AB#1041](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1041), [AB#1043](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1043), [AB#1044](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1044)

#### User changes
- When not otherwise specified through other advanced report search filters, restrict report search to Published reports.
- When searching for reports, automatically add a state filter on Published reports by default.

#### Superuser changes
- None

#### Admin changes
- Admins now have a direct link to just their own Draft reports on the home page.
- Admins have an additional advanced search filter for reports: Include all Drafts, which, when set, will include other users' Draft reports in addition to the admins' own reports.

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [x] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [x] Added and/or updated unit tests
  - [x] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
