### PR TITLE
Correct endOfTourDate logic

### DIFF
--- a/client/src/pages/people/Form.js
+++ b/client/src/pages/people/Form.js
@@ -180,9 +180,8 @@ const PersonForm = ({
         const isAdmin = currentUser && currentUser.isAdmin()
         const isAdvisor = Person.isAdvisor(values)
         const isPendingVerification = Person.isPendingVerification(values)
-        const endOfTourDateInPast = values.endOfTourDate
-          ? values.endOfTourDate <= Date.now()
-          : false
+        const endOfTourDateInPast =
+          values.endOfTourDate && values.endOfTourDate <= Date.now()
         const willAutoKickPosition =
           values.status === Model.STATUS.INACTIVE &&
           values.position &&
@@ -687,7 +686,7 @@ const PersonForm = ({
                   onChange={value =>
                     setFieldValue(
                       "endOfTourDate",
-                      moment(value).endOf("day").format()
+                      value && moment(value).endOf("day").toDate()
                     )}
                   onBlur={() => setFieldTouched("endOfTourDate")}
                   widget={

--- a/client/tests/webdriver/baseSpecs/onboardNewUser.spec.js
+++ b/client/tests/webdriver/baseSpecs/onboardNewUser.spec.js
@@ -32,18 +32,18 @@ describe("Onboard new user login", () => {
     await browser.pause(500) // wait for the page transition and rendering of custom fields
 
     // Check that these are properly copied from the authentication server
-    await (await OnboardPage.getLastName()).waitForDisplayed()
     await (await OnboardPage.getLastName()).waitForExist()
+    await (await OnboardPage.getLastName()).waitForDisplayed()
     expect(await (await OnboardPage.getLastName()).getValue()).to.equal(
       ONBOARD_USER.lastName
     )
-    await (await OnboardPage.getFirstName()).waitForDisplayed()
     await (await OnboardPage.getFirstName()).waitForExist()
+    await (await OnboardPage.getFirstName()).waitForDisplayed()
     expect(await (await OnboardPage.getFirstName()).getValue()).to.equal(
       ONBOARD_USER.firstName
     )
-    await (await OnboardPage.getEmailAddress()).waitForDisplayed()
     await (await OnboardPage.getEmailAddress()).waitForExist()
+    await (await OnboardPage.getEmailAddress()).waitForDisplayed()
     expect(await (await OnboardPage.getEmailAddress()).getValue()).to.equal(
       ONBOARD_USER.emailAddress
     )
@@ -51,12 +51,12 @@ describe("Onboard new user login", () => {
 
   it("Should not save if endOfTourDate is not in the future", async() => {
     await (await OnboardPage.getEndOfTourDate()).waitForExist()
-    await (await OnboardPage.getEndOfTourDate()).click()
+    await (await OnboardPage.getEndOfTourDate()).waitForDisplayed()
 
-    await (await OnboardPage.getEndOfTourToday()).waitForDisplayed()
-    await (await OnboardPage.getEndOfTourToday()).waitForExist()
-    // select a date
-    await (await OnboardPage.getEndOfTourToday()).click()
+    const yesterday = moment().subtract(1, "days").format("DD-MM-YYYY")
+    await OnboardPage.deleteInput(OnboardPage.getEndOfTourDate())
+    await (await OnboardPage.getEndOfTourDate()).setValue(yesterday)
+
     await (await OnboardPage.getLastName()).click()
     const errorMessage = await (await OnboardPage.getEndOfTourDate())
       .$("..")

--- a/client/tests/webdriver/baseSpecs/showAttachment.spec.js
+++ b/client/tests/webdriver/baseSpecs/showAttachment.spec.js
@@ -12,6 +12,35 @@ const ATTACHMENT_MIMETYPE = "image/png"
 const ATTACHMENT_USED_IN = "A test report from Arthur"
 const ATTACHMENT_SIZE = 12316
 
+async function checkDownloadedFile(attachmentName, attachmentSize) {
+  const testEnv =
+    (process.env.GIT_TAG_NAME && "remote") || process.env.TEST_ENV || "local"
+  if (testEnv === "local") {
+    // Local
+    const stats = fs.statSync(attachmentName)
+    // eslint-disable-next-line no-unused-expressions
+    expect(stats.isFile()).to.be.true
+    expect(stats.size).to.equal(attachmentSize)
+    // clean up
+    fs.rmSync(attachmentName)
+  } else {
+    // On BrowserStack
+    // Don't specify the name, just assume it was the last downloaded file (actual filename may be different!)
+    const fileExists = await browser.executeScript(
+      'browserstack_executor: {"action": "fileExists"}',
+      []
+    )
+    // eslint-disable-next-line no-unused-expressions
+    expect(fileExists).to.be.true
+    const fileProperties = await browser.executeScript(
+      'browserstack_executor: {"action": "getFileProperties"}',
+      []
+    )
+    expect(fileProperties.size).to.equal(attachmentSize)
+    // Can't delete the file here
+  }
+}
+
 describe("Show attachment page", () => {
   beforeEach("Open the show attachment page", async() => {
     await ShowAttachment.open(ATTACHMENT_UUID)
@@ -28,12 +57,7 @@ describe("Show attachment page", () => {
       await downloadButton.click()
       await browser.pause(1000)
       // file should be downloaded by now
-      const stats = fs.statSync(ATTACHMENT_NAME)
-      // eslint-disable-next-line no-unused-expressions
-      expect(stats.isFile()).to.be.true
-      expect(stats.size).to.equal(ATTACHMENT_SIZE)
-      // clean up
-      fs.rmSync(ATTACHMENT_NAME)
+      await checkDownloadedFile(ATTACHMENT_NAME, ATTACHMENT_SIZE)
     })
     it("We should see image of attachment", async() => {
       await (await ShowAttachment.getImage()).waitForExist()

--- a/client/tests/webdriver/pages/insights.page.js
+++ b/client/tests/webdriver/pages/insights.page.js
@@ -2,7 +2,7 @@ import Page from "./page"
 
 // Copied from src/pages/insights/Show.js
 const NOT_APPROVED_REPORTS = "not-approved-reports"
-const CANCELLED_REPORTS = "cancelled-reports"
+const CANCELLED_REPORTS = "cancelled-engagement-reports"
 const REPORTS_BY_TASK = "reports-by-task"
 const REPORTS_BY_DAY_OF_WEEK = "reports-by-day-of-week"
 const FUTURE_ENGAGEMENTS_BY_LOCATION = "future-engagements-by-location"


### PR DESCRIPTION
- Correct endOfTourDate logic for [AB#1038](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1038), and update the test, since "today" is now an acceptable value
- Fix test for [AB#1041](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1041)
- [AB#866](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/866) Fix attachment download test when running on BrowserStack