### PR TITLE
Be able to add location in engagement report

### DIFF
--- a/anet-dictionary.yml
+++ b/anet-dictionary.yml
@@ -3,6 +3,7 @@ CONNECTION_ERROR_MSG: Connection to the server is lost
 VERSION_CHANGED_MSG: "There is a new version of ANET, click here to load the new version (CAUTION: save any unsaved changes first)"
 SUPPORT_EMAIL_ADDR: support@example.com
 
+regularUsersCanCreateLocations: false
 engagementsIncludeTimeAndDuration: true
 
 calendarOptions:

--- a/anet-dictionary.yml
+++ b/anet-dictionary.yml
@@ -3,7 +3,7 @@ CONNECTION_ERROR_MSG: Connection to the server is lost
 VERSION_CHANGED_MSG: "There is a new version of ANET, click here to load the new version (CAUTION: save any unsaved changes first)"
 SUPPORT_EMAIL_ADDR: support@example.com
 
-regularUsersCanCreateLocations: false
+regularUsersCanCreateLocations: true
 engagementsIncludeTimeAndDuration: true
 
 calendarOptions:
@@ -789,6 +789,7 @@ fields:
       label: Description
       placeholder: Fill in the description of this location
     superuserTypeOptions: [POINT_LOCATION]
+    regularuserTypeOptions: [POINT_LOCATION]
     format: LAT_LON
     customFields:
       multipleButtons:

--- a/client/src/components/GeoLocation.js
+++ b/client/src/components/GeoLocation.js
@@ -88,7 +88,7 @@ export const BaseGeoLocation = ({
   }
 
   return (
-    <div id="fg-location">
+    <div id="fg-geoLocation">
       <CoordinatesFormField
         coordinates={coordinates}
         editable
@@ -348,7 +348,7 @@ const CoordinateActionButtons = ({
   setLocationFormat
 }) => {
   return (
-    <Col sm={4} style={{ padding: "0 8px" }}>
+    <Col sm={3} style={{ padding: "0 8px" }}>
       <Tooltip2 content="Clear coordinates">
         <Button
           variant="outline-danger"

--- a/client/src/components/GeoLocation.js
+++ b/client/src/components/GeoLocation.js
@@ -348,7 +348,7 @@ const CoordinateActionButtons = ({
   setLocationFormat
 }) => {
   return (
-    <Col sm={3} style={{ padding: "0 8px" }}>
+    <Col sm={4} style={{ padding: "0 8px" }}>
       <Tooltip2 content="Clear coordinates">
         <Button
           variant="outline-danger"

--- a/client/src/components/advancedSelectWidget/AdvancedSelect.js
+++ b/client/src/components/advancedSelectWidget/AdvancedSelect.js
@@ -308,77 +308,69 @@ const AdvancedSelect = ({
                 popoverClassName="advanced-select-popover bp4-popover2-content-sizing"
                 content={
                   <Row id={`${fieldName}-popover`} className="border-between">
-                    <FilterAsNav
-                      items={filterDefs}
-                      currentFilter={filterType}
-                      handleOnClick={changeFilterType}
-                    />
+                    {(showCreateEntityComponent && (
+                      <Col md="12">
+                        {createEntityComponent(searchTerms, setDoReset)}
+                      </Col>
+                    )) || (
+                      <>
+                        <FilterAsNav
+                          items={filterDefs}
+                          currentFilter={filterType}
+                          handleOnClick={changeFilterType}
+                        />
 
-                    <FilterAsDropdown
-                      items={filterDefs}
-                      handleOnChange={handleOnChangeSelect}
-                    />
+                        <FilterAsDropdown
+                          items={filterDefs}
+                          handleOnChange={handleOnChangeSelect}
+                        />
 
-                    <Col md={hasMultipleItems(filterDefs) ? 9 : 12}>
-                      <OverlayTable
-                        fieldName={fieldName}
-                        items={items}
-                        pageNum={pageNum}
-                        selectedItems={value}
-                        handleAddItem={item => {
-                          handleAddItem(item)
-                          if (closeOverlayOnAdd) {
-                            setDoReset(true)
-                          }
-                        }}
-                        handleRemoveItem={handleRemoveItem}
-                        objectType={objectType}
-                        columns={[""].concat(overlayColumns)}
-                        renderRow={overlayRenderRow}
-                        isLoading={isLoading}
-                        loaderMessage={
-                          (createEntityComponent && (
-                            <>
-                              {(showCreateEntityComponent && (
-                                <div>
-                                  {createEntityComponent(
-                                    searchTerms,
-                                    setDoReset
-                                  )}
-                                </div>
-                              )) || (
-                                <>
+                        <Col md={hasMultipleItems(filterDefs) ? 9 : 12}>
+                          <OverlayTable
+                            fieldName={fieldName}
+                            items={items}
+                            pageNum={pageNum}
+                            selectedItems={value}
+                            handleAddItem={item => {
+                              handleAddItem(item)
+                              if (closeOverlayOnAdd) {
+                                setDoReset(true)
+                              }
+                            }}
+                            handleRemoveItem={handleRemoveItem}
+                            objectType={objectType}
+                            columns={[""].concat(overlayColumns)}
+                            renderRow={overlayRenderRow}
+                            isLoading={isLoading}
+                            loaderMessage={
+                              <div style={{ width: "300px" }}>
+                                <div>No results found.</div>
+                                {createEntityComponent && (
                                   <div>
-                                    No results found.
-                                    <span
+                                    <Button
                                       id="createEntityLink"
-                                      className="asLink"
                                       onClick={() =>
                                         setShowCreateEntityComponent(true)}
                                     >
-                                      Click here to create a new {fieldName}
-                                    </span>
+                                      Create a new {fieldName}
+                                    </Button>
                                   </div>
-                                </>
-                              )}
-                            </>
-                          )) || (
-                            <div style={{ width: "300px" }}>
-                              No results found
-                            </div>
-                          )
-                        }
-                      />
-                      <UltimatePagination
-                        Component="footer"
-                        componentClassName="searchPagination"
-                        className="float-end"
-                        pageNum={pageNum}
-                        pageSize={pageSize}
-                        totalCount={totalCount}
-                        goToPage={goToPage}
-                      />
-                    </Col>
+                                )}
+                              </div>
+                            }
+                          />
+                          <UltimatePagination
+                            Component="footer"
+                            componentClassName="searchPagination"
+                            className="float-end"
+                            pageNum={pageNum}
+                            pageSize={pageSize}
+                            totalCount={totalCount}
+                            goToPage={goToPage}
+                          />
+                        </Col>
+                      </>
+                    )}
                   </Row>
                 }
                 isOpen={showOverlay}
@@ -494,7 +486,6 @@ const AdvancedSelect = ({
     setPageNum(results && filterResults ? filterResults.pageNum : 0)
     setIsLoading(shouldFetchResults)
     setFetchType(shouldFetchResults ? FETCH_TYPE.NORMAL : FETCH_TYPE.NONE)
-    setShowCreateEntityComponent(false)
   }
 
   function goToPage(pageNum) {

--- a/client/src/components/advancedSelectWidget/AdvancedSelect.js
+++ b/client/src/components/advancedSelectWidget/AdvancedSelect.js
@@ -112,7 +112,8 @@ export const propTypes = {
   // Optional: GraphQL string of fields to return from search.
   fields: PropTypes.string,
   handleAddItem: PropTypes.func,
-  handleRemoveItem: PropTypes.func
+  handleRemoveItem: PropTypes.func,
+  createEntityComponent: PropTypes.func
 }
 
 const AdvancedSelect = ({
@@ -137,7 +138,8 @@ const AdvancedSelect = ({
   queryParams,
   fields,
   handleAddItem,
-  handleRemoveItem
+  handleRemoveItem,
+  createEntityComponent
 }) => {
   const firstFilter = Object.keys(filterDefs)[0]
 
@@ -156,6 +158,8 @@ const AdvancedSelect = ({
   const [results, setResults] = useState({})
   const [showOverlay, setShowOverlay] = useState(false)
   const [isLoading, setIsLoading] = useState(false)
+  const [showCreateEntityComponent, setShowCreateEntityComponent] =
+    useState(false)
   const [fetchType, setFetchType] = useState(FETCH_TYPE.NONE)
   const [doReset, setDoReset] = useState(false)
 
@@ -283,6 +287,7 @@ const AdvancedSelect = ({
       setIsLoading(false)
       setShowOverlay(false)
       setFilterType(firstFilter)
+      setShowCreateEntityComponent(false)
       if (!keepSearchText) {
         setSearchTerms(selectedValueAsString)
       }
@@ -332,7 +337,36 @@ const AdvancedSelect = ({
                         renderRow={overlayRenderRow}
                         isLoading={isLoading}
                         loaderMessage={
-                          <div style={{ width: "300px" }}>No results found</div>
+                          (createEntityComponent && (
+                            <>
+                              {(showCreateEntityComponent && (
+                                <div>
+                                  {createEntityComponent(
+                                    searchTerms,
+                                    setDoReset
+                                  )}
+                                </div>
+                              )) || (
+                                <>
+                                  <div>
+                                    No results found.
+                                    <span
+                                      id="createEntityLink"
+                                      className="asLink"
+                                      onClick={() =>
+                                        setShowCreateEntityComponent(true)}
+                                    >
+                                      Click here to create a new {fieldName}
+                                    </span>
+                                  </div>
+                                </>
+                              )}
+                            </>
+                          )) || (
+                            <div style={{ width: "300px" }}>
+                              No results found
+                            </div>
+                          )
                         }
                       />
                       <UltimatePagination
@@ -460,6 +494,7 @@ const AdvancedSelect = ({
     setPageNum(results && filterResults ? filterResults.pageNum : 0)
     setIsLoading(shouldFetchResults)
     setFetchType(shouldFetchResults ? FETCH_TYPE.NORMAL : FETCH_TYPE.NONE)
+    setShowCreateEntityComponent(false)
   }
 
   function goToPage(pageNum) {

--- a/client/src/components/advancedSelectWidget/AdvancedSingleSelect.js
+++ b/client/src/components/advancedSelectWidget/AdvancedSingleSelect.js
@@ -14,6 +14,7 @@ const AdvancedSingleSelect = props => {
       {...props}
       handleAddItem={handleAddItem}
       handleRemoveItem={handleRemoveItem}
+      createEntityComponent={props.createEntityComponent}
       closeOverlayOnAdd
       selectedValueAsString={
         _isEmpty(props.value)

--- a/client/src/pages/locations/Form.js
+++ b/client/src/pages/locations/Form.js
@@ -56,6 +56,9 @@ const LOCATION_TYPES_ADMIN = [
 const LOCATION_TYPES_SUPERUSER =
   Settings?.fields?.location?.superuserTypeOptions
 
+const LOCATION_TYPES_REGULARUSER =
+  Settings?.fields?.location?.regularuserTypeOptions
+
 const LocationForm = ({
   edit,
   title,
@@ -385,7 +388,7 @@ const LocationForm = ({
       case Position.TYPE.SUPERUSER:
         return LOCATION_TYPES_SUPERUSER
       default:
-        return []
+        return LOCATION_TYPES_REGULARUSER
     }
   }
 

--- a/client/src/pages/reports/Form.js
+++ b/client/src/pages/reports/Form.js
@@ -50,6 +50,7 @@ import {
   Task
 } from "models"
 import moment from "moment"
+import LocationForm from "pages/locations/Form"
 import { RECURRENCE_TYPE } from "periodUtils"
 import pluralize from "pluralize"
 import PropTypes from "prop-types"
@@ -250,6 +251,8 @@ const ReportForm = ({
   const attachmentEditEnabled =
     attachmentsEnabled &&
     (!Settings.fields.attachment.restrictToAdmins || currentUser.isAdmin())
+  const canCreateLocation =
+    Settings.regularUsersCanCreateLocations || currentUser.isSuperuser()
   const classificationButtons = Object.entries(
     Settings.classification.choices
   ).map(([value, label]) => ({
@@ -572,6 +575,26 @@ const ReportForm = ({
                       fields={Location.autocompleteQuery}
                       valueKey="name"
                       addon={LOCATIONS_ICON}
+                      createEntityComponent={
+                        (canCreateLocation &&
+                          ((searchText, setDoReset) => (
+                            <LocationForm
+                              initialValues={new Location({ name: searchText })}
+                              title="Create New Location"
+                              afterSaveActions={value => {
+                                // validation will be done by setFieldValue
+                                setFieldTouched("location", true, false) // onBlur doesn't work when selecting an option
+                                setFieldValue("location", value, true)
+                                setDoReset(true)
+                                toast.success("The location has been saved")
+                              }}
+                              afterCancelActions={() => {
+                                setDoReset(true)
+                              }}
+                            />
+                          ))) ||
+                        null
+                      }
                     />
                   }
                   extraColElem={

--- a/src/main/java/mil/dds/anet/AnetApplication.java
+++ b/src/main/java/mil/dds/anet/AnetApplication.java
@@ -374,7 +374,7 @@ public class AnetApplication extends Application<AnetConfiguration> {
     final LoggingResource loggingResource = new LoggingResource();
     final PersonResource personResource = new PersonResource(engine, configuration);
     final TaskResource taskResource = new TaskResource(engine, configuration);
-    final LocationResource locationResource = new LocationResource(engine);
+    final LocationResource locationResource = new LocationResource(engine, configuration);
     final OrganizationResource orgResource = new OrganizationResource(engine);
     final PositionResource positionResource = new PositionResource(engine);
     final ReportResource reportResource = new ReportResource(engine, configuration);

--- a/src/main/java/mil/dds/anet/resources/LocationResource.java
+++ b/src/main/java/mil/dds/anet/resources/LocationResource.java
@@ -23,7 +23,7 @@ import mil.dds.anet.utils.Utils;
 
 public class LocationResource {
 
-  protected final AnetConfiguration config;
+  private final AnetConfiguration config;
   private final AnetObjectEngine engine;
   private final LocationDao dao;
 
@@ -66,9 +66,7 @@ public class LocationResource {
     l.setDescription(
         Utils.isEmptyHtml(l.getDescription()) ? null : Utils.sanitizeHtml(l.getDescription()));
     final Person user = DaoUtils.getUserFromContext(context);
-    final boolean regularUsersCanAddLocations =
-        Boolean.TRUE.equals(config.getDictionaryEntry("regularUsersCanCreateLocations"));
-    if (!regularUsersCanAddLocations) {
+    if (Boolean.FALSE.equals(config.getDictionaryEntry("regularUsersCanCreateLocations"))) {
       assertPermission(user, DaoUtils.getUuid(l));
     }
     if (l.getName() == null || l.getName().trim().length() == 0) {

--- a/src/main/java/mil/dds/anet/resources/LocationResource.java
+++ b/src/main/java/mil/dds/anet/resources/LocationResource.java
@@ -14,6 +14,7 @@ import mil.dds.anet.beans.Location;
 import mil.dds.anet.beans.Person;
 import mil.dds.anet.beans.lists.AnetBeanList;
 import mil.dds.anet.beans.search.LocationSearchQuery;
+import mil.dds.anet.config.AnetConfiguration;
 import mil.dds.anet.database.LocationDao;
 import mil.dds.anet.utils.AnetAuditLogger;
 import mil.dds.anet.utils.AuthUtils;
@@ -22,10 +23,12 @@ import mil.dds.anet.utils.Utils;
 
 public class LocationResource {
 
+  protected final AnetConfiguration config;
   private final AnetObjectEngine engine;
   private final LocationDao dao;
 
-  public LocationResource(AnetObjectEngine engine) {
+  public LocationResource(AnetObjectEngine engine, AnetConfiguration config) {
+    this.config = config;
     this.engine = engine;
     this.dao = engine.getLocationDao();
   }
@@ -63,7 +66,11 @@ public class LocationResource {
     l.setDescription(
         Utils.isEmptyHtml(l.getDescription()) ? null : Utils.sanitizeHtml(l.getDescription()));
     final Person user = DaoUtils.getUserFromContext(context);
-    assertPermission(user, DaoUtils.getUuid(l));
+    final boolean regularUsersCanAddLocations =
+        Boolean.TRUE.equals(config.getDictionaryEntry("regularUsersCanCreateLocations"));
+    if (!regularUsersCanAddLocations) {
+      assertPermission(user, DaoUtils.getUuid(l));
+    }
     if (l.getName() == null || l.getName().trim().length() == 0) {
       throw new WebApplicationException("Location name must not be empty", Status.BAD_REQUEST);
     }

--- a/src/main/resources/anet-schema.yml
+++ b/src/main/resources/anet-schema.yml
@@ -399,6 +399,12 @@ properties:
     title: The support email address
     description: The email address where support requests can be sent.
 
+  regularUsersCanCreateLocations:
+    type: boolean
+    default: false
+    title: Whether regular users can also create locations
+    description: Used for locations; if set to `true` all ANET users can create or edit locations
+
   engagementsIncludeTimeAndDuration:
     type: boolean
     default: false

--- a/src/main/resources/anet-schema.yml
+++ b/src/main/resources/anet-schema.yml
@@ -821,6 +821,13 @@ properties:
               type: string
               enum:
                 [VIRTUAL_LOCATION, PHYSICAL_LOCATION, GEOGRAPHICAL_AREA, POINT_LOCATION, ADVISOR_LOCATION, PRINCIPAL_LOCATION]
+          regularuserTypeOptions:
+            type: array
+            uniqueItems: true
+            items:
+              type: string
+              enum:
+                [VIRTUAL_LOCATION, PHYSICAL_LOCATION, GEOGRAPHICAL_AREA, POINT_LOCATION, ADVISOR_LOCATION, PRINCIPAL_LOCATION]
           format:
             type: string
             title: Default format for location

--- a/src/test/java/mil/dds/anet/test/resources/LocationResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/LocationResourceTest.java
@@ -74,36 +74,34 @@ public class LocationResourceTest extends AbstractResourceTest {
 
   @Test
   void locationCreateSuperuserPermissionTest() {
-    createLocation(getSuperuser(), false);
+    createLocation(getSuperuser(), true);
   }
 
   @Test
   void locationCreateRegularUserPermissionTest() {
-    // By default the test dictionary dos not allows regular users to create locations
-    createLocation(getRegularUser(), false);
-    // Now test when they are allowed
+    // By default, the test dictionary allows regular users to create locations
+    createLocation(getRegularUser(), true);
+    // Now test when they are not allowed
     final AnetConfiguration config = dropwizardApp.getConfiguration();
     final Map<String, Object> dict = new HashMap<>(config.getDictionary());
-    dict.put("regularUsersCanCreateLocations", true);
+    dict.put("regularUsersCanCreateLocations", false);
     config.setDictionary(dict);
-    createLocation(getRegularUser(), true);
+    createLocation(getRegularUser(), false);
   }
 
-  private void createLocation(Person user, boolean regularUsersCanCreateLocations) {
-    final Position position = user.getPosition();
-    final boolean isSuperuser = position.getType() == PositionType.SUPERUSER;
+  private void createLocation(Person user, boolean shouldSucceed) {
     final LocationInput lInput = TestData.createLocationInput("The Boat Dock2", 43.21, -87.65);
     try {
       final Location l = withCredentials(user.getDomainUsername(),
           t -> mutationExecutor.createLocation(FIELDS, lInput));
-      if (regularUsersCanCreateLocations || isSuperuser) {
+      if (shouldSucceed) {
         assertThat(l).isNotNull();
         assertThat(l.getUuid()).isNotNull();
       } else {
         fail("Expected an Exception");
       }
     } catch (Exception expectedException) {
-      if (isSuperuser) {
+      if (shouldSucceed) {
         fail("Unexpected Exception", expectedException);
       }
     }

--- a/testDictionaries/no-custom-fields.yml
+++ b/testDictionaries/no-custom-fields.yml
@@ -2,6 +2,7 @@ CONNECTION_ERROR_MSG: Connection to the server is lost
 VERSION_CHANGED_MSG: "There is a new version of ANET, click here to load the new version (CAUTION: save any unsaved changes first)"
 SUPPORT_EMAIL_ADDR: support@example.com
 
+regularUsersCanCreateLocations: false
 engagementsIncludeTimeAndDuration: true
 
 calendarOptions:

--- a/testDictionaries/no-custom-fields.yml
+++ b/testDictionaries/no-custom-fields.yml
@@ -2,7 +2,7 @@ CONNECTION_ERROR_MSG: Connection to the server is lost
 VERSION_CHANGED_MSG: "There is a new version of ANET, click here to load the new version (CAUTION: save any unsaved changes first)"
 SUPPORT_EMAIL_ADDR: support@example.com
 
-regularUsersCanCreateLocations: false
+regularUsersCanCreateLocations: true
 engagementsIncludeTimeAndDuration: true
 
 calendarOptions:
@@ -533,6 +533,7 @@ fields:
       label: Description
       placeholder: Fill in the description of this location
     superuserTypeOptions: [POINT_LOCATION]
+    regularuserTypeOptions: [POINT_LOCATION]
     format: LAT_LON
 
   position:


### PR DESCRIPTION
Some customers want regulars users to be able to add locations from within the report form if they do not exist. This featureis configurable through the dictionary.
If activated, when the user types a location name in the report form and no matches are found, the "no results found" message will also contain a link to open the new location form within the pop-up. The user can then create a new location which gets automatically assigned to the report.

Closes [AB#996](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/996)

#### User changes
- They can create locations within the report form if allowed in the dictionary.

#### Superuser changes
- They can always create locations within the report form.

#### Admin changes
- None.

#### System admin changes
- [x] anet.yml or anet-dictionary.yml needs change
  ```
  regularUsersCanCreateLocations: false
  […]
  fields:
    […]
    location:
      […]
      superuserTypeOptions: [POINT_LOCATION]
      regularuserTypeOptions: [POINT_LOCATION]
      […]
  ```
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [x] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [x] Opened debt issues for anything not resolved here
