### PR TITLE
Ability to select advisors or interlocutors names in calendar

### DIFF
--- a/anet-dictionary.yml
+++ b/anet-dictionary.yml
@@ -6,7 +6,7 @@ SUPPORT_EMAIL_ADDR: support@example.com
 engagementsIncludeTimeAndDuration: true
 
 calendarOptions:
-  attendeesType: Advisor
+  attendeesType: advisor
 
 dateFormats:
   email:

--- a/anet-dictionary.yml
+++ b/anet-dictionary.yml
@@ -5,6 +5,9 @@ SUPPORT_EMAIL_ADDR: support@example.com
 
 engagementsIncludeTimeAndDuration: true
 
+calendarOptions:
+  attendeesType: Advisor
+
 dateFormats:
   email:
     date: d MMMM yyyy Z

--- a/client/src/components/Calendar.js
+++ b/client/src/components/Calendar.js
@@ -9,6 +9,9 @@ import PropTypes from "prop-types"
 import React from "react"
 import "./Calendar.css"
 
+export const ATTENDEE_TYPE_ADVISOR = "Advisor"
+export const ATTENDEE_TYPE_INTERLOCUTOR = "Interlocutor"
+
 const Calendar = ({ events, eventClick, calendarComponentRef }) => (
   <FullCalendar
     plugins={[dayGridPlugin, timeGridPlugin, listPlugin, interactionPlugin]}

--- a/client/src/components/Calendar.js
+++ b/client/src/components/Calendar.js
@@ -9,9 +9,6 @@ import PropTypes from "prop-types"
 import React from "react"
 import "./Calendar.css"
 
-export const ATTENDEE_TYPE_ADVISOR = "Advisor"
-export const ATTENDEE_TYPE_INTERLOCUTOR = "Interlocutor"
-
 const Calendar = ({ events, eventClick, calendarComponentRef }) => (
   <FullCalendar
     plugins={[dayGridPlugin, timeGridPlugin, listPlugin, interactionPlugin]}

--- a/client/src/components/ReportCalendar.js
+++ b/client/src/components/ReportCalendar.js
@@ -22,6 +22,10 @@ const GQL_GET_REPORT_LIST = gql`
           uuid
           name
         }
+        primaryInterlocutor {
+          uuid
+          name
+        }
         interlocutorOrg {
           uuid
           shortName
@@ -45,10 +49,12 @@ const GQL_GET_REPORT_LIST = gql`
 const ReportCalendar = ({
   pageDispatchers: { showLoading, hideLoading },
   queryParams,
-  setTotalCount
+  setTotalCount,
+  attendeeType
 }) => {
   const navigate = useNavigate()
   const prevReportQuery = useRef(null)
+  const prevAttendeeType = useRef(null)
   const apiPromise = useRef(null)
   const calendarComponentRef = useRef(null)
   return (
@@ -69,11 +75,15 @@ const ReportCalendar = ({
       engagementDateStart: moment(fetchInfo.start).startOf("day"),
       engagementDateEnd: moment(fetchInfo.end).endOf("day")
     })
-    if (_isEqual(prevReportQuery.current, reportQuery)) {
+    if (
+      _isEqual(prevReportQuery.current, reportQuery) &&
+      _isEqual(prevAttendeeType.current, attendeeType)
+    ) {
       // Optimise, return previous API promise instead of calling API.query again
       return apiPromise.current
     }
     prevReportQuery.current = reportQuery
+    prevAttendeeType.current = attendeeType
     if (setTotalCount) {
       // Reset the total count
       setTotalCount(null)
@@ -88,7 +98,7 @@ const ReportCalendar = ({
         const { totalCount } = data.reportList
         setTotalCount(totalCount)
       }
-      const results = reportsToEvents(reports)
+      const results = reportsToEvents(reports, attendeeType)
       hideLoading()
       return results
     })
@@ -99,7 +109,8 @@ const ReportCalendar = ({
 ReportCalendar.propTypes = {
   pageDispatchers: PageDispatchersPropType,
   queryParams: PropTypes.object,
-  setTotalCount: PropTypes.func
+  setTotalCount: PropTypes.func,
+  attendeeType: PropTypes.string.isRequired
 }
 
 export default ReportCalendar

--- a/client/src/components/ReportCollection.js
+++ b/client/src/components/ReportCollection.js
@@ -10,10 +10,13 @@ import ReportStatistics from "components/ReportStatistics"
 import ReportSummary from "components/ReportSummary"
 import ReportTable from "components/ReportTable"
 import { RECURRENCE_TYPE, useResponsiveNumberOfPeriods } from "periodUtils"
+import pluralize from "pluralize"
 import PropTypes from "prop-types"
 import React, { useState } from "react"
 import { Button } from "react-bootstrap"
 import { connect } from "react-redux"
+import Settings from "settings"
+import { ATTENDEE_TYPE_ADVISOR, ATTENDEE_TYPE_INTERLOCUTOR } from "./Calendar"
 
 export const FORMAT_CALENDAR = "calendar"
 export const FORMAT_SUMMARY = "summary"
@@ -38,6 +41,9 @@ const ReportCollection = ({
   const [numberOfPeriods, setNumberOfPeriods] = useState(3)
   const contRef = useResponsiveNumberOfPeriods(setNumberOfPeriods)
   const [viewFormat, setViewFormat] = useState(viewFormats[0])
+  const [calendarAttendeeType, setCalendarAttendeeType] = useState(
+    Settings.calendarOptions.attendeesType
+  )
   const showHeader = viewFormats.length > 1 || reportsFilter
   const statisticsRecurrence = [RECURRENCE_TYPE.MONTHLY]
   const idSuffix = mapId || paginationKey || "reports"
@@ -47,39 +53,63 @@ const ReportCollection = ({
         {showHeader && (
           <header>
             {viewFormats.length > 1 && (
-              <ButtonToggleGroup
-                value={viewFormat}
-                onChange={setViewFormat}
-                className="d-print-none"
-              >
-                {viewFormats.includes(FORMAT_TABLE) && (
-                  <Button value={FORMAT_TABLE} variant="outline-secondary">
-                    Table
-                  </Button>
+              <>
+                <ButtonToggleGroup
+                  value={viewFormat}
+                  onChange={setViewFormat}
+                  className="d-print-none"
+                >
+                  {viewFormats.includes(FORMAT_TABLE) && (
+                    <Button value={FORMAT_TABLE} variant="outline-secondary">
+                      Table
+                    </Button>
+                  )}
+                  {viewFormats.includes(FORMAT_SUMMARY) && (
+                    <Button value={FORMAT_SUMMARY} variant="outline-secondary">
+                      Summary
+                    </Button>
+                  )}
+                  {viewFormats.includes(FORMAT_CALENDAR) && (
+                    <Button value={FORMAT_CALENDAR} variant="outline-secondary">
+                      Calendar
+                    </Button>
+                  )}
+                  {viewFormats.includes(FORMAT_MAP) && (
+                    <Button value={FORMAT_MAP} variant="outline-secondary">
+                      Map
+                    </Button>
+                  )}
+                  {viewFormats.includes(FORMAT_STATISTICS) && (
+                    <Button
+                      value={FORMAT_STATISTICS}
+                      variant="outline-secondary"
+                    >
+                      Statistics
+                    </Button>
+                  )}
+                </ButtonToggleGroup>
+                {viewFormat === FORMAT_CALENDAR && (
+                  <ButtonToggleGroup
+                    value={calendarAttendeeType}
+                    onChange={setCalendarAttendeeType}
+                    className="float-end"
+                  >
+                    <Button
+                      value={ATTENDEE_TYPE_ADVISOR}
+                      variant="outline-secondary"
+                    >
+                      {pluralize(Settings.fields.advisor.person.name)}
+                    </Button>
+                    <Button
+                      value={ATTENDEE_TYPE_INTERLOCUTOR}
+                      variant="outline-secondary"
+                    >
+                      {pluralize(Settings.fields.interlocutor.person.name)}
+                    </Button>
+                  </ButtonToggleGroup>
                 )}
-                {viewFormats.includes(FORMAT_SUMMARY) && (
-                  <Button value={FORMAT_SUMMARY} variant="outline-secondary">
-                    Summary
-                  </Button>
-                )}
-                {viewFormats.includes(FORMAT_CALENDAR) && (
-                  <Button value={FORMAT_CALENDAR} variant="outline-secondary">
-                    Calendar
-                  </Button>
-                )}
-                {viewFormats.includes(FORMAT_MAP) && (
-                  <Button value={FORMAT_MAP} variant="outline-secondary">
-                    Map
-                  </Button>
-                )}
-                {viewFormats.includes(FORMAT_STATISTICS) && (
-                  <Button value={FORMAT_STATISTICS} variant="outline-secondary">
-                    Statistics
-                  </Button>
-                )}
-              </ButtonToggleGroup>
+              </>
             )}
-
             {reportsFilter && (
               <div className="reports-filter">Filter: {reportsFilter}</div>
             )}
@@ -92,6 +122,7 @@ const ReportCollection = ({
               pageDispatchers={pageDispatchers}
               queryParams={queryParams}
               setTotalCount={setTotalCount}
+              attendeeType={calendarAttendeeType}
             />
           )}
           {viewFormat === FORMAT_TABLE && (

--- a/client/src/components/ReportCollection.js
+++ b/client/src/components/ReportCollection.js
@@ -4,7 +4,10 @@ import {
   mapPageDispatchersToProps,
   PageDispatchersPropType
 } from "components/Page"
-import ReportCalendar from "components/ReportCalendar"
+import ReportCalendar, {
+  ATTENDEE_TYPE_ADVISOR,
+  ATTENDEE_TYPE_INTERLOCUTOR
+} from "components/ReportCalendar"
 import ReportMap from "components/ReportMap"
 import ReportStatistics from "components/ReportStatistics"
 import ReportSummary from "components/ReportSummary"
@@ -16,7 +19,6 @@ import React, { useState } from "react"
 import { Button } from "react-bootstrap"
 import { connect } from "react-redux"
 import Settings from "settings"
-import { ATTENDEE_TYPE_ADVISOR, ATTENDEE_TYPE_INTERLOCUTOR } from "./Calendar"
 
 export const FORMAT_CALENDAR = "calendar"
 export const FORMAT_SUMMARY = "summary"

--- a/client/src/components/aggregations/utils.js
+++ b/client/src/components/aggregations/utils.js
@@ -2,12 +2,14 @@ import RichTextEditor from "components/RichTextEditor"
 import _clone from "lodash/clone"
 import _cloneDeep from "lodash/cloneDeep"
 import _isEmpty from "lodash/isEmpty"
+import _isEqual from "lodash/isEqual"
 import { Person, Report } from "models"
 import moment from "moment"
 import { AssessmentPeriodPropType, PeriodPropType } from "periodUtils"
 import PropTypes from "prop-types"
 import React from "react"
 import Settings from "settings"
+import { ATTENDEE_TYPE_INTERLOCUTOR } from "../Calendar"
 
 export const aggregationWidgetPropTypes = {
   widgetId: PropTypes.string.isRequired,
@@ -213,11 +215,14 @@ export const GET_CALENDAR_EVENTS_FROM = {
   [CALENDAR_OBJECT_TYPES.REPORT]: reportsToEvents
 }
 
-export function reportsToEvents(reports) {
+export function reportsToEvents(reports, attendeeType) {
   return reports
     .map(r => {
-      const who =
-        (r.primaryAdvisor && new Person(r.primaryAdvisor).toString()) || ""
+      const who = _isEqual(attendeeType, ATTENDEE_TYPE_INTERLOCUTOR)
+        ? (r.primaryInterlocutor &&
+            new Person(r.primaryInterlocutor).toString()) ||
+          ""
+        : (r.primaryAdvisor && new Person(r.primaryAdvisor).toString()) || ""
       const where =
         (r.interlocutorOrg && r.interlocutorOrg.shortName) ||
         (r.location && r.location.name) ||

--- a/client/src/components/aggregations/utils.js
+++ b/client/src/components/aggregations/utils.js
@@ -2,14 +2,12 @@ import RichTextEditor from "components/RichTextEditor"
 import _clone from "lodash/clone"
 import _cloneDeep from "lodash/cloneDeep"
 import _isEmpty from "lodash/isEmpty"
-import _isEqual from "lodash/isEqual"
 import { Person, Report } from "models"
 import moment from "moment"
 import { AssessmentPeriodPropType, PeriodPropType } from "periodUtils"
 import PropTypes from "prop-types"
 import React from "react"
 import Settings from "settings"
-import { ATTENDEE_TYPE_INTERLOCUTOR } from "../Calendar"
 
 export const aggregationWidgetPropTypes = {
   widgetId: PropTypes.string.isRequired,
@@ -215,10 +213,10 @@ export const GET_CALENDAR_EVENTS_FROM = {
   [CALENDAR_OBJECT_TYPES.REPORT]: reportsToEvents
 }
 
-export function reportsToEvents(reports, attendeeType) {
+export function reportsToEvents(reports, showInterlocutors) {
   return reports
     .map(r => {
-      const who = _isEqual(attendeeType, ATTENDEE_TYPE_INTERLOCUTOR)
+      const who = showInterlocutors
         ? (r.primaryInterlocutor &&
             new Person(r.primaryInterlocutor).toString()) ||
           ""

--- a/src/main/resources/anet-schema.yml
+++ b/src/main/resources/anet-schema.yml
@@ -476,6 +476,15 @@ properties:
                 title: The long date/time format if `engagementsIncludeTimeAndDuration` is `true`
                 description: Used to show the report engagement date/time in the user interface; should be easy to read, e.g. "Sunday, 6 December 1998 @ 15:30"; see https://momentjs.com/docs/#/displaying/format/ for format specifiers.
 
+  calendarOptions:
+    type: object
+    additionalProperties: false
+    required: [attendeesType]
+    properties:
+      attendeesType:
+        type: string
+        description: This value determines which names are shown by default in the report calendar, either advisor or interlocutor.
+        enum: [Advisor, Interlocutor]
   menuOptions:
     type: object
     additionalProperties: false

--- a/src/main/resources/anet-schema.yml
+++ b/src/main/resources/anet-schema.yml
@@ -370,6 +370,7 @@ required:
   - VERSION_CHANGED_MSG
   - SUPPORT_EMAIL_ADDR
   - dateFormats
+  - calendarOptions
   - reportWorkflow
   - maxTextFieldLength
   - fields
@@ -484,7 +485,8 @@ properties:
       attendeesType:
         type: string
         description: This value determines which names are shown by default in the report calendar, either advisor or interlocutor.
-        enum: [Advisor, Interlocutor]
+        enum: [advisor, interlocutor]
+
   menuOptions:
     type: object
     additionalProperties: false

--- a/testDictionaries/no-custom-fields.yml
+++ b/testDictionaries/no-custom-fields.yml
@@ -4,6 +4,9 @@ SUPPORT_EMAIL_ADDR: support@example.com
 
 engagementsIncludeTimeAndDuration: true
 
+calendarOptions:
+  attendeesType: advisor
+
 dateFormats:
   email:
     date: d MMMM yyyy Z


### PR DESCRIPTION
In the calendar the users can now select whether advisor or interlocutor names are showed in the events. The initial option comes from the dictionary. 

Closes [AB#1050](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1050)

#### User changes
In the calendar the users can now select whether advisor or interlocutor names are showed in the events. The initial option comes from the dictionary. 

#### Superuser changes
None

#### Admin changes
None

#### System admin changes
- [x] anet.yml or anet-dictionary.yml needs change
  Add the following setting to the dictionary:

```
calendarOptions:
  attendeesType: Advisor
```

This determines with type of attendee will be used by defult in the calendar.
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
