### PR TITLE
Add customFields columns to full-text index

### DIFF
--- a/insertBaseData-psql.sql
+++ b/insertBaseData-psql.sql
@@ -78,6 +78,10 @@ INSERT INTO people (uuid, name, status, "phoneNumber", rank, biography, "user", 
   ('87fdbc6a-3109-4e11-9702-a894d6ca31ef', 'DMIN, Arthur', '0', NULL, 'CIV', 'An administrator', true, 'arthur', 'abc72322-1452-4222-bb71-a0b3db435175', 'Albania', 'MALE', CURRENT_TIMESTAMP + INTERVAL '1 year', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
   ('46ba6a73-0cd7-4efb-8e99-215e98cc5987', 'SCOTT, Michael', '0', NULL, 'CIV', 'Worlds best boss.', true, 'michael', 'bd482701-2342-4a50-ba92-d956007a8828', 'United States of America', 'MALE', CURRENT_TIMESTAMP + INTERVAL '1 year', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
 
+UPDATE people
+SET "customFields"='{"inputField":"Lorem ipsum dolor sit amet"}'
+WHERE uuid='87fdbc6a-3109-4e11-9702-a894d6ca31ef';
+
 -- Email addresses for people
 INSERT INTO "emailAddresses" (network, address, "relatedObjectType", "relatedObjectUuid") VALUES
 -- Advisors
@@ -181,6 +185,10 @@ INSERT INTO locations (uuid, type, name, "createdAt", "updatedAt") VALUES
   (N'c136bf89-cc24-43a5-8f51-0f41dfc9ab77', 'PP', 'MoI Mazar-i-Sharif', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
   (N'b0979678-0ed0-4b42-9b26-9976fcfa1b81', 'PP', 'MoI Office Building ABC', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
 
+UPDATE locations
+SET "customFields"='{"inputFieldName":"consectetur adipisici elit"}'
+WHERE uuid=N'b0979678-0ed0-4b42-9b26-9976fcfa1b81';
+
 -- Create advisor positions
 INSERT INTO positions (uuid, name, type, role, status, "currentPersonUuid", "locationUuid", "createdAt", "updatedAt") VALUES
   (uuid_generate_v4(), 'ANET Administrator', 3, 0, 0, NULL, 'c8fdb53f-6f93-46fc-b0fa-f005c7b49667', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
@@ -226,6 +234,10 @@ INSERT INTO positions (uuid, name, type, role, status, "currentPersonUuid", "loc
   (uuid_generate_v4(), 'EF 9 Approver', 0, 0, 0, NULL, '7339f9e3-99d1-497a-9e3b-1269c4c287fe', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
   (uuid_generate_v4(), 'LNG Advisor A', 0, 0, 0, NULL, '8c138750-91ce-41bf-9b4c-9f0ddc73608b', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
   (uuid_generate_v4(), 'LNG Advisor B', 0, 0, 0, NULL, '8c138750-91ce-41bf-9b4c-9f0ddc73608b', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+
+UPDATE positions
+SET "customFields"='{"inputFieldName":"sed eiusmod tempor incidunt ut labore et dolore magna aliqua"}'
+WHERE uuid=N'05c42ce0-34a0-4391-8b2f-c4cd85ee6b47';
 
 -- Email addresses for advisor positions
 INSERT INTO "emailAddresses" (network, address, "relatedObjectType", "relatedObjectUuid") VALUES
@@ -399,6 +411,10 @@ INSERT INTO organizations(uuid, "shortName", "longName", "parentOrgUuid", "creat
   (uuid_generate_v4(), 'EF 6.1', '', (SELECT uuid FROM organizations WHERE "shortName" = 'EF 6'), CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
   (uuid_generate_v4(), 'EF 6.2', '', (SELECT uuid FROM organizations WHERE "shortName" = 'EF 6'), CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
 
+UPDATE organizations
+SET "customFields"='{"inputFieldName":"quis nostrud exercitation ullamco laboris"}'
+WHERE "shortName"='ANET Administrators';
+
 -- Email addresses for organizations
 INSERT INTO "emailAddresses" (network, address, "relatedObjectType", "relatedObjectUuid") VALUES
   ('Internet', 'lng@example.com', 'organizations', '70193ee9-05b4-4aac-80b5-75609825db9f'),
@@ -505,6 +521,10 @@ INSERT INTO tasks (uuid, "shortName", "longName", category, "createdAt", "update
   (uuid_generate_v4(), 'TAAC-W', '', 'EF', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, NULL),
   (uuid_generate_v4(), 'TAAC-C', '', 'EF', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, NULL),
   (uuid_generate_v4(), 'TAAC Air', '', 'EF', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, NULL);
+
+UPDATE tasks
+SET "customFields"='{"projectStatus":"red"}'
+WHERE uuid='9b9f4205-0721-4893-abf8-69e020d4db23';
 
 INSERT INTO "taskTaskedOrganizations" ("taskUuid", "organizationUuid") VALUES
   ((SELECT uuid from tasks where "shortName" = '1.1.A'), (SELECT uuid from organizations where "shortName"='EF 1.1')),
@@ -694,11 +714,12 @@ UPDATE positions SET "locationUuid" = (SELECT uuid from LOCATIONS where name = '
 -- Write a couple of reports!
 
 SELECT ('''' || N'9bb1861c-1f55-4a1b-bd3d-3c1f56d739b5' || '''') AS reportuuid \gset
-INSERT INTO reports (uuid, "createdAt", "updatedAt", "locationUuid", intent, text, "nextSteps", state, "engagementDate", atmosphere, "advisorOrganizationUuid", "interlocutorOrganizationUuid") VALUES
+INSERT INTO reports (uuid, "createdAt", "updatedAt", "locationUuid", intent, text, "nextSteps", state, "engagementDate", atmosphere, "advisorOrganizationUuid", "interlocutorOrganizationUuid", "customFields") VALUES
   (:reportuuid, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, (SELECT uuid from locations where name='General Hospital'), 'Discuss improvements in Annual Budgeting process',
   'Today I met with this dude to tell him all the great things that he can do to improve his budgeting process. I hope he listened to me',
   'Meet with the dude again next week', 2, '2016-05-25', 0,
-  (SELECT uuid FROM organizations where "shortName" = 'EF 2.1'), (SELECT uuid FROM organizations WHERE "longName" LIKE 'Ministry of Defense'));
+  (SELECT uuid FROM organizations where "shortName" = 'EF 2.1'), (SELECT uuid FROM organizations WHERE "longName" LIKE 'Ministry of Defense'),
+   '{"echelons":"Ut enim ad minim veniam"}');
 INSERT INTO "reportPeople" ("personUuid", "reportUuid", "isPrimary", "isAuthor", "isInterlocutor") VALUES
   ((SELECT uuid FROM people where name = 'STEVESON, Steve'), :reportuuid, TRUE, FALSE, TRUE),
   ((SELECT uuid FROM people where "domainUsername" = 'jack'), :reportuuid, TRUE, TRUE, FALSE);

--- a/insertBaseData-psql.sql
+++ b/insertBaseData-psql.sql
@@ -714,12 +714,11 @@ UPDATE positions SET "locationUuid" = (SELECT uuid from LOCATIONS where name = '
 -- Write a couple of reports!
 
 SELECT ('''' || N'9bb1861c-1f55-4a1b-bd3d-3c1f56d739b5' || '''') AS reportuuid \gset
-INSERT INTO reports (uuid, "createdAt", "updatedAt", "locationUuid", intent, text, "nextSteps", state, "engagementDate", atmosphere, "advisorOrganizationUuid", "interlocutorOrganizationUuid", "customFields") VALUES
+INSERT INTO reports (uuid, "createdAt", "updatedAt", "locationUuid", intent, text, "nextSteps", state, "engagementDate", atmosphere, "advisorOrganizationUuid", "interlocutorOrganizationUuid") VALUES
   (:reportuuid, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, (SELECT uuid from locations where name='General Hospital'), 'Discuss improvements in Annual Budgeting process',
   'Today I met with this dude to tell him all the great things that he can do to improve his budgeting process. I hope he listened to me',
   'Meet with the dude again next week', 2, '2016-05-25', 0,
-  (SELECT uuid FROM organizations where "shortName" = 'EF 2.1'), (SELECT uuid FROM organizations WHERE "longName" LIKE 'Ministry of Defense'),
-   '{"echelons":"Ut enim ad minim veniam"}');
+  (SELECT uuid FROM organizations where "shortName" = 'EF 2.1'), (SELECT uuid FROM organizations WHERE "longName" LIKE 'Ministry of Defense'));
 INSERT INTO "reportPeople" ("personUuid", "reportUuid", "isPrimary", "isAuthor", "isInterlocutor") VALUES
   ((SELECT uuid FROM people where name = 'STEVESON, Steve'), :reportuuid, TRUE, FALSE, TRUE),
   ((SELECT uuid FROM people where "domainUsername" = 'jack'), :reportuuid, TRUE, TRUE, FALSE);
@@ -888,10 +887,11 @@ INSERT INTO "reportPeople" ("personUuid", "reportUuid", "isPrimary", "isAuthor",
   ((SELECT uuid FROM people where "domainUsername" = 'erin'), :reportuuid, TRUE, TRUE, FALSE);
 
 SELECT ('''' || uuid_generate_v4() || '''') AS reportuuid \gset
-INSERT INTO reports (uuid, "createdAt", "updatedAt", "locationUuid", intent, text, "nextSteps", "keyOutcomes", state, "engagementDate", atmosphere, "advisorOrganizationUuid", "interlocutorOrganizationUuid") VALUES
+INSERT INTO reports (uuid, "createdAt", "updatedAt", "locationUuid", intent, text, "nextSteps", "keyOutcomes", state, "engagementDate", atmosphere, "advisorOrganizationUuid", "interlocutorOrganizationUuid","customFields") VALUES
   (:reportuuid, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, (SELECT uuid from locations where name='General Hospital'), 'A test report from Arthur', '',
   'keep on testing!','have reports in organizations', 2, CURRENT_TIMESTAMP + INTERVAL '1 minute', 0,
-  (SELECT uuid FROM organizations where "shortName" = 'ANET Administrators'), (SELECT uuid FROM organizations WHERE "longName" LIKE 'Ministry of Interior'));
+  (SELECT uuid FROM organizations where "shortName" = 'ANET Administrators'), (SELECT uuid FROM organizations WHERE "longName" LIKE 'Ministry of Interior'),
+   '{"invisibleCustomFields":["formCustomFields.trainingEvent","formCustomFields.numberTrained","formCustomFields.levelTrained","formCustomFields.trainingDate","formCustomFields.assetsUsed"],"itemsAgreed":[],"echelons":"Ut enim ad minim veniam","systemProcess":"","multipleButtons":["advise"],"additionalEngagementNeeded":[],"relatedObject":null,"relatedReport":null}');
 INSERT INTO "reportPeople" ("personUuid", "reportUuid", "isPrimary", "isAuthor", "isInterlocutor") VALUES
   ((SELECT uuid FROM people where "domainUsername" = 'arthur'), :reportuuid, TRUE, TRUE, FALSE),
   ((SELECT uuid FROM people where name = 'SHARTON, Shardul'), :reportuuid, TRUE, FALSE, TRUE),

--- a/insertBaseData-psql.sql
+++ b/insertBaseData-psql.sql
@@ -79,8 +79,8 @@ INSERT INTO people (uuid, name, status, "phoneNumber", rank, biography, "user", 
   ('46ba6a73-0cd7-4efb-8e99-215e98cc5987', 'SCOTT, Michael', '0', NULL, 'CIV', 'Worlds best boss.', true, 'michael', 'bd482701-2342-4a50-ba92-d956007a8828', 'United States of America', 'MALE', CURRENT_TIMESTAMP + INTERVAL '1 year', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
 
 UPDATE people
-SET "customFields"='{"inputField":"Lorem ipsum dolor sit amet"}'
-WHERE uuid='87fdbc6a-3109-4e11-9702-a894d6ca31ef';
+SET "customFields"='{"invisibleCustomFields":["formCustomFields.textareaFieldName","formCustomFields.numberFieldName"],"arrayFieldName":[],"nlt_dt":null,"nlt":null,"colourOptions":"","inputFieldName":"Lorem ipsum dolor sit amet","multipleButtons":[],"placeOfResidence":null,"placeOfBirth":null}'
+WHERE name='DMIN, Arthur';
 
 -- Email addresses for people
 INSERT INTO "emailAddresses" (network, address, "relatedObjectType", "relatedObjectUuid") VALUES
@@ -186,8 +186,8 @@ INSERT INTO locations (uuid, type, name, "createdAt", "updatedAt") VALUES
   (N'b0979678-0ed0-4b42-9b26-9976fcfa1b81', 'PP', 'MoI Office Building ABC', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
 
 UPDATE locations
-SET "customFields"='{"inputFieldName":"consectetur adipisici elit"}'
-WHERE uuid=N'b0979678-0ed0-4b42-9b26-9976fcfa1b81';
+SET "customFields"='{"invisibleCustomFields":["formCustomFields.textareaFieldName","formCustomFields.numberFieldName"],"arrayFieldName":[],"nlt_dt":null,"nlt":null,"colourOptions":"","inputFieldName":"consectetur adipisici elit","multipleButtons":[]}'
+WHERE name='MoI Coffee Shop';
 
 -- Create advisor positions
 INSERT INTO positions (uuid, name, type, role, status, "currentPersonUuid", "locationUuid", "createdAt", "updatedAt") VALUES
@@ -236,8 +236,8 @@ INSERT INTO positions (uuid, name, type, role, status, "currentPersonUuid", "loc
   (uuid_generate_v4(), 'LNG Advisor B', 0, 0, 0, NULL, '8c138750-91ce-41bf-9b4c-9f0ddc73608b', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
 
 UPDATE positions
-SET "customFields"='{"inputFieldName":"sed eiusmod tempor incidunt ut labore et dolore magna aliqua"}'
-WHERE uuid=N'05c42ce0-34a0-4391-8b2f-c4cd85ee6b47';
+SET "customFields"='{"invisibleCustomFields":["formCustomFields.textareaFieldName","formCustomFields.numberFieldName"],"arrayFieldName":[],"nlt_dt":null,"nlt":null,"colourOptions":"","inputFieldName":"sed eiusmod tempor incidunt ut labore et dolore magna aliqua","multipleButtons":[]}'
+WHERE name='EF 5.1 Advisor Quality Assurance';
 
 -- Email addresses for advisor positions
 INSERT INTO "emailAddresses" (network, address, "relatedObjectType", "relatedObjectUuid") VALUES
@@ -412,8 +412,8 @@ INSERT INTO organizations(uuid, "shortName", "longName", "parentOrgUuid", "creat
   (uuid_generate_v4(), 'EF 6.2', '', (SELECT uuid FROM organizations WHERE "shortName" = 'EF 6'), CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
 
 UPDATE organizations
-SET "customFields"='{"inputFieldName":"quis nostrud exercitation ullamco laboris"}'
-WHERE "shortName"='ANET Administrators';
+SET "customFields"='{"invisibleCustomFields":["formCustomFields.textareaFieldName","formCustomFields.numberFieldName"],"arrayFieldName":[],"nlt_dt":null,"nlt":null,"colourOptions":"","inputFieldName":"quis nostrud exercitation ullamco laboris","multipleButtons":[]}'
+WHERE "shortName"='LNG';
 
 -- Email addresses for organizations
 INSERT INTO "emailAddresses" (network, address, "relatedObjectType", "relatedObjectUuid") VALUES
@@ -523,8 +523,8 @@ INSERT INTO tasks (uuid, "shortName", "longName", category, "createdAt", "update
   (uuid_generate_v4(), 'TAAC Air', '', 'EF', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, NULL);
 
 UPDATE tasks
-SET "customFields"='{"projectStatus":"red"}'
-WHERE uuid='9b9f4205-0721-4893-abf8-69e020d4db23';
+SET "customFields"='{"invisibleCustomFields":[],"projectStatus":"RED"}'
+WHERE "shortName"='EF 3';
 
 INSERT INTO "taskTaskedOrganizations" ("taskUuid", "organizationUuid") VALUES
   ((SELECT uuid from tasks where "shortName" = '1.1.A'), (SELECT uuid from organizations where "shortName"='EF 1.1')),

--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -4874,8 +4874,8 @@
 		<dropColumn tableName="people" columnName="emailAddress" />
 	</changeSet>
 
-	<changeSet id="add-custom-fields-to-fulltext-index" author="chessray">
-		<sql dbms="postgresql">
+	<changeSet id="add-customFields-to-fulltext-index" author="chessray">
+		<sql>
 			<!-- Drop full-text materialized views (incl. indexes) since we cannot just ALTER them;
 			     copied from multiple changesets -->
 			DROP MATERIALIZED VIEW mv_fts_reports;
@@ -4884,6 +4884,23 @@
 			DROP MATERIALIZED VIEW mv_fts_positions;
 			DROP MATERIALIZED VIEW mv_fts_organizations;
 			DROP MATERIALIZED VIEW mv_fts_tasks;
+
+			-- TODO: Ideally, this should recurse down the JSON structure; left as an exercise…
+			CREATE OR REPLACE FUNCTION jsonb_value_agg (p_json text, ignore_key text default 'invisibleCustomFields')
+				RETURNS text
+			AS
+			'
+			BEGIN
+				RETURN coalesce(string_agg(value, '' ''), '' '')
+				FROM jsonb_each_text(p_json::jsonb)
+				WHERE key != ignore_key;
+			EXCEPTION
+				WHEN OTHERS THEN
+				RETURN NULL;
+			END;
+			'
+			LANGUAGE plpgsql
+			IMMUTABLE;
 
 			ALTER TABLE reports DROP COLUMN full_text;
 			ALTER TABLE reports
@@ -4896,8 +4913,8 @@
 							|| to_tsvector('simple', coalesce(reports."nextSteps", '')), ${fts_high}) ||
 					setweight(to_tsvector(${fts_config}, coalesce(reports.text, ''))
 							|| to_tsvector('simple', coalesce(reports.text, '')), ${fts_low}) ||
-					setweight(to_tsvector(${fts_config}, coalesce(reports."customFields", ''))
-							|| to_tsvector('simple', coalesce(reports."customFields", '')), ${fts_lower})
+					setweight(to_tsvector(${fts_config}, jsonb_value_agg(reports."customFields"))
+							|| to_tsvector('simple', jsonb_value_agg(reports."customFields")), ${fts_lower})
 				) STORED;
 
 			ALTER TABLE people DROP COLUMN full_text;
@@ -4909,8 +4926,8 @@
 					setweight(to_tsvector('simple', coalesce(people."phoneNumber", '')), ${fts_high}) ||
 					setweight(to_tsvector(${fts_config}, coalesce(people.biography, ''))
 							|| to_tsvector('simple', coalesce(people.biography, '')), ${fts_low}) ||
-					setweight(to_tsvector(${fts_config}, coalesce(people."customFields", ''))
-							|| to_tsvector('simple', coalesce(people."customFields", '')), ${fts_lower})
+					setweight(to_tsvector(${fts_config}, jsonb_value_agg(people."customFields"))
+							|| to_tsvector('simple', jsonb_value_agg(people."customFields")), ${fts_lower})
 				) STORED;
 
 			ALTER TABLE locations DROP COLUMN full_text;
@@ -4920,8 +4937,8 @@
 							|| to_tsvector('simple', coalesce(locations.name, '')), ${fts_high}) ||
 					setweight(to_tsvector(${fts_config}, coalesce(locations.description, ''))
 							|| to_tsvector('simple', coalesce(locations.description, '')), ${fts_low}) ||
-					setweight(to_tsvector(${fts_config}, coalesce(locations."customFields", ''))
-							|| to_tsvector('simple', coalesce(locations."customFields", '')), ${fts_lower})
+					setweight(to_tsvector(${fts_config}, jsonb_value_agg(locations."customFields"))
+							|| to_tsvector('simple', jsonb_value_agg(locations."customFields")), ${fts_lower})
 				) STORED;
 
 			ALTER TABLE positions DROP COLUMN full_text;
@@ -4930,8 +4947,8 @@
 					setweight(to_tsvector('simple', coalesce(positions.code, '')), ${fts_high}) ||
 					setweight(to_tsvector(${fts_config}, coalesce(positions.name, ''))
 							|| to_tsvector('simple', coalesce(positions.name, '')), ${fts_high}) ||
-					setweight(to_tsvector(${fts_config}, coalesce(positions."customFields", ''))
-							|| to_tsvector('simple', coalesce(positions."customFields", '')), ${fts_lower})
+					setweight(to_tsvector(${fts_config}, jsonb_value_agg(positions."customFields"))
+							|| to_tsvector('simple', jsonb_value_agg(positions."customFields")), ${fts_lower})
 				) STORED;
 
 			ALTER TABLE organizations DROP COLUMN full_text;
@@ -4943,8 +4960,8 @@
 							|| to_tsvector('simple', coalesce(organizations."longName", '')), ${fts_low}) ||
 					setweight(to_tsvector(${fts_config}, coalesce(organizations.profile, ''))
 							|| to_tsvector('simple', coalesce(organizations.profile, '')), ${fts_low}) ||
-					setweight(to_tsvector(${fts_config}, coalesce(organizations."customFields", ''))
-							|| to_tsvector('simple', coalesce(organizations."customFields", '')), ${fts_lower})
+					setweight(to_tsvector(${fts_config}, jsonb_value_agg(organizations."customFields"))
+							|| to_tsvector('simple', jsonb_value_agg(organizations."customFields")), ${fts_lower})
 				) STORED;
 
 			ALTER TABLE tasks DROP COLUMN full_text;
@@ -4955,8 +4972,8 @@
 							|| to_tsvector('simple', coalesce(tasks."longName", '')), ${fts_high}) ||
 					setweight(to_tsvector(${fts_config}, coalesce(tasks.description, ''))
 							|| to_tsvector('simple', coalesce(tasks.description, '')), ${fts_low}) ||
-					setweight(to_tsvector(${fts_config}, coalesce(tasks."customFields", ''))
-							|| to_tsvector('simple', coalesce(tasks."customFields", '')), ${fts_lower})
+					setweight(to_tsvector(${fts_config}, jsonb_value_agg(tasks."customFields"))
+							|| to_tsvector('simple', jsonb_value_agg(tasks."customFields")), ${fts_lower})
 				) STORED;
 
 			CREATE MATERIALIZED VIEW IF NOT EXISTS mv_fts_reports(uuid, full_text) AS
@@ -5070,4 +5087,5 @@
 		</sql>
 		<!-- Rolling back is not useful anymore -->
 	</changeSet>
+
 </databaseChangeLog>

--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -4874,17 +4874,27 @@
 		<dropColumn tableName="people" columnName="emailAddress" />
 	</changeSet>
 
-	<changeSet id="add-customFields-to-fulltext-index" author="chessray">
+	<changeSet id="add-customFields-to-fulltext-index" author="chessray" runInTransaction="false">
 		<sql>
 			<!-- Drop full-text materialized views (incl. indexes) since we cannot just ALTER them;
 			     copied from multiple changesets -->
-			DROP MATERIALIZED VIEW mv_fts_reports;
-			DROP MATERIALIZED VIEW mv_fts_people;
 			DROP MATERIALIZED VIEW mv_fts_locations;
-			DROP MATERIALIZED VIEW mv_fts_positions;
 			DROP MATERIALIZED VIEW mv_fts_organizations;
+			DROP MATERIALIZED VIEW mv_fts_people;
+			DROP MATERIALIZED VIEW mv_fts_positions;
+			DROP MATERIALIZED VIEW mv_fts_reports;
 			DROP MATERIALIZED VIEW mv_fts_tasks;
 
+			<!-- Drop generated full-text columns;
+			     copied from multiple changesets -->
+			ALTER TABLE locations DROP COLUMN full_text;
+			ALTER TABLE organizations DROP COLUMN full_text;
+			ALTER TABLE people DROP COLUMN full_text;
+			ALTER TABLE positions DROP COLUMN full_text;
+			ALTER TABLE reports DROP COLUMN full_text;
+			ALTER TABLE tasks DROP COLUMN full_text;
+
+			<!-- Define functions for aggregating JSON values recursively, to be used in the full-text index -->
 			CREATE OR REPLACE FUNCTION jsonb_value_agg (p_json jsonb, ignore_key text default 'invisibleCustomFields')
 				RETURNS text
 			AS
@@ -4937,7 +4947,50 @@
 			LANGUAGE plpgsql
 			IMMUTABLE;
 
-			ALTER TABLE reports DROP COLUMN full_text;
+			<!-- Re-add generated full-text columns, with the customFields column included-->
+			ALTER TABLE locations
+				ADD COLUMN full_text tsvector GENERATED ALWAYS AS (
+					setweight(to_tsvector(${fts_config}, coalesce(locations.name, ''))
+							|| to_tsvector('simple', coalesce(locations.name, '')), ${fts_high}) ||
+					setweight(to_tsvector(${fts_config}, coalesce(locations.description, ''))
+							|| to_tsvector('simple', coalesce(locations.description, '')), ${fts_low}) ||
+					setweight(to_tsvector(${fts_config}, jsonb_value_agg(locations."customFields"::jsonb))
+							|| to_tsvector('simple', jsonb_value_agg(locations."customFields"::jsonb)), ${fts_lower})
+				) STORED;
+
+			ALTER TABLE organizations
+				ADD COLUMN full_text tsvector GENERATED ALWAYS AS (
+					setweight(to_tsvector('simple', coalesce(organizations."identificationCode", '')), ${fts_high}) ||
+					setweight(to_tsvector('simple', coalesce(organizations."shortName", '')), ${fts_high}) ||
+					setweight(to_tsvector(${fts_config}, coalesce(organizations."longName", ''))
+							|| to_tsvector('simple', coalesce(organizations."longName", '')), ${fts_low}) ||
+					setweight(to_tsvector(${fts_config}, coalesce(organizations.profile, ''))
+							|| to_tsvector('simple', coalesce(organizations.profile, '')), ${fts_low}) ||
+					setweight(to_tsvector(${fts_config}, jsonb_value_agg(organizations."customFields"::jsonb))
+							|| to_tsvector('simple', jsonb_value_agg(organizations."customFields"::jsonb)), ${fts_lower})
+				) STORED;
+
+			ALTER TABLE people
+				ADD COLUMN full_text tsvector GENERATED ALWAYS AS (
+					setweight(to_tsvector('simple', coalesce(people.name, '')), ${fts_high}) ||
+					setweight(to_tsvector('simple', coalesce(people.code, '')), ${fts_high}) ||
+					setweight(to_tsvector('simple', coalesce(people."domainUsername", '')), ${fts_high}) ||
+					setweight(to_tsvector('simple', coalesce(people."phoneNumber", '')), ${fts_high}) ||
+					setweight(to_tsvector(${fts_config}, coalesce(people.biography, ''))
+							|| to_tsvector('simple', coalesce(people.biography, '')), ${fts_low}) ||
+					setweight(to_tsvector(${fts_config}, jsonb_value_agg(people."customFields"::jsonb))
+							|| to_tsvector('simple', jsonb_value_agg(people."customFields"::jsonb)), ${fts_lower})
+				) STORED;
+
+			ALTER TABLE positions
+				ADD COLUMN full_text tsvector GENERATED ALWAYS AS (
+					setweight(to_tsvector('simple', coalesce(positions.code, '')), ${fts_high}) ||
+					setweight(to_tsvector(${fts_config}, coalesce(positions.name, ''))
+							|| to_tsvector('simple', coalesce(positions.name, '')), ${fts_high}) ||
+					setweight(to_tsvector(${fts_config}, jsonb_value_agg(positions."customFields"::jsonb))
+							|| to_tsvector('simple', jsonb_value_agg(positions."customFields"::jsonb)), ${fts_lower})
+				) STORED;
+
 			ALTER TABLE reports
 				ADD COLUMN full_text tsvector GENERATED ALWAYS AS (
 					setweight(to_tsvector(${fts_config}, coalesce(reports.intent, ''))
@@ -4952,54 +5005,6 @@
 							|| to_tsvector('simple', jsonb_value_agg(reports."customFields"::jsonb)), ${fts_lower})
 				) STORED;
 
-			ALTER TABLE people DROP COLUMN full_text;
-			ALTER TABLE people
-				ADD COLUMN full_text tsvector GENERATED ALWAYS AS (
-					setweight(to_tsvector('simple', coalesce(people.name, '')), ${fts_high}) ||
-					setweight(to_tsvector('simple', coalesce(people.code, '')), ${fts_high}) ||
-					setweight(to_tsvector('simple', coalesce(people."domainUsername", '')), ${fts_high}) ||
-					setweight(to_tsvector('simple', coalesce(people."phoneNumber", '')), ${fts_high}) ||
-					setweight(to_tsvector(${fts_config}, coalesce(people.biography, ''))
-							|| to_tsvector('simple', coalesce(people.biography, '')), ${fts_low}) ||
-					setweight(to_tsvector(${fts_config}, jsonb_value_agg(people."customFields"::jsonb))
-							|| to_tsvector('simple', jsonb_value_agg(people."customFields"::jsonb)), ${fts_lower})
-				) STORED;
-
-			ALTER TABLE locations DROP COLUMN full_text;
-			ALTER TABLE locations
-				ADD COLUMN full_text tsvector GENERATED ALWAYS AS (
-					setweight(to_tsvector(${fts_config}, coalesce(locations.name, ''))
-							|| to_tsvector('simple', coalesce(locations.name, '')), ${fts_high}) ||
-					setweight(to_tsvector(${fts_config}, coalesce(locations.description, ''))
-							|| to_tsvector('simple', coalesce(locations.description, '')), ${fts_low}) ||
-					setweight(to_tsvector(${fts_config}, jsonb_value_agg(locations."customFields"::jsonb))
-							|| to_tsvector('simple', jsonb_value_agg(locations."customFields"::jsonb)), ${fts_lower})
-				) STORED;
-
-			ALTER TABLE positions DROP COLUMN full_text;
-			ALTER TABLE positions
-				ADD COLUMN full_text tsvector GENERATED ALWAYS AS (
-					setweight(to_tsvector('simple', coalesce(positions.code, '')), ${fts_high}) ||
-					setweight(to_tsvector(${fts_config}, coalesce(positions.name, ''))
-							|| to_tsvector('simple', coalesce(positions.name, '')), ${fts_high}) ||
-					setweight(to_tsvector(${fts_config}, jsonb_value_agg(positions."customFields"::jsonb))
-							|| to_tsvector('simple', jsonb_value_agg(positions."customFields"::jsonb)), ${fts_lower})
-				) STORED;
-
-			ALTER TABLE organizations DROP COLUMN full_text;
-			ALTER TABLE organizations
-				ADD COLUMN full_text tsvector GENERATED ALWAYS AS (
-					setweight(to_tsvector('simple', coalesce(organizations."identificationCode", '')), ${fts_high}) ||
-					setweight(to_tsvector('simple', coalesce(organizations."shortName", '')), ${fts_high}) ||
-					setweight(to_tsvector(${fts_config}, coalesce(organizations."longName", ''))
-							|| to_tsvector('simple', coalesce(organizations."longName", '')), ${fts_low}) ||
-					setweight(to_tsvector(${fts_config}, coalesce(organizations.profile, ''))
-							|| to_tsvector('simple', coalesce(organizations.profile, '')), ${fts_low}) ||
-					setweight(to_tsvector(${fts_config}, jsonb_value_agg(organizations."customFields"::jsonb))
-							|| to_tsvector('simple', jsonb_value_agg(organizations."customFields"::jsonb)), ${fts_lower})
-				) STORED;
-
-			ALTER TABLE tasks DROP COLUMN full_text;
 			ALTER TABLE tasks
 				ADD COLUMN full_text tsvector GENERATED ALWAYS AS (
 					setweight(to_tsvector('simple', coalesce(tasks."shortName", '')), ${fts_high}) ||
@@ -5011,23 +5016,41 @@
 							|| to_tsvector('simple', jsonb_value_agg(tasks."customFields"::jsonb)), ${fts_lower})
 				) STORED;
 
-			CREATE MATERIALIZED VIEW IF NOT EXISTS mv_fts_reports(uuid, full_text) AS
-			SELECT
-				reports.uuid,
-				reports.full_text
-					|| coalesce(tsvector_agg(notes.full_text), ''::tsvector)
-			FROM reports
-					LEFT JOIN "noteRelatedObjects" ON "noteRelatedObjects"."relatedObjectType" = 'reports'
-				AND "noteRelatedObjects"."relatedObjectUuid" = reports.uuid
-					LEFT JOIN notes ON notes.uuid = "noteRelatedObjects"."noteUuid"
-			GROUP BY reports.uuid
-				WITH DATA;
-			CREATE UNIQUE INDEX "UQ_mv_fts_reports_uuid" ON mv_fts_reports(uuid);
-			CREATE INDEX "FT_mv_fts_reports" ON mv_fts_reports USING gin(full_text);
-			CREATE INDEX "TR_reports_uuid" ON mv_fts_reports USING gin(uuid gin_trgm_ops);
-
 			<!-- Re-create full-text materialized views and indexes;
-			     copied from the last changeset the respective fulltext view has been created before -->
+			     copied from the last changeset where the respective view was created before -->
+			CREATE MATERIALIZED VIEW IF NOT EXISTS mv_fts_locations(uuid, full_text) AS
+			SELECT
+				locations.uuid,
+				locations.full_text
+					|| coalesce(tsvector_agg(notes.full_text), ''::tsvector)
+			FROM locations
+					LEFT JOIN "noteRelatedObjects" ON "noteRelatedObjects"."relatedObjectType" = 'locations'
+				AND "noteRelatedObjects"."relatedObjectUuid" = locations.uuid
+					LEFT JOIN notes ON notes.uuid = "noteRelatedObjects"."noteUuid"
+			GROUP BY locations.uuid
+				WITH DATA;
+			CREATE UNIQUE INDEX "UQ_mv_fts_locations_uuid" ON mv_fts_locations(uuid);
+			CREATE INDEX "FT_mv_fts_locations" ON mv_fts_locations USING gin(full_text);
+			CREATE INDEX "TR_locations_uuid" ON mv_fts_locations USING gin(uuid gin_trgm_ops);
+
+			CREATE MATERIALIZED VIEW IF NOT EXISTS mv_fts_organizations(uuid, full_text) AS
+			SELECT
+				organizations.uuid,
+				organizations.full_text
+					|| coalesce(tsvector_agg(notes.full_text), ''::tsvector)
+					|| coalesce(tsvector_agg("emailAddresses".full_text), ''::tsvector)
+			FROM organizations
+					LEFT JOIN "noteRelatedObjects" ON "noteRelatedObjects"."relatedObjectType" = 'organizations'
+				AND "noteRelatedObjects"."relatedObjectUuid" = organizations.uuid
+					LEFT JOIN notes ON notes.uuid = "noteRelatedObjects"."noteUuid"
+					LEFT JOIN "emailAddresses" ON "emailAddresses"."relatedObjectType" = 'organizations'
+				AND "emailAddresses"."relatedObjectUuid" = organizations.uuid
+			GROUP BY organizations.uuid
+				WITH DATA;
+			CREATE UNIQUE INDEX "UQ_mv_fts_organizations_uuid" ON mv_fts_organizations(uuid);
+			CREATE INDEX "FT_mv_fts_organizations" ON mv_fts_organizations USING gin(full_text);
+			CREATE INDEX "TR_organizations_uuid" ON mv_fts_organizations USING gin(uuid gin_trgm_ops);
+
 			CREATE MATERIALIZED VIEW IF NOT EXISTS mv_fts_people(uuid, full_text) AS
 			SELECT
 				people.uuid,
@@ -5049,21 +5072,6 @@
 			CREATE UNIQUE INDEX "UQ_mv_fts_people_uuid" ON mv_fts_people(uuid);
 			CREATE INDEX "FT_mv_fts_people" ON mv_fts_people USING gin(full_text);
 			CREATE INDEX "TR_people_uuid" ON mv_fts_people USING gin(uuid gin_trgm_ops);
-
-			CREATE MATERIALIZED VIEW IF NOT EXISTS mv_fts_locations(uuid, full_text) AS
-			SELECT
-				locations.uuid,
-				locations.full_text
-					|| coalesce(tsvector_agg(notes.full_text), ''::tsvector)
-			FROM locations
-					LEFT JOIN "noteRelatedObjects" ON "noteRelatedObjects"."relatedObjectType" = 'locations'
-				AND "noteRelatedObjects"."relatedObjectUuid" = locations.uuid
-					LEFT JOIN notes ON notes.uuid = "noteRelatedObjects"."noteUuid"
-			GROUP BY locations.uuid
-				WITH DATA;
-			CREATE UNIQUE INDEX "UQ_mv_fts_locations_uuid" ON mv_fts_locations(uuid);
-			CREATE INDEX "FT_mv_fts_locations" ON mv_fts_locations USING gin(full_text);
-			CREATE INDEX "TR_locations_uuid" ON mv_fts_locations USING gin(uuid gin_trgm_ops);
 
 			CREATE MATERIALIZED VIEW IF NOT EXISTS mv_fts_positions(uuid, full_text) AS
 			SELECT
@@ -5087,23 +5095,20 @@
 			CREATE INDEX "FT_mv_fts_positions" ON mv_fts_positions USING gin(full_text);
 			CREATE INDEX "TR_positions_uuid" ON mv_fts_positions USING gin(uuid gin_trgm_ops);
 
-			CREATE MATERIALIZED VIEW IF NOT EXISTS mv_fts_organizations(uuid, full_text) AS
+			CREATE MATERIALIZED VIEW IF NOT EXISTS mv_fts_reports(uuid, full_text) AS
 			SELECT
-				organizations.uuid,
-				organizations.full_text
+				reports.uuid,
+				reports.full_text
 					|| coalesce(tsvector_agg(notes.full_text), ''::tsvector)
-					|| coalesce(tsvector_agg("emailAddresses".full_text), ''::tsvector)
-			FROM organizations
-					LEFT JOIN "noteRelatedObjects" ON "noteRelatedObjects"."relatedObjectType" = 'organizations'
-				AND "noteRelatedObjects"."relatedObjectUuid" = organizations.uuid
+			FROM reports
+					LEFT JOIN "noteRelatedObjects" ON "noteRelatedObjects"."relatedObjectType" = 'reports'
+				AND "noteRelatedObjects"."relatedObjectUuid" = reports.uuid
 					LEFT JOIN notes ON notes.uuid = "noteRelatedObjects"."noteUuid"
-					LEFT JOIN "emailAddresses" ON "emailAddresses"."relatedObjectType" = 'organizations'
-				AND "emailAddresses"."relatedObjectUuid" = organizations.uuid
-			GROUP BY organizations.uuid
+			GROUP BY reports.uuid
 				WITH DATA;
-			CREATE UNIQUE INDEX "UQ_mv_fts_organizations_uuid" ON mv_fts_organizations(uuid);
-			CREATE INDEX "FT_mv_fts_organizations" ON mv_fts_organizations USING gin(full_text);
-			CREATE INDEX "TR_organizations_uuid" ON mv_fts_organizations USING gin(uuid gin_trgm_ops);
+			CREATE UNIQUE INDEX "UQ_mv_fts_reports_uuid" ON mv_fts_reports(uuid);
+			CREATE INDEX "FT_mv_fts_reports" ON mv_fts_reports USING gin(full_text);
+			CREATE INDEX "TR_reports_uuid" ON mv_fts_reports USING gin(uuid gin_trgm_ops);
 
 			CREATE MATERIALIZED VIEW IF NOT EXISTS mv_fts_tasks(uuid, full_text) AS
 			SELECT

--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -4885,14 +4885,49 @@
 			DROP MATERIALIZED VIEW mv_fts_organizations;
 			DROP MATERIALIZED VIEW mv_fts_tasks;
 
-			-- TODO: Ideally, this should recurse down the JSON structure; left as an exercise…
-			CREATE OR REPLACE FUNCTION jsonb_value_agg (p_json text, ignore_key text default 'invisibleCustomFields')
+			CREATE OR REPLACE FUNCTION jsonb_value_agg (p_json jsonb, ignore_key text default 'invisibleCustomFields')
 				RETURNS text
 			AS
 			'
 			BEGIN
-				RETURN coalesce(string_agg(value, '' ''), '' '')
-				FROM jsonb_each_text(p_json::jsonb)
+				RETURN CASE
+					WHEN jsonb_typeof(p_json) = ''array'' THEN jsonb_array_value_agg(p_json, ignore_key)
+					WHEN jsonb_typeof(p_json) = ''object'' THEN jsonb_object_value_agg(p_json, ignore_key)
+					WHEN jsonb_typeof(p_json) = ''string''
+						AND p_json #>> ''{}'' !~ ''^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{1,3}Z$''
+						THEN coalesce(p_json #>> ''{}'', '''')
+					ELSE ''''
+				END;
+			EXCEPTION
+				WHEN OTHERS THEN
+				RETURN NULL;
+			END;
+			'
+			LANGUAGE plpgsql
+			IMMUTABLE;
+
+			CREATE OR REPLACE FUNCTION jsonb_array_value_agg (p_json jsonb, ignore_key text default 'invisibleCustomFields')
+				RETURNS text
+			AS
+			'
+			BEGIN
+				RETURN string_agg(jsonb_value_agg(value, ignore_key), '' '')
+				FROM jsonb_array_elements(p_json);
+			EXCEPTION
+				WHEN OTHERS THEN
+				RETURN NULL;
+			END;
+			'
+			LANGUAGE plpgsql
+			IMMUTABLE;
+
+			CREATE OR REPLACE FUNCTION jsonb_object_value_agg (p_json jsonb, ignore_key text default 'invisibleCustomFields')
+				RETURNS text
+			AS
+			'
+			BEGIN
+				RETURN string_agg(jsonb_value_agg(value, ignore_key), '' '')
+				FROM jsonb_each(p_json)
 				WHERE key != ignore_key;
 			EXCEPTION
 				WHEN OTHERS THEN
@@ -4913,8 +4948,8 @@
 							|| to_tsvector('simple', coalesce(reports."nextSteps", '')), ${fts_high}) ||
 					setweight(to_tsvector(${fts_config}, coalesce(reports.text, ''))
 							|| to_tsvector('simple', coalesce(reports.text, '')), ${fts_low}) ||
-					setweight(to_tsvector(${fts_config}, jsonb_value_agg(reports."customFields"))
-							|| to_tsvector('simple', jsonb_value_agg(reports."customFields")), ${fts_lower})
+					setweight(to_tsvector(${fts_config}, jsonb_value_agg(reports."customFields"::jsonb))
+							|| to_tsvector('simple', jsonb_value_agg(reports."customFields"::jsonb)), ${fts_lower})
 				) STORED;
 
 			ALTER TABLE people DROP COLUMN full_text;
@@ -4926,8 +4961,8 @@
 					setweight(to_tsvector('simple', coalesce(people."phoneNumber", '')), ${fts_high}) ||
 					setweight(to_tsvector(${fts_config}, coalesce(people.biography, ''))
 							|| to_tsvector('simple', coalesce(people.biography, '')), ${fts_low}) ||
-					setweight(to_tsvector(${fts_config}, jsonb_value_agg(people."customFields"))
-							|| to_tsvector('simple', jsonb_value_agg(people."customFields")), ${fts_lower})
+					setweight(to_tsvector(${fts_config}, jsonb_value_agg(people."customFields"::jsonb))
+							|| to_tsvector('simple', jsonb_value_agg(people."customFields"::jsonb)), ${fts_lower})
 				) STORED;
 
 			ALTER TABLE locations DROP COLUMN full_text;
@@ -4937,8 +4972,8 @@
 							|| to_tsvector('simple', coalesce(locations.name, '')), ${fts_high}) ||
 					setweight(to_tsvector(${fts_config}, coalesce(locations.description, ''))
 							|| to_tsvector('simple', coalesce(locations.description, '')), ${fts_low}) ||
-					setweight(to_tsvector(${fts_config}, jsonb_value_agg(locations."customFields"))
-							|| to_tsvector('simple', jsonb_value_agg(locations."customFields")), ${fts_lower})
+					setweight(to_tsvector(${fts_config}, jsonb_value_agg(locations."customFields"::jsonb))
+							|| to_tsvector('simple', jsonb_value_agg(locations."customFields"::jsonb)), ${fts_lower})
 				) STORED;
 
 			ALTER TABLE positions DROP COLUMN full_text;
@@ -4947,8 +4982,8 @@
 					setweight(to_tsvector('simple', coalesce(positions.code, '')), ${fts_high}) ||
 					setweight(to_tsvector(${fts_config}, coalesce(positions.name, ''))
 							|| to_tsvector('simple', coalesce(positions.name, '')), ${fts_high}) ||
-					setweight(to_tsvector(${fts_config}, jsonb_value_agg(positions."customFields"))
-							|| to_tsvector('simple', jsonb_value_agg(positions."customFields")), ${fts_lower})
+					setweight(to_tsvector(${fts_config}, jsonb_value_agg(positions."customFields"::jsonb))
+							|| to_tsvector('simple', jsonb_value_agg(positions."customFields"::jsonb)), ${fts_lower})
 				) STORED;
 
 			ALTER TABLE organizations DROP COLUMN full_text;
@@ -4960,8 +4995,8 @@
 							|| to_tsvector('simple', coalesce(organizations."longName", '')), ${fts_low}) ||
 					setweight(to_tsvector(${fts_config}, coalesce(organizations.profile, ''))
 							|| to_tsvector('simple', coalesce(organizations.profile, '')), ${fts_low}) ||
-					setweight(to_tsvector(${fts_config}, jsonb_value_agg(organizations."customFields"))
-							|| to_tsvector('simple', jsonb_value_agg(organizations."customFields")), ${fts_lower})
+					setweight(to_tsvector(${fts_config}, jsonb_value_agg(organizations."customFields"::jsonb))
+							|| to_tsvector('simple', jsonb_value_agg(organizations."customFields"::jsonb)), ${fts_lower})
 				) STORED;
 
 			ALTER TABLE tasks DROP COLUMN full_text;
@@ -4972,8 +5007,8 @@
 							|| to_tsvector('simple', coalesce(tasks."longName", '')), ${fts_high}) ||
 					setweight(to_tsvector(${fts_config}, coalesce(tasks.description, ''))
 							|| to_tsvector('simple', coalesce(tasks.description, '')), ${fts_low}) ||
-					setweight(to_tsvector(${fts_config}, jsonb_value_agg(tasks."customFields"))
-							|| to_tsvector('simple', jsonb_value_agg(tasks."customFields")), ${fts_lower})
+					setweight(to_tsvector(${fts_config}, jsonb_value_agg(tasks."customFields"::jsonb))
+							|| to_tsvector('simple', jsonb_value_agg(tasks."customFields"::jsonb)), ${fts_lower})
 				) STORED;
 
 			CREATE MATERIALIZED VIEW IF NOT EXISTS mv_fts_reports(uuid, full_text) AS

--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -4874,4 +4874,200 @@
 		<dropColumn tableName="people" columnName="emailAddress" />
 	</changeSet>
 
+	<changeSet id="add-custom-fields-to-fulltext-index" author="chessray">
+		<sql dbms="postgresql">
+			<!-- Drop full-text materialized views (incl. indexes) since we cannot just ALTER them;
+			     copied from multiple changesets -->
+			DROP MATERIALIZED VIEW mv_fts_reports;
+			DROP MATERIALIZED VIEW mv_fts_people;
+			DROP MATERIALIZED VIEW mv_fts_locations;
+			DROP MATERIALIZED VIEW mv_fts_positions;
+			DROP MATERIALIZED VIEW mv_fts_organizations;
+			DROP MATERIALIZED VIEW mv_fts_tasks;
+
+			ALTER TABLE reports DROP COLUMN full_text;
+			ALTER TABLE reports
+				ADD COLUMN full_text tsvector GENERATED ALWAYS AS (
+					setweight(to_tsvector(${fts_config}, coalesce(reports.intent, ''))
+							|| to_tsvector('simple', coalesce(reports.intent, '')), ${fts_high}) ||
+					setweight(to_tsvector(${fts_config}, coalesce(reports."keyOutcomes", ''))
+							|| to_tsvector('simple', coalesce(reports."keyOutcomes", '')), ${fts_high}) ||
+					setweight(to_tsvector(${fts_config}, coalesce(reports."nextSteps", ''))
+							|| to_tsvector('simple', coalesce(reports."nextSteps", '')), ${fts_high}) ||
+					setweight(to_tsvector(${fts_config}, coalesce(reports.text, ''))
+							|| to_tsvector('simple', coalesce(reports.text, '')), ${fts_low}) ||
+					setweight(to_tsvector(${fts_config}, coalesce(reports."customFields", ''))
+							|| to_tsvector('simple', coalesce(reports."customFields", '')), ${fts_lower})
+				) STORED;
+
+			ALTER TABLE people DROP COLUMN full_text;
+			ALTER TABLE people
+				ADD COLUMN full_text tsvector GENERATED ALWAYS AS (
+					setweight(to_tsvector('simple', coalesce(people.name, '')), ${fts_high}) ||
+					setweight(to_tsvector('simple', coalesce(people.code, '')), ${fts_high}) ||
+					setweight(to_tsvector('simple', coalesce(people."domainUsername", '')), ${fts_high}) ||
+					setweight(to_tsvector('simple', coalesce(people."phoneNumber", '')), ${fts_high}) ||
+					setweight(to_tsvector(${fts_config}, coalesce(people.biography, ''))
+							|| to_tsvector('simple', coalesce(people.biography, '')), ${fts_low}) ||
+					setweight(to_tsvector(${fts_config}, coalesce(people."customFields", ''))
+							|| to_tsvector('simple', coalesce(people."customFields", '')), ${fts_lower})
+				) STORED;
+
+			ALTER TABLE locations DROP COLUMN full_text;
+			ALTER TABLE locations
+				ADD COLUMN full_text tsvector GENERATED ALWAYS AS (
+					setweight(to_tsvector(${fts_config}, coalesce(locations.name, ''))
+							|| to_tsvector('simple', coalesce(locations.name, '')), ${fts_high}) ||
+					setweight(to_tsvector(${fts_config}, coalesce(locations.description, ''))
+							|| to_tsvector('simple', coalesce(locations.description, '')), ${fts_low}) ||
+					setweight(to_tsvector(${fts_config}, coalesce(locations."customFields", ''))
+							|| to_tsvector('simple', coalesce(locations."customFields", '')), ${fts_lower})
+				) STORED;
+
+			ALTER TABLE positions DROP COLUMN full_text;
+			ALTER TABLE positions
+				ADD COLUMN full_text tsvector GENERATED ALWAYS AS (
+					setweight(to_tsvector('simple', coalesce(positions.code, '')), ${fts_high}) ||
+					setweight(to_tsvector(${fts_config}, coalesce(positions.name, ''))
+							|| to_tsvector('simple', coalesce(positions.name, '')), ${fts_high}) ||
+					setweight(to_tsvector(${fts_config}, coalesce(positions."customFields", ''))
+							|| to_tsvector('simple', coalesce(positions."customFields", '')), ${fts_lower})
+				) STORED;
+
+			ALTER TABLE organizations DROP COLUMN full_text;
+			ALTER TABLE organizations
+				ADD COLUMN full_text tsvector GENERATED ALWAYS AS (
+					setweight(to_tsvector('simple', coalesce(organizations."identificationCode", '')), ${fts_high}) ||
+					setweight(to_tsvector('simple', coalesce(organizations."shortName", '')), ${fts_high}) ||
+					setweight(to_tsvector(${fts_config}, coalesce(organizations."longName", ''))
+							|| to_tsvector('simple', coalesce(organizations."longName", '')), ${fts_low}) ||
+					setweight(to_tsvector(${fts_config}, coalesce(organizations.profile, ''))
+							|| to_tsvector('simple', coalesce(organizations.profile, '')), ${fts_low}) ||
+					setweight(to_tsvector(${fts_config}, coalesce(organizations."customFields", ''))
+							|| to_tsvector('simple', coalesce(organizations."customFields", '')), ${fts_lower})
+				) STORED;
+
+			ALTER TABLE tasks DROP COLUMN full_text;
+			ALTER TABLE tasks
+				ADD COLUMN full_text tsvector GENERATED ALWAYS AS (
+					setweight(to_tsvector('simple', coalesce(tasks."shortName", '')), ${fts_high}) ||
+					setweight(to_tsvector(${fts_config}, coalesce(tasks."longName", ''))
+							|| to_tsvector('simple', coalesce(tasks."longName", '')), ${fts_high}) ||
+					setweight(to_tsvector(${fts_config}, coalesce(tasks.description, ''))
+							|| to_tsvector('simple', coalesce(tasks.description, '')), ${fts_low}) ||
+					setweight(to_tsvector(${fts_config}, coalesce(tasks."customFields", ''))
+							|| to_tsvector('simple', coalesce(tasks."customFields", '')), ${fts_lower})
+				) STORED;
+
+			CREATE MATERIALIZED VIEW IF NOT EXISTS mv_fts_reports(uuid, full_text) AS
+			SELECT
+				reports.uuid,
+				reports.full_text
+					|| coalesce(tsvector_agg(notes.full_text), ''::tsvector)
+			FROM reports
+					LEFT JOIN "noteRelatedObjects" ON "noteRelatedObjects"."relatedObjectType" = 'reports'
+				AND "noteRelatedObjects"."relatedObjectUuid" = reports.uuid
+					LEFT JOIN notes ON notes.uuid = "noteRelatedObjects"."noteUuid"
+			GROUP BY reports.uuid
+				WITH DATA;
+			CREATE UNIQUE INDEX "UQ_mv_fts_reports_uuid" ON mv_fts_reports(uuid);
+			CREATE INDEX "FT_mv_fts_reports" ON mv_fts_reports USING gin(full_text);
+			CREATE INDEX "TR_reports_uuid" ON mv_fts_reports USING gin(uuid gin_trgm_ops);
+
+			<!-- Re-create full-text materialized views and indexes;
+			     copied from the last changeset the respective fulltext view has been created before -->
+			CREATE MATERIALIZED VIEW IF NOT EXISTS mv_fts_people(uuid, full_text) AS
+			SELECT
+				people.uuid,
+				people.full_text
+					|| coalesce(tsvector_agg(positions.full_text), ''::tsvector)
+					|| coalesce(tsvector_agg(organizations.full_text), ''::tsvector)
+					|| coalesce(tsvector_agg(notes.full_text), ''::tsvector)
+					|| coalesce(tsvector_agg("emailAddresses".full_text), ''::tsvector)
+			FROM people
+					LEFT JOIN positions ON positions."currentPersonUuid" = people.uuid
+					LEFT JOIN organizations ON organizations.uuid = positions."organizationUuid"
+					LEFT JOIN "noteRelatedObjects" ON "noteRelatedObjects"."relatedObjectType" = 'people'
+				AND "noteRelatedObjects"."relatedObjectUuid" = people.uuid
+					LEFT JOIN notes ON notes.uuid = "noteRelatedObjects"."noteUuid"
+					LEFT JOIN "emailAddresses" ON "emailAddresses"."relatedObjectType" = 'people'
+				AND "emailAddresses"."relatedObjectUuid" = people.uuid
+			GROUP BY people.uuid
+				WITH DATA;
+			CREATE UNIQUE INDEX "UQ_mv_fts_people_uuid" ON mv_fts_people(uuid);
+			CREATE INDEX "FT_mv_fts_people" ON mv_fts_people USING gin(full_text);
+			CREATE INDEX "TR_people_uuid" ON mv_fts_people USING gin(uuid gin_trgm_ops);
+
+			CREATE MATERIALIZED VIEW IF NOT EXISTS mv_fts_locations(uuid, full_text) AS
+			SELECT
+				locations.uuid,
+				locations.full_text
+					|| coalesce(tsvector_agg(notes.full_text), ''::tsvector)
+			FROM locations
+					LEFT JOIN "noteRelatedObjects" ON "noteRelatedObjects"."relatedObjectType" = 'locations'
+				AND "noteRelatedObjects"."relatedObjectUuid" = locations.uuid
+					LEFT JOIN notes ON notes.uuid = "noteRelatedObjects"."noteUuid"
+			GROUP BY locations.uuid
+				WITH DATA;
+			CREATE UNIQUE INDEX "UQ_mv_fts_locations_uuid" ON mv_fts_locations(uuid);
+			CREATE INDEX "FT_mv_fts_locations" ON mv_fts_locations USING gin(full_text);
+			CREATE INDEX "TR_locations_uuid" ON mv_fts_locations USING gin(uuid gin_trgm_ops);
+
+			CREATE MATERIALIZED VIEW IF NOT EXISTS mv_fts_positions(uuid, full_text) AS
+			SELECT
+				positions.uuid,
+				positions.full_text
+					|| coalesce(tsvector_agg(people.full_text), ''::tsvector)
+					|| coalesce(tsvector_agg(organizations.full_text), ''::tsvector)
+					|| coalesce(tsvector_agg(notes.full_text), ''::tsvector)
+					|| coalesce(tsvector_agg("emailAddresses".full_text), ''::tsvector)
+			FROM positions
+					LEFT JOIN people ON people.uuid = positions."currentPersonUuid"
+					LEFT JOIN organizations ON organizations.uuid = positions."organizationUuid"
+					LEFT JOIN "noteRelatedObjects" ON "noteRelatedObjects"."relatedObjectType" = 'positions'
+				AND "noteRelatedObjects"."relatedObjectUuid" = positions.uuid
+					LEFT JOIN notes ON notes.uuid = "noteRelatedObjects"."noteUuid"
+					LEFT JOIN "emailAddresses" ON "emailAddresses"."relatedObjectType" = 'positions'
+				AND "emailAddresses"."relatedObjectUuid" = positions.uuid
+			GROUP BY positions.uuid
+				WITH DATA;
+			CREATE UNIQUE INDEX "UQ_mv_fts_positions" ON mv_fts_positions(uuid);
+			CREATE INDEX "FT_mv_fts_positions" ON mv_fts_positions USING gin(full_text);
+			CREATE INDEX "TR_positions_uuid" ON mv_fts_positions USING gin(uuid gin_trgm_ops);
+
+			CREATE MATERIALIZED VIEW IF NOT EXISTS mv_fts_organizations(uuid, full_text) AS
+			SELECT
+				organizations.uuid,
+				organizations.full_text
+					|| coalesce(tsvector_agg(notes.full_text), ''::tsvector)
+					|| coalesce(tsvector_agg("emailAddresses".full_text), ''::tsvector)
+			FROM organizations
+					LEFT JOIN "noteRelatedObjects" ON "noteRelatedObjects"."relatedObjectType" = 'organizations'
+				AND "noteRelatedObjects"."relatedObjectUuid" = organizations.uuid
+					LEFT JOIN notes ON notes.uuid = "noteRelatedObjects"."noteUuid"
+					LEFT JOIN "emailAddresses" ON "emailAddresses"."relatedObjectType" = 'organizations'
+				AND "emailAddresses"."relatedObjectUuid" = organizations.uuid
+			GROUP BY organizations.uuid
+				WITH DATA;
+			CREATE UNIQUE INDEX "UQ_mv_fts_organizations_uuid" ON mv_fts_organizations(uuid);
+			CREATE INDEX "FT_mv_fts_organizations" ON mv_fts_organizations USING gin(full_text);
+			CREATE INDEX "TR_organizations_uuid" ON mv_fts_organizations USING gin(uuid gin_trgm_ops);
+
+			CREATE MATERIALIZED VIEW IF NOT EXISTS mv_fts_tasks(uuid, full_text) AS
+			SELECT
+				tasks.uuid,
+				tasks.full_text
+					|| coalesce(tsvector_agg(notes.full_text), ''::tsvector)
+			FROM tasks
+					LEFT JOIN "noteRelatedObjects" ON "noteRelatedObjects"."relatedObjectType" = 'tasks'
+				AND "noteRelatedObjects"."relatedObjectUuid" = tasks.uuid
+					LEFT JOIN notes ON notes.uuid = "noteRelatedObjects"."noteUuid"
+			GROUP BY tasks.uuid
+				WITH DATA;
+			CREATE UNIQUE INDEX "UQ_mv_fts_tasks" ON mv_fts_tasks(uuid);
+			CREATE INDEX "FT_mv_fts_tasks" ON mv_fts_tasks USING gin(full_text);
+			CREATE INDEX "TR_tasks_uuid" ON mv_fts_tasks USING gin(uuid gin_trgm_ops);
+		</sql>
+		<!-- Rolling back is not useful anymore -->
+	</changeSet>
 </databaseChangeLog>

--- a/src/test/java/mil/dds/anet/test/resources/LocationResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/LocationResourceTest.java
@@ -143,4 +143,13 @@ public class LocationResourceTest extends AbstractResourceTest {
     }
   }
 
+  @Test
+  void shouldBeSearchableViaCustomFields() {
+    final LocationSearchQueryInput query =
+        LocationSearchQueryInput.builder().withText("consectetur").build();
+    final AnetBeanList_Location searchObjects =
+        withCredentials(adminUser, t -> queryExecutor.locationList(getListFields(FIELDS), query));
+    assertThat(searchObjects).isNotNull();
+    assertThat(searchObjects.getTotalCount()).isGreaterThan(0);
+  }
 }

--- a/src/test/java/mil/dds/anet/test/resources/LocationResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/LocationResourceTest.java
@@ -151,7 +151,7 @@ public class LocationResourceTest extends AbstractResourceTest {
     final AnetBeanList_Location searchObjects =
         withCredentials(adminUser, t -> queryExecutor.locationList(getListFields(FIELDS), query));
     assertThat(searchObjects).isNotNull();
-    assertThat(searchObjects.getTotalCount()).isEqualTo(1);
+    assertThat(searchObjects.getTotalCount()).isOne();
     assertThat(searchObjects.getList()).allSatisfy(
         searchResult -> assertThat(searchResult.getCustomFields()).contains(searchText));
   }

--- a/src/test/java/mil/dds/anet/test/resources/LocationResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/LocationResourceTest.java
@@ -145,11 +145,14 @@ public class LocationResourceTest extends AbstractResourceTest {
 
   @Test
   void shouldBeSearchableViaCustomFields() {
+    final var searchText = "consectetur";
     final LocationSearchQueryInput query =
-        LocationSearchQueryInput.builder().withText("consectetur").build();
+        LocationSearchQueryInput.builder().withText(searchText).build();
     final AnetBeanList_Location searchObjects =
         withCredentials(adminUser, t -> queryExecutor.locationList(getListFields(FIELDS), query));
     assertThat(searchObjects).isNotNull();
-    assertThat(searchObjects.getTotalCount()).isGreaterThan(0);
+    assertThat(searchObjects.getTotalCount()).isEqualTo(1);
+    assertThat(searchObjects.getList()).allSatisfy(
+        searchResult -> assertThat(searchResult.getCustomFields()).contains(searchText));
   }
 }

--- a/src/test/java/mil/dds/anet/test/resources/OrganizationResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/OrganizationResourceTest.java
@@ -567,10 +567,13 @@ class OrganizationResourceTest extends AbstractResourceTest {
 
   @Test
   void shouldBeSearchableViaCustomFields() {
-    final var query = OrganizationSearchQueryInput.builder().withText("exercitation").build();
+    final var searchText = "exercitation";
+    final var query = OrganizationSearchQueryInput.builder().withText(searchText).build();
     final var searchObjects = withCredentials(adminUser,
         t -> queryExecutor.organizationList(getListFields(FIELDS), query));
     assertThat(searchObjects).isNotNull();
-    assertThat(searchObjects.getTotalCount()).isGreaterThan(0);
+    assertThat(searchObjects.getTotalCount()).isEqualTo(1);
+    assertThat(searchObjects.getList()).allSatisfy(
+        searchResult -> assertThat(searchResult.getCustomFields()).contains(searchText));
   }
 }

--- a/src/test/java/mil/dds/anet/test/resources/OrganizationResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/OrganizationResourceTest.java
@@ -572,7 +572,7 @@ class OrganizationResourceTest extends AbstractResourceTest {
     final var searchObjects = withCredentials(adminUser,
         t -> queryExecutor.organizationList(getListFields(FIELDS), query));
     assertThat(searchObjects).isNotNull();
-    assertThat(searchObjects.getTotalCount()).isEqualTo(1);
+    assertThat(searchObjects.getTotalCount()).isOne();
     assertThat(searchObjects.getList()).allSatisfy(
         searchResult -> assertThat(searchResult.getCustomFields()).contains(searchText));
   }

--- a/src/test/java/mil/dds/anet/test/resources/OrganizationResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/OrganizationResourceTest.java
@@ -565,4 +565,12 @@ class OrganizationResourceTest extends AbstractResourceTest {
     assertThat(numOrg).isOne();
   }
 
+  @Test
+  void shouldBeSearchableViaCustomFields() {
+    final var query = OrganizationSearchQueryInput.builder().withText("exercitation").build();
+    final var searchObjects = withCredentials(adminUser,
+        t -> queryExecutor.organizationList(getListFields(FIELDS), query));
+    assertThat(searchObjects).isNotNull();
+    assertThat(searchObjects.getTotalCount()).isGreaterThan(0);
+  }
 }

--- a/src/test/java/mil/dds/anet/test/resources/PersonResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/PersonResourceTest.java
@@ -884,4 +884,13 @@ public class PersonResourceTest extends AbstractResourceTest {
     }
   }
 
+  @Test
+  void shouldBeSearchableViaCustomFields() {
+    final PersonSearchQueryInput query =
+        PersonSearchQueryInput.builder().withText("lorem ipsum").build();
+    final AnetBeanList_Person searchObjects =
+        withCredentials(adminUser, t -> queryExecutor.personList(getListFields(FIELDS), query));
+    assertThat(searchObjects).isNotNull();
+    assertThat(searchObjects.getTotalCount()).isGreaterThan(0);
+  }
 }

--- a/src/test/java/mil/dds/anet/test/resources/PersonResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/PersonResourceTest.java
@@ -886,11 +886,14 @@ public class PersonResourceTest extends AbstractResourceTest {
 
   @Test
   void shouldBeSearchableViaCustomFields() {
+    final var searchText = "ipsum";
     final PersonSearchQueryInput query =
-        PersonSearchQueryInput.builder().withText("lorem ipsum").build();
+        PersonSearchQueryInput.builder().withText(searchText).build();
     final AnetBeanList_Person searchObjects =
         withCredentials(adminUser, t -> queryExecutor.personList(getListFields(FIELDS), query));
     assertThat(searchObjects).isNotNull();
-    assertThat(searchObjects.getTotalCount()).isGreaterThan(0);
+    assertThat(searchObjects.getTotalCount()).isEqualTo(1);
+    assertThat(searchObjects.getList()).allSatisfy(
+        searchResult -> assertThat(searchResult.getCustomFields()).contains(searchText));
   }
 }

--- a/src/test/java/mil/dds/anet/test/resources/PersonResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/PersonResourceTest.java
@@ -892,7 +892,7 @@ public class PersonResourceTest extends AbstractResourceTest {
     final AnetBeanList_Person searchObjects =
         withCredentials(adminUser, t -> queryExecutor.personList(getListFields(FIELDS), query));
     assertThat(searchObjects).isNotNull();
-    assertThat(searchObjects.getTotalCount()).isEqualTo(1);
+    assertThat(searchObjects.getTotalCount()).isOne();
     assertThat(searchObjects.getList()).allSatisfy(
         searchResult -> assertThat(searchResult.getCustomFields()).contains(searchText));
   }

--- a/src/test/java/mil/dds/anet/test/resources/PositionResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/PositionResourceTest.java
@@ -746,4 +746,12 @@ public class PositionResourceTest extends AbstractResourceTest {
     assertThat(positionUpdated.getPreviousPeople()).hasSize(2);
   }
 
+  @Test
+  void shouldBeSearchableViaCustomFields() {
+    final var query = PositionSearchQueryInput.builder().withText("aliqua").build();
+    final var searchObjects =
+        withCredentials(adminUser, t -> queryExecutor.positionList(getListFields(FIELDS), query));
+    assertThat(searchObjects).isNotNull();
+    assertThat(searchObjects.getTotalCount()).isGreaterThan(0);
+  }
 }

--- a/src/test/java/mil/dds/anet/test/resources/PositionResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/PositionResourceTest.java
@@ -748,10 +748,13 @@ public class PositionResourceTest extends AbstractResourceTest {
 
   @Test
   void shouldBeSearchableViaCustomFields() {
-    final var query = PositionSearchQueryInput.builder().withText("aliqua").build();
+    final var searchText = "aliqua";
+    final var query = PositionSearchQueryInput.builder().withText(searchText).build();
     final var searchObjects =
         withCredentials(adminUser, t -> queryExecutor.positionList(getListFields(FIELDS), query));
     assertThat(searchObjects).isNotNull();
-    assertThat(searchObjects.getTotalCount()).isGreaterThan(0);
+    assertThat(searchObjects.getTotalCount()).isEqualTo(1);
+    assertThat(searchObjects.getList()).allSatisfy(
+        searchResult -> assertThat(searchResult.getCustomFields()).contains(searchText));
   }
 }

--- a/src/test/java/mil/dds/anet/test/resources/PositionResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/PositionResourceTest.java
@@ -753,7 +753,7 @@ public class PositionResourceTest extends AbstractResourceTest {
     final var searchObjects =
         withCredentials(adminUser, t -> queryExecutor.positionList(getListFields(FIELDS), query));
     assertThat(searchObjects).isNotNull();
-    assertThat(searchObjects.getTotalCount()).isEqualTo(1);
+    assertThat(searchObjects.getTotalCount()).isOne();
     assertThat(searchObjects.getList()).allSatisfy(
         searchResult -> assertThat(searchResult.getCustomFields()).contains(searchText));
   }

--- a/src/test/java/mil/dds/anet/test/resources/ReportResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/ReportResourceTest.java
@@ -2493,4 +2493,12 @@ class ReportResourceTest extends AbstractResourceTest {
     assertThat(updatedReport.getState()).isEqualTo(ReportState.DRAFT);
   }
 
+  @Test
+  void shouldBeSearchableViaCustomFields() {
+    final var query = ReportSearchQueryInput.builder().withText("minim").build();
+    final var searchObjects =
+        withCredentials(adminUser, t -> queryExecutor.reportList(getListFields(FIELDS), query));
+    assertThat(searchObjects).isNotNull();
+    assertThat(searchObjects.getTotalCount()).isGreaterThan(0);
+  }
 }

--- a/src/test/java/mil/dds/anet/test/resources/ReportResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/ReportResourceTest.java
@@ -2500,7 +2500,7 @@ class ReportResourceTest extends AbstractResourceTest {
     final var searchObjects =
         withCredentials(adminUser, t -> queryExecutor.reportList(getListFields(FIELDS), query));
     assertThat(searchObjects).isNotNull();
-    assertThat(searchObjects.getTotalCount()).isEqualTo(1);
+    assertThat(searchObjects.getTotalCount()).isOne();
     assertThat(searchObjects.getList()).allSatisfy(
         searchResult -> assertThat(searchResult.getCustomFields()).contains(searchText));
   }

--- a/src/test/java/mil/dds/anet/test/resources/ReportResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/ReportResourceTest.java
@@ -2495,10 +2495,13 @@ class ReportResourceTest extends AbstractResourceTest {
 
   @Test
   void shouldBeSearchableViaCustomFields() {
-    final var query = ReportSearchQueryInput.builder().withText("minim").build();
+    final var searchText = "minim";
+    final var query = ReportSearchQueryInput.builder().withText(searchText).build();
     final var searchObjects =
         withCredentials(adminUser, t -> queryExecutor.reportList(getListFields(FIELDS), query));
     assertThat(searchObjects).isNotNull();
-    assertThat(searchObjects.getTotalCount()).isGreaterThan(0);
+    assertThat(searchObjects.getTotalCount()).isEqualTo(1);
+    assertThat(searchObjects.getList()).allSatisfy(
+        searchResult -> assertThat(searchResult.getCustomFields()).contains(searchText));
   }
 }

--- a/src/test/java/mil/dds/anet/test/resources/TaskResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/TaskResourceTest.java
@@ -391,7 +391,7 @@ class TaskResourceTest extends AbstractResourceTest {
     final var searchObjects =
         withCredentials(adminUser, t -> queryExecutor.taskList(getListFields(FIELDS), query));
     assertThat(searchObjects).isNotNull();
-    assertThat(searchObjects.getTotalCount()).isEqualTo(1);
+    assertThat(searchObjects.getTotalCount()).isOne();
     assertThat(searchObjects.getList()).allSatisfy(
         searchResult -> assertThat(searchResult.getCustomFields()).contains(searchText));
   }

--- a/src/test/java/mil/dds/anet/test/resources/TaskResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/TaskResourceTest.java
@@ -386,11 +386,13 @@ class TaskResourceTest extends AbstractResourceTest {
 
   @Test
   void shouldBeSearchableViaCustomFields() {
-    final var query = TaskSearchQueryInput.builder().withText("red").build();
+    final var searchText = "RED";
+    final var query = TaskSearchQueryInput.builder().withText(searchText).build();
     final var searchObjects =
         withCredentials(adminUser, t -> queryExecutor.taskList(getListFields(FIELDS), query));
     assertThat(searchObjects).isNotNull();
-    assertThat(searchObjects.getTotalCount()).isGreaterThan(0);
+    assertThat(searchObjects.getTotalCount()).isEqualTo(1);
+    assertThat(searchObjects.getList()).allSatisfy(
+        searchResult -> assertThat(searchResult.getCustomFields()).contains(searchText));
   }
-
 }

--- a/src/test/java/mil/dds/anet/test/resources/TaskResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/TaskResourceTest.java
@@ -384,4 +384,13 @@ class TaskResourceTest extends AbstractResourceTest {
     }
   }
 
+  @Test
+  void shouldBeSearchableViaCustomFields() {
+    final var query = TaskSearchQueryInput.builder().withText("red").build();
+    final var searchObjects =
+        withCredentials(adminUser, t -> queryExecutor.taskList(getListFields(FIELDS), query));
+    assertThat(searchObjects).isNotNull();
+    assertThat(searchObjects.getTotalCount()).isGreaterThan(0);
+  }
+
 }


### PR DESCRIPTION
Custom fields are now included in the full-text search index.

Closes [AB#1009](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1009)

#### User changes
- The results for a full-text search extend to custom fields.

#### Superuser changes
- None.

#### Admin changes
- None.

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [x] db needs migration
  Note: since this updates the full-text index, running this on a large database may take several minutes to complete.
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [x] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
