### PR TITLE
Be able to set a security classification for an engagement report

### DIFF
--- a/anet-dictionary.yml
+++ b/anet-dictionary.yml
@@ -38,6 +38,14 @@ reportWorkflow:
 
 maxTextFieldLength: 250
 
+classification:
+  label: Security Marking
+  choices:
+    undefined: Undefined
+    public: Public
+    NU: NATO UNCLASSIFIED
+    NU_rel_EU: NATO UNCLASSIFIED Releasable to EU
+
 fields:
 
   task:
@@ -325,14 +333,6 @@ fields:
     description:
       label: Description
       placeholder: Enter a description of this attachment
-    classification:
-      type: enum
-      label: Security Marking
-      choices:
-        undefined: Undefined
-        public: Public
-        NU: NATO UNCLASSIFIED
-        NU_rel_EU: NATO UNCLASSIFIED Releasable to EU
     mimeTypes:
       - application/pdf
       - image/avif

--- a/client/src/components/Compact.js
+++ b/client/src/components/Compact.js
@@ -118,11 +118,29 @@ const CompactViewS = styled.div`
     }
   }
 `
+export const ClassifiedHeaderContent = ({ classification }) => {
+  return (
+    <ClassifiedHeaderContentS>
+      <div className="reportField">
+        <label style={{ fontWeight: "bold" }}>
+          {Settings.classification.label}:
+        </label>
+        &nbsp;
+        <span>{classification.toUpperCase()}</span>
+      </div>
+    </ClassifiedHeaderContentS>
+  )
+}
 
-export const CompactHeaderContent = ({
-  classification,
-  sensitiveInformation
-}) => {
+ClassifiedHeaderContent.propTypes = {
+  classification: PropTypes.string
+}
+
+const ClassifiedHeaderContentS = styled.div`
+  text-align: center;
+`
+
+export const CompactHeaderContent = ({ sensitiveInformation }) => {
   const { appSettings } = useContext(AppContext)
   return (
     <HeaderContentS bgc={appSettings[SETTING_KEY_COLOR]}>
@@ -130,14 +148,12 @@ export const CompactHeaderContent = ({
       <ClassificationBoxS>
         <ClassificationBanner />
         {sensitiveInformation && <SensitivityInformation />}
-        <span>Classification: {classification}</span>
       </ClassificationBoxS>
     </HeaderContentS>
   )
 }
 
 CompactHeaderContent.propTypes = {
-  classification: PropTypes.string,
   sensitiveInformation: PropTypes.bool
 }
 

--- a/client/src/components/Compact.js
+++ b/client/src/components/Compact.js
@@ -119,7 +119,10 @@ const CompactViewS = styled.div`
   }
 `
 
-export const CompactHeaderContent = ({ sensitiveInformation }) => {
+export const CompactHeaderContent = ({
+  classification,
+  sensitiveInformation
+}) => {
   const { appSettings } = useContext(AppContext)
   return (
     <HeaderContentS bgc={appSettings[SETTING_KEY_COLOR]}>
@@ -127,12 +130,14 @@ export const CompactHeaderContent = ({ sensitiveInformation }) => {
       <ClassificationBoxS>
         <ClassificationBanner />
         {sensitiveInformation && <SensitivityInformation />}
+        <span>Classification: {classification}</span>
       </ClassificationBoxS>
     </HeaderContentS>
   )
 }
 
 CompactHeaderContent.propTypes = {
+  classification: PropTypes.string,
   sensitiveInformation: PropTypes.bool
 }
 

--- a/client/src/components/Compact.js
+++ b/client/src/components/Compact.js
@@ -118,35 +118,17 @@ const CompactViewS = styled.div`
     }
   }
 `
-export const ClassifiedHeaderContent = ({ classification }) => {
-  return (
-    <ClassifiedHeaderContentS>
-      <div className="reportField">
-        <label style={{ fontWeight: "bold" }}>
-          {Settings.classification.label}:
-        </label>
-        &nbsp;
-        <span>{classification.toUpperCase()}</span>
-      </div>
-    </ClassifiedHeaderContentS>
-  )
-}
 
-ClassifiedHeaderContent.propTypes = {
-  classification: PropTypes.string
-}
-
-const ClassifiedHeaderContentS = styled.div`
-  text-align: center;
-`
-
-export const CompactHeaderContent = ({ sensitiveInformation }) => {
+export const CompactHeaderContent = ({
+  classification,
+  sensitiveInformation
+}) => {
   const { appSettings } = useContext(AppContext)
   return (
     <HeaderContentS bgc={appSettings[SETTING_KEY_COLOR]}>
       <img src={anetLogo} alt="logo" width="50" height="12" />
       <ClassificationBoxS>
-        <ClassificationBanner />
+        <ClassificationBanner classification={classification} />
         {sensitiveInformation && <SensitivityInformation />}
       </ClassificationBoxS>
     </HeaderContentS>
@@ -154,6 +136,7 @@ export const CompactHeaderContent = ({ sensitiveInformation }) => {
 }
 
 CompactHeaderContent.propTypes = {
+  classification: PropTypes.string,
   sensitiveInformation: PropTypes.bool
 }
 
@@ -287,12 +270,16 @@ const FooterContentS = styled.div`
   background-color: ${props => props.bgc} !important;
 `
 
-const ClassificationBanner = () => {
+const ClassificationBanner = ({ classification }) => {
   return (
     <ClassificationBannerS>
-      <CompactSecurityBanner />
+      <CompactSecurityBanner classification={classification} />
     </ClassificationBannerS>
   )
+}
+
+ClassificationBanner.propTypes = {
+  classification: PropTypes.string
 }
 
 const ClassificationBannerS = styled.div`

--- a/client/src/components/SecurityBanner.js
+++ b/client/src/components/SecurityBanner.js
@@ -208,19 +208,30 @@ ConnectionBanner.propTypes = {
   connection: PropTypes.object.isRequired
 }
 
-export const CompactSecurityBanner = () => {
+export const CompactSecurityBanner = ({ classification }) => {
   const { appSettings } = useContext(AppContext)
   return (
     <CompactBannerS className="banner" bgc={appSettings[SETTING_KEY_COLOR]}>
-      <span className="classificationText">
-        {appSettings[SETTING_KEY_CLASSIFICATION]?.toUpperCase() || ""}
-      </span>{" "}
-      <span className="releasabilityText">
-        {utils.titleCase(appSettings[SETTING_KEY_RELEASABILITY] || "")}
-      </span>
+      {(classification && (
+        <span className="classificationText">{classification}</span>
+      )) || (
+        <>
+          <span className="classificationText">
+            {appSettings[SETTING_KEY_CLASSIFICATION]?.toUpperCase() || ""}
+          </span>{" "}
+          <span className="releasabilityText">
+            {utils.titleCase(appSettings[SETTING_KEY_RELEASABILITY] || "")}
+          </span>
+        </>
+      )}
     </CompactBannerS>
   )
 }
+
+CompactSecurityBanner.propTypes = {
+  classification: PropTypes.string
+}
+
 const CompactBannerS = styled.div`
   & > span.classificationText {
     font-weight: bold;

--- a/client/src/components/previews/AttachmentPreview.js
+++ b/client/src/components/previews/AttachmentPreview.js
@@ -71,7 +71,7 @@ const AttachmentPreview = ({ className, uuid }) => {
             />
             <DictionaryField
               wrappedComponent={PreviewField}
-              dictProps={Settings.fields.attachment.classification}
+              dictProps={Settings.classification}
               value={Attachment.humanNameOfStatus(
                 attachment.classification
               ).toUpperCase()}

--- a/client/src/components/previews/AttachmentPreview.js
+++ b/client/src/components/previews/AttachmentPreview.js
@@ -72,9 +72,8 @@ const AttachmentPreview = ({ className, uuid }) => {
             <DictionaryField
               wrappedComponent={PreviewField}
               dictProps={Settings.classification}
-              value={Attachment.humanNameOfStatus(
-                attachment.classification
-              ).toUpperCase()}
+              name="classification"
+              value={Settings.classification.choices[attachment.classification]}
             />
           </Col>
         </Row>

--- a/client/src/components/previews/ReportPreview.js
+++ b/client/src/components/previews/ReportPreview.js
@@ -176,6 +176,13 @@ const ReportPreview = ({ className, uuid }) => {
             <div id="report-summary">
               <DictionaryField
                 wrappedComponent={PreviewField}
+                dictProps={Settings.classification}
+                value={Report.humanNameOfStatus(
+                  report.classification
+                ).toUpperCase()}
+              />
+              <DictionaryField
+                wrappedComponent={PreviewField}
                 dictProps={Settings.fields.report.intent}
                 name="intent"
                 style={{ marginBottom: 0 }}

--- a/client/src/components/previews/ReportPreview.js
+++ b/client/src/components/previews/ReportPreview.js
@@ -132,6 +132,14 @@ const ReportPreview = ({ className, uuid }) => {
   const reportTitle = report.intent || `#${report.uuid}`
   return (
     <div className={`report-preview preview-content-scroll ${className || ""}`}>
+      {report.classification && (
+        <div style={{ width: "100%", fontSize: "18px", textAlign: "center" }}>
+          <span style={{ fontWeight: "bold" }}>
+            {Settings.classification.choices[report.classification]}
+          </span>
+        </div>
+      )}
+
       {report.isPublished() && (
         <div className="preview-section text-center">
           <h4 className="text-danger">This {reportType} is PUBLISHED.</h4>
@@ -170,13 +178,6 @@ const ReportPreview = ({ className, uuid }) => {
 
       <h4 className="ellipsized-text">Report {reportTitle}</h4>
       <div className="preview-section">
-        <DictionaryField
-          wrappedComponent={PreviewField}
-          dictProps={Settings.classification}
-          name="classification"
-          value={Settings.classification.choices[report.classification]}
-        />
-
         <PreviewField
           extraColForValue
           label="Summary"

--- a/client/src/components/previews/ReportPreview.js
+++ b/client/src/components/previews/ReportPreview.js
@@ -170,6 +170,13 @@ const ReportPreview = ({ className, uuid }) => {
 
       <h4 className="ellipsized-text">Report {reportTitle}</h4>
       <div className="preview-section">
+        <DictionaryField
+          wrappedComponent={PreviewField}
+          dictProps={Settings.classification}
+          name="classification"
+          value={Settings.classification.choices[report.classification]}
+        />
+
         <PreviewField
           extraColForValue
           label="Summary"
@@ -195,13 +202,6 @@ const ReportPreview = ({ className, uuid }) => {
               />
             </div>
           }
-        />
-
-        <DictionaryField
-          wrappedComponent={PreviewField}
-          dictProps={Settings.classification}
-          name="classification"
-          value={Settings.classification.choices[report.classification]}
         />
 
         <DictionaryField

--- a/client/src/components/previews/ReportPreview.js
+++ b/client/src/components/previews/ReportPreview.js
@@ -20,6 +20,7 @@ const GQL_GET_REPORT = gql`
     report(uuid: $uuid) {
       uuid
       intent
+      classification
       engagementDate
       duration
       atmosphere
@@ -176,13 +177,6 @@ const ReportPreview = ({ className, uuid }) => {
             <div id="report-summary">
               <DictionaryField
                 wrappedComponent={PreviewField}
-                dictProps={Settings.classification}
-                value={Report.humanNameOfStatus(
-                  report.classification
-                ).toUpperCase()}
-              />
-              <DictionaryField
-                wrappedComponent={PreviewField}
                 dictProps={Settings.fields.report.intent}
                 name="intent"
                 style={{ marginBottom: 0 }}
@@ -201,6 +195,13 @@ const ReportPreview = ({ className, uuid }) => {
               />
             </div>
           }
+        />
+
+        <DictionaryField
+          wrappedComponent={PreviewField}
+          dictProps={Settings.classification}
+          name="classification"
+          value={Settings.classification.choices[report.classification]}
         />
 
         <DictionaryField

--- a/client/src/models/Attachment.js
+++ b/client/src/models/Attachment.js
@@ -1,5 +1,4 @@
 import Model from "components/Model"
-import utils from "utils"
 import * as yup from "yup"
 
 export default class Attachment extends Model {
@@ -34,16 +33,8 @@ export default class Attachment extends Model {
 
   static autocompleteQuery = Attachment.basicFieldsQuery
 
-  static humanNameOfStatus(status) {
-    return utils.sentenceCase(status)
-  }
-
   constructor(props) {
     super(Model.fillObject(props, Attachment.yupSchema))
-  }
-
-  humanNameOfStatus() {
-    return Attachment.humanNameOfStatus(this.status)
   }
 
   static FILTERED_CLIENT_SIDE_FIELDS = []

--- a/client/src/models/Report.js
+++ b/client/src/models/Report.js
@@ -331,6 +331,10 @@ export default class Report extends Model {
     super(Model.fillObject(props, Report.yupSchema))
   }
 
+  static humanNameOfStatus(status) {
+    return utils.sentenceCase(status)
+  }
+
   static isDraft(state) {
     return state === Report.STATE.DRAFT
   }

--- a/client/src/models/Report.js
+++ b/client/src/models/Report.js
@@ -260,7 +260,8 @@ export default class Report extends Model {
         .object()
         .nullable()
         .default({ uuid: null, text: null }),
-      authorizationGroups: yup.array().nullable().default([])
+      authorizationGroups: yup.array().nullable().default([]),
+      classification: yup.string().nullable().default(null)
     })
     // not actually in the database, the database contains the JSON customFields
     .concat(Report.customFieldsSchema)

--- a/client/src/pages/attachments/Form.js
+++ b/client/src/pages/attachments/Form.js
@@ -134,6 +134,7 @@ const AttachmentForm = ({ edit, title, initialValues }) => {
                         name="classification"
                         component={FieldHelper.RadioButtonToggleGroupField}
                         buttons={classificationButtons}
+                        enableClear
                         onChange={value =>
                           setFieldValue("classification", value)}
                       />

--- a/client/src/pages/attachments/Form.js
+++ b/client/src/pages/attachments/Form.js
@@ -45,7 +45,7 @@ const AttachmentForm = ({ edit, title, initialValues }) => {
   const [error, setError] = useState(null)
   const canEdit =
     currentUser.isAdmin() || currentUser.uuid === initialValues.author.uuid
-  const classifications = Settings.fields.attachment.classification.choices
+  const classifications = Settings.classification.choices
   const classificationButtons = Object.keys(classifications).map(key => ({
     value: key,
     label: classifications[key]
@@ -129,7 +129,7 @@ const AttachmentForm = ({ edit, title, initialValues }) => {
                     {canEdit ? (
                       <DictionaryField
                         wrappedComponent={FastField}
-                        dictProps={Settings.fields.attachment.classification}
+                        dictProps={Settings.classification}
                         name="classification"
                         component={FieldHelper.RadioButtonToggleGroupField}
                         buttons={classificationButtons}
@@ -139,7 +139,7 @@ const AttachmentForm = ({ edit, title, initialValues }) => {
                     ) : (
                       <DictionaryField
                         wrappedComponent={FastField}
-                        dictProps={Settings.fields.attachment.classification}
+                        dictProps={Settings.classification}
                         name="classification"
                         component={FieldHelper.ReadonlyField}
                       />

--- a/client/src/pages/attachments/Form.js
+++ b/client/src/pages/attachments/Form.js
@@ -45,10 +45,11 @@ const AttachmentForm = ({ edit, title, initialValues }) => {
   const [error, setError] = useState(null)
   const canEdit =
     currentUser.isAdmin() || currentUser.uuid === initialValues.author.uuid
-  const classifications = Settings.classification.choices
-  const classificationButtons = Object.keys(classifications).map(key => ({
-    value: key,
-    label: classifications[key]
+  const classificationButtons = Object.entries(
+    Settings.classification.choices
+  ).map(([value, label]) => ({
+    value,
+    label
   }))
 
   return (

--- a/client/src/pages/attachments/Show.js
+++ b/client/src/pages/attachments/Show.js
@@ -171,8 +171,7 @@ const AttachmentShow = ({ pageDispatchers }) => {
             )}
           </>
         )
-        const classifications =
-          Settings.fields.attachment.classification.choices
+        const classifications = Settings.classification.choices
         return (
           <div>
             <Messages success={stateSuccess} error={stateError} />
@@ -218,7 +217,7 @@ const AttachmentShow = ({ pageDispatchers }) => {
                     />
                     <DictionaryField
                       wrappedComponent={Field}
-                      dictProps={Settings.fields.attachment.classification}
+                      dictProps={Settings.classification}
                       name="classification"
                       component={FieldHelper.ReadonlyField}
                       humanValue={classifications[attachment.classification]}

--- a/client/src/pages/attachments/Show.js
+++ b/client/src/pages/attachments/Show.js
@@ -171,7 +171,6 @@ const AttachmentShow = ({ pageDispatchers }) => {
             )}
           </>
         )
-        const classifications = Settings.classification.choices
         return (
           <div>
             <Messages success={stateSuccess} error={stateError} />
@@ -220,7 +219,11 @@ const AttachmentShow = ({ pageDispatchers }) => {
                       dictProps={Settings.classification}
                       name="classification"
                       component={FieldHelper.ReadonlyField}
-                      humanValue={classifications[attachment.classification]}
+                      humanValue={
+                        Settings.classification.choices[
+                          attachment.classification
+                        ]
+                      }
                     />
                     <Field
                       name="used in"

--- a/client/src/pages/reports/Compact.js
+++ b/client/src/pages/reports/Compact.js
@@ -50,6 +50,7 @@ const GQL_GET_REPORT = gql`
     report(uuid: $uuid) {
       uuid
       intent
+      classification
       engagementDate
       duration
       atmosphere
@@ -305,7 +306,7 @@ const CompactReportView = ({ pageDispatchers }) => {
             pageSize={pageSize}
             backgroundText={backgroundText}
           >
-            <CompactHeaderContent />
+            <CompactHeaderContent classification={report.classification} />
             <CompactTable>
               <FullColumn>
                 <CompactTitle
@@ -326,6 +327,14 @@ const CompactReportView = ({ pageDispatchers }) => {
                   wrappedComponent={CompactRow}
                   dictProps={Settings.fields.report.keyOutcomes}
                   content={report.keyOutcomes}
+                  className="reportField"
+                />
+                <DictionaryField
+                  wrappedComponent={CompactRow}
+                  dictProps={Settings.classification}
+                  content={
+                    Settings.classification.choices[report.classification]
+                  }
                   className="reportField"
                 />
                 {!report.cancelled && (

--- a/client/src/pages/reports/Compact.js
+++ b/client/src/pages/reports/Compact.js
@@ -6,7 +6,6 @@ import AppContext from "components/AppContext"
 import InstantAssessmentsContainerField from "components/assessments/instant/InstantAssessmentsContainerField"
 import { BreadcrumbTrail } from "components/BreadcrumbTrail"
 import CompactTable, {
-  ClassifiedHeaderContent,
   CompactFooterContent,
   CompactHeaderContent,
   CompactRow,
@@ -307,11 +306,11 @@ const CompactReportView = ({ pageDispatchers }) => {
             pageSize={pageSize}
             backgroundText={backgroundText}
           >
-            {report.classification == null ? (
-              <CompactHeaderContent />
-            ) : (
-              <ClassifiedHeaderContent classification={report.classification} />
-            )}
+            <CompactHeaderContent
+              classification={
+                Settings.classification.choices[report.classification]
+              }
+            />
             <CompactTable>
               <FullColumn>
                 <CompactTitle

--- a/client/src/pages/reports/Compact.js
+++ b/client/src/pages/reports/Compact.js
@@ -6,6 +6,7 @@ import AppContext from "components/AppContext"
 import InstantAssessmentsContainerField from "components/assessments/instant/InstantAssessmentsContainerField"
 import { BreadcrumbTrail } from "components/BreadcrumbTrail"
 import CompactTable, {
+  ClassifiedHeaderContent,
   CompactFooterContent,
   CompactHeaderContent,
   CompactRow,
@@ -306,7 +307,11 @@ const CompactReportView = ({ pageDispatchers }) => {
             pageSize={pageSize}
             backgroundText={backgroundText}
           >
-            <CompactHeaderContent classification={report.classification} />
+            {report.classification == null ? (
+              <CompactHeaderContent />
+            ) : (
+              <ClassifiedHeaderContent classification={report.classification} />
+            )}
             <CompactTable>
               <FullColumn>
                 <CompactTitle
@@ -327,14 +332,6 @@ const CompactReportView = ({ pageDispatchers }) => {
                   wrappedComponent={CompactRow}
                   dictProps={Settings.fields.report.keyOutcomes}
                   content={report.keyOutcomes}
-                  className="reportField"
-                />
-                <DictionaryField
-                  wrappedComponent={CompactRow}
-                  dictProps={Settings.classification}
-                  content={
-                    Settings.classification.choices[report.classification]
-                  }
                   className="reportField"
                 />
                 {!report.cancelled && (

--- a/client/src/pages/reports/Edit.js
+++ b/client/src/pages/reports/Edit.js
@@ -25,6 +25,7 @@ const GQL_GET_REPORT = gql`
     report(uuid: $uuid) {
       uuid
       intent
+      classification
       engagementDate
       duration
       atmosphere

--- a/client/src/pages/reports/Form.js
+++ b/client/src/pages/reports/Form.js
@@ -250,6 +250,12 @@ const ReportForm = ({
   const attachmentEditEnabled =
     attachmentsEnabled &&
     (!Settings.fields.attachment.restrictToAdmins || currentUser.isAdmin())
+  const classificationButtons = Object.entries(
+    Settings.classification.choices
+  ).map(([value, label]) => ({
+    value,
+    label
+  }))
 
   let recents = []
   if (data) {
@@ -486,6 +492,15 @@ const ReportForm = ({
                     </>
                   }
                   className="meeting-goal"
+                />
+
+                <DictionaryField
+                  wrappedComponent={FastField}
+                  dictProps={Settings.classification}
+                  name="classification"
+                  component={FieldHelper.RadioButtonToggleGroupField}
+                  buttons={classificationButtons}
+                  onChange={value => setFieldValue("classification", value)}
                 />
 
                 <DictionaryField

--- a/client/src/pages/reports/Form.js
+++ b/client/src/pages/reports/Form.js
@@ -466,6 +466,14 @@ const ReportForm = ({
               <Fieldset>
                 <DictionaryField
                   wrappedComponent={FastField}
+                  dictProps={Settings.classification}
+                  name="classification"
+                  component={FieldHelper.RadioButtonToggleGroupField}
+                  buttons={classificationButtons}
+                  onChange={value => setFieldValue("classification", value)}
+                />
+                <DictionaryField
+                  wrappedComponent={FastField}
                   dictProps={Settings.fields.report.intent}
                   name="intent"
                   component={FieldHelper.InputField}
@@ -492,15 +500,6 @@ const ReportForm = ({
                     </>
                   }
                   className="meeting-goal"
-                />
-
-                <DictionaryField
-                  wrappedComponent={FastField}
-                  dictProps={Settings.classification}
-                  name="classification"
-                  component={FieldHelper.RadioButtonToggleGroupField}
-                  buttons={classificationButtons}
-                  onChange={value => setFieldValue("classification", value)}
                 />
 
                 <DictionaryField

--- a/client/src/pages/reports/Form.js
+++ b/client/src/pages/reports/Form.js
@@ -470,6 +470,7 @@ const ReportForm = ({
                   name="classification"
                   component={FieldHelper.RadioButtonToggleGroupField}
                   buttons={classificationButtons}
+                  enableClear
                   onChange={value => setFieldValue("classification", value)}
                 />
                 <DictionaryField

--- a/client/src/pages/reports/Show.js
+++ b/client/src/pages/reports/Show.js
@@ -58,6 +58,7 @@ const GQL_GET_REPORT = gql`
     report(uuid: $uuid) {
       uuid
       intent
+      classification
       engagementDate
       duration
       atmosphere
@@ -571,6 +572,13 @@ const ReportShow = ({ setSearchQuery, pageDispatchers }) => {
                         wrappedComponent={Field}
                         dictProps={Settings.fields.report.nextSteps}
                         name="nextSteps"
+                        component={FieldHelper.ReadonlyField}
+                        style={{ marginBottom: 0 }}
+                      />
+                      <DictionaryField
+                        wrappedComponent={Field}
+                        dictProps={Settings.classification}
+                        name="classification"
                         component={FieldHelper.ReadonlyField}
                         style={{ marginBottom: 0 }}
                       />

--- a/client/src/pages/reports/Show.js
+++ b/client/src/pages/reports/Show.js
@@ -446,7 +446,7 @@ const ReportShow = ({ setSearchQuery, pageDispatchers }) => {
               <div
                 style={{ width: "100%", fontSize: "18px", textAlign: "center" }}
               >
-                <span style={{ fontWeight: "bold" }}>
+                <span style={{ fontWeight: "bold" }} id="report-classification">
                   {Settings.classification.choices[report.classification]}
                 </span>
               </div>

--- a/client/src/pages/reports/Show.js
+++ b/client/src/pages/reports/Show.js
@@ -575,14 +575,17 @@ const ReportShow = ({ setSearchQuery, pageDispatchers }) => {
                         component={FieldHelper.ReadonlyField}
                         style={{ marginBottom: 0 }}
                       />
-                      <DictionaryField
-                        wrappedComponent={Field}
-                        dictProps={Settings.classification}
-                        name="classification"
-                        component={FieldHelper.ReadonlyField}
-                        style={{ marginBottom: 0 }}
-                      />
                     </div>
+                  }
+                />
+
+                <DictionaryField
+                  wrappedComponent={Field}
+                  dictProps={Settings.classification}
+                  name="classification"
+                  component={FieldHelper.ReadonlyField}
+                  humanValue={
+                    Settings.classification.choices[report.classification]
                   }
                 />
 

--- a/client/src/pages/reports/Show.js
+++ b/client/src/pages/reports/Show.js
@@ -442,6 +442,16 @@ const ReportShow = ({ setSearchQuery, pageDispatchers }) => {
 
             <Messages success={saveSuccess} error={saveError} />
 
+            {report.classification && (
+              <div
+                style={{ width: "100%", fontSize: "18px", textAlign: "center" }}
+              >
+                <span style={{ fontWeight: "bold" }}>
+                  {Settings.classification.choices[report.classification]}
+                </span>
+              </div>
+            )}
+
             {report.isPublished() && (
               <Fieldset style={{ textAlign: "center" }}>
                 <h4 className="text-danger">This {reportType} is PUBLISHED.</h4>
@@ -548,15 +558,6 @@ const ReportShow = ({ setSearchQuery, pageDispatchers }) => {
                 action={action}
               />
               <Fieldset className="show-report-overview">
-                <DictionaryField
-                  wrappedComponent={Field}
-                  dictProps={Settings.classification}
-                  name="classification"
-                  component={FieldHelper.ReadonlyField}
-                  humanValue={
-                    Settings.classification.choices[report.classification]
-                  }
-                />
                 <Field
                   label="Summary"
                   name="summary"

--- a/client/src/pages/reports/Show.js
+++ b/client/src/pages/reports/Show.js
@@ -548,6 +548,15 @@ const ReportShow = ({ setSearchQuery, pageDispatchers }) => {
                 action={action}
               />
               <Fieldset className="show-report-overview">
+                <DictionaryField
+                  wrappedComponent={Field}
+                  dictProps={Settings.classification}
+                  name="classification"
+                  component={FieldHelper.ReadonlyField}
+                  humanValue={
+                    Settings.classification.choices[report.classification]
+                  }
+                />
                 <Field
                   label="Summary"
                   name="summary"
@@ -576,16 +585,6 @@ const ReportShow = ({ setSearchQuery, pageDispatchers }) => {
                         style={{ marginBottom: 0 }}
                       />
                     </div>
-                  }
-                />
-
-                <DictionaryField
-                  wrappedComponent={Field}
-                  dictProps={Settings.classification}
-                  name="classification"
-                  component={FieldHelper.ReadonlyField}
-                  humanValue={
-                    Settings.classification.choices[report.classification]
                   }
                 />
 

--- a/client/stories/0-general/attachments.stories.mdx
+++ b/client/stories/0-general/attachments.stories.mdx
@@ -29,8 +29,7 @@ Users can also clear their own avatar, but not set a new one, as only admins can
 
 Other relevant settings are:
 
-- `fields.attachment.classification`: this defines the available classification labels for
-   attachments
+- `classification`: this defines the available classification labels for attachments and reports
 - `fields.attachment.mimeTypes`: this defines the available MIME types for attachments, e.g.
   * application/pdf
   * image/avif

--- a/client/tests/webdriver/baseSpecs/showReport.spec.js
+++ b/client/tests/webdriver/baseSpecs/showReport.spec.js
@@ -2,8 +2,6 @@ import { expect } from "chai"
 import MyReports, { REPORT_STATES } from "../pages/myReports.page"
 import ShowReport from "../pages/report/showReport.page"
 
-const REPORT_CLASSIFICATION = ""
-
 describe("Show report page", () => {
   beforeEach("Open the show report page", async() => {
     await MyReports.open("arthur")
@@ -31,11 +29,6 @@ describe("Show report page", () => {
         await ShowReport.getTasksEngagementAssessments()
       ).$$("[name*=question3]")
       expect(question3Assessments).to.have.length(2)
-      await (await ShowReport.getClassification()).waitForExist()
-      await (await ShowReport.getClassification()).waitForDisplayed()
-      expect(await (await ShowReport.getClassification()).getText()).to.equal(
-        REPORT_CLASSIFICATION
-      )
     })
   })
   describe("When on the show page of a report with attachment(s)", () => {
@@ -54,6 +47,26 @@ describe("Show report page", () => {
       await (await ShowReport.getImageClick()).click()
       await expect(await browser.getUrl()).to.include(
         "/attachments/f076406f-1a9b-4fc9-8ab2-cd2a138ec26d"
+      )
+    })
+  })
+})
+
+const REPORT_CLASSIFICATION = "NATO UNCLASSIFIED"
+describe("Show report page with classification", () => {
+  beforeEach("Open the show report page", async() => {
+    await MyReports.open("arthur")
+    await MyReports.selectReport(
+      "A classified report from Arthur",
+      REPORT_STATES.DRAFT
+    )
+  })
+  describe("When on the show page of a report with classification", () => {
+    it("We should see the classification related to the current report", async() => {
+      await (await ShowReport.getClassification()).waitForExist()
+      await (await ShowReport.getClassification()).waitForDisplayed()
+      expect(await (await ShowReport.getClassification()).getText()).to.equal(
+        REPORT_CLASSIFICATION
       )
     })
   })

--- a/client/tests/webdriver/baseSpecs/showReport.spec.js
+++ b/client/tests/webdriver/baseSpecs/showReport.spec.js
@@ -1,5 +1,4 @@
 import { expect } from "chai"
-import ShowAttachment from "../pages/attachment/showAttachment.page"
 import MyReports, { REPORT_STATES } from "../pages/myReports.page"
 import ShowReport from "../pages/report/showReport.page"
 
@@ -32,11 +31,11 @@ describe("Show report page", () => {
         await ShowReport.getTasksEngagementAssessments()
       ).$$("[name*=question3]")
       expect(question3Assessments).to.have.length(2)
-      await (await ShowAttachment.getClassification()).waitForExist()
-      await (await ShowAttachment.getClassification()).waitForDisplayed()
-      expect(
-        await (await ShowAttachment.getClassification()).getText()
-      ).to.equal(REPORT_CLASSIFICATION)
+      await (await ShowReport.getClassification()).waitForExist()
+      await (await ShowReport.getClassification()).waitForDisplayed()
+      expect(await (await ShowReport.getClassification()).getText()).to.equal(
+        REPORT_CLASSIFICATION
+      )
     })
   })
   describe("When on the show page of a report with attachment(s)", () => {

--- a/client/tests/webdriver/baseSpecs/showReport.spec.js
+++ b/client/tests/webdriver/baseSpecs/showReport.spec.js
@@ -1,6 +1,9 @@
 import { expect } from "chai"
+import ShowAttachment from "../pages/attachment/showAttachment.page"
 import MyReports, { REPORT_STATES } from "../pages/myReports.page"
 import ShowReport from "../pages/report/showReport.page"
+
+const REPORT_CLASSIFICATION = ""
 
 describe("Show report page", () => {
   beforeEach("Open the show report page", async() => {
@@ -29,9 +32,14 @@ describe("Show report page", () => {
         await ShowReport.getTasksEngagementAssessments()
       ).$$("[name*=question3]")
       expect(question3Assessments).to.have.length(2)
+      await (await ShowAttachment.getClassification()).waitForExist()
+      await (await ShowAttachment.getClassification()).waitForDisplayed()
+      expect(
+        await (await ShowAttachment.getClassification()).getText()
+      ).to.equal(REPORT_CLASSIFICATION)
     })
   })
-  describe("WHen on the show page of a report with attachment(s)", () => {
+  describe("When on the show page of a report with attachment(s)", () => {
     it("We should see a container for Attachment List", async() => {
       // Attachment container
       await (await ShowReport.getAttachments()).waitForExist()

--- a/client/tests/webdriver/pages/report/showReport.page.js
+++ b/client/tests/webdriver/pages/report/showReport.page.js
@@ -11,7 +11,7 @@ class ShowReport extends Page {
   REPORT_IS_APPROVED = "This report is APPROVED."
 
   async getClassification() {
-    return browser.$("#classification")
+    return browser.$("#report-classification")
   }
 
   async getEditReportButton() {

--- a/client/tests/webdriver/pages/report/showReport.page.js
+++ b/client/tests/webdriver/pages/report/showReport.page.js
@@ -10,6 +10,10 @@ class ShowReport extends Page {
   REPORT_IS_PENDING_APPROVALS = "This report is PENDING approvals."
   REPORT_IS_APPROVED = "This report is APPROVED."
 
+  async getClassification() {
+    return browser.$("#classification")
+  }
+
   async getEditReportButton() {
     return browser.$("//a[text()='Edit']")
   }

--- a/insertBaseData-psql.sql
+++ b/insertBaseData-psql.sql
@@ -776,7 +776,7 @@ INSERT INTO "reportTasks" ("taskUuid", "reportUuid") VALUES
 SELECT ('''' || uuid_generate_v4() || '''') AS reportuuid \gset
 INSERT INTO reports (uuid, "createdAt", "updatedAt", "locationUuid", intent, text, "nextSteps", "keyOutcomes", state, "engagementDate", atmosphere, "advisorOrganizationUuid", "interlocutorOrganizationUuid", "classification") VALUES
   (:reportuuid, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, (SELECT uuid from locations where name='General Hospital'), 'A classified report from Arthur', '',
-  'keep on testing!','check the classification', 0, CURRENT_TIMESTAMP + INTERVAL '1 minute', 0,
+  'keep on testing!', 'check the classification', 0, CURRENT_TIMESTAMP + INTERVAL '1 minute', 0,
   (SELECT uuid FROM organizations where "shortName" = 'ANET Administrators'), (SELECT uuid FROM organizations WHERE "longName" LIKE 'Ministry of Interior'), 'NU');
 INSERT INTO "reportPeople" ("personUuid", "reportUuid", "isPrimary", "isAuthor", "isInterlocutor") VALUES
   ((SELECT uuid FROM people where "emailAddress"='hunter+arthur@example.com'), :reportuuid, TRUE, TRUE, FALSE),
@@ -784,7 +784,6 @@ INSERT INTO "reportPeople" ("personUuid", "reportUuid", "isPrimary", "isAuthor",
   ((SELECT uuid FROM people where "emailAddress"='lin+guist@example.com'), :reportuuid, FALSE, FALSE, FALSE),
   ((SELECT uuid FROM people where "emailAddress"='kyleson+kyle@example.com'), :reportuuid, FALSE, FALSE, TRUE),
   ((SELECT uuid FROM people where "emailAddress"='chrisville+chris@example.com'), :reportuuid, FALSE, FALSE, TRUE);
-
 
 SELECT ('''' || uuid_generate_v4() || '''') AS reportuuid \gset
 INSERT INTO reports (uuid, "createdAt", "updatedAt", "locationUuid", intent, text, "nextSteps", "keyOutcomes", state, "engagementDate", atmosphere, "advisorOrganizationUuid", "interlocutorOrganizationUuid") VALUES

--- a/insertBaseData-psql.sql
+++ b/insertBaseData-psql.sql
@@ -774,6 +774,19 @@ INSERT INTO "reportTasks" ("taskUuid", "reportUuid") VALUES
   ((SELECT uuid from tasks where "shortName" = '1.2.B'), :reportuuid);
 
 SELECT ('''' || uuid_generate_v4() || '''') AS reportuuid \gset
+INSERT INTO reports (uuid, "createdAt", "updatedAt", "locationUuid", intent, text, "nextSteps", "keyOutcomes", state, "engagementDate", atmosphere, "advisorOrganizationUuid", "interlocutorOrganizationUuid", "classification") VALUES
+  (:reportuuid, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, (SELECT uuid from locations where name='General Hospital'), 'A classified report from Arthur', '',
+  'keep on testing!','check the classification', 0, CURRENT_TIMESTAMP + INTERVAL '1 minute', 0,
+  (SELECT uuid FROM organizations where "shortName" = 'ANET Administrators'), (SELECT uuid FROM organizations WHERE "longName" LIKE 'Ministry of Interior'), 'NU');
+INSERT INTO "reportPeople" ("personUuid", "reportUuid", "isPrimary", "isAuthor", "isInterlocutor") VALUES
+  ((SELECT uuid FROM people where "emailAddress"='hunter+arthur@example.com'), :reportuuid, TRUE, TRUE, FALSE),
+  ((SELECT uuid FROM people where "emailAddress"='hunter+shardul@example.com'), :reportuuid, TRUE, FALSE, TRUE),
+  ((SELECT uuid FROM people where "emailAddress"='lin+guist@example.com'), :reportuuid, FALSE, FALSE, FALSE),
+  ((SELECT uuid FROM people where "emailAddress"='kyleson+kyle@example.com'), :reportuuid, FALSE, FALSE, TRUE),
+  ((SELECT uuid FROM people where "emailAddress"='chrisville+chris@example.com'), :reportuuid, FALSE, FALSE, TRUE);
+
+
+SELECT ('''' || uuid_generate_v4() || '''') AS reportuuid \gset
 INSERT INTO reports (uuid, "createdAt", "updatedAt", "locationUuid", intent, text, "nextSteps", "keyOutcomes", state, "engagementDate", atmosphere, "advisorOrganizationUuid", "interlocutorOrganizationUuid") VALUES
   (:reportuuid, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, (SELECT uuid from locations where name='General Hospital'), 'A test report to be unpublished from Arthur', '',
   'I need to edit this report so unpublish it please','have reports in organizations', 2, CURRENT_TIMESTAMP + INTERVAL '1 minute', 0,

--- a/src/main/java/mil/dds/anet/beans/Report.java
+++ b/src/main/java/mil/dds/anet/beans/Report.java
@@ -19,6 +19,7 @@ import mil.dds.anet.AnetObjectEngine;
 import mil.dds.anet.utils.DaoUtils;
 import mil.dds.anet.utils.IdDataLoaderKey;
 import mil.dds.anet.utils.Utils;
+import mil.dds.anet.views.AbstractAnetBean;
 import mil.dds.anet.views.AbstractCustomizableAnetBean;
 import mil.dds.anet.views.UuidFetcher;
 
@@ -620,12 +621,7 @@ public class Report extends AbstractCustomizableAnetBean
     // Check if there are report actions for this step
     final Optional<ReportAction> existing =
         actions.stream().filter(a -> Objects.equals(DaoUtils.getUuid(step), a.getStepUuid()))
-            .max(new Comparator<ReportAction>() {
-              @Override
-              public int compare(ReportAction a, ReportAction b) {
-                return a.getCreatedAt().compareTo(b.getCreatedAt());
-              }
-            });
+            .max(Comparator.comparing(AbstractAnetBean::getCreatedAt));
     return existing.isPresent() ? null : step;
   }
 
@@ -690,7 +686,7 @@ public class Report extends AbstractCustomizableAnetBean
   private CompletableFuture<List<ApprovalStep>> getPlanningWorkflowForRelatedObject(
       Map<String, Object> context, AnetObjectEngine engine, String relatedObjectUuid) {
     if (relatedObjectUuid == null) {
-      return CompletableFuture.completedFuture(new ArrayList<ApprovalStep>());
+      return CompletableFuture.completedFuture(new ArrayList<>());
     }
 
     return engine.getPlanningApprovalStepsForRelatedObject(context, relatedObjectUuid);
@@ -699,7 +695,7 @@ public class Report extends AbstractCustomizableAnetBean
   private CompletableFuture<List<ApprovalStep>> getWorkflowForRelatedObject(
       Map<String, Object> context, AnetObjectEngine engine, String relatedObjectUuid) {
     if (relatedObjectUuid == null) {
-      return CompletableFuture.completedFuture(new ArrayList<ApprovalStep>());
+      return CompletableFuture.completedFuture(new ArrayList<>());
     }
 
     return engine.getApprovalStepsForRelatedObject(context, relatedObjectUuid);
@@ -783,7 +779,7 @@ public class Report extends AbstractCustomizableAnetBean
 
   @GraphQLQuery(name = "engagementStatus")
   public List<EngagementStatus> loadEngagementStatus() {
-    LinkedList<EngagementStatus> statuses = new LinkedList<EngagementStatus>();
+    LinkedList<EngagementStatus> statuses = new LinkedList<>();
     if (state == ReportState.CANCELLED) {
       statuses.add(EngagementStatus.CANCELLED);
     }
@@ -799,11 +795,12 @@ public class Report extends AbstractCustomizableAnetBean
 
   @Override
   public boolean equals(Object o) {
-    if (!(o instanceof Report)) {
+    if (!(o instanceof final Report r)) {
       return false;
     }
-    final Report r = (Report) o;
-    return super.equals(o) && Objects.equals(r.getUuid(), uuid)
+
+    return super.equals(o)
+        && Objects.equals(r.getUuid(), uuid)
         && Objects.equals(r.getState(), state)
         && Objects.equals(r.getApprovalStepUuid(), getApprovalStepUuid())
         && Objects.equals(r.getCreatedAt(), createdAt)
@@ -811,12 +808,15 @@ public class Report extends AbstractCustomizableAnetBean
         && Objects.equals(r.getEngagementDate(), engagementDate)
         && Objects.equals(r.getDuration(), duration)
         && Objects.equals(r.getLocationUuid(), getLocationUuid())
-        && Objects.equals(r.getIntent(), intent) && Objects.equals(r.getExsum(), exsum)
+        && Objects.equals(r.getIntent(), intent)
+        && Objects.equals(r.getExsum(), exsum)
         && Objects.equals(r.getAtmosphere(), atmosphere)
         && Objects.equals(r.getAtmosphereDetails(), atmosphereDetails)
-        && Objects.equals(r.getReportPeople(), reportPeople) && Objects.equals(r.getTasks(), tasks)
+        && Objects.equals(r.getReportPeople(), reportPeople)
+        && Objects.equals(r.getTasks(), tasks)
         && Objects.equals(r.getReportText(), reportText)
-        && Objects.equals(r.getNextSteps(), nextSteps) && Objects.equals(r.getComments(), comments)
+        && Objects.equals(r.getNextSteps(), nextSteps)
+        && Objects.equals(r.getComments(), comments)
         && Objects.equals(r.getReportSensitiveInformation(), reportSensitiveInformation)
         && Objects.equals(r.getAuthorizationGroups(), authorizationGroups);
   }

--- a/src/main/java/mil/dds/anet/beans/Report.java
+++ b/src/main/java/mil/dds/anet/beans/Report.java
@@ -799,8 +799,7 @@ public class Report extends AbstractCustomizableAnetBean
       return false;
     }
 
-    return super.equals(o)
-        && Objects.equals(r.getUuid(), uuid)
+    return super.equals(o) && Objects.equals(r.getUuid(), uuid)
         && Objects.equals(r.getState(), state)
         && Objects.equals(r.getApprovalStepUuid(), getApprovalStepUuid())
         && Objects.equals(r.getCreatedAt(), createdAt)
@@ -808,15 +807,12 @@ public class Report extends AbstractCustomizableAnetBean
         && Objects.equals(r.getEngagementDate(), engagementDate)
         && Objects.equals(r.getDuration(), duration)
         && Objects.equals(r.getLocationUuid(), getLocationUuid())
-        && Objects.equals(r.getIntent(), intent)
-        && Objects.equals(r.getExsum(), exsum)
+        && Objects.equals(r.getIntent(), intent) && Objects.equals(r.getExsum(), exsum)
         && Objects.equals(r.getAtmosphere(), atmosphere)
         && Objects.equals(r.getAtmosphereDetails(), atmosphereDetails)
-        && Objects.equals(r.getReportPeople(), reportPeople)
-        && Objects.equals(r.getTasks(), tasks)
+        && Objects.equals(r.getReportPeople(), reportPeople) && Objects.equals(r.getTasks(), tasks)
         && Objects.equals(r.getReportText(), reportText)
-        && Objects.equals(r.getNextSteps(), nextSteps)
-        && Objects.equals(r.getComments(), comments)
+        && Objects.equals(r.getNextSteps(), nextSteps) && Objects.equals(r.getComments(), comments)
         && Objects.equals(r.getReportSensitiveInformation(), reportSensitiveInformation)
         && Objects.equals(r.getAuthorizationGroups(), authorizationGroups);
   }

--- a/src/main/java/mil/dds/anet/beans/Report.java
+++ b/src/main/java/mil/dds/anet/beans/Report.java
@@ -91,6 +91,11 @@ public class Report extends AbstractCustomizableAnetBean
   @GraphQLQuery
   @GraphQLInputField
   String reportText;
+
+  @GraphQLQuery
+  @GraphQLInputField
+  private String classification;
+
   // annotated below
   private List<ReportPerson> reportPeople;
   // annotated below
@@ -191,6 +196,14 @@ public class Report extends AbstractCustomizableAnetBean
 
   public void setDuration(Integer duration) {
     this.duration = duration;
+  }
+
+  public String getClassification() {
+    return classification;
+  }
+
+  public void setClassification(final String classification) {
+    this.classification = classification;
   }
 
   @GraphQLQuery(name = "location")

--- a/src/main/java/mil/dds/anet/database/ReportDao.java
+++ b/src/main/java/mil/dds/anet/database/ReportDao.java
@@ -72,8 +72,9 @@ public class ReportDao extends AnetSubscribableObjectDao<Report, ReportSearchQue
       LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
   // Must always retrieve these e.g. for ORDER BY or search post-processing
-  public static final String[] minimalFields = {"uuid", "approvalStepUuid",
-      "advisorOrganizationUuid", "createdAt", "updatedAt", "engagementDate", "releasedAt", "state"};
+  public static final String[] minimalFields =
+      {"uuid", "approvalStepUuid", "advisorOrganizationUuid", "createdAt", "updatedAt",
+          "engagementDate", "releasedAt", "state", "classification"};
   public static final String[] additionalFields = {"duration", "intent", "exsum", "locationUuid",
       "interlocutorOrganizationUuid", "atmosphere", "cancelledReason", "atmosphereDetails", "text",
       "keyOutcomes", "nextSteps", "customFields"};
@@ -119,11 +120,11 @@ public class ReportDao extends AnetSubscribableObjectDao<Report, ReportSearchQue
         + "text, \"keyOutcomes\", \"nextSteps\", "
         + "\"engagementDate\", \"releasedAt\", duration, atmosphere, \"cancelledReason\", "
         + "\"atmosphereDetails\", \"advisorOrganizationUuid\", "
-        + "\"interlocutorOrganizationUuid\", \"customFields\") VALUES "
+        + "\"interlocutorOrganizationUuid\", \"customFields\", \"classification\") VALUES "
         + "(:uuid, :state, :createdAt, :updatedAt, :locationUuid, :intent, "
         + ":exsum, :reportText, :keyOutcomes, :nextSteps, :engagementDate, :releasedAt, "
         + ":duration, :atmosphere, :cancelledReason, :atmosphereDetails, :advisorOrgUuid, "
-        + ":interlocutorOrgUuid, :customFields)";
+        + ":interlocutorOrgUuid, :customFields, :classification)";
 
     getDbHandle().createUpdate(sql).bindBean(r)
         .bind("createdAt", DaoUtils.asLocalDateTime(r.getCreatedAt()))
@@ -238,8 +239,8 @@ public class ReportDao extends AnetSubscribableObjectDao<Report, ReportSearchQue
         + "\"atmosphereDetails\" = :atmosphereDetails, "
         + "\"cancelledReason\" = :cancelledReason, "
         + "\"interlocutorOrganizationUuid\" = :interlocutorOrgUuid, "
-        + "\"advisorOrganizationUuid\" = :advisorOrgUuid, "
-        + "\"customFields\" = :customFields WHERE uuid = :uuid";
+        + "\"advisorOrganizationUuid\" = :advisorOrgUuid, " + "\"customFields\" = :customFields, "
+        + "\"classification\" = :classification WHERE uuid = :uuid";
 
     return getDbHandle().createUpdate(sql).bindBean(r)
         .bind("updatedAt", DaoUtils.asLocalDateTime(r.getUpdatedAt()))

--- a/src/main/java/mil/dds/anet/database/ReportDao.java
+++ b/src/main/java/mil/dds/anet/database/ReportDao.java
@@ -506,9 +506,8 @@ public class ReportDao extends AnetSubscribableObjectDao<Report, ReportSearchQue
     sql.append("organizations.\"shortName\" AS \"organizationShortName\",");
     sql.append("%3$s");
     sql.append("%4$s");
-    sql.append(" ")
-       .append(String.format(getWeekFormat(), "reports.\"createdAt\""))
-       .append(" AS week,");
+    sql.append(" ").append(String.format(getWeekFormat(), "reports.\"createdAt\""))
+        .append(" AS week,");
     sql.append("COUNT(\"reportPeople\".\"personUuid\") AS \"nrReportsSubmitted\"");
 
     sql.append(" FROM ");
@@ -624,9 +623,8 @@ public class ReportDao extends AnetSubscribableObjectDao<Report, ReportSearchQue
     final Map<String, List<?>> listArgs = new HashMap<>();
 
     StringBuilder sql = new StringBuilder();
-    sql.append("/* RollupQuery */ SELECT ")
-       .append(orgColumn)
-       .append(" as \"orgUuid\", state, count(*) AS count ");
+    sql.append("/* RollupQuery */ SELECT ").append(orgColumn)
+        .append(" as \"orgUuid\", state, count(*) AS count ");
     sql.append("FROM reports WHERE ");
 
     sql.append("\"releasedAt\" >= :startDate and \"releasedAt\" < :endDate "
@@ -637,20 +635,14 @@ public class ReportDao extends AnetSubscribableObjectDao<Report, ReportSearchQue
         getRollupEngagmentStart(start));
 
     if (!Utils.isEmptyOrNull(orgs)) {
-      sql.append("AND ")
-         .append(orgColumn)
-         .append(" IN ( <orgUuids> ) ");
+      sql.append("AND ").append(orgColumn).append(" IN ( <orgUuids> ) ");
       listArgs.put("orgUuids",
           orgs.stream().map(AbstractAnetBean::getUuid).collect(Collectors.toList()));
     } else if (missingOrgReports) {
-      sql.append(" AND ")
-         .append(orgColumn)
-         .append(" IS NULL ");
+      sql.append(" AND ").append(orgColumn).append(" IS NULL ");
     }
 
-    sql.append("GROUP BY ")
-       .append(orgColumn)
-       .append(", state");
+    sql.append("GROUP BY ").append(orgColumn).append(", state");
 
     final Query q = getDbHandle().createQuery(sql.toString()).bindMap(sqlArgs);
     for (final Map.Entry<String, List<?>> listArg : listArgs.entrySet()) {
@@ -806,10 +798,8 @@ public class ReportDao extends AnetSubscribableObjectDao<Report, ReportSearchQue
     final ReportPublishedEmail action = new ReportPublishedEmail();
     action.setReport(r);
     email.setAction(action);
-    email.setToAddresses(
-        r.loadAuthors(AnetObjectEngine.getInstance().getContext()).join().stream()
-            .map(Person::getEmailAddress)
-            .collect(Collectors.toList()));
+    email.setToAddresses(r.loadAuthors(AnetObjectEngine.getInstance().getContext()).join().stream()
+        .map(Person::getEmailAddress).collect(Collectors.toList()));
     AnetEmailWorker.sendEmailAsync(email);
   }
 

--- a/src/main/java/mil/dds/anet/database/mappers/ReportMapper.java
+++ b/src/main/java/mil/dds/anet/database/mappers/ReportMapper.java
@@ -1,5 +1,7 @@
 package mil.dds.anet.database.mappers;
 
+import static mil.dds.anet.database.mappers.MapperUtils.*;
+
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import mil.dds.anet.beans.Report;
@@ -16,27 +18,25 @@ public class ReportMapper implements RowMapper<Report> {
     Report r = new Report();
     MapperUtils.setCustomizableBeanFields(r, rs, "reports");
 
-    r.setState(MapperUtils.getEnumIdx(rs, "reports_state", ReportState.class));
-    r.setEngagementDate(MapperUtils.getInstantAsLocalDateTime(rs, "reports_engagementDate"));
-    r.setDuration(MapperUtils.getOptionalInt(rs, "reports_duration"));
-    r.setReleasedAt(MapperUtils.getInstantAsLocalDateTime(rs, "reports_releasedAt"));
-    r.setLocationUuid(MapperUtils.getOptionalString(rs, "reports_locationUuid"));
-    r.setApprovalStepUuid(MapperUtils.getOptionalString(rs, "reports_approvalStepUuid"));
+    r.setState(getEnumIdx(rs, "reports_state", ReportState.class));
+    r.setEngagementDate(getInstantAsLocalDateTime(rs, "reports_engagementDate"));
+    r.setDuration(getOptionalInt(rs, "reports_duration"));
+    r.setReleasedAt(getInstantAsLocalDateTime(rs, "reports_releasedAt"));
+    r.setLocationUuid(getOptionalString(rs, "reports_locationUuid"));
+    r.setApprovalStepUuid(getOptionalString(rs, "reports_approvalStepUuid"));
 
-    r.setIntent(MapperUtils.getOptionalString(rs, "reports_intent"));
-    r.setExsum(MapperUtils.getOptionalString(rs, "reports_exsum"));
-    r.setAtmosphere(MapperUtils.getEnumIdx(rs, "reports_atmosphere", Atmosphere.class));
-    r.setAtmosphereDetails(MapperUtils.getOptionalString(rs, "reports_atmosphereDetails"));
-    r.setCancelledReason(
-        MapperUtils.getEnumIdx(rs, "reports_cancelledReason", ReportCancelledReason.class));
+    r.setIntent(getOptionalString(rs, "reports_intent"));
+    r.setExsum(getOptionalString(rs, "reports_exsum"));
+    r.setAtmosphere(getEnumIdx(rs, "reports_atmosphere", Atmosphere.class));
+    r.setAtmosphereDetails(getOptionalString(rs, "reports_atmosphereDetails"));
+    r.setCancelledReason(getEnumIdx(rs, "reports_cancelledReason", ReportCancelledReason.class));
 
-    r.setReportText(MapperUtils.getOptionalString(rs, "reports_text"));
-    r.setKeyOutcomes(MapperUtils.getOptionalString(rs, "reports_keyOutcomes"));
-    r.setNextSteps(MapperUtils.getOptionalString(rs, "reports_nextSteps"));
+    r.setReportText(getOptionalString(rs, "reports_text"));
+    r.setKeyOutcomes(getOptionalString(rs, "reports_keyOutcomes"));
+    r.setNextSteps(getOptionalString(rs, "reports_nextSteps"));
 
-    r.setAdvisorOrgUuid(MapperUtils.getOptionalString(rs, "reports_advisorOrganizationUuid"));
-    r.setInterlocutorOrgUuid(
-        MapperUtils.getOptionalString(rs, "reports_interlocutorOrganizationUuid"));
+    r.setAdvisorOrgUuid(getOptionalString(rs, "reports_advisorOrganizationUuid"));
+    r.setInterlocutorOrgUuid(getOptionalString(rs, "reports_interlocutorOrganizationUuid"));
 
     if (MapperUtils.containsColumnNamed(rs, "totalCount")) {
       ctx.define("totalCount", rs.getInt("totalCount"));
@@ -44,6 +44,8 @@ public class ReportMapper implements RowMapper<Report> {
     if (MapperUtils.containsColumnNamed(rs, "engagementDayOfWeek")) {
       r.setEngagementDayOfWeek(rs.getInt("engagementDayOfWeek"));
     }
+
+    r.setClassification(getOptionalString(rs, "reports_classification"));
 
     return r;
   }

--- a/src/main/java/mil/dds/anet/resources/ReportResource.java
+++ b/src/main/java/mil/dds/anet/resources/ReportResource.java
@@ -135,6 +135,8 @@ public class ReportResource {
       throw new WebApplicationException("Can only create Draft reports", Status.BAD_REQUEST);
     }
 
+    ResourceUtils.assertAllowedClassification(r.getClassification());
+
     Person primaryAdvisor = findPrimaryAttendee(r, false);
     if (r.getAdvisorOrgUuid() == null && primaryAdvisor != null) {
       logger.debug("Setting advisor org for new report based on {}", primaryAdvisor);
@@ -150,8 +152,6 @@ public class ReportResource {
 
     r.setReportText(
         Utils.isEmptyHtml(r.getReportText()) ? null : Utils.sanitizeHtml(r.getReportText()));
-
-    ResourceUtils.assertAllowedClassification(r.getClassification());
 
     final Report created = dao.insert(r, author);
 
@@ -209,7 +209,6 @@ public class ReportResource {
    * @return the report as it was stored in the database before this method was called.
    */
   private Report executeReportUpdates(Person editor, Report r) {
-    ResourceUtils.assertAllowedClassification(r.getClassification());
     // Verify this person has access to edit this report
     // Either they are an author, or an approver for the current step.
     final Report existing = dao.getByUuid(r.getUuid());
@@ -228,6 +227,7 @@ public class ReportResource {
     // Only *existing* authors can change a report!
     final boolean isAuthor = existing.isAuthor(editor);
     assertCanUpdateReport(r, editor, isAuthor);
+    ResourceUtils.assertAllowedClassification(r.getClassification());
 
     // State should not change when report is being edited by an approver
     // State should change to draft when the report is being edited by one of the existing authors
@@ -885,7 +885,7 @@ public class ReportResource {
     @Override
     public int compare(final RollupGraph o1, final RollupGraph o2) {
 
-      int result;
+      final int result;
 
       if (o1.getOrg() != null && o2.getOrg() == null) {
         result = -1;

--- a/src/main/java/mil/dds/anet/utils/ResourceUtils.java
+++ b/src/main/java/mil/dds/anet/utils/ResourceUtils.java
@@ -106,7 +106,9 @@ public class ResourceUtils {
   }
 
   private static void checkAndFixText(final Note n) {
-    if (n.getText() == null || n.getText().trim().length() == 0) {
+    if (n.getText() == null || n.getText()
+                                .trim()
+                                .isEmpty()) {
       throw new WebApplicationException("Note text must not be empty", Status.BAD_REQUEST);
     }
     sanitizeText(n);

--- a/src/main/java/mil/dds/anet/utils/ResourceUtils.java
+++ b/src/main/java/mil/dds/anet/utils/ResourceUtils.java
@@ -3,8 +3,10 @@ package mil.dds.anet.utils;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import java.lang.invoke.MethodHandles;
 import java.util.List;
+import java.util.Map;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response.Status;
+import mil.dds.anet.AnetObjectEngine;
 import mil.dds.anet.beans.Note;
 import mil.dds.anet.beans.Note.NoteType;
 import mil.dds.anet.beans.PersonPositionHistory;
@@ -129,4 +131,19 @@ public class ResourceUtils {
     }
   }
 
+  @SuppressWarnings("unchecked")
+  public static Map<String, String> getAllowedClassifications() {
+    return (Map<String, String>) ((Map<String, Object>) AnetObjectEngine.getConfiguration()
+        .getDictionaryEntry("classification")).get("choices");
+  }
+
+  public static void assertAllowedClassification(final String classificationKey) {
+    if (classificationKey != null) {
+      // if the classification is set, check if it is valid
+      final var allowedClassifications = getAllowedClassifications();
+      if (!allowedClassifications.containsKey(classificationKey)) {
+        throw new WebApplicationException("Classification is not allowed", Status.BAD_REQUEST);
+      }
+    }
+  }
 }

--- a/src/main/java/mil/dds/anet/utils/ResourceUtils.java
+++ b/src/main/java/mil/dds/anet/utils/ResourceUtils.java
@@ -106,9 +106,7 @@ public class ResourceUtils {
   }
 
   private static void checkAndFixText(final Note n) {
-    if (n.getText() == null || n.getText()
-                                .trim()
-                                .isEmpty()) {
+    if (n.getText() == null || n.getText().trim().isEmpty()) {
       throw new WebApplicationException("Note text must not be empty", Status.BAD_REQUEST);
     }
     sanitizeText(n);

--- a/src/main/resources/anet-schema.yml
+++ b/src/main/resources/anet-schema.yml
@@ -372,6 +372,7 @@ required:
   - dateFormats
   - reportWorkflow
   - maxTextFieldLength
+  - classification
   - fields
   - pinned_ORGs
   - non_reporting_ORGs
@@ -530,6 +531,14 @@ properties:
     title: The maximum number of characters allowed in selected text fields
     description: Used in the UI for report intent, report key outcomes, report next steps, authorization group description
 
+  classification:
+    type: object
+    properties:
+      label:
+        type: string
+      choices:
+        type: object
+
   fields:
     type: object
     additionalProperties: false
@@ -598,7 +607,7 @@ properties:
       attachment:
         type: object
         additionalProperties: false
-        required: [featureDisabled, restrictToAdmins, fileName, caption, description, classification]
+        required: [featureDisabled, restrictToAdmins, fileName, caption, description]
         properties:
           featureDisabled:
             type: boolean
@@ -614,8 +623,6 @@ properties:
             "$ref": "#/$defs/inputField"
           description:
             "$ref": "#/$defs/inputField"
-          classification:
-            "$ref": "#/$defs/customField"
           mimeTypes:
             type: array
             title: The allowed MIME types for uploading attachments

--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -4725,4 +4725,5 @@
 			<column name="classification" type="${long_text_type}" />
 		</addColumn>
 	</changeSet>
+
 </databaseChangeLog>

--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -4720,4 +4720,9 @@
 		</createIndex>
 	</changeSet>
 
+	<changeSet id="add_classification_to_reports" author="Chessray">
+		<addColumn tableName="reports">
+			<column name="classification" type="${long_text_type}" />
+		</addColumn>
+	</changeSet>
 </databaseChangeLog>

--- a/src/test/java/mil/dds/anet/test/resources/AbstractResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/AbstractResourceTest.java
@@ -1,5 +1,6 @@
 package mil.dds.anet.test.resources;
 
+import static mil.dds.anet.utils.ResourceUtils.getAllowedClassifications;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
@@ -473,4 +474,7 @@ public abstract class AbstractResourceTest {
     return ClientBuilder.newBuilder().register(HttpAuthenticationFeature.basic(user, user)).build();
   }
 
+  protected String getFirstClassification() {
+    return getAllowedClassifications().keySet().iterator().next();
+  }
 }

--- a/src/test/java/mil/dds/anet/test/resources/AbstractResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/AbstractResourceTest.java
@@ -308,7 +308,8 @@ public abstract class AbstractResourceTest {
 
   protected static List<ApprovalStepInput> getApprovalStepsInput(
       final List<ApprovalStep> approvalSteps) {
-    return approvalSteps.stream().map(AbstractResourceTest::getApprovalStepInput).collect(Collectors.toList());
+    return approvalSteps.stream().map(AbstractResourceTest::getApprovalStepInput)
+        .collect(Collectors.toList());
   }
 
   protected static AuthorizationGroupInput getAuthorizationGroupInput(
@@ -334,7 +335,8 @@ public abstract class AbstractResourceTest {
 
   protected static List<OrganizationInput> getOrganizationsInput(
       final List<Organization> organizations) {
-    return organizations.stream().map(AbstractResourceTest::getOrganizationInput).collect(Collectors.toList());
+    return organizations.stream().map(AbstractResourceTest::getOrganizationInput)
+        .collect(Collectors.toList());
   }
 
   protected static List<PersonInput> getPeopleInput(
@@ -348,7 +350,8 @@ public abstract class AbstractResourceTest {
 
   protected static List<ReportPersonInput> getReportPeopleInput(
       final List<ReportPerson> reportPeople) {
-    return reportPeople.stream().map(AbstractResourceTest::getReportPersonInput).collect(Collectors.toList());
+    return reportPeople.stream().map(AbstractResourceTest::getReportPersonInput)
+        .collect(Collectors.toList());
   }
 
   protected static ReportPersonInput getReportPersonInput(final ReportPerson reportPerson) {
@@ -360,7 +363,8 @@ public abstract class AbstractResourceTest {
   }
 
   protected static List<PositionInput> getPositionsInput(final List<Position> positions) {
-    return positions.stream().map(AbstractResourceTest::getPositionInput).collect(Collectors.toList());
+    return positions.stream().map(AbstractResourceTest::getPositionInput)
+        .collect(Collectors.toList());
   }
 
   protected static PersonPositionHistoryInput getPersonPositionHistoryInput(

--- a/src/test/java/mil/dds/anet/test/resources/AbstractResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/AbstractResourceTest.java
@@ -308,7 +308,7 @@ public abstract class AbstractResourceTest {
 
   protected static List<ApprovalStepInput> getApprovalStepsInput(
       final List<ApprovalStep> approvalSteps) {
-    return approvalSteps.stream().map(as -> getApprovalStepInput(as)).collect(Collectors.toList());
+    return approvalSteps.stream().map(AbstractResourceTest::getApprovalStepInput).collect(Collectors.toList());
   }
 
   protected static AuthorizationGroupInput getAuthorizationGroupInput(
@@ -325,7 +325,7 @@ public abstract class AbstractResourceTest {
   }
 
   protected static List<NoteInput> getNotesInput(final List<Note> notes) {
-    return notes.stream().map(n -> getNoteInput(n)).collect(Collectors.toList());
+    return notes.stream().map(AbstractResourceTest::getNoteInput).collect(Collectors.toList());
   }
 
   protected static OrganizationInput getOrganizationInput(final Organization organization) {
@@ -334,12 +334,12 @@ public abstract class AbstractResourceTest {
 
   protected static List<OrganizationInput> getOrganizationsInput(
       final List<Organization> organizations) {
-    return organizations.stream().map(o -> getOrganizationInput(o)).collect(Collectors.toList());
+    return organizations.stream().map(AbstractResourceTest::getOrganizationInput).collect(Collectors.toList());
   }
 
   protected static List<PersonInput> getPeopleInput(
       final List<mil.dds.anet.test.client.Person> people) {
-    return people.stream().map(p -> getPersonInput(p)).collect(Collectors.toList());
+    return people.stream().map(AbstractResourceTest::getPersonInput).collect(Collectors.toList());
   }
 
   protected static PersonInput getPersonInput(final mil.dds.anet.test.client.Person person) {
@@ -348,7 +348,7 @@ public abstract class AbstractResourceTest {
 
   protected static List<ReportPersonInput> getReportPeopleInput(
       final List<ReportPerson> reportPeople) {
-    return reportPeople.stream().map(rp -> getReportPersonInput(rp)).collect(Collectors.toList());
+    return reportPeople.stream().map(AbstractResourceTest::getReportPersonInput).collect(Collectors.toList());
   }
 
   protected static ReportPersonInput getReportPersonInput(final ReportPerson reportPerson) {
@@ -360,7 +360,7 @@ public abstract class AbstractResourceTest {
   }
 
   protected static List<PositionInput> getPositionsInput(final List<Position> positions) {
-    return positions.stream().map(p -> getPositionInput(p)).collect(Collectors.toList());
+    return positions.stream().map(AbstractResourceTest::getPositionInput).collect(Collectors.toList());
   }
 
   protected static PersonPositionHistoryInput getPersonPositionHistoryInput(
@@ -370,7 +370,7 @@ public abstract class AbstractResourceTest {
 
   protected static List<PersonPositionHistoryInput> getPersonPositionHistoryInput(
       final List<PersonPositionHistory> history) {
-    return history.stream().map(pph -> getPersonPositionHistoryInput(pph))
+    return history.stream().map(AbstractResourceTest::getPersonPositionHistoryInput)
         .collect(Collectors.toList());
   }
 

--- a/src/test/java/mil/dds/anet/test/resources/AttachmentResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/AttachmentResourceTest.java
@@ -706,10 +706,4 @@ public class AttachmentResourceTest extends AbstractResourceTest {
     final var allowedMimeTypes = AttachmentResource.getAllowedMimeTypes();
     return allowedMimeTypes.get(0);
   }
-
-  private String getFirstClassification() {
-    final var allowedClassifications = AttachmentResource.getAllowedClassifications();
-    return allowedClassifications.keySet().iterator().next();
-  }
-
 }

--- a/src/test/java/mil/dds/anet/test/resources/ReportResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/ReportResourceTest.java
@@ -2309,7 +2309,7 @@ public class ReportResourceTest extends AbstractResourceTest {
     // Admin should normally find only their own drafts
     AnetBeanList_Report adminDraftReports =
         adminQueryExecutor.reportList(getListFields(FIELDS), draftsQuery);
-    assertThat(adminDraftReports.getTotalCount()).isOne();
+    assertThat(adminDraftReports.getTotalCount()).isEqualTo(2);
     // List should not include Erin's draft
     assertThat(adminDraftReports.getList())
         .noneMatch(report -> report.getUuid().equals(erinsDraftReport.getUuid()));

--- a/src/test/java/mil/dds/anet/test/resources/ReportResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/ReportResourceTest.java
@@ -104,7 +104,7 @@ public class ReportResourceTest extends AbstractResourceTest {
   private static final String REPORT_FIELDS =
       "uuid intent exsum state cancelledReason atmosphere atmosphereDetails"
           + " engagementDate duration engagementDayOfWeek keyOutcomes nextSteps reportText"
-          + " createdAt updatedAt customFields";
+          + " createdAt updatedAt customFields classification";
   private static final String ROLLUP_FIELDS =
       String.format("{ org { %1$s } published cancelled }", _ORGANIZATION_FIELDS);
   private static final String _TASK_FIELDS = "uuid shortName longName category";
@@ -646,7 +646,8 @@ public class ReportResourceTest extends AbstractResourceTest {
             .withNextSteps("This is the next steps on a report")
             .withKeyOutcomes("These are the key outcomes of this engagement")
             .withAdvisorOrg(getOrganizationInput(advisorOrg))
-            .withInterlocutorOrg(getOrganizationInput(reportAttendeeOrg)).build();
+            .withInterlocutorOrg(getOrganizationInput(reportAttendeeOrg))
+            .withClassification(getFirstClassification()).build();
     final Report created = authorMutationExecutor.createReport(FIELDS, rInput);
     assertThat(created).isNotNull();
     assertThat(created.getUuid()).isNotNull();

--- a/src/test/java/mil/dds/anet/test/utils/ResourceUtilsTest.java
+++ b/src/test/java/mil/dds/anet/test/utils/ResourceUtilsTest.java
@@ -1,5 +1,11 @@
 package mil.dds.anet.test.utils;
 
+import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
+import static mil.dds.anet.utils.ResourceUtils.assertAllowedClassification;
+import static mil.dds.anet.utils.ResourceUtils.getAllowedClassifications;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.api.BDDAssertions.thenNoException;
+import static org.assertj.core.api.BDDAssertions.thenThrownBy;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.lang.invoke.MethodHandles;
@@ -8,14 +14,20 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Response;
 import mil.dds.anet.beans.Person;
 import mil.dds.anet.beans.PersonPositionHistory;
 import mil.dds.anet.beans.Position;
+import mil.dds.anet.test.integration.utils.TestApp;
 import mil.dds.anet.utils.ResourceUtils;
+import net.bytebuddy.utility.RandomString;
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@ExtendWith(TestApp.class)
 public class ResourceUtilsTest {
 
   protected static final Logger logger =
@@ -174,5 +186,24 @@ public class ResourceUtilsTest {
 
   private Instant toInstant(final Object testDate) {
     return testDate == null ? null : Instant.parse((String) testDate);
+  }
+
+  @Test
+  void shouldContainClassificationEntries() {
+    then(getAllowedClassifications()).isNotNull().isNotEmpty();
+  }
+
+  @Test
+  void shouldPassWithoutExceptionForExistingClassification() {
+    thenNoException().isThrownBy(() -> assertAllowedClassification("undefined"));
+  }
+
+  @Test
+  void shouldThrowWebApplicationExceptionForUnknownClassification() {
+    thenThrownBy(() -> assertAllowedClassification(RandomString.make()))
+        .isInstanceOf(WebApplicationException.class).hasMessage("Classification is not allowed")
+        .asInstanceOf(InstanceOfAssertFactories.type(WebApplicationException.class))
+        .extracting(WebApplicationException::getResponse).extracting(Response::getStatus)
+        .isEqualTo(BAD_REQUEST.getStatusCode());
   }
 }

--- a/src/test/java/mil/dds/anet/test/utils/ResourceUtilsTest.java
+++ b/src/test/java/mil/dds/anet/test/utils/ResourceUtilsTest.java
@@ -1,11 +1,10 @@
 package mil.dds.anet.test.utils;
 
-import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 import static mil.dds.anet.utils.ResourceUtils.assertAllowedClassification;
 import static mil.dds.anet.utils.ResourceUtils.getAllowedClassifications;
-import static org.assertj.core.api.BDDAssertions.then;
-import static org.assertj.core.api.BDDAssertions.thenNoException;
-import static org.assertj.core.api.BDDAssertions.thenThrownBy;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.lang.invoke.MethodHandles;
@@ -14,14 +13,11 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.core.Response;
 import mil.dds.anet.beans.Person;
 import mil.dds.anet.beans.PersonPositionHistory;
 import mil.dds.anet.beans.Position;
 import mil.dds.anet.test.integration.utils.TestApp;
 import mil.dds.anet.utils.ResourceUtils;
-import net.bytebuddy.utility.RandomString;
-import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.slf4j.Logger;
@@ -190,20 +186,17 @@ public class ResourceUtilsTest {
 
   @Test
   void shouldContainClassificationEntries() {
-    then(getAllowedClassifications()).isNotNull().isNotEmpty();
+    assertThat(getAllowedClassifications()).isNotNull().isNotEmpty();
   }
 
   @Test
   void shouldPassWithoutExceptionForExistingClassification() {
-    thenNoException().isThrownBy(() -> assertAllowedClassification("undefined"));
+    assertThatNoException().isThrownBy(() -> assertAllowedClassification("undefined"));
   }
 
   @Test
   void shouldThrowWebApplicationExceptionForUnknownClassification() {
-    thenThrownBy(() -> assertAllowedClassification(RandomString.make()))
-        .isInstanceOf(WebApplicationException.class).hasMessage("Classification is not allowed")
-        .asInstanceOf(InstanceOfAssertFactories.type(WebApplicationException.class))
-        .extracting(WebApplicationException::getResponse).extracting(Response::getStatus)
-        .isEqualTo(BAD_REQUEST.getStatusCode());
+    assertThatThrownBy(() -> assertAllowedClassification("Totally public"))
+        .isInstanceOf(WebApplicationException.class).hasMessage("Classification is not allowed");
   }
 }

--- a/src/test/resources/anet.graphql
+++ b/src/test/resources/anet.graphql
@@ -815,6 +815,7 @@ type Report {
   authorizationGroups: [AuthorizationGroup]
   authors: [ReportPerson]
   cancelledReason: ReportCancelledReason
+  classification: String
   comments: [Comment]
   createdAt: Instant
   customFields: String
@@ -876,6 +877,7 @@ input ReportInput {
   atmosphereDetails: String
   authorizationGroups: [AuthorizationGroupInput]
   cancelledReason: ReportCancelledReason
+  classification: String
   comments: [CommentInput]
   createdAt: Instant
   customFields: String

--- a/testDictionaries/no-custom-fields.yml
+++ b/testDictionaries/no-custom-fields.yml
@@ -37,6 +37,15 @@ reportWorkflow:
 
 maxTextFieldLength: 250
 
+classification:
+  type: enum
+  label: Security Marking
+  choices:
+    undefined: Undefined
+    public: Public
+    NU: NATO UNCLASSIFIED
+    NU_rel_EU: NATO UNCLASSIFIED Releasable to EU
+
 fields:
 
   task:
@@ -309,14 +318,6 @@ fields:
     description:
       label: Description
       placeholder: Enter a description of this attachment
-    classification:
-      type: enum
-      label: Security Marking
-      choices:
-        undefined: Undefined
-        public: Public
-        NU: NATO UNCLASSIFIED
-        NU_rel_EU: NATO UNCLASSIFIED Releasable to EU
     mimeTypes:
       - application/pdf
       - image/avif

--- a/testDictionaries/no-custom-fields.yml
+++ b/testDictionaries/no-custom-fields.yml
@@ -38,7 +38,6 @@ reportWorkflow:
 maxTextFieldLength: 250
 
 classification:
-  type: enum
   label: Security Marking
   choices:
     undefined: Undefined


### PR DESCRIPTION
Be able to set a security classification for an individual engagement report.

Closes [AB#1053](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1053)

#### User changes
- Reports display a "Security Marking" which can be edited.

#### Superuser changes
- None

#### Admin changes
- None

#### System admin changes
- [x] anet.yml or anet-dictionary.yml needs change
  The `classification` setting that was previously under `fields.attachment` should now be moved to the top level since it is used for both the attachment and the report classifications:
  ```
  maxTextFieldLength: 250
  
  classification:
    label: Security Marking
    choices:
      […]
  
  fields:
    […]
  ```
- [x] db needs migration
- [x] documentation has changed
- [x] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [x] Added and/or updated unit tests
  - [x] Added and/or updated e2e tests
  - [x] Added and/or updated data migrations
  - [x] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
