### PR TITLE
Prevent duplicate profiles on account reactivation

### DIFF
--- a/client/src/pages/people/Form.js
+++ b/client/src/pages/people/Form.js
@@ -159,9 +159,6 @@ const PersonForm = ({
           values.status === Model.STATUS.INACTIVE &&
           values.position &&
           !!values.position.uuid
-        const warnDomainUsername =
-          values.status === Model.STATUS.INACTIVE &&
-          !_isEmpty(values.domainUsername)
         const authorizedSensitiveFields =
           currentUser &&
           Person.getAuthorizedSensitiveFields(
@@ -552,15 +549,6 @@ const PersonForm = ({
                             Setting this person to inactive will automatically
                             remove them from the{" "}
                             <strong>{values.position.name}</strong> position.
-                          </Alert>
-                        )}
-                        {warnDomainUsername && (
-                          <Alert variant="warning">
-                            Setting this person to inactive means the next
-                            person to logon with the username{" "}
-                            <strong>{values.domainUsername}</strong> will have
-                            to create a new profile. Do you want the next person
-                            to login with this username to create a new profile?
                           </Alert>
                         )}
                       </DictionaryField>

--- a/src/main/java/mil/dds/anet/AnetApplication.java
+++ b/src/main/java/mil/dds/anet/AnetApplication.java
@@ -211,17 +211,9 @@ public class AnetApplication extends Application<AnetConfiguration> {
               return updatePerson(dao, existingPerson, openIdSubject, username);
             }
 
-            // Fall back to email
-            final String email = token.getEmail();
-            p = dao.findByEmailAddress(email);
-            if (!p.isEmpty()) {
-              final Person existingPerson = p.get(0);
-              logger.trace("found existing user={} by emailAddress={}", existingPerson, email);
-              return updatePerson(dao, existingPerson, openIdSubject, username);
-            }
-
             // Not found, first time this user has ever logged in
-            return createPerson(dao, openIdSubject, username, email, getCombinedName(token));
+            return createPerson(dao, openIdSubject, username, token.getEmail(),
+                getCombinedName(token));
           }
 
           private Person updatePerson(final PersonDao dao, final Person person,

--- a/src/main/java/mil/dds/anet/database/PersonDao.java
+++ b/src/main/java/mil/dds/anet/database/PersonDao.java
@@ -213,22 +213,6 @@ public class PersonDao extends AnetSubscribableObjectDao<Person, PersonSearchQue
   }
 
   @InTransaction
-  // Should only be used during authentication
-  public List<Person> findByEmailAddress(String emailAddress) {
-    if (Utils.isEmptyOrNull(emailAddress)) {
-      return Collections.emptyList();
-    }
-    return getDbHandle()
-        .createQuery("/* findByEmailAddress */ SELECT " + PERSON_FIELDS + ","
-            + PositionDao.POSITION_FIELDS
-            + "FROM people LEFT JOIN positions ON people.uuid = positions.\"currentPersonUuid\" "
-            + "LEFT JOIN \"emailAddresses\" ON \"emailAddresses\".\"relatedObjectType\" = '"
-            + TABLE_NAME + "' AND people.uuid = \"emailAddresses\".\"relatedObjectUuid\" "
-            + "WHERE \"emailAddresses\".address = :emailAddress")
-        .bind("emailAddress", emailAddress).map(new PersonMapper()).list();
-  }
-
-  @InTransaction
   public List<Person> findByOpenIdSubject(String openIdSubject, boolean activeUser) {
     if (Utils.isEmptyOrNull(openIdSubject)) {
       return Collections.emptyList();

--- a/src/main/java/mil/dds/anet/database/PersonDao.java
+++ b/src/main/java/mil/dds/anet/database/PersonDao.java
@@ -24,6 +24,7 @@ import mil.dds.anet.AnetObjectEngine;
 import mil.dds.anet.beans.Person;
 import mil.dds.anet.beans.PersonPositionHistory;
 import mil.dds.anet.beans.Position;
+import mil.dds.anet.beans.WithStatus;
 import mil.dds.anet.beans.lists.AnetBeanList;
 import mil.dds.anet.beans.recentActivity.Activity;
 import mil.dds.anet.beans.search.PersonSearchQuery;
@@ -144,11 +145,13 @@ public class PersonDao extends AnetSubscribableObjectDao<Person, PersonSearchQue
   public int updateAuthenticationDetails(Person p) {
     DaoUtils.setUpdateFields(p);
     final String sql = "/* personUpdateAuthenticationDetails */ UPDATE people "
-        + "SET \"openIdSubject\" = :openIdSubject , \"updatedAt\" = :updatedAt "
-        + "WHERE uuid = :uuid";
-    final int nr = getDbHandle().createUpdate(sql).bind("openIdSubject", p.getOpenIdSubject())
-        .bind("updatedAt", DaoUtils.asLocalDateTime(p.getUpdatedAt())).bind("uuid", p.getUuid())
-        .execute();
+        + "SET \"openIdSubject\" = :openIdSubject , \"domainUsername\" = :domainUsername, "
+        + "status = :status, \"user\" = :user, \"pendingVerification\" = :pendingVerification, "
+        + "\"endOfTourDate\" = :endOfTourDate, \"updatedAt\" = :updatedAt WHERE uuid = :uuid";
+    final int nr = getDbHandle().createUpdate(sql).bindBean(p)
+        .bind("updatedAt", DaoUtils.asLocalDateTime(p.getUpdatedAt()))
+        .bind("endOfTourDate", DaoUtils.asLocalDateTime(p.getEndOfTourDate()))
+        .bind("status", DaoUtils.getEnumId(p.getStatus())).execute();
     evictFromCache(p);
     // The openIdSubject has changed, evict original person as well
     evictFromCache(findInCache(p));
@@ -205,11 +208,8 @@ public class PersonDao extends AnetSubscribableObjectDao<Person, PersonSearchQue
         .createQuery("/* findByDomainUsername */ SELECT " + PERSON_FIELDS + ","
             + PositionDao.POSITION_FIELDS
             + "FROM people LEFT JOIN positions ON people.uuid = positions.\"currentPersonUuid\" "
-            + "WHERE people.user = :user AND people.\"domainUsername\" = :domainUsername "
-            + "AND people.status != :inactiveStatus")
-        .bind("user", true).bind("domainUsername", domainUsername)
-        .bind("inactiveStatus", DaoUtils.getEnumId(Person.Status.INACTIVE)).map(new PersonMapper())
-        .list();
+            + "WHERE people.\"domainUsername\" = :domainUsername")
+        .bind("domainUsername", domainUsername).map(new PersonMapper()).list();
   }
 
   @InTransaction
@@ -224,15 +224,12 @@ public class PersonDao extends AnetSubscribableObjectDao<Person, PersonSearchQue
             + "FROM people LEFT JOIN positions ON people.uuid = positions.\"currentPersonUuid\" "
             + "LEFT JOIN \"emailAddresses\" ON \"emailAddresses\".\"relatedObjectType\" = '"
             + TABLE_NAME + "' AND people.uuid = \"emailAddresses\".\"relatedObjectUuid\" "
-            + "WHERE people.user = :user AND \"emailAddresses\".address = :emailAddress "
-            + "AND people.status != :inactiveStatus")
-        .bind("user", true).bind("emailAddress", emailAddress)
-        .bind("inactiveStatus", DaoUtils.getEnumId(Person.Status.INACTIVE)).map(new PersonMapper())
-        .list();
+            + "WHERE \"emailAddresses\".address = :emailAddress")
+        .bind("emailAddress", emailAddress).map(new PersonMapper()).list();
   }
 
   @InTransaction
-  public List<Person> findByOpenIdSubject(String openIdSubject) {
+  public List<Person> findByOpenIdSubject(String openIdSubject, boolean activeUser) {
     if (Utils.isEmptyOrNull(openIdSubject)) {
       return Collections.emptyList();
     }
@@ -240,15 +237,19 @@ public class PersonDao extends AnetSubscribableObjectDao<Person, PersonSearchQue
     if (person != null) {
       return Collections.singletonList(person);
     }
-    final List<Person> people = getDbHandle()
-        .createQuery("/* findByOpenIdSubject */ SELECT " + PERSON_FIELDS + ","
-            + PositionDao.POSITION_FIELDS
+    String sql =
+        "/* findByOpenIdSubject */ SELECT " + PERSON_FIELDS + "," + PositionDao.POSITION_FIELDS
             + "FROM people LEFT JOIN positions ON people.uuid = positions.\"currentPersonUuid\" "
-            + "WHERE people.user = :user AND people.\"openIdSubject\" = :openIdSubject "
-            + "AND people.status != :inactiveStatus")
-        .bind("user", true).bind("openIdSubject", openIdSubject)
-        .bind("inactiveStatus", DaoUtils.getEnumId(Person.Status.INACTIVE)).map(new PersonMapper())
-        .list();
+            + "WHERE people.\"openIdSubject\" = :openIdSubject";
+    if (activeUser) {
+      sql += " AND people.user = :user AND people.status != :inactiveStatus";
+    }
+    final Query query = getDbHandle().createQuery(sql).bind("openIdSubject", openIdSubject);
+    if (activeUser) {
+      query.bind("user", true).bind("inactiveStatus",
+          DaoUtils.getEnumId(WithStatus.Status.INACTIVE));
+    }
+    final List<Person> people = query.map(new PersonMapper()).list();
     // There should at most one match
     people.stream().forEach(p -> putInCache(p));
     return people;
@@ -316,7 +317,7 @@ public class PersonDao extends AnetSubscribableObjectDao<Person, PersonSearchQue
 
   /**
    * Just to be on the safe side, we only cache objects retrieved inside
-   * {@link #findByOpenIdSubject(String)}.
+   * {@link #findByOpenIdSubject(String, boolean)}.
    *
    * @param person the person to be evicted from the domain users cache
    */

--- a/src/main/java/mil/dds/anet/resources/PersonResource.java
+++ b/src/main/java/mil/dds/anet/resources/PersonResource.java
@@ -17,6 +17,7 @@ import mil.dds.anet.beans.EmailAddress;
 import mil.dds.anet.beans.Person;
 import mil.dds.anet.beans.Position;
 import mil.dds.anet.beans.Position.PositionType;
+import mil.dds.anet.beans.WithStatus;
 import mil.dds.anet.beans.lists.AnetBeanList;
 import mil.dds.anet.beans.search.PersonSearchQuery;
 import mil.dds.anet.config.AnetConfiguration;
@@ -158,19 +159,14 @@ public class PersonResource {
     }
 
     // If person changed to inactive, clear out the user status and domainUsername and openIdSubject
-    if (Person.Status.INACTIVE.equals(p.getStatus())
-        && !Person.Status.INACTIVE.equals(existing.getStatus())) {
-      AnetAuditLogger.log("Person {} user status set to false, "
-          + "and domainUsername '{}' and openIdSubject '{}' cleared by {} because they are now inactive",
-          p, existing.getDomainUsername(), existing.getOpenIdSubject(), user);
-      p.setUser(false);
-      p.setDomainUsername(null);
-      p.setOpenIdSubject(null);
+    if (WithStatus.Status.INACTIVE.equals(p.getStatus())
+        && !WithStatus.Status.INACTIVE.equals(existing.getStatus())) {
+      AnetAuditLogger.log("Person {} user status set to false", p);
       dao.updateAuthenticationDetails(p);
     }
 
     // Automatically remove people from a position if they are inactive.
-    if (Person.Status.INACTIVE.equals(p.getStatus()) && p.getPosition() != null) {
+    if (WithStatus.Status.INACTIVE.equals(p.getStatus()) && p.getPosition() != null) {
       Position existingPos = DaoUtils.getPosition(existing);
       if (existingPos != null) {
         // A user can reset 'themselves' if the account was incorrect ("This is not me")

--- a/src/test/java/mil/dds/anet/test/resources/AdminResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/AdminResourceTest.java
@@ -103,7 +103,7 @@ class AdminResourceTest extends AbstractResourceTest {
     final boolean isAdmin = user.getPosition().getType() == PositionType.ADMINISTRATOR;
 
     // Cache a person
-    engine.getPersonDao().findByOpenIdSubject(user.getOpenIdSubject());
+    engine.getPersonDao().findByOpenIdSubject(user.getOpenIdSubject(), true);
 
     try {
       final String result =


### PR DESCRIPTION
When a user profile is deactived (e.g. because their end of tour date has passed), account-related information is no longer cleared from the database. So if they reactivate their account, they will get their original profile back.

Closes [AB#1037](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1037)

#### User changes
- Reactivating your account after it has been deactivated will give you back your original profile.

#### Superuser changes
- None

#### Admin changes
- None

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [x] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here