### PR TITLE
Add administrative positions to authorization groups

### DIFF
--- a/client/src/components/Attachment/AttachmentRelatedObjectsTable.js
+++ b/client/src/components/Attachment/AttachmentRelatedObjectsTable.js
@@ -5,7 +5,7 @@ import { Table } from "react-bootstrap"
 
 const AttachmentRelatedObjectsTable = ({ relatedObjects }) => {
   return (
-    <div id="related_objects">
+    <div className="related_objects">
       {!relatedObjects?.length ? (
         <em>No linked objects</em>
       ) : (

--- a/client/src/components/Nav.js
+++ b/client/src/components/Nav.js
@@ -1,6 +1,7 @@
 import { clearSearchQuery, resetPages } from "actions"
 import AppContext from "components/AppContext"
 import ResponsiveLayoutContext from "components/ResponsiveLayoutContext"
+import _isEmpty from "lodash/isEmpty"
 import { Organization } from "models"
 import { INSIGHT_DETAILS, INSIGHTS } from "pages/insights/Show"
 import pluralize from "pluralize"
@@ -137,6 +138,7 @@ const Navigation = ({ allOrganizations, resetPages, clearSearchQuery }) => {
 
   const inMyCounterParts = path.startsWith("/positions/counterparts")
   const inMyTasks = path.startsWith("/tasks/mine")
+  const inMyAuthorizationGroups = path.startsWith("/authorizationGroups/mine")
   const inMyReports = path.startsWith("/reports/mine")
   const inMySubscriptions = path.startsWith("/subscriptions/mine")
   const inInsights = path.startsWith("/insights")
@@ -153,6 +155,7 @@ const Navigation = ({ allOrganizations, resetPages, clearSearchQuery }) => {
       inMyCounterParts ||
       inMyReports ||
       inMyTasks ||
+      inMyAuthorizationGroups ||
       inMySubscriptions ||
       inMySavedSearches
     ) {
@@ -163,6 +166,7 @@ const Navigation = ({ allOrganizations, resetPages, clearSearchQuery }) => {
     inMyCounterParts,
     inMyReports,
     inMyTasks,
+    inMyAuthorizationGroups,
     inMySubscriptions,
     inMySavedSearches
   ])
@@ -267,6 +271,17 @@ const Navigation = ({ allOrganizations, resetPages, clearSearchQuery }) => {
           >
             My Saved Searches
           </SidebarLink>
+          {!_isEmpty(
+            currentUser?.position?.authorizationGroupsAdministrated
+          ) && (
+            <SidebarLink
+              id="my-authorizationGroups-nav"
+              linkTo={{ pathname: "/authorizationGroups/mine" }}
+              handleOnClick={resetPages}
+            >
+              My Authorization Groups
+            </SidebarLink>
+          )}
         </div>
       </Collapse>
 

--- a/client/src/components/RelatedObjectsTable.js
+++ b/client/src/components/RelatedObjectsTable.js
@@ -95,7 +95,7 @@ export const RelatedObjectsTableInput = ({
   }))
 
   return (
-    <div id="related_objects">
+    <div className="related_objects">
       <MultiTypeAdvancedSelectComponent
         value={fieldValue}
         objectType={objectType}

--- a/client/src/models/AuthorizationGroup.js
+++ b/client/src/models/AuthorizationGroup.js
@@ -22,6 +22,7 @@ export default class AuthorizationGroup extends Model {
       .string()
       .required()
       .default(() => Model.STATUS.ACTIVE),
+    administrativePositions: yup.array().nullable().default([]),
     authorizationGroupRelatedObjects: yup.array().nullable().default([])
   })
 

--- a/client/src/pages/App.js
+++ b/client/src/pages/App.js
@@ -46,6 +46,9 @@ const GQL_GET_APP_DATA = gql`
         role
         status
         isApprover
+        authorizationGroupsAdministrated {
+          uuid
+        }
         organization {
           uuid
           shortName
@@ -128,6 +131,9 @@ const GQL_GET_APP_DATA = gql`
           descendantOrgs {
             uuid
           }
+        }
+        authorizationGroupsAdministrated {
+          uuid
         }
       }
     }

--- a/client/src/pages/Routing.js
+++ b/client/src/pages/Routing.js
@@ -1,5 +1,7 @@
 import AppContext from "components/AppContext"
+import _isEmpty from "lodash/isEmpty"
 import AuthorizationGroupEdit from "pages/admin/authorizationgroup/Edit"
+import MyAuthorizationGroups from "pages/admin/authorizationgroup/MyAuthorizationGroups"
 import AuthorizationGroupNew from "pages/admin/authorizationgroup/New"
 import AuthorizationGroupShow from "pages/admin/authorizationgroup/Show"
 import AuthorizationGroups from "pages/admin/AuthorizationGroups"
@@ -134,33 +136,47 @@ const Routing = () => {
           <Route path="edit" element={<TaskEdit />} />
         </Route>
       </Route>
-      {currentUser.isAdmin() && (
+      <Route path="authorizationGroups">
+        {!_isEmpty(currentUser?.position?.authorizationGroupsAdministrated) && (
+          <Route path="mine" element={<MyAuthorizationGroups />} />
+        )}
+      </Route>
+      {(currentUser.isAdmin() ||
+        !_isEmpty(currentUser?.position?.authorizationGroupsAdministrated)) && (
         <Route path={PAGE_URLS.ADMIN}>
-          <Route index element={<AdminIndex />} />
-          {!Settings.automaticallyAllowAllNewUsers && (
-            <Route
-              path="usersPendingVerification"
-              element={<UsersPendingVerification />}
-            />
-          )}
-          <Route path="merge">
-            <Route path="people" element={<MergePeople />} />
-            <Route path="positions" element={<MergePositions />} />
-            <Route path="locations" element={<MergeLocations />} />
-          </Route>
           <Route path="authorizationGroups">
-            <Route index element={<AuthorizationGroups />} />
-            <Route path="new" element={<AuthorizationGroupNew />} />
+            {currentUser.isAdmin() && (
+              <>
+                <Route index element={<AuthorizationGroups />} />
+                <Route path="new" element={<AuthorizationGroupNew />} />
+              </>
+            )}
             <Route path=":uuid">
               <Route index element={<AuthorizationGroupShow />} />
               <Route path="edit" element={<AuthorizationGroupEdit />} />
             </Route>
           </Route>
-          <Route path="userActivities">
-            <Route path="perPeriod" element={<UserActivitiesPerPeriod />} />
-            <Route path="overTime" element={<UserActivitiesOverTime />} />
-          </Route>
-          <Route path="graphiql" element={<GraphiQL />} />
+          {currentUser.isAdmin() && (
+            <>
+              <Route index element={<AdminIndex />} />
+              {!Settings.automaticallyAllowAllNewUsers && (
+                <Route
+                  path="usersPendingVerification"
+                  element={<UsersPendingVerification />}
+                />
+              )}
+              <Route path="merge">
+                <Route path="people" element={<MergePeople />} />
+                <Route path="positions" element={<MergePositions />} />
+                <Route path="locations" element={<MergeLocations />} />
+              </Route>
+              <Route path="userActivities">
+                <Route path="perPeriod" element={<UserActivitiesPerPeriod />} />
+                <Route path="overTime" element={<UserActivitiesOverTime />} />
+              </Route>
+              <Route path="graphiql" element={<GraphiQL />} />
+            </>
+          )}
         </Route>
       )}
       <Route path={PAGE_URLS.INSIGHTS}>

--- a/client/src/pages/admin/authorizationgroup/Edit.js
+++ b/client/src/pages/admin/authorizationgroup/Edit.js
@@ -20,6 +20,30 @@ const GQL_GET_AUTHORIZATION_GROUP = gql`
       name
       description
       status
+      administrativePositions {
+        uuid
+        name
+        code
+        type
+        role
+        status
+        location {
+          uuid
+          name
+        }
+        organization {
+          uuid
+          shortName
+          longName
+          identificationCode
+        }
+        person {
+          uuid
+          name
+          rank
+          avatarUuid
+        }
+      }
       authorizationGroupRelatedObjects {
         relatedObjectType
         relatedObjectUuid

--- a/client/src/pages/admin/authorizationgroup/MyAuthorizationGroups.js
+++ b/client/src/pages/admin/authorizationgroup/MyAuthorizationGroups.js
@@ -1,0 +1,98 @@
+import { gql } from "@apollo/client"
+import { DEFAULT_PAGE_PROPS, DEFAULT_SEARCH_PROPS } from "actions"
+import API from "api"
+import Fieldset from "components/Fieldset"
+import {
+  mapPageDispatchersToProps,
+  PageDispatchersPropType,
+  useBoilerplate,
+  usePageTitle
+} from "components/Page"
+import React from "react"
+import { connect } from "react-redux"
+import AuthorizationGroupTable from "../AuthorizationGroupTable"
+
+const GQL_GET_MY_AUTHORIZATION_GROUPS = gql`
+  query {
+    me {
+      uuid
+      position {
+        authorizationGroupsAdministrated {
+          uuid
+          name
+          description
+          status
+          authorizationGroupRelatedObjects {
+            relatedObjectType
+            relatedObjectUuid
+            relatedObject {
+              ... on Organization {
+                uuid
+                shortName
+                longName
+                identificationCode
+              }
+              ... on Person {
+                uuid
+                name
+                rank
+                avatarUuid
+              }
+              ... on Position {
+                uuid
+                type
+                name
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+`
+
+const MyAuthorizationGroups = ({ pageDispatchers }) => {
+  const { loading, error, data } = API.useApiQuery(
+    GQL_GET_MY_AUTHORIZATION_GROUPS
+  )
+  const { done, result } = useBoilerplate({
+    loading,
+    error,
+    pageProps: DEFAULT_PAGE_PROPS,
+    searchProps: DEFAULT_SEARCH_PROPS,
+    pageDispatchers
+  })
+  usePageTitle("My Authorization Groups")
+  if (done) {
+    return result
+  }
+
+  const authorizationGroupsAdministrated =
+    data?.me?.position?.authorizationGroupsAdministrated || []
+
+  return (
+    <div>
+      <Fieldset
+        id="my-authorization-groups"
+        title="Authorization Groups I administrate"
+      >
+        <AuthorizationGroupTable
+          authorizationGroups={authorizationGroupsAdministrated}
+        />
+      </Fieldset>
+    </div>
+  )
+}
+
+MyAuthorizationGroups.propTypes = {
+  pageDispatchers: PageDispatchersPropType
+}
+
+const mapDispatchToProps = (dispatch, ownProps) => {
+  const pageDispatchers = mapPageDispatchersToProps(dispatch, ownProps)
+  return {
+    ...pageDispatchers
+  }
+}
+
+export default connect(null, mapDispatchToProps)(MyAuthorizationGroups)

--- a/client/src/pages/admin/authorizationgroup/Show.js
+++ b/client/src/pages/admin/authorizationgroup/Show.js
@@ -12,6 +12,7 @@ import {
   useBoilerplate,
   usePageTitle
 } from "components/Page"
+import PositionTable from "components/PositionTable"
 import { RelatedObjectsTable } from "components/RelatedObjectsTable"
 import ReportCollection from "components/ReportCollection"
 import { Field, Form, Formik } from "formik"
@@ -27,6 +28,30 @@ const GQL_GET_AUTHORIZATION_GROUP = gql`
       name
       description
       status
+      administrativePositions {
+        uuid
+        name
+        code
+        type
+        role
+        status
+        location {
+          uuid
+          name
+        }
+        organization {
+          uuid
+          shortName
+          longName
+          identificationCode
+        }
+        person {
+          uuid
+          name
+          rank
+          avatarUuid
+        }
+      }
       authorizationGroupRelatedObjects {
         relatedObjectType
         relatedObjectUuid
@@ -81,7 +106,11 @@ const AuthorizationGroupShow = ({ pageDispatchers }) => {
   )
   const stateSuccess = routerLocation.state?.success
   const stateError = routerLocation.state?.error
-  const canEdit = currentUser.isSuperuser()
+  const isAssignedSuperuser =
+    currentUser.position?.authorizationGroupsAdministrated?.some(
+      aga => aga.uuid === authorizationGroup.uuid
+    )
+  const canEdit = currentUser.isAdmin() || isAssignedSuperuser
 
   return (
     <Formik enableReinitialize initialValues={authorizationGroup}>
@@ -116,6 +145,12 @@ const AuthorizationGroupShow = ({ pageDispatchers }) => {
                   name="status"
                   component={FieldHelper.ReadonlyField}
                   humanValue={AuthorizationGroup.humanNameOfStatus}
+                />
+              </Fieldset>
+
+              <Fieldset title="Assigned superusers">
+                <PositionTable
+                  positions={authorizationGroup.administrativePositions}
                 />
               </Fieldset>
 

--- a/client/stories/2-superuser/authorizationGroups.stories.mdx
+++ b/client/stories/2-superuser/authorizationGroups.stories.mdx
@@ -1,0 +1,12 @@
+import { Meta } from "@storybook/addon-docs"
+
+<Meta title="2. ANET Superuser Stories/My Authorization Groups" />
+
+## My Authorization Groups
+
+As stated in the [Authorization Groups for Sensitive information](/docs/0-anet-stories-sensitive-information-and-authorization-groups--docs#sensitive-information-and-authorization-groups)
+section, an administrator can define the available authorization groups, and assign superusers to
+manage them.
+
+If a superuser has been assigned administrative rights on authorization groups, these will be
+available as *My Authorization Groups* under the *My Work* section.

--- a/client/stories/3-admin/4-authorizationGroups.stories.mdx
+++ b/client/stories/3-admin/4-authorizationGroups.stories.mdx
@@ -17,6 +17,10 @@ choose. Add people, positions, and/or organizations belonging to the group. Acce
 to the people in the group, plus people currently occupying the positions in the group, plus people
 occupying positions in the organizations (including their sub-organization hierarchy) in the group.
 
+You can also assign superusers to an authorization group, which means they then have administrative
+rights on that group. The exceptions being that superusers cannot create new authorization groups,
+and they can't change the assigned superusers of groups they manage.
+
 Setting a group to *Inactive* means the group will no longer be shown to report authors when
 selecting groups for sensitive information text in an engagement report.
 

--- a/client/tests/webdriver/pages/createAuthorizationGroup.page.js
+++ b/client/tests/webdriver/pages/createAuthorizationGroup.page.js
@@ -41,9 +41,39 @@ class CreateAuthorizationGroup extends Page {
     return browser.$("#relatedObjects")
   }
 
+  async getRelatedObjectsTable() {
+    return browser.$(".related_objects_table")
+  }
+
+  async getRelatedObjectsTableEntry(relatedObjectText) {
+    return (await this.getRelatedObjectsTable()).$(
+      `//tr/td/span/a[text()="${relatedObjectText}"]`
+    )
+  }
+
   async getRelatedObjectsAdvancedSelectFirstItem() {
     return browser.$(
       "#entitySelect-popover tbody tr:first-child td:nth-child(2) span"
+    )
+  }
+
+  async getAdministrativePositionsInput() {
+    return browser.$("#administrativePositions")
+  }
+
+  async getAdministrativePositionsTable() {
+    return browser.$(".positions_table")
+  }
+
+  async getAdministrativePositionsTableEntry(administrativePositionText) {
+    return (await this.getAdministrativePositionsTable()).$(
+      `//tr/td/span/a[text()="${administrativePositionText}"]`
+    )
+  }
+
+  async getAdministrativePositionsAdvancedSelectFirstItem() {
+    return browser.$(
+      "#administrativePositions-popover tbody tr:first-child td:nth-child(2) span"
     )
   }
 
@@ -51,27 +81,39 @@ class CreateAuthorizationGroup extends Page {
     return browser.$("#formBottomSubmit")
   }
 
+  async getEditButton() {
+    return browser.$("//a[text()='Edit']")
+  }
+
+  async getMemberTypeButton(memberType) {
+    return browser.$(`button=${memberType}`)
+  }
+
+  async getMyAuthorizationGroups() {
+    return browser.$("#my-authorization-groups")
+  }
+
+  async getAuthorizationGroupLink(authorizationGroupName) {
+    return (await this.getMyAuthorizationGroups()).$(
+      `//tr/td/span/a[text()="${authorizationGroupName}"]`
+    )
+  }
+
   async open() {
     // Only admin users can create authorization groups
     await super.openAsAdminUser(PAGE_URL)
   }
 
-  async waitForRelatedObjectsAdvancedSelectToChange(value) {
-    await (await this.getRelatedObjectsAdvancedSelectFirstItem()).waitForExist()
+  async waitForAdvancedSelectToChange(value, getFirstItemCallback) {
+    await (await getFirstItemCallback()).waitForExist()
     return browser.waitUntil(
       async() => {
-        return (
-          (await (
-            await this.getRelatedObjectsAdvancedSelectFirstItem()
-          ).getText()) === value
-        )
+        return (await (await getFirstItemCallback()).getText()) === value
       },
       {
         timeout: 5000,
         timeoutMsg:
-          'Expected relatedObjects advanced select input to contain "' +
-          value +
-          '" after 5s'
+          'Expected advanced select input to contain "' + value + '" after 5s'
       }
     )
   }

--- a/src/main/java/mil/dds/anet/beans/AuthorizationGroup.java
+++ b/src/main/java/mil/dds/anet/beans/AuthorizationGroup.java
@@ -21,6 +21,8 @@ public class AuthorizationGroup extends AbstractAnetBean implements RelatableObj
   private String description;
   // annotated below
   private List<GenericRelatedObject> authorizationGroupRelatedObjects;
+  // annotated below
+  private List<Position> administrativePositions;
   @GraphQLQuery
   @GraphQLInputField
   private Status status;
@@ -61,6 +63,28 @@ public class AuthorizationGroup extends AbstractAnetBean implements RelatableObj
 
   public List<GenericRelatedObject> getAuthorizationGroupRelatedObjects() {
     return authorizationGroupRelatedObjects;
+  }
+
+  @GraphQLQuery(name = "administrativePositions")
+  public CompletableFuture<List<Position>> loadAdministrativePositions(
+      @GraphQLRootContext Map<String, Object> context) {
+    if (administrativePositions != null) {
+      return CompletableFuture.completedFuture(administrativePositions);
+    }
+    return AnetObjectEngine.getInstance().getAuthorizationGroupDao()
+        .getAdministrativePositionsForAuthorizationGroup(context, uuid).thenApply(o -> {
+          administrativePositions = o;
+          return o;
+        });
+  }
+
+  public List<Position> getAdministrativePositions() {
+    return administrativePositions;
+  }
+
+  @GraphQLInputField(name = "administrativePositions")
+  public void setAdministrativePositions(List<Position> positions) {
+    this.administrativePositions = positions;
   }
 
   @Override

--- a/src/main/java/mil/dds/anet/beans/Position.java
+++ b/src/main/java/mil/dds/anet/beans/Position.java
@@ -64,6 +64,8 @@ public class Position extends AbstractCustomizableAnetBean
   private List<Task> responsibleTasks;
   // annotated below
   private List<Organization> organizationsAdministrated;
+  // annotated below
+  private List<AuthorizationGroup> authorizationGroupsAdministrated;
 
   public String getName() {
     return name;
@@ -308,6 +310,15 @@ public class Position extends AbstractCustomizableAnetBean
           organizationsAdministrated = o;
           return o;
         });
+  }
+
+  @GraphQLQuery(name = "authorizationGroupsAdministrated")
+  public List<AuthorizationGroup> getAuthorizationGroupsAdministrated() {
+    if (authorizationGroupsAdministrated == null) {
+      authorizationGroupsAdministrated = AnetObjectEngine.getInstance().getAuthorizationGroupDao()
+          .getAuthorizationGroupsAdministratedByPosition(uuid);
+    }
+    return authorizationGroupsAdministrated;
   }
 
   @Override

--- a/src/main/java/mil/dds/anet/database/ReportDao.java
+++ b/src/main/java/mil/dds/anet/database/ReportDao.java
@@ -292,11 +292,12 @@ public class ReportDao extends AnetSubscribableObjectDao<Report, ReportSearchQue
   }
 
   @InTransaction
-  public int removeAuthorizationGroupFromReport(AuthorizationGroup a, Report r) {
+  public int removeAuthorizationGroupFromReport(String authorizationGroupUuid, String reportUuid) {
     return getDbHandle().createUpdate(
         "/* removeAuthorizationGroupFromReport*/ DELETE FROM \"reportAuthorizationGroups\" "
             + "WHERE \"reportUuid\" = :reportUuid AND \"authorizationGroupUuid\" = :authorizationGroupUuid")
-        .bind("reportUuid", r.getUuid()).bind("authorizationGroupUuid", a.getUuid()).execute();
+        .bind("reportUuid", reportUuid).bind("authorizationGroupUuid", authorizationGroupUuid)
+        .execute();
   }
 
   @InTransaction

--- a/src/main/java/mil/dds/anet/database/TaskDao.java
+++ b/src/main/java/mil/dds/anet/database/TaskDao.java
@@ -167,11 +167,11 @@ public class TaskDao extends AnetSubscribableObjectDao<Task, TaskSearchQuery> {
   }
 
   @InTransaction
-  public int removePositionFromTask(Position p, Task t) {
+  public int removePositionFromTask(String positionUuid, String taskUuid) {
     return getDbHandle()
         .createUpdate("/* removePositionFromTask*/ DELETE FROM \"taskResponsiblePositions\" "
             + "WHERE \"taskUuid\" = :taskUuid AND \"positionUuid\" = :positionUuid")
-        .bind("taskUuid", t.getUuid()).bind("positionUuid", p.getUuid()).execute();
+        .bind("taskUuid", taskUuid).bind("positionUuid", positionUuid).execute();
   }
 
   public CompletableFuture<List<Position>> getResponsiblePositionsForTask(
@@ -189,12 +189,12 @@ public class TaskDao extends AnetSubscribableObjectDao<Task, TaskSearchQuery> {
   }
 
   @InTransaction
-  public int removeTaskedOrganizationsFromTask(Organization o, String taskUuid) {
+  public int removeTaskedOrganizationsFromTask(String organizationUuid, String taskUuid) {
     return getDbHandle()
         .createUpdate(
             "/* removeTaskedOrganizationsFromTask*/ DELETE FROM \"taskTaskedOrganizations\" "
                 + "WHERE \"taskUuid\" = :taskUuid AND \"organizationUuid\" = :organizationUuid")
-        .bind("taskUuid", taskUuid).bind("organizationUuid", o.getUuid()).execute();
+        .bind("taskUuid", taskUuid).bind("organizationUuid", organizationUuid).execute();
   }
 
   public CompletableFuture<List<Organization>> getTaskedOrganizationsForTask(

--- a/src/main/java/mil/dds/anet/resources/AuthorizationGroupResource.java
+++ b/src/main/java/mil/dds/anet/resources/AuthorizationGroupResource.java
@@ -4,18 +4,22 @@ import io.leangen.graphql.annotations.GraphQLArgument;
 import io.leangen.graphql.annotations.GraphQLMutation;
 import io.leangen.graphql.annotations.GraphQLQuery;
 import io.leangen.graphql.annotations.GraphQLRootContext;
+import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response.Status;
 import mil.dds.anet.AnetObjectEngine;
 import mil.dds.anet.beans.AuthorizationGroup;
 import mil.dds.anet.beans.Person;
+import mil.dds.anet.beans.Position;
 import mil.dds.anet.beans.lists.AnetBeanList;
 import mil.dds.anet.beans.search.AuthorizationGroupSearchQuery;
 import mil.dds.anet.database.AuthorizationGroupDao;
 import mil.dds.anet.utils.AnetAuditLogger;
 import mil.dds.anet.utils.AuthUtils;
 import mil.dds.anet.utils.DaoUtils;
+import mil.dds.anet.utils.Utils;
 
 public class AuthorizationGroupResource {
 
@@ -44,29 +48,54 @@ public class AuthorizationGroupResource {
   @GraphQLMutation(name = "createAuthorizationGroup")
   public AuthorizationGroup createAuthorizationGroup(
       @GraphQLRootContext Map<String, Object> context,
-      @GraphQLArgument(name = "authorizationGroup") AuthorizationGroup t) {
+      @GraphQLArgument(name = "authorizationGroup") AuthorizationGroup a) {
     final Person user = DaoUtils.getUserFromContext(context);
     AuthUtils.assertAdministrator(user);
-    if (t.getName() == null || t.getName().trim().isEmpty()) {
+    if (a.getName() == null || a.getName().trim().isEmpty()) {
       throw new WebApplicationException("Authorization group name must not be empty",
           Status.BAD_REQUEST);
     }
-    t = dao.insert(t);
-    AnetAuditLogger.log("AuthorizationGroup {} created by {}", t, user);
-    return t;
+    a = dao.insert(a);
+
+    // Add administrative positions
+    dao.addAdministrativePositions(a.getUuid(), a.getAdministrativePositions());
+
+    AnetAuditLogger.log("AuthorizationGroup {} created by {}", a, user);
+    return a;
   }
 
   @GraphQLMutation(name = "updateAuthorizationGroup")
   public Integer updateAuthorizationGroup(@GraphQLRootContext Map<String, Object> context,
-      @GraphQLArgument(name = "authorizationGroup") AuthorizationGroup t) {
+      @GraphQLArgument(name = "authorizationGroup") AuthorizationGroup a) {
     final Person user = DaoUtils.getUserFromContext(context);
-    AuthUtils.assertAdministrator(user);
-    final int numRows = dao.update(t);
+    final List<Position> existingAdministrativePositions =
+        dao.getAdministrativePositionsForAuthorizationGroup(
+            AnetObjectEngine.getInstance().getContext(), DaoUtils.getUuid(a)).join();
+    // User has to be admin or must hold an administrative position for the authorizationGroup
+    if (!AuthUtils.isAdmin(user)) {
+      final Position userPosition = DaoUtils.getPosition(user);
+      final boolean canUpdate = existingAdministrativePositions.stream()
+          .anyMatch(p -> Objects.equals(DaoUtils.getUuid(p), DaoUtils.getUuid(userPosition)));
+      if (!canUpdate) {
+        throw new WebApplicationException(AuthUtils.UNAUTH_MESSAGE, Status.FORBIDDEN);
+      }
+    }
+
+    final int numRows = dao.update(a);
     if (numRows == 0) {
       throw new WebApplicationException("Couldn't process authorization group update",
           Status.NOT_FOUND);
     }
-    AnetAuditLogger.log("AuthorizationGroup {} updated by {}", t, user);
+
+    // Update administrative positions
+    if (a.getAdministrativePositions() != null) {
+      Utils.addRemoveElementsByUuid(existingAdministrativePositions, a.getAdministrativePositions(),
+          newPosition -> dao.addAdministrativePositions(a.getUuid(), List.of(newPosition)),
+          oldPositionUuid -> dao.removeAdministrativePositions(a.getUuid(),
+              List.of(oldPositionUuid)));
+    }
+
+    AnetAuditLogger.log("AuthorizationGroup {} updated by {}", a, user);
     // GraphQL mutations *have* to return something, so we return the number of updated rows
     return numRows;
   }

--- a/src/main/java/mil/dds/anet/resources/OrganizationResource.java
+++ b/src/main/java/mil/dds/anet/resources/OrganizationResource.java
@@ -167,9 +167,11 @@ public class OrganizationResource {
 
     if (org.getTasks() != null) {
       logger.debug("Editing tasks for {}", org);
-      Utils.addRemoveElementsByUuid(existing.loadTasks(engine.getContext()).join(), org.getTasks(),
+      final List<Task> existingTasks = existing.loadTasks(engine.getContext()).join();
+      Utils.addRemoveElementsByUuid(existingTasks, org.getTasks(),
           newTask -> engine.getTaskDao().addTaskedOrganizationsToTask(org, newTask),
-          oldTaskUuid -> engine.getTaskDao().removeTaskedOrganizationsFromTask(org, oldTaskUuid));
+          oldTaskUuid -> engine.getTaskDao().removeTaskedOrganizationsFromTask(org.getUuid(),
+              oldTaskUuid));
     }
 
     if (AuthUtils.isAdmin(user) && org.getAdministratingPositions() != null) {

--- a/src/main/java/mil/dds/anet/resources/TaskResource.java
+++ b/src/main/java/mil/dds/anet/resources/TaskResource.java
@@ -119,35 +119,18 @@ public class TaskResource {
       }
       // Update positions:
       if (t.getResponsiblePositions() != null) {
-        for (final Position p : t.getResponsiblePositions()) {
-          Optional<Position> existingPosition = existingResponsiblePositions.stream()
-              .filter(el -> el.getUuid().equals(p.getUuid())).findFirst();
-          if (existingPosition.isPresent()) {
-            existingResponsiblePositions.remove(existingPosition.get());
-          } else {
-            dao.addPositionToTask(p, t);
-          }
-        }
-        for (final Position p : existingResponsiblePositions) {
-          dao.removePositionFromTask(p, t);
-        }
+        Utils.addRemoveElementsByUuid(existingResponsiblePositions, t.getResponsiblePositions(),
+            newPos -> dao.addPositionToTask(newPos, t),
+            oldPosUuid -> dao.removePositionFromTask(oldPosUuid, t.getUuid()));
       }
+
       // Update tasked organizations:
       if (t.getTaskedOrganizations() != null) {
         final List<Organization> existingTaskedOrganizations =
             dao.getTaskedOrganizationsForTask(engine.getContext(), t.getUuid()).join();
-        for (final Organization org : t.getTaskedOrganizations()) {
-          Optional<Organization> existingOrganization = existingTaskedOrganizations.stream()
-              .filter(el -> el.getUuid().equals(org.getUuid())).findFirst();
-          if (existingOrganization.isPresent()) {
-            existingTaskedOrganizations.remove(existingOrganization.get());
-          } else {
-            dao.addTaskedOrganizationsToTask(org, t);
-          }
-        }
-        for (final Organization org : existingTaskedOrganizations) {
-          dao.removeTaskedOrganizationsFromTask(org, t.getUuid());
-        }
+        Utils.addRemoveElementsByUuid(existingTaskedOrganizations, t.getTaskedOrganizations(),
+            newOrg -> dao.addTaskedOrganizationsToTask(newOrg, t),
+            oldOrgUuid -> dao.removeTaskedOrganizationsFromTask(oldOrgUuid, t.getUuid()));
       }
 
       // Load the existing task, so we can check for differences.

--- a/src/main/java/mil/dds/anet/utils/BatchingUtils.java
+++ b/src/main/java/mil/dds/anet/utils/BatchingUtils.java
@@ -103,6 +103,13 @@ public final class BatchingUtils {
                 () -> engine.getAuthorizationGroupDao().getByIds(keys), dispatcherService),
             dataLoaderOptions));
     dataLoaderRegistry.register(
+        FkDataLoaderKey.AUTHORIZATION_GROUP_ADMINISTRATIVE_POSITIONS.toString(),
+        DataLoaderFactory.newDataLoader(
+            (BatchLoader<String, List<Position>>) foreignKeys -> CompletableFuture.supplyAsync(
+                () -> engine.getAuthorizationGroupDao().getAdministrativePositions(foreignKeys),
+                dispatcherService),
+            dataLoaderOptions));
+    dataLoaderRegistry.register(
         FkDataLoaderKey.AUTHORIZATION_GROUP_AUTHORIZATION_GROUP_RELATED_OBJECTS.toString(),
         DataLoaderFactory.newDataLoader(
             (BatchLoader<String, List<GenericRelatedObject>>) foreignKeys -> CompletableFuture

--- a/src/main/java/mil/dds/anet/utils/FkDataLoaderKey.java
+++ b/src/main/java/mil/dds/anet/utils/FkDataLoaderKey.java
@@ -5,6 +5,7 @@ public enum FkDataLoaderKey {
   APPROVAL_STEP_APPROVERS, // approvalStep.approvers
   ATTACHMENT_ATTACHMENT_RELATED_OBJECTS, // attachment.attachmentRelatedObjects
   ATTACHMENT_RELATED_OBJECT_ATTACHMENTS, // attachmentRelatedObject.attachments
+  AUTHORIZATION_GROUP_ADMINISTRATIVE_POSITIONS, // authorizationGroup.administrativePositions
   AUTHORIZATION_GROUP_AUTHORIZATION_GROUP_RELATED_OBJECTS, // authorizationGroup.authorizationGroupRelatedObjects
   NOTE_NOTE_RELATED_OBJECTS, // note.noteRelatedObjects
   NOTE_RELATED_OBJECT_NOTES, // noteRelatedObject.notes

--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -4676,4 +4676,48 @@
 		</createIndex>
 	</changeSet>
 
+	<changeSet id="add_authorizationGroup_administrative_positions" author="gjvoosten">
+		<createTable tableName="authorizationGroupAdministrativePositions">
+			<column name="authorizationGroupUuid" type="${uuid_type}">
+				<constraints nullable="false"/>
+			</column>
+			<column name="positionUuid" type="${uuid_type}">
+				<constraints nullable="false"/>
+			</column>
+		</createTable>
+		<addUniqueConstraint
+			tableName="authorizationGroupAdministrativePositions"
+			columnNames="authorizationGroupUuid, positionUuid"
+			constraintName="UQ_uniqueAuthorizationGroupAdministrativePositions"
+		/>
+		<addForeignKeyConstraint
+			baseColumnNames="authorizationGroupUuid"
+			baseTableName="authorizationGroupAdministrativePositions"
+			constraintName="FK_authorizationGroupAdministrativePositions_authorizationGroup"
+			referencedColumnNames="uuid"
+			referencedTableName="authorizationGroups"
+			onDelete="NO ACTION" onUpdate="NO ACTION"
+		/>
+		<addForeignKeyConstraint
+			constraintName="FK_authorizationGroupAdministrativePositions_position"
+			baseColumnNames="positionUuid"
+			baseTableName="authorizationGroupAdministrativePositions"
+			referencedColumnNames="uuid"
+			referencedTableName="positions"
+			onDelete="NO ACTION" onUpdate="NO ACTION"
+		/>
+		<createIndex
+			indexName="IDX_authorizationGroupAdministrativePositions_authorizationGroupUuid"
+			tableName="authorizationGroupAdministrativePositions"
+		>
+			<column name="authorizationGroupUuid"/>
+		</createIndex>
+		<createIndex
+			indexName="IDX_authorizationGroupAdministrativePositions_positionUuid"
+			tableName="authorizationGroupAdministrativePositions"
+		>
+			<column name="positionUuid"/>
+		</createIndex>
+	</changeSet>
+
 </databaseChangeLog>

--- a/src/test/java/mil/dds/anet/test/resources/AbstractResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/AbstractResourceTest.java
@@ -27,6 +27,8 @@ import mil.dds.anet.database.mappers.MapperUtils;
 import mil.dds.anet.test.client.AnetBeanList_Person;
 import mil.dds.anet.test.client.ApprovalStep;
 import mil.dds.anet.test.client.ApprovalStepInput;
+import mil.dds.anet.test.client.AuthorizationGroup;
+import mil.dds.anet.test.client.AuthorizationGroupInput;
 import mil.dds.anet.test.client.Location;
 import mil.dds.anet.test.client.LocationInput;
 import mil.dds.anet.test.client.Note;
@@ -302,6 +304,11 @@ public abstract class AbstractResourceTest {
   protected static List<ApprovalStepInput> getApprovalStepsInput(
       final List<ApprovalStep> approvalSteps) {
     return approvalSteps.stream().map(as -> getApprovalStepInput(as)).collect(Collectors.toList());
+  }
+
+  protected static AuthorizationGroupInput getAuthorizationGroupInput(
+      final AuthorizationGroup authorizationGroup) {
+    return getInput(authorizationGroup, AuthorizationGroupInput.class);
   }
 
   protected static LocationInput getLocationInput(final Location location) {

--- a/src/test/java/mil/dds/anet/test/resources/AuthorizationGroupResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/AuthorizationGroupResourceTest.java
@@ -1,0 +1,137 @@
+package mil.dds.anet.test.resources;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Fail.fail;
+
+import com.graphql_java_generator.exception.GraphQLRequestExecutionException;
+import com.graphql_java_generator.exception.GraphQLRequestPreparationException;
+import java.util.List;
+import javax.ws.rs.ForbiddenException;
+import mil.dds.anet.database.OrganizationDao;
+import mil.dds.anet.database.PersonDao;
+import mil.dds.anet.database.PositionDao;
+import mil.dds.anet.test.client.AuthorizationGroup;
+import mil.dds.anet.test.client.AuthorizationGroupInput;
+import mil.dds.anet.test.client.GenericRelatedObjectInput;
+import mil.dds.anet.test.client.Status;
+import mil.dds.anet.test.client.util.MutationExecutor;
+import org.junit.jupiter.api.Test;
+
+class AuthorizationGroupResourceTest extends AbstractResourceTest {
+  private static final String FIELDS = "{ uuid name description status"
+      + " administrativePositions { uuid name code type role status location { uuid name }"
+      + " organization { uuid shortName longName identificationCode }"
+      + " person { uuid name rank avatarUuid } }"
+      + " authorizationGroupRelatedObjects { relatedObjectType relatedObjectUuid"
+      + " relatedObject { " + "... on Organization { uuid shortName longName identificationCode }"
+      + " ... on Person { uuid name rank avatarUuid }"
+      + " ... on Position { uuid type name } } } }";
+
+  @Test
+  void testCreateAsAdmin()
+      throws GraphQLRequestPreparationException, GraphQLRequestExecutionException {
+    final AuthorizationGroupInput authorizationGroupInput = getAuthorizationGroupInput();
+    final AuthorizationGroup authorizationGroup =
+        adminMutationExecutor.createAuthorizationGroup(FIELDS, authorizationGroupInput);
+    assertThat(authorizationGroup).isNotNull();
+    assertThat(authorizationGroup.getUuid()).isNotNull();
+    assertThat(authorizationGroup.getAdministrativePositions())
+        .hasSameSizeAs(authorizationGroupInput.getAdministrativePositions());
+    assertThat(authorizationGroup.getAuthorizationGroupRelatedObjects())
+        .hasSameSizeAs(authorizationGroupInput.getAuthorizationGroupRelatedObjects());
+  }
+
+  @Test
+  void testCreateAsSuperuser()
+      throws GraphQLRequestPreparationException, GraphQLRequestExecutionException {
+    final MutationExecutor superuserMutationExecutor =
+        getMutationExecutor(getSuperuser().getDomainUsername());
+    final AuthorizationGroupInput authorizationGroupInput = getAuthorizationGroupInput();
+    try {
+      superuserMutationExecutor.createAuthorizationGroup(FIELDS, authorizationGroupInput);
+      fail("Expected ForbiddenException");
+    } catch (ForbiddenException expectedException) {
+    }
+  }
+
+  @Test
+  void testEditAsWrongSuperuser()
+      throws GraphQLRequestPreparationException, GraphQLRequestExecutionException {
+    final MutationExecutor superuserMutationExecutor = getMutationExecutor("jacob");
+    final AuthorizationGroupInput authorizationGroupInput = getAuthorizationGroupInput();
+    final AuthorizationGroup authorizationGroup =
+        adminMutationExecutor.createAuthorizationGroup(FIELDS, authorizationGroupInput);
+    assertThat(authorizationGroup).isNotNull();
+    try {
+      superuserMutationExecutor.updateAuthorizationGroup("",
+          getAuthorizationGroupInput(authorizationGroup));
+      fail("Expected ForbiddenException");
+    } catch (ForbiddenException expectedException) {
+    }
+  }
+
+  @Test
+  void testEditAsSuperuser()
+      throws GraphQLRequestPreparationException, GraphQLRequestExecutionException {
+    final MutationExecutor superuserMutationExecutor =
+        getMutationExecutor(getSuperuser().getDomainUsername());
+    final AuthorizationGroupInput authorizationGroupInput = getAuthorizationGroupInput();
+    final AuthorizationGroup authorizationGroup =
+        adminMutationExecutor.createAuthorizationGroup(FIELDS, authorizationGroupInput);
+    assertThat(authorizationGroup).isNotNull();
+    final AuthorizationGroupInput updatedAuthorizationGroupInput =
+        getAuthorizationGroupInput(authorizationGroup);
+    updatedAuthorizationGroupInput.getAuthorizationGroupRelatedObjects().remove(0);
+    updatedAuthorizationGroupInput.getAdministrativePositions().remove(0);
+    final Integer nrUpdated =
+        superuserMutationExecutor.updateAuthorizationGroup("", updatedAuthorizationGroupInput);
+    assertThat(nrUpdated).isOne();
+    final AuthorizationGroup updatedAuthorizationGroup =
+        adminQueryExecutor.authorizationGroup(FIELDS, authorizationGroup.getUuid());
+    assertThat(updatedAuthorizationGroup.getAdministrativePositions())
+        .hasSize(authorizationGroupInput.getAdministrativePositions().size() - 1);
+    assertThat(updatedAuthorizationGroup.getAuthorizationGroupRelatedObjects())
+        .hasSize(authorizationGroupInput.getAuthorizationGroupRelatedObjects().size() - 1);
+  }
+
+  @Test
+  void testCreateAsUser()
+      throws GraphQLRequestPreparationException, GraphQLRequestExecutionException {
+    final AuthorizationGroupInput authorizationGroupInput = getAuthorizationGroupInput();
+    try {
+      jackMutationExecutor.createAuthorizationGroup(FIELDS, authorizationGroupInput);
+      fail("Expected ForbiddenException");
+    } catch (ForbiddenException expectedException) {
+    }
+  }
+
+  @Test
+  void testEditAsUser()
+      throws GraphQLRequestPreparationException, GraphQLRequestExecutionException {
+    final AuthorizationGroupInput authorizationGroupInput = getAuthorizationGroupInput();
+    final AuthorizationGroup authorizationGroup =
+        adminMutationExecutor.createAuthorizationGroup(FIELDS, authorizationGroupInput);
+    assertThat(authorizationGroup).isNotNull();
+    try {
+      jackMutationExecutor.updateAuthorizationGroup("",
+          getAuthorizationGroupInput(authorizationGroup));
+      fail("Expected ForbiddenException");
+    } catch (ForbiddenException expectedException) {
+    }
+  }
+
+  private static AuthorizationGroupInput getAuthorizationGroupInput() {
+    return AuthorizationGroupInput.builder().withName("test authorization group")
+        .withDescription("test authorization group description").withStatus(Status.ACTIVE)
+        .withAdministrativePositions(
+            getPositionsInput(List.of(admin.getPosition(), getSuperuser().getPosition())))
+        .withAuthorizationGroupRelatedObjects(List.of(
+            GenericRelatedObjectInput.builder().withRelatedObjectType(PositionDao.TABLE_NAME)
+                .withRelatedObjectUuid(getRegularUser().getPosition().getUuid()).build(),
+            GenericRelatedObjectInput.builder().withRelatedObjectType(PersonDao.TABLE_NAME)
+                .withRelatedObjectUuid(getElizabethElizawell().getUuid()).build(),
+            GenericRelatedObjectInput.builder().withRelatedObjectType(OrganizationDao.TABLE_NAME)
+                .withRelatedObjectUuid(admin.getPosition().getOrganization().getUuid()).build()))
+        .build();
+  }
+}

--- a/src/test/resources/anet.graphql
+++ b/src/test/resources/anet.graphql
@@ -215,6 +215,7 @@ input AttachmentInput {
 
 """"""
 type AuthorizationGroup {
+  administrativePositions: [Position]
   authorizationGroupRelatedObjects: [GenericRelatedObject]
   createdAt: Instant
   description: String
@@ -226,6 +227,7 @@ type AuthorizationGroup {
 
 """"""
 input AuthorizationGroupInput {
+  administrativePositions: [PositionInput]
   authorizationGroupRelatedObjects: [GenericRelatedObjectInput]
   createdAt: Instant
   description: String
@@ -661,6 +663,7 @@ enum PersonSearchSortBy {
 type Position {
   associatedPositions: [Position]
   attachments: [Attachment]
+  authorizationGroupsAdministrated: [AuthorizationGroup]
   code: String
   createdAt: Instant
   customFields: String


### PR DESCRIPTION
Allow admins to assign superusers to administrate authorization groups, and allow supersusers to manage their authorization groups.

Closes [AB#964](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/964)

#### User changes
- None

#### Superuser changes
- When an admin assigns a superuser to have administrative rights on an authorization group, that superuser can manage it.

#### Admin changes
- An admin can assign superusers administrative rights on authorization groups.

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [x] db needs migration
- [x] documentation has changed
- [x] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [x] Added and/or updated unit tests
  - [x] Added and/or updated e2e tests
  - [x] Added and/or updated data migrations
  - [x] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here