### PR TITLE
Ability to maximize map

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -141,7 +141,7 @@
     "leaflet-defaulticon-compatibility": "0.1.2",
     "leaflet-geosearch": "3.11.1",
     "leaflet-gesture-handling": "1.2.2",
-    "leaflet.fullscreen": "3.0.1",
+    "leaflet.fullscreen": "3.0.2",
     "leaflet.markercluster": "1.5.3",
     "locale-compare-polyfill": "0.0.2",
     "lodash": "4.17.21",

--- a/client/package.json
+++ b/client/package.json
@@ -141,6 +141,7 @@
     "leaflet-defaulticon-compatibility": "0.1.2",
     "leaflet-geosearch": "3.11.1",
     "leaflet-gesture-handling": "1.2.2",
+    "leaflet.fullscreen": "3.0.1",
     "leaflet.markercluster": "1.5.3",
     "locale-compare-polyfill": "0.0.2",
     "lodash": "4.17.21",

--- a/client/src/components/Leaflet.js
+++ b/client/src/components/Leaflet.js
@@ -9,6 +9,8 @@ import {
 import "leaflet-geosearch/assets/css/leaflet.css"
 import { GestureHandling } from "leaflet-gesture-handling"
 import "leaflet-gesture-handling/dist/leaflet-gesture-handling.css"
+import "leaflet.fullscreen"
+import "leaflet.fullscreen/Control.FullScreen.css"
 import { MarkerClusterGroup } from "leaflet.markercluster"
 import "leaflet.markercluster/dist/MarkerCluster.css"
 import "leaflet.markercluster/dist/MarkerCluster.Default.css"
@@ -144,7 +146,12 @@ const Leaflet = ({
   useEffect(() => {
     Map.addInitHook("addHandler", "gestureHandling", GestureHandling)
     const mapOptions = Object.assign(
-      { zoomControl: true, gestureHandling: true },
+      {
+        zoomControl: true,
+        gestureHandling: true,
+        fullscreenControl: true,
+        fullscreenControlOptions: { position: "topleft" }
+      },
       Settings.imagery.mapOptions.leafletOptions,
       Settings.imagery.mapOptions.crs && {
         crs: CRS[Settings.imagery.mapOptions.crs]

--- a/client/tests/webdriver/baseSpecs/createNewLocation.spec.js
+++ b/client/tests/webdriver/baseSpecs/createNewLocation.spec.js
@@ -96,4 +96,18 @@ describe("When creating a new Location", () => {
     expect(await (await CreateNewLocation.getDuplicatesButton()).isExisting())
       .to.be.false
   })
+
+  it("Should allow map maximisation", async() => {
+    expect(
+      await (
+        await CreateNewLocation.getMaximiseLeafletButton()
+      ).getAttribute("title")
+    ).to.equal("Full Screen")
+    await (await CreateNewLocation.getMaximiseLeafletButton()).click()
+    expect(
+      await (
+        await CreateNewLocation.getMaximiseLeafletButton()
+      ).getAttribute("title")
+    ).to.equal("Exit Full Screen")
+  })
 })

--- a/client/tests/webdriver/pages/location/createNewLocation.page.js
+++ b/client/tests/webdriver/pages/location/createNewLocation.page.js
@@ -39,6 +39,10 @@ class CreateNewLocation extends Page {
     return browser.$("div.modal-content")
   }
 
+  async getMaximiseLeafletButton() {
+    return browser.$('//a[@role="button"][@aria-label="Full Screen"]')
+  }
+
   async getModalCloseButton() {
     return (await this.getModalContent()).$(".btn-close")
   }

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -6328,6 +6328,7 @@ __metadata:
     leaflet-defaulticon-compatibility: "npm:0.1.2"
     leaflet-geosearch: "npm:3.11.1"
     leaflet-gesture-handling: "npm:1.2.2"
+    leaflet.fullscreen: "npm:3.0.1"
     leaflet.markercluster: "npm:1.5.3"
     locale-compare-polyfill: "npm:0.0.2"
     lodash: "npm:4.17.21"
@@ -14218,6 +14219,13 @@ __metadata:
   version: 1.2.2
   resolution: "leaflet-gesture-handling@npm:1.2.2"
   checksum: 10c0/cf1175c8cdc7ac9446e82716a46cca0e017506a4dc0b2103f0bb94b852000e1ee4e04698caedc40c400e9d07ac677c7636b6d0bc6a5b04c8fd527040ada7e7fa
+  languageName: node
+  linkType: hard
+
+"leaflet.fullscreen@npm:3.0.1":
+  version: 3.0.1
+  resolution: "leaflet.fullscreen@npm:3.0.1"
+  checksum: 10c0/f64af85825b7a4bd03969947670ba95dd1bc47f3011f0e3a2a797ff1f2ff48d1c5e7b60df9fac3887aa72aee867a738dc1559645e59e1cbc3b6d1ade89705d96
   languageName: node
   linkType: hard
 

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -6328,7 +6328,7 @@ __metadata:
     leaflet-defaulticon-compatibility: "npm:0.1.2"
     leaflet-geosearch: "npm:3.11.1"
     leaflet-gesture-handling: "npm:1.2.2"
-    leaflet.fullscreen: "npm:3.0.1"
+    leaflet.fullscreen: "npm:3.0.2"
     leaflet.markercluster: "npm:1.5.3"
     locale-compare-polyfill: "npm:0.0.2"
     lodash: "npm:4.17.21"
@@ -14222,10 +14222,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"leaflet.fullscreen@npm:3.0.1":
-  version: 3.0.1
-  resolution: "leaflet.fullscreen@npm:3.0.1"
-  checksum: 10c0/f64af85825b7a4bd03969947670ba95dd1bc47f3011f0e3a2a797ff1f2ff48d1c5e7b60df9fac3887aa72aee867a738dc1559645e59e1cbc3b6d1ade89705d96
+"leaflet.fullscreen@npm:3.0.2":
+  version: 3.0.2
+  resolution: "leaflet.fullscreen@npm:3.0.2"
+  checksum: 10c0/8a3546945df78cfcd2d83811e4c1f8488f863cfc964b39a4bdb3d41f0611b7560547c7f7a869d855aef8692a8bb30371abea3d0b015d01050ad3fe5707240bae
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Included a fullscreen component which allows maximizing the map views.

Closes [AB#1052](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1052)

#### User changes
- Users can set maps to full-screen and back

#### Superuser changes
- None

#### Admin changes
- None

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [x] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
