### PR TITLE
Make sure the advanced select pop-up inside the advanced search is visible

### DIFF
--- a/client/src/components/advancedSelectWidget/AdvancedSelect.js
+++ b/client/src/components/advancedSelectWidget/AdvancedSelect.js
@@ -297,15 +297,12 @@ const AdvancedSelect = ({
     <>
       {!(disabled && renderSelectedWithDelete) && (
         <>
-          <div
-            id={`${fieldName}-popover`}
-            className={classNames(className, "advanced-select-popover")}
-          >
+          <div className={classNames(className, "advanced-select-popover")}>
             <InputGroup>
               <Popover2
-                popoverClassName="bp4-popover2-content-sizing"
+                popoverClassName="advanced-select-popover bp4-popover2-content-sizing"
                 content={
-                  <Row className="border-between">
+                  <Row id={`${fieldName}-popover`} className="border-between">
                     <FilterAsNav
                       items={filterDefs}
                       currentFilter={filterType}
@@ -355,21 +352,19 @@ const AdvancedSelect = ({
                 disabled={disabled}
                 interactionKind={Popover2InteractionKind.CLICK}
                 onInteraction={handleInteraction}
-                usePortal={false}
+                usePortal
                 autoFocus={false}
                 enforceFocus={false}
                 placement="bottom"
                 modifiers={{
                   preventOverflow: {
-                    options: {
-                      rootBoundary: "viewport"
-                    }
+                    enabled: false
                   },
                   hide: {
                     enabled: false
                   },
                   flip: {
-                    enabled: false
+                    enabled: true
                   }
                 }}
               >
@@ -474,7 +469,7 @@ const AdvancedSelect = ({
 }
 AdvancedSelect.propTypes = propTypes
 AdvancedSelect.defaultProps = {
-  pageSize: 6,
+  pageSize: 5,
   disabled: false,
   filterDefs: {},
   closeOverlayOnAdd: false,

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -984,6 +984,8 @@ header.searchPagination {
 .advanced-select-popover .bp4-popover2-content {
   min-width: 400px;
   max-width: 90vw !important;
+  max-height: 47vh !important;
+  overflow-y: scroll;
 }
 
 .advanced-search {
@@ -996,15 +998,6 @@ header.searchPagination {
 
 .advanced-search-form {
   padding-bottom: 5px;
-}
-
-.advanced-search .col-3 select {
-  margin-top: -8px;
-}
-
-.advanced-search .col-1 .btn img,
-.advanced-search .col-sm-1 .btn img {
-  vertical-align: baseline;
 }
 
 .general-banner {

--- a/client/tests/webdriver/customFieldsSpecs/createReport.spec.js
+++ b/client/tests/webdriver/customFieldsSpecs/createReport.spec.js
@@ -174,6 +174,9 @@ describe("Create report form page", () => {
 
       // Check search query does not reset when changing object type
       // Default input type is People
+      await (
+        await CreateReport.getTestMultiReferenceFieldButton("People")
+      ).scrollIntoView()
       expect(
         await (
           await CreateReport.getTestMultiReferenceField()
@@ -195,6 +198,9 @@ describe("Create report form page", () => {
         ).getText()
       ).to.include(SEARCH_PEOPLE_COMPLETE_1)
       // Change input type to Organizations
+      await (
+        await CreateReport.getTestMultiReferenceFieldButton("Organizations")
+      ).scrollIntoView()
       await (
         await CreateReport.getTestMultiReferenceFieldButton("Organizations")
       ).click()
@@ -219,6 +225,9 @@ describe("Create report form page", () => {
         ).getText()
       ).to.include(SEARCH_ORGANIZATION_COMPLETE)
       // Change input type to Positions
+      await (
+        await CreateReport.getTestMultiReferenceFieldButton("Positions")
+      ).scrollIntoView()
       await (
         await CreateReport.getTestMultiReferenceFieldButton("Positions")
       ).click()
@@ -249,6 +258,9 @@ describe("Create report form page", () => {
         await (await CreateReport.getTestMultiReferenceField()).getValue()
       ).to.equal(SEARCH_KEY)
       // Change input type to People
+      await (
+        await CreateReport.getTestMultiReferenceFieldButton("People")
+      ).scrollIntoView()
       await (
         await CreateReport.getTestMultiReferenceFieldButton("People")
       ).click()
@@ -326,6 +338,9 @@ describe("Create report form page", () => {
       ).to.include(PERSON_VALUE_2)
 
       // Change input type to Positions
+      await (
+        await CreateReport.getTestMultiReferenceFieldButton("Positions")
+      ).scrollIntoView()
       await (
         await CreateReport.getTestMultiReferenceFieldButton("Positions")
       ).click()

--- a/client/tests/webdriver/pages/createFutureReport.page.js
+++ b/client/tests/webdriver/pages/createFutureReport.page.js
@@ -23,7 +23,7 @@ class CreateFutureReport extends CreateReport {
   }
 
   async getAttendeesFieldAdvancedSelectFirstItem() {
-    return (await this.getAttendeesFieldFormGroup()).$(
+    return browser.$(
       `div[id="${attId}-popover"] tbody tr:first-child td:nth-child(2)`
     )
   }
@@ -59,7 +59,7 @@ class CreateFutureReport extends CreateReport {
   }
 
   async getTasksFieldAdvancedSelectFirstItem() {
-    return (await this.getTasksFieldFormGroup()).$(
+    return browser.$(
       `div[id="${tskId}-popover"] tbody tr:first-child td:nth-child(2)`
     )
   }

--- a/client/tests/webdriver/pages/createReport.page.js
+++ b/client/tests/webdriver/pages/createReport.page.js
@@ -77,7 +77,7 @@ export class CreateReport extends Page {
   }
 
   async getTestReferenceFieldAdvancedSelectFirstItem() {
-    return (await this.getTestReferenceFieldFormGroup()).$(
+    return browser.$(
       `div[id="${RELATED_REPORT_ID}-popover"] tbody tr:first-child td:nth-child(2)`
     )
   }
@@ -116,12 +116,10 @@ export class CreateReport extends Page {
   }
 
   async getTestMultiReferenceFieldAdvancedSelect() {
-    await (await this.getTestMultiReferenceFieldFormGroup())
+    await browser
       .$(`div[id="${ADDITIONAL_ENGAGEMENTS_ID}-popover"] tbody`)
       .waitForExist()
-    return (await this.getTestMultiReferenceFieldFormGroup()).$(
-      `div[id="${ADDITIONAL_ENGAGEMENTS_ID}-popover"] tbody`
-    )
+    return browser.$(`div[id="${ADDITIONAL_ENGAGEMENTS_ID}-popover"] tbody`)
   }
 
   async getEngagementTypesFieldFormGroup() {


### PR DESCRIPTION
The advanced select pop-up inside the advanced search could be partly invisible, and difficult to reach by scrolling. With this change, the advanced select is now always completely visible on screen.

Closes [AB#1042](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1042)

#### User changes
- The advanced select is now always completely visible on screen.

#### Superuser changes
- None

#### Admin changes
- None

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [x] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
