### PR TITLE
Show authorizationGroups for people, positions and organizations

### DIFF
--- a/anet-dictionary.yml
+++ b/anet-dictionary.yml
@@ -639,6 +639,8 @@ fields:
     biography:
       label: Biography
       placeholder: Fill in the biography of this person
+    authorizationGroups:
+      label: Authorization groups
     customFields:
       placeOfBirth:
         type: anet_object
@@ -888,6 +890,8 @@ fields:
         member: Member
         deputy: Deputy
         leader: Leader
+    authorizationGroups:
+      label: Authorization groups
 
     customFields:
       multipleButtons:
@@ -994,6 +998,8 @@ fields:
     profile:
       label: Profile
       placeholder: Fill in the profile of this organization
+    authorizationGroups:
+      label: Authorization groups
     assessments:
       organizationAnnually:
         label: Interaction Plan
@@ -1157,6 +1163,7 @@ fields:
         - user
         - domainUsername
         - openIdSubject
+        - authorizationGroups
         - emailAddress
         - multipleButtons
         - inputFieldName

--- a/client/src/components/AuthorizationGroupTable.js
+++ b/client/src/components/AuthorizationGroupTable.js
@@ -12,6 +12,8 @@ import Settings from "settings"
 const AuthorizationGroupTable = ({
   id,
   authorizationGroups,
+  showMembers,
+  showStatus,
   pageSize,
   pageNum,
   totalCount,
@@ -28,13 +30,17 @@ const AuthorizationGroupTable = ({
         <tr>
           <th>{Settings.fields.authorizationGroup.name?.label}</th>
           <th>{Settings.fields.authorizationGroup.description?.label}</th>
-          <th>
-            {
-              Settings.fields.authorizationGroup
-                .authorizationGroupRelatedObjects?.label
-            }
-          </th>
-          <th>{Settings.fields.authorizationGroup.status?.label}</th>
+          {showMembers && (
+            <th>
+              {
+                Settings.fields.authorizationGroup
+                  .authorizationGroupRelatedObjects?.label
+              }
+            </th>
+          )}
+          {showStatus && (
+            <th>{Settings.fields.authorizationGroup.status?.label}</th>
+          )}
         </tr>
       </thead>
 
@@ -48,17 +54,21 @@ const AuthorizationGroupTable = ({
               />
             </td>
             <td>{authorizationGroup.description}</td>
-            <td>
-              {authorizationGroup.authorizationGroupRelatedObjects.map(agro => (
-                <div key={agro.relatedObjectUuid}>
-                  <LinkTo
-                    modelType={agro.relatedObjectType}
-                    model={agro.relatedObject}
-                  />
-                </div>
-              ))}
-            </td>
-            <td>{authorizationGroup.humanNameOfStatus()} </td>
+            {showMembers && (
+              <td>
+                {authorizationGroup.authorizationGroupRelatedObjects.map(
+                  agro => (
+                    <div key={agro.relatedObjectUuid}>
+                      <LinkTo
+                        modelType={agro.relatedObjectType}
+                        model={agro.relatedObject}
+                      />
+                    </div>
+                  )
+                )}
+              </td>
+            )}
+            {showStatus && <td>{authorizationGroup.humanNameOfStatus()} </td>}
           </tr>
         ))}
       </tbody>
@@ -86,6 +96,9 @@ AuthorizationGroupTable.propTypes = {
   id: PropTypes.string,
   // list of authorizationGroups:
   authorizationGroups: PropTypes.array.isRequired,
+  // optional columns
+  showMembers: PropTypes.bool,
+  showStatus: PropTypes.bool,
   // fill these when pagination wanted:
   totalCount: PropTypes.number,
   pageNum: PropTypes.number,

--- a/client/src/components/Model.js
+++ b/client/src/components/Model.js
@@ -614,7 +614,8 @@ export default class Model {
       // No groups defined means: anybody has read access, nobody has write access
       return forReading
     }
-    const userAuthorizationGroupUuids = user?.authorizationGroupUuids ?? []
+    const userAuthorizationGroupUuids =
+      user?.authorizationGroups?.map(ag => ag.uuid) ?? []
     return !!authorizationGroupUuids?.some(ag =>
       userAuthorizationGroupUuids.includes(ag)
     )
@@ -961,10 +962,13 @@ export default class Model {
       return true
     }
     // Else user has to be in the authorizationGroups
-    const userAuthGroupUuids = user?.authorizationGroupUuids ?? []
+    const userAuthorizationGroupUuids =
+      user?.authorizationGroups?.map(ag => ag.uuid) ?? []
     const fieldAuthGroupUuids =
       customSensitiveInformationField?.authorizationGroupUuids || []
-    return fieldAuthGroupUuids.some(uuid => userAuthGroupUuids.includes(uuid))
+    return fieldAuthGroupUuids.some(uuid =>
+      userAuthorizationGroupUuids.includes(uuid)
+    )
   }
 
   static getAuthorizedSensitiveFields(

--- a/client/src/models/Person.js
+++ b/client/src/models/Person.js
@@ -465,7 +465,7 @@ export default class Person extends Model {
   static FILTERED_CLIENT_SIDE_FIELDS = [
     "firstName",
     "lastName",
-    "authorizationGroupUuids"
+    "authorizationGroups"
   ]
 
   static filterClientSideFields(obj, ...additionalFields) {

--- a/client/src/pages/App.js
+++ b/client/src/pages/App.js
@@ -37,7 +37,9 @@ const GQL_GET_APP_DATA = gql`
       emailAddress
       pendingVerification
       code
-      authorizationGroupUuids
+      authorizationGroups {
+        uuid
+      }
       position {
         uuid
         name

--- a/client/src/pages/authorizationGroups/MyAuthorizationGroups.js
+++ b/client/src/pages/authorizationGroups/MyAuthorizationGroups.js
@@ -78,6 +78,8 @@ const MyAuthorizationGroups = ({ pageDispatchers }) => {
       >
         <AuthorizationGroupTable
           authorizationGroups={authorizationGroupsAdministrated}
+          showMembers
+          showStatus
         />
       </Fieldset>
     </div>

--- a/client/src/pages/organizations/Show.js
+++ b/client/src/pages/organizations/Show.js
@@ -5,6 +5,7 @@ import AppContext from "components/AppContext"
 import Approvals from "components/approvals/Approvals"
 import AssessmentResultsContainer from "components/assessments/AssessmentResultsContainer"
 import AttachmentCard from "components/Attachment/AttachmentCard"
+import AuthorizationGroupTable from "components/AuthorizationGroupTable"
 import { ReadonlyCustomFields } from "components/CustomFields"
 import DictionaryField from "components/DictionaryField"
 import * as FieldHelper from "components/FieldHelper"
@@ -153,6 +154,11 @@ const GQL_GET_ORGANIZATION = gql`
             ...personFields
           }
         }
+      }
+      authorizationGroups {
+        uuid
+        name
+        description
       }
       attachments {
         ${Attachment.basicFieldsQuery}
@@ -437,6 +443,18 @@ const OrganizationShow = ({ pageDispatchers }) => {
                     }
                   />
                 )}
+
+                <DictionaryField
+                  wrappedComponent={Field}
+                  dictProps={Settings.fields.organization.authorizationGroups}
+                  name="authorizationGroups"
+                  component={FieldHelper.ReadonlyField}
+                  humanValue={
+                    <AuthorizationGroupTable
+                      authorizationGroups={organization.authorizationGroups}
+                    />
+                  }
+                />
 
                 <DictionaryField
                   wrappedComponent={Field}

--- a/client/src/pages/people/Show.js
+++ b/client/src/pages/people/Show.js
@@ -7,6 +7,7 @@ import AppContext from "components/AppContext"
 import AssessmentResultsContainer from "components/assessments/AssessmentResultsContainer"
 import AssignPositionModal from "components/AssignPositionModal"
 import AttachmentCard from "components/Attachment/AttachmentCard"
+import AuthorizationGroupTable from "components/AuthorizationGroupTable"
 import { mapReadonlyCustomFieldsToComps } from "components/CustomFields"
 import DictionaryField from "components/DictionaryField"
 import EditAssociatedPositionsModal from "components/EditAssociatedPositionsModal"
@@ -116,6 +117,11 @@ const GQL_GET_PERSON = gql`
           uuid
           name
         }
+      }
+      authorizationGroups {
+        uuid
+        name
+        description
       }
       attachments {
         ${Attachment.basicFieldsQuery}
@@ -503,6 +509,11 @@ const PersonShow = ({ pageDispatchers }) => {
 
     // map fields that have specific human value
     const humanValuesExceptions = {
+      authorizationGroups: (
+        <AuthorizationGroupTable
+          authorizationGroups={person.authorizationGroups}
+        />
+      ),
       biography: <RichTextEditor readOnly value={person.biography} />,
       user: utils.formatBoolean(person.user),
       emailAddress: emailHumanValue,

--- a/client/src/pages/positions/Show.js
+++ b/client/src/pages/positions/Show.js
@@ -4,6 +4,7 @@ import API from "api"
 import AppContext from "components/AppContext"
 import AssignPersonModal from "components/AssignPersonModal"
 import AssociatedPositions from "components/AssociatedPositions"
+import AuthorizationGroupTable from "components/AuthorizationGroupTable"
 import ConfirmDestructive from "components/ConfirmDestructive"
 import { ReadonlyCustomFields } from "components/CustomFields"
 import DictionaryField from "components/DictionaryField"
@@ -41,6 +42,11 @@ const GQL_GET_POSITION = gql`
   query($uuid: String!) {
     position(uuid: $uuid) {
       ${Position.allFieldsQuery}
+      authorizationGroups {
+        uuid
+        name
+        description
+      }
     }
   }
 `
@@ -233,6 +239,18 @@ const PositionShow = ({ pageDispatchers }) => {
                   dictProps={Settings.fields.position.code}
                   name="code"
                   component={FieldHelper.ReadonlyField}
+                />
+
+                <DictionaryField
+                  wrappedComponent={Field}
+                  dictProps={Settings.fields.position.authorizationGroups}
+                  name="authorizationGroups"
+                  component={FieldHelper.ReadonlyField}
+                  humanValue={
+                    <AuthorizationGroupTable
+                      authorizationGroups={position.authorizationGroups}
+                    />
+                  }
                 />
 
                 <DictionaryField

--- a/client/src/pages/searches/Search.js
+++ b/client/src/pages/searches/Search.js
@@ -669,6 +669,8 @@ const AuthorizationGroups = ({
   return (
     <AuthorizationGroupTable
       authorizationGroups={authorizationGroups}
+      showMembers
+      showStatus
       pageSize={pageSize}
       pageNum={curPage}
       totalCount={totalCount}

--- a/client/tests/webdriver/baseSpecs/showOrganization.spec.js
+++ b/client/tests/webdriver/baseSpecs/showOrganization.spec.js
@@ -4,6 +4,7 @@ import Search from "../pages/search.page"
 import ShowOrganization from "../pages/showOrganization.page"
 
 const ORGANIZATION_UUID = "ccbee4bb-08b8-42df-8cb5-65e8172f657b" // EF 2.2
+const ORGANIZATION_WITH_AG_UUID = "7f939a44-b9e4-48e0-98f5-7d0ea38a6ecf" // EF 5.1
 const ORGANIZATION_EF2_SEARCH_STRING = "EF 2"
 const ORGANIZATION_EF22_SEARCH_STRING = "EF 2.2"
 const LEADER_POSITION_TEXT = "EF 2.2 Final Reviewer"
@@ -99,6 +100,27 @@ describe("Show organization page", () => {
 
       // Log out
       await ShowOrganization.logout()
+    })
+  })
+
+  describe("When on the show page of an organization with authorizationGroup(s)", () => {
+    it("We should see a table with authorizationGroups", async() => {
+      await ShowOrganization.open(ORGANIZATION_WITH_AG_UUID)
+      await (
+        await ShowOrganization.getAuthorizationGroupsTable()
+      ).waitForExist()
+      await (
+        await ShowOrganization.getAuthorizationGroupsTable()
+      ).waitForDisplayed()
+      expect(
+        await (await ShowOrganization.getAuthorizationGroupsTable()).getText()
+      ).to.contain("EF 5")
+    })
+    it("We can go to the show page of authorizationGroup", async() => {
+      await (await ShowOrganization.getAuthorizationGroup(1)).click()
+      await expect(await browser.getUrl()).to.include(
+        "/authorizationGroups/ab1a7d99-4529-44b1-a118-bdee3ca8296b"
+      )
     })
   })
 

--- a/client/tests/webdriver/baseSpecs/showPerson.spec.js
+++ b/client/tests/webdriver/baseSpecs/showPerson.spec.js
@@ -2,8 +2,26 @@ import { expect } from "chai"
 import ShowPerson from "../pages/showPerson.page"
 
 const PERSON_UUID = "df9c7381-56ac-4bc5-8e24-ec524bccd7e9"
+const PERSON_WITH_AG_UUID = "31cba227-f6c6-49e9-9483-fce441bea624" // CIV BRATTON, Creed
 
 describe("Show person page", () => {
+  describe("When on the show page of a person with authorizationGroup(s)", () => {
+    it("We should see a table with authorizationGroups", async() => {
+      await ShowPerson.open(PERSON_WITH_AG_UUID)
+      await (await ShowPerson.getAuthorizationGroupsTable()).waitForExist()
+      await (await ShowPerson.getAuthorizationGroupsTable()).waitForDisplayed()
+      expect(
+        await (await ShowPerson.getAuthorizationGroupsTable()).getText()
+      ).to.contain("EF 5")
+    })
+    it("We can go to the show page of authorizationGroup", async() => {
+      await (await ShowPerson.getAuthorizationGroup(1)).click()
+      await expect(await browser.getUrl()).to.include(
+        "/authorizationGroups/ab1a7d99-4529-44b1-a118-bdee3ca8296b"
+      )
+    })
+  })
+
   describe("When on the show page of a person with attachment(s)", () => {
     it("We should see a container for Attachment List", async() => {
       await ShowPerson.open(PERSON_UUID)

--- a/client/tests/webdriver/baseSpecs/showPosition.spec.js
+++ b/client/tests/webdriver/baseSpecs/showPosition.spec.js
@@ -1,0 +1,25 @@
+import { expect } from "chai"
+import ShowPosition from "../pages/showPosition.page"
+
+const POSITION_WITH_AG_UUID = "05c42ce0-34a0-4391-8b2f-c4cd85ee6b47" // EF 5.1 Advisor Quality Assurance
+
+describe("Show position page", () => {
+  describe("When on the show page of a position with authorizationGroup(s)", () => {
+    it("We should see a table with authorizationGroups", async() => {
+      await ShowPosition.open(POSITION_WITH_AG_UUID)
+      await (await ShowPosition.getAuthorizationGroupsTable()).waitForExist()
+      await (
+        await ShowPosition.getAuthorizationGroupsTable()
+      ).waitForDisplayed()
+      expect(
+        await (await ShowPosition.getAuthorizationGroupsTable()).getText()
+      ).to.contain("EF 5")
+    })
+    it("We can go to the show page of authorizationGroup", async() => {
+      await (await ShowPosition.getAuthorizationGroup(1)).click()
+      await expect(await browser.getUrl()).to.include(
+        "/authorizationGroups/ab1a7d99-4529-44b1-a118-bdee3ca8296b"
+      )
+    })
+  })
+})

--- a/client/tests/webdriver/pages/showOrganization.page.js
+++ b/client/tests/webdriver/pages/showOrganization.page.js
@@ -175,6 +175,15 @@ class ShowOrganization extends Page {
       timeout: 20000
     })
   }
+
+  async getAuthorizationGroupsTable() {
+    return browser.$("#authorizationGroups table")
+  }
+
+  async getAuthorizationGroup(i) {
+    const agTable = await this.getAuthorizationGroupsTable()
+    return agTable.$(`tbody tr:nth-child(${i}) td:first-child a`)
+  }
 }
 
 export default new ShowOrganization()

--- a/client/tests/webdriver/pages/showPerson.page.js
+++ b/client/tests/webdriver/pages/showPerson.page.js
@@ -223,6 +223,15 @@ class ShowPerson extends Page {
       await this.getInvalidFeedback()
     ).map(async errorDiv => await errorDiv.getText())
   }
+
+  async getAuthorizationGroupsTable() {
+    return browser.$("#authorizationGroups table")
+  }
+
+  async getAuthorizationGroup(i) {
+    const agTable = await this.getAuthorizationGroupsTable()
+    return agTable.$(`tbody tr:nth-child(${i}) td:first-child a`)
+  }
 }
 
 export default new ShowPerson()

--- a/client/tests/webdriver/pages/showPosition.page.js
+++ b/client/tests/webdriver/pages/showPosition.page.js
@@ -1,0 +1,20 @@
+import Page from "./page"
+
+const PAGE_URL = "/positions/:uuid"
+
+class ShowPosition extends Page {
+  async open(uuid) {
+    await super.open(PAGE_URL.replace(":uuid", uuid))
+  }
+
+  async getAuthorizationGroupsTable() {
+    return browser.$("#authorizationGroups table")
+  }
+
+  async getAuthorizationGroup(i) {
+    const agTable = await this.getAuthorizationGroupsTable()
+    return agTable.$(`tbody tr:nth-child(${i}) td:first-child a`)
+  }
+}
+
+export default new ShowPosition()

--- a/insertBaseData-psql.sql
+++ b/insertBaseData-psql.sql
@@ -889,6 +889,7 @@ INSERT INTO "authorizationGroups" (uuid, name, description, status, "createdAt",
   ('1050c9e3-e679-4c60-8bdc-5139fbc1c10b', 'EF 1.1', 'The complete EF 1.1 organisation', 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
   ('39a78d51-c351-452c-9206-4305ec8dd76d', 'EF 2.1', 'The complete EF 2.1 organisation', 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
   ('c21e7321-7ec5-4837-8805-a302f9575754', 'EF 2.2', 'The complete EF 2.2 organisation', 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+  ('ab1a7d99-4529-44b1-a118-bdee3ca8296b', 'EF 5', 'The complete EF 5 organization', 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
   ('90a5196d-acf3-4a81-8ff9-3a8c7acabdf3', 'Inactive positions', 'Inactive positions', 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
 
 -- Authorization group members
@@ -904,6 +905,10 @@ INSERT INTO "authorizationGroupRelatedObjects" ("authorizationGroupUuid", "relat
   SELECT 'c21e7321-7ec5-4837-8805-a302f9575754', 'organizations', o.uuid
   FROM organizations o
   WHERE o."shortName" = 'EF 2.2';
+INSERT INTO "authorizationGroupRelatedObjects" ("authorizationGroupUuid", "relatedObjectType", "relatedObjectUuid")
+  SELECT 'ab1a7d99-4529-44b1-a118-bdee3ca8296b', 'organizations', o.uuid
+  FROM organizations o
+  WHERE o."shortName" = 'EF 5';
 INSERT INTO "authorizationGroupRelatedObjects" ("authorizationGroupUuid", "relatedObjectType", "relatedObjectUuid")
   SELECT '90a5196d-acf3-4a81-8ff9-3a8c7acabdf3', 'positions', p.uuid
   FROM positions p

--- a/src/main/java/mil/dds/anet/beans/Organization.java
+++ b/src/main/java/mil/dds/anet/beans/Organization.java
@@ -8,6 +8,7 @@ import io.leangen.graphql.annotations.GraphQLRootContext;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import mil.dds.anet.AnetObjectEngine;
 import mil.dds.anet.beans.search.FkBatchParams;
@@ -17,6 +18,8 @@ import mil.dds.anet.beans.search.OrganizationSearchQuery;
 import mil.dds.anet.beans.search.PositionSearchQuery;
 import mil.dds.anet.beans.search.RecursiveFkBatchParams;
 import mil.dds.anet.beans.search.TaskSearchQuery;
+import mil.dds.anet.database.AuthorizationGroupDao;
+import mil.dds.anet.database.OrganizationDao;
 import mil.dds.anet.utils.IdDataLoaderKey;
 import mil.dds.anet.utils.Utils;
 import mil.dds.anet.views.AbstractCustomizableAnetBean;
@@ -56,6 +59,8 @@ public class Organization extends AbstractCustomizableAnetBean
   List<Task> tasks;
   // annotated below
   List<Position> administratingPositions;
+  // annotated below
+  private List<AuthorizationGroup> authorizationGroups;
 
   @GraphQLQuery(name = "location")
   public CompletableFuture<Location> loadLocation(@GraphQLRootContext Map<String, Object> context) {
@@ -307,6 +312,21 @@ public class Organization extends AbstractCustomizableAnetBean
   @GraphQLInputField(name = "administratingPositions")
   public void setAdministratingPositions(List<Position> administratingPositions) {
     this.administratingPositions = administratingPositions;
+  }
+
+  @GraphQLQuery(name = "authorizationGroups")
+  public List<AuthorizationGroup> loadAuthorizationGroups() {
+    if (authorizationGroups == null) {
+      AuthorizationGroupDao authorizationGroupDao =
+          AnetObjectEngine.getInstance().getAuthorizationGroupDao();
+      final Set<String> authorizationGroupUuids = authorizationGroupDao
+          .getAuthorizationGroupUuidsForRelatedObject(OrganizationDao.TABLE_NAME, uuid);
+      if (authorizationGroupUuids != null) {
+        authorizationGroups = AnetObjectEngine.getInstance().getAuthorizationGroupDao()
+            .getByIds(authorizationGroupUuids.stream().toList());
+      }
+    }
+    return authorizationGroups;
   }
 
   @Override

--- a/src/main/java/mil/dds/anet/beans/Position.java
+++ b/src/main/java/mil/dds/anet/beans/Position.java
@@ -8,11 +8,14 @@ import io.leangen.graphql.annotations.GraphQLRootContext;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import mil.dds.anet.AnetObjectEngine;
 import mil.dds.anet.beans.search.M2mBatchParams;
 import mil.dds.anet.beans.search.OrganizationSearchQuery;
 import mil.dds.anet.beans.search.TaskSearchQuery;
+import mil.dds.anet.database.AuthorizationGroupDao;
+import mil.dds.anet.database.PositionDao;
 import mil.dds.anet.utils.IdDataLoaderKey;
 import mil.dds.anet.utils.Utils;
 import mil.dds.anet.views.AbstractCustomizableAnetBean;
@@ -66,6 +69,8 @@ public class Position extends AbstractCustomizableAnetBean
   private List<Organization> organizationsAdministrated;
   // annotated below
   private List<AuthorizationGroup> authorizationGroupsAdministrated;
+  // annotated below
+  private List<AuthorizationGroup> authorizationGroups;
 
   public String getName() {
     return name;
@@ -319,6 +324,21 @@ public class Position extends AbstractCustomizableAnetBean
           .getAuthorizationGroupsAdministratedByPosition(uuid);
     }
     return authorizationGroupsAdministrated;
+  }
+
+  @GraphQLQuery(name = "authorizationGroups")
+  public List<AuthorizationGroup> loadAuthorizationGroups() {
+    if (authorizationGroups == null) {
+      AuthorizationGroupDao authorizationGroupDao =
+          AnetObjectEngine.getInstance().getAuthorizationGroupDao();
+      final Set<String> authorizationGroupUuids = authorizationGroupDao
+          .getAuthorizationGroupUuidsForRelatedObject(PositionDao.TABLE_NAME, uuid);
+      if (authorizationGroupUuids != null) {
+        authorizationGroups = AnetObjectEngine.getInstance().getAuthorizationGroupDao()
+            .getByIds(authorizationGroupUuids.stream().toList());
+      }
+    }
+    return authorizationGroups;
   }
 
   @Override

--- a/src/main/java/mil/dds/anet/utils/DaoUtils.java
+++ b/src/main/java/mil/dds/anet/utils/DaoUtils.java
@@ -144,7 +144,7 @@ public class DaoUtils {
     if (user == null) {
       return Collections.emptySet();
     }
-    return user.loadAuthorizationGroupUuids();
+    return user.getAuthorizationGroupUuids();
   }
 
   public static boolean isUserInAuthorizationGroup(final Set<String> userAuthorizationGroupUuids,

--- a/src/main/resources/anet-schema.yml
+++ b/src/main/resources/anet-schema.yml
@@ -726,7 +726,7 @@ properties:
         additionalProperties: false
         required: [status, firstName, lastName, position, prevPositions, domainUsername, openIdSubject,
                    emailAddress, phoneNumber, country, code, rank, ranks, gender, endOfTourDate,
-                   biography]
+                   biography, authorizationGroups]
         properties:
           status:
             "$ref": "#/$defs/labeledField"
@@ -766,6 +766,8 @@ properties:
             "$ref": "#/$defs/optionableExcludableInputField"
           biography:
             "$ref": "#/$defs/inputField"
+          authorizationGroups:
+            "$ref": "#/$defs/labeledField"
           customFields:
             type: object
             additionalProperties:
@@ -808,7 +810,7 @@ properties:
       position:
         type: object
         additionalProperties: false
-        required: [status, name, type, code, organization, role]
+        required: [status, name, type, code, organization, role, authorizationGroups]
         properties:
           status:
             "$ref": "#/$defs/labeledField"
@@ -822,6 +824,8 @@ properties:
             "$ref": "#/$defs/inputField"
           location:
             "$ref": "#/$defs/optionableInputField"
+          authorizationGroups:
+            "$ref": "#/$defs/labeledField"
           role:
             type: object
             unevaluatedProperties: false
@@ -853,7 +857,7 @@ properties:
       organization:
         type: object
         additionalProperties: false
-        required: [status, shortName, longName, identificationCode, type, parentOrg, childrenOrgs, location, profile]
+        required: [status, shortName, longName, identificationCode, type, parentOrg, childrenOrgs, location, profile, authorizationGroups]
         properties:
           status:
             "$ref": "#/$defs/labeledField"
@@ -873,6 +877,8 @@ properties:
             "$ref": "#/$defs/inputField"
           profile:
             "$ref": "#/$defs/inputField"
+          authorizationGroups:
+            "$ref": "#/$defs/labeledField"
           assessments:
             type: object
             additionalProperties:

--- a/src/test/java/mil/dds/anet/test/resources/AuthorizationGroupResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/AuthorizationGroupResourceTest.java
@@ -15,6 +15,9 @@ import mil.dds.anet.test.client.AuthorizationGroup;
 import mil.dds.anet.test.client.AuthorizationGroupInput;
 import mil.dds.anet.test.client.AuthorizationGroupSearchQueryInput;
 import mil.dds.anet.test.client.GenericRelatedObjectInput;
+import mil.dds.anet.test.client.Organization;
+import mil.dds.anet.test.client.Person;
+import mil.dds.anet.test.client.Position;
 import mil.dds.anet.test.client.Status;
 import mil.dds.anet.test.client.util.MutationExecutor;
 import org.junit.jupiter.api.Test;
@@ -145,5 +148,36 @@ class AuthorizationGroupResourceTest extends AbstractResourceTest {
             GenericRelatedObjectInput.builder().withRelatedObjectType(OrganizationDao.TABLE_NAME)
                 .withRelatedObjectUuid(admin.getPosition().getOrganization().getUuid()).build()))
         .build();
+  }
+
+  @Test
+  void testAuthorizationGroupsByRelatedObject()
+      throws GraphQLRequestPreparationException, GraphQLRequestExecutionException {
+    // Authorization group EF 5 should transitively contain all related objects below
+    final String expectedAuthorizationGroupUuid = "ab1a7d99-4529-44b1-a118-bdee3ca8296b";
+    final String fields = "{ uuid authorizationGroups { uuid } }";
+
+    // CIV BRATTON, Creed
+    final Person person = jackQueryExecutor.person(fields, "31cba227-f6c6-49e9-9483-fce441bea624");
+    assertThat(person).isNotNull();
+    assertThat(person.getAuthorizationGroups()).hasSize(1);
+    assertThat(person.getAuthorizationGroups().get(0).getUuid())
+        .isEqualTo(expectedAuthorizationGroupUuid);
+
+    // EF 5.1 Advisor Quality Assurance
+    final Position position =
+        jackQueryExecutor.position(fields, "05c42ce0-34a0-4391-8b2f-c4cd85ee6b47");
+    assertThat(position).isNotNull();
+    assertThat(position.getAuthorizationGroups()).hasSize(1);
+    assertThat(position.getAuthorizationGroups().get(0).getUuid())
+        .isEqualTo(expectedAuthorizationGroupUuid);
+
+    // EF 5.1
+    final Organization organization =
+        jackQueryExecutor.organization(fields, "7f939a44-b9e4-48e0-98f5-7d0ea38a6ecf");
+    assertThat(organization).isNotNull();
+    assertThat(organization.getAuthorizationGroups()).hasSize(1);
+    assertThat(organization.getAuthorizationGroups().get(0).getUuid())
+        .isEqualTo(expectedAuthorizationGroupUuid);
   }
 }

--- a/src/test/resources/anet.graphql
+++ b/src/test/resources/anet.graphql
@@ -487,6 +487,7 @@ type Organization {
   approvalSteps: [ApprovalStep]
   ascendantOrgs(query: OrganizationSearchQueryInput): [Organization]
   attachments: [Attachment]
+  authorizationGroups: [AuthorizationGroup]
   childrenOrgs(query: OrganizationSearchQueryInput): [Organization]
   createdAt: Instant
   customFields: String
@@ -557,7 +558,7 @@ type Person {
   attachments: [Attachment]
   attendedReports(query: ReportSearchQueryInput): AnetBeanList_Report
   authoredReports(query: ReportSearchQueryInput): AnetBeanList_Report
-  authorizationGroupUuids: [String]
+  authorizationGroups: [AuthorizationGroup]
   avatarUuid: String
   biography: String
   code: String
@@ -664,6 +665,7 @@ enum PersonSearchSortBy {
 type Position {
   associatedPositions: [Position]
   attachments: [Attachment]
+  authorizationGroups: [AuthorizationGroup]
   authorizationGroupsAdministrated: [AuthorizationGroup]
   code: String
   createdAt: Instant
@@ -904,7 +906,7 @@ type ReportPerson {
   attendee: Boolean!
   author: Boolean!
   authoredReports(query: ReportSearchQueryInput): AnetBeanList_Report
-  authorizationGroupUuids: [String]
+  authorizationGroups: [AuthorizationGroup]
   avatarUuid: String
   biography: String
   code: String

--- a/src/test/resources/graphQLTests/appQuery.gql
+++ b/src/test/resources/graphQLTests/appQuery.gql
@@ -7,7 +7,9 @@ me {
   emailAddress
   pendingVerification
   code
-  authorizationGroupUuids
+  authorizationGroups {
+    uuid
+  }
   position {
     uuid
     name

--- a/testDictionaries/no-custom-fields.yml
+++ b/testDictionaries/no-custom-fields.yml
@@ -493,6 +493,8 @@ fields:
     biography:
       label: Biography
       placeholder: Fill in the biography of this person
+    authorizationGroups:
+      label: Authorization groups
     customSensitiveInformation:
       birthday:
         type: date
@@ -554,6 +556,8 @@ fields:
         member: Member
         deputy: Deputy
         leader: Leader
+    authorizationGroups:
+      label: Authorization groups
 
   organization:
     status:
@@ -581,6 +585,8 @@ fields:
     profile:
       label: Profile
       placeholder: Fill in the profile of this organization
+    authorizationGroups:
+      label: Authorization groups
     assessments:
       organizationAnnually:
         label: Interaction Plan
@@ -666,6 +672,7 @@ fields:
         - user
         - domainUsername
         - openIdSubject
+        - authorizationGroups
         - emailAddress
         - phoneNumber
         - country


### PR DESCRIPTION
On the details pages of people, positions and organizations, show a table with the authorizationGroups that they're (transitively) a member of.

Closes [AB#1015](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1015)

#### User changes
- On the details pages of people, positions and organizations you can see which authorizationGroups they belong to.

#### Superuser changes
- None.

#### Admin changes
- None.

#### System admin changes
- [x] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [x] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [x] Added and/or updated unit tests
  - [x] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here