### PR TITLE
Allow all users to access the Insights menu

### DIFF
--- a/client/src/components/Nav.js
+++ b/client/src/components/Nav.js
@@ -394,20 +394,18 @@ const Navigation = ({ allOrganizations, resetPages, clearSearchQuery }) => {
         Help
       </SidebarLink>
 
-      {(currentUser.isAdmin() || currentUser.isSuperuser()) && (
-        <NavDropdown title="Insights" id="insights" active={inInsights}>
-          {INSIGHTS.map(insight => (
-            <SidebarContainer
-              key={insight}
-              linkTo={`/insights/${insight}`}
-              handleOnClick={clearSearchQuery}
-              setIsMenuLinksOpened={() => setIsMenuLinksOpened(false)}
-            >
-              {INSIGHT_DETAILS[insight].navTitle}
-            </SidebarContainer>
-          ))}
-        </NavDropdown>
-      )}
+      <NavDropdown title="Insights" id="insights" active={inInsights}>
+        {INSIGHTS.map(insight => (
+          <SidebarContainer
+            key={insight}
+            linkTo={`/insights/${insight}`}
+            handleOnClick={clearSearchQuery}
+            setIsMenuLinksOpened={() => setIsMenuLinksOpened(false)}
+          >
+            {INSIGHT_DETAILS[insight].navTitle}
+          </SidebarContainer>
+        ))}
+      </NavDropdown>
 
       {Settings.dashboards && (
         <NavDropdown title="Dashboards" id="dashboards" active={inDashboards}>

--- a/client/src/components/Nav.js
+++ b/client/src/components/Nav.js
@@ -3,7 +3,11 @@ import AppContext from "components/AppContext"
 import ResponsiveLayoutContext from "components/ResponsiveLayoutContext"
 import _isEmpty from "lodash/isEmpty"
 import { Organization } from "models"
-import { INSIGHT_DETAILS, INSIGHTS } from "pages/insights/Show"
+import {
+  INSIGHT_DETAILS,
+  INSIGHTS,
+  PENDING_ASSESSMENTS_BY_POSITION
+} from "pages/insights/Show"
 import pluralize from "pluralize"
 import PropTypes from "prop-types"
 import React, { useContext, useEffect, useMemo, useState } from "react"
@@ -109,6 +113,13 @@ SidebarContainer.propTypes = {
   children: PropTypes.node,
   handleOnClick: PropTypes.func,
   setIsMenuLinksOpened: PropTypes.func
+}
+
+function hasAccessToInsight(currentUser, insight) {
+  return (
+    insight !== PENDING_ASSESSMENTS_BY_POSITION ||
+    currentUser.hasAssignedPosition()
+  )
 }
 
 const Navigation = ({ allOrganizations, resetPages, clearSearchQuery }) => {
@@ -395,7 +406,9 @@ const Navigation = ({ allOrganizations, resetPages, clearSearchQuery }) => {
       </SidebarLink>
 
       <NavDropdown title="Insights" id="insights" active={inInsights}>
-        {INSIGHTS.map(insight => (
+        {INSIGHTS.filter(insight =>
+          hasAccessToInsight(currentUser, insight)
+        ).map(insight => (
           <SidebarContainer
             key={insight}
             linkTo={`/insights/${insight}`}

--- a/client/src/pages/insights/Show.js
+++ b/client/src/pages/insights/Show.js
@@ -140,7 +140,7 @@ const InsightsShow = ({ pageDispatchers, searchQuery, setSearchQuery }) => {
   const orgQuery = currentUser.isAdmin()
     ? {}
     : {
-      organizationUuid: currentUser.position.organization.uuid,
+      organizationUuid: currentUser?.position?.organization?.uuid,
       orgRecurseStrategy: currentUser.isSuperuser()
         ? RECURSE_STRATEGY.CHILDREN
         : RECURSE_STRATEGY.NONE

--- a/client/tests/webdriver/baseSpecs/insights.spec.js
+++ b/client/tests/webdriver/baseSpecs/insights.spec.js
@@ -2,7 +2,7 @@ import { expect } from "chai"
 import Insights, { INSIGHTS } from "../pages/insights.page"
 
 describe("Insights pages", () => {
-  it("Should open each insights page", async() => {
+  it("Should open each insights page for admin user", async() => {
     await Insights.openAsAdminUser()
     for (const insight of INSIGHTS) {
       await (await Insights.getInsightsMenu()).waitForExist()
@@ -16,5 +16,40 @@ describe("Insights pages", () => {
       expect(await (await Insights.getInsightDiv(insight)).isExisting()).to.be
         .true
     }
+    await Insights.logout()
+  })
+
+  it("Should open each insights page for super user", async() => {
+    await Insights.openAsSuperuser()
+    for (const insight of INSIGHTS) {
+      await (await Insights.getInsightsMenu()).waitForExist()
+      await (await Insights.getInsightsMenu()).waitForDisplayed()
+      await (await Insights.getInsightsMenu()).click()
+      await (await Insights.getInsightLink(insight)).click()
+      await (
+        await Insights.getAlert()
+      ).waitForDisplayed({ timeout: 1000, reverse: true })
+      // eslint-disable-next-line no-unused-expressions
+      expect(await (await Insights.getInsightDiv(insight)).isExisting()).to.be
+        .true
+    }
+    await Insights.logout()
+  })
+
+  it("Should open each insights page for regular user", async() => {
+    await Insights.openAsPositionlessUser()
+    for (const insight of INSIGHTS) {
+      await (await Insights.getInsightsMenu()).waitForExist()
+      await (await Insights.getInsightsMenu()).waitForDisplayed()
+      await (await Insights.getInsightsMenu()).click()
+      await (await Insights.getInsightLink(insight)).click()
+      await (
+        await Insights.getAlert()
+      ).waitForDisplayed({ timeout: 1000, reverse: true })
+      // eslint-disable-next-line no-unused-expressions
+      expect(await (await Insights.getInsightDiv(insight)).isExisting()).to.be
+        .true
+    }
+    await Insights.logout()
   })
 })

--- a/client/tests/webdriver/baseSpecs/insights.spec.js
+++ b/client/tests/webdriver/baseSpecs/insights.spec.js
@@ -1,5 +1,8 @@
 import { expect } from "chai"
-import Insights, { INSIGHTS } from "../pages/insights.page"
+import Insights, {
+  INSIGHTS,
+  PENDING_ASSESSMENTS_BY_POSITION
+} from "../pages/insights.page"
 
 describe("Insights pages", () => {
   it("Should open each insights page for admin user", async() => {
@@ -36,9 +39,11 @@ describe("Insights pages", () => {
     await Insights.logout()
   })
 
-  it("Should open each insights page for regular user", async() => {
+  it("Should open each insights page except pending assessments for regular user", async() => {
     await Insights.openAsPositionlessUser()
-    for (const insight of INSIGHTS) {
+    for (const insight of INSIGHTS.filter(
+      ins => ins !== PENDING_ASSESSMENTS_BY_POSITION
+    )) {
       await (await Insights.getInsightsMenu()).waitForExist()
       await (await Insights.getInsightsMenu()).waitForDisplayed()
       await (await Insights.getInsightsMenu()).click()
@@ -50,6 +55,17 @@ describe("Insights pages", () => {
       expect(await (await Insights.getInsightDiv(insight)).isExisting()).to.be
         .true
     }
+
+    await (await Insights.getInsightsMenu()).waitForExist()
+    await (await Insights.getInsightsMenu()).waitForDisplayed()
+    await (await Insights.getInsightsMenu()).click()
+    // eslint-disable-next-line no-unused-expressions
+    expect(
+      await (
+        await Insights.getInsightLink(PENDING_ASSESSMENTS_BY_POSITION)
+      ).isExisting()
+    ).to.be.false
+
     await Insights.logout()
   })
 })

--- a/client/tests/webdriver/pages/insights.page.js
+++ b/client/tests/webdriver/pages/insights.page.js
@@ -6,7 +6,7 @@ const CANCELLED_REPORTS = "cancelled-engagement-reports"
 const REPORTS_BY_TASK = "reports-by-task"
 const REPORTS_BY_DAY_OF_WEEK = "reports-by-day-of-week"
 const FUTURE_ENGAGEMENTS_BY_LOCATION = "future-engagements-by-location"
-const PENDING_ASSESSMENTS_BY_POSITION = "pending-assessments-by-position"
+export const PENDING_ASSESSMENTS_BY_POSITION = "pending-assessments-by-position"
 const ADVISOR_REPORTS = "advisor-reports"
 export const INSIGHTS = [
   NOT_APPROVED_REPORTS,

--- a/src/test/java/mil/dds/anet/test/resources/ReportResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/ReportResourceTest.java
@@ -1947,23 +1947,15 @@ public class ReportResourceTest extends AbstractResourceTest {
 
   private void advisorReportInsights(final Person user)
       throws GraphQLRequestExecutionException, GraphQLRequestPreparationException {
-    final Position position = user.getPosition();
-    final boolean isSuperuser = position.getType() == PositionType.SUPERUSER;
     try {
       createTestReport();
       final List<AdvisorReportsEntry> advisorReports =
           getQueryExecutor(user.getDomainUsername()).advisorReportInsights(
               "{ uuid name stats { week nrReportsSubmitted nrEngagementsAttended } }", "-1", 3);
-      if (isSuperuser) {
-        assertThat(advisorReports).isNotNull();
-        assertThat(advisorReports.size()).isPositive();
-      } else {
-        fail("Expected ForbiddenException");
-      }
+      assertThat(advisorReports).isNotNull();
+      assertThat(advisorReports.size()).isPositive();
     } catch (ForbiddenException expectedException) {
-      if (isSuperuser) {
-        fail("Unexpected ForbiddenException");
-      }
+      fail("Unexpected ForbiddenException");
     }
   }
 


### PR DESCRIPTION
All users can now access the reporting under Insights.

Closes [AB#1054](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1054)

#### User changes
- Insights will be visible now.
- Users without a position will not be able to access pending assessments.

#### Superuser changes
- None

#### Admin changes
- None

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [x] Added and/or updated unit tests
  - [x] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
