### PR TITLE
Add advanced search filter on people's current position type

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -160,6 +160,7 @@ dependencies {
 	testImplementation 'org.powermock:powermock-module-junit4-rule:2.0.9'
 
 	testImplementation 'org.junit.jupiter:junit-jupiter-api:5.10.2'
+	testImplementation 'org.junit.jupiter:junit-jupiter-params:5.10.2'
 	testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.10.2'
 
 	// Avoid "ERROR StatusLogger Log4j2 could not find a logging implementation.

--- a/client/src/components/SearchFilters.js
+++ b/client/src/components/SearchFilters.js
@@ -42,10 +42,7 @@ import LOCATIONS_ICON from "resources/locations.png"
 import PEOPLE_ICON from "resources/people.png"
 import POSITIONS_ICON from "resources/positions.png"
 import TASKS_ICON from "resources/tasks.png"
-import {
-  POSITION_POSITION_TYPE_FILTER_KEY,
-  RECURSE_STRATEGY
-} from "searchUtils"
+import { RECURSE_STRATEGY } from "searchUtils"
 import Settings from "settings"
 
 export const SearchQueryPropType = PropTypes.shape({
@@ -407,6 +404,23 @@ export const searchFilters = function(includeAdminFilters) {
           labels: ["Yes", "No"]
         }
       },
+      "Holding Position As": {
+        component: SelectFilter,
+        deserializer: deserializeSelectFilter,
+        props: {
+          queryKey: "positionType",
+          options: [
+            Position.TYPE.REGULAR,
+            Position.TYPE.SUPERUSER,
+            Position.TYPE.ADMINISTRATOR
+          ],
+          labels: [
+            Settings.fields.regular.position.name,
+            Settings.fields.superuser.position.name,
+            Settings.fields.administrator.position.name
+          ]
+        }
+      },
       "Pending Verification": {
         component: RadioButtonFilter,
         deserializer: deserializeSelectFilter,
@@ -458,7 +472,7 @@ export const searchFilters = function(includeAdminFilters) {
 
   filters[SEARCH_OBJECT_TYPES.POSITIONS] = {
     filters: {
-      [POSITION_POSITION_TYPE_FILTER_KEY]: {
+      Type: {
         component: SelectFilter,
         dictProps: Settings.fields.position.type,
         deserializer: deserializeSelectFilter,
@@ -473,8 +487,7 @@ export const searchFilters = function(includeAdminFilters) {
             Settings.fields.regular.position.name,
             Settings.fields.superuser.position.name,
             Settings.fields.administrator.position.name
-          ],
-          isPositionTypeFilter: true
+          ]
         }
       },
       "Within Organization": {

--- a/client/src/components/advancedSearch/SelectFilter.js
+++ b/client/src/components/advancedSearch/SelectFilter.js
@@ -10,7 +10,6 @@ const SelectFilter = ({
   queryKey,
   value: inputValue,
   onChange,
-  isPositionTypeFilter,
   options,
   labels
 }) => {
@@ -57,8 +56,7 @@ SelectFilter.propTypes = {
     })
   ]),
   onChange: PropTypes.func, // eslint-disable-line react/no-unused-prop-types
-  asFormField: PropTypes.bool,
-  isPositionTypeFilter: PropTypes.bool
+  asFormField: PropTypes.bool
 }
 SelectFilter.defaultProps = {
   asFormField: true

--- a/client/src/searchUtils.js
+++ b/client/src/searchUtils.js
@@ -1,5 +1,3 @@
-export const POSITION_POSITION_TYPE_FILTER_KEY = "Position Type"
-
 export const RECURSE_STRATEGY = {
   NONE: "NONE",
   CHILDREN: "CHILDREN",

--- a/client/tests/webdriver/baseSpecs/advancedSearch.spec.js
+++ b/client/tests/webdriver/baseSpecs/advancedSearch.spec.js
@@ -1,32 +1,33 @@
 import { expect } from "chai"
+import _isEmpty from "lodash/isEmpty"
 import AdvancedSearch from "../pages/advancedSearch"
 import Home from "../pages/home.page"
 
 const ANET_OBJECT_TYPES = {
   Reports: {
-    sampleFilter: "Author"
+    sampleFilters: ["Author"]
   },
   People: {
-    sampleFilter: "Organization"
+    sampleFilters: ["Within Organization", "Holding Position As"]
   },
   Organizations: {
-    sampleFilter: "Within Organization"
+    sampleFilters: ["Within Organization"]
   },
   Positions: {
-    sampleFilter: "Type"
+    sampleFilters: ["Type"]
   },
   Locations: {
-    sampleFilter: "Type"
+    sampleFilters: ["Type"]
   },
   "Objective / Efforts": {
-    sampleFilter: "Organization"
+    sampleFilters: ["Within Organization"]
   },
   "Authorization Groups": {
-    sampleFilter: undefined
+    sampleFilters: []
   }
 }
 const COMMON_FILTER_TEXT = "Status"
-const ALL_COMMON_FILTERS = [COMMON_FILTER_TEXT, "Subscribed"]
+const ALL_COMMON_FILTERS = [COMMON_FILTER_TEXT, "Subscribed", "With Email"]
 
 const PERSON_DEFAULT_FILTER = "Pending Verification"
 const PERSON_INDEX = 1
@@ -107,9 +108,9 @@ describe("When using advanced search", () => {
     const buttons = await AdvancedSearch.getAnetObjectSearchToggleButtons()
     for (const [i, button] of buttons.entries()) {
       await button.click()
-      const sampleFilter =
-        ANET_OBJECT_TYPES[await getObjectType(i)].sampleFilter
-      if (sampleFilter) {
+      const sampleFilters =
+        ANET_OBJECT_TYPES[await getObjectType(i)].sampleFilters
+      if (!_isEmpty(sampleFilters)) {
         await (await AdvancedSearch.getAddFilterButtonText()).waitForExist()
         await (await AdvancedSearch.getAddFilterButtonText()).waitForDisplayed()
         expect(
@@ -123,17 +124,18 @@ describe("When using advanced search", () => {
     const buttons = await AdvancedSearch.getAnetObjectSearchToggleButtons()
     for (const [i, button] of buttons.entries()) {
       await button.click()
-      const sampleFilter =
-        ANET_OBJECT_TYPES[await getObjectType(i)].sampleFilter
-      if (sampleFilter) {
-        await (await AdvancedSearch.getAddFilterButtonText()).waitForExist()
-        await (await AdvancedSearch.getAddFilterButtonText()).waitForDisplayed()
+      const sampleFilters =
+        ANET_OBJECT_TYPES[await getObjectType(i)].sampleFilters
+      if (!_isEmpty(sampleFilters)) {
         await (await AdvancedSearch.getAddFilterButton()).click()
         await (await AdvancedSearch.getAddFilterPopover()).waitForExist()
         await (await AdvancedSearch.getAddFilterPopover()).waitForDisplayed()
-        expect(
-          await (await AdvancedSearch.getAddFilterPopover()).getText()
-        ).to.match(new RegExp(sampleFilter))
+        for (const sampleFilter of sampleFilters) {
+          expect(
+            await (await AdvancedSearch.getAddFilterPopover()).getText()
+          ).to.match(new RegExp(sampleFilter))
+          await (await AdvancedSearch.getSearchFilter(sampleFilter)).click()
+        }
       }
     }
   })

--- a/src/main/java/mil/dds/anet/beans/search/PersonSearchQuery.java
+++ b/src/main/java/mil/dds/anet/beans/search/PersonSearchQuery.java
@@ -3,6 +3,8 @@ package mil.dds.anet.beans.search;
 import io.leangen.graphql.annotations.GraphQLInputField;
 import io.leangen.graphql.annotations.GraphQLQuery;
 import java.time.Instant;
+import java.util.List;
+import mil.dds.anet.beans.Position.PositionType;
 
 public class PersonSearchQuery extends SubscribableObjectSearchQuery<PersonSearchSortBy> {
 
@@ -44,6 +46,11 @@ public class PersonSearchQuery extends SubscribableObjectSearchQuery<PersonSearc
   @GraphQLQuery
   @GraphQLInputField
   Boolean hasBiography;
+
+  // Find people whose current position is of the given type
+  @GraphQLQuery
+  @GraphQLInputField
+  List<PositionType> positionType;
 
   public PersonSearchQuery() {
     super(PersonSearchSortBy.NAME);
@@ -129,6 +136,14 @@ public class PersonSearchQuery extends SubscribableObjectSearchQuery<PersonSearc
 
   public void setHasBiography(Boolean hasBiography) {
     this.hasBiography = hasBiography;
+  }
+
+  public List<PositionType> getPositionType() {
+    return positionType;
+  }
+
+  public void setPositionType(List<PositionType> positionType) {
+    this.positionType = positionType;
   }
 
   @Override

--- a/src/main/java/mil/dds/anet/search/AbstractPersonSearcher.java
+++ b/src/main/java/mil/dds/anet/search/AbstractPersonSearcher.java
@@ -14,6 +14,7 @@ import mil.dds.anet.database.PersonDao;
 import mil.dds.anet.database.mappers.PersonMapper;
 import mil.dds.anet.search.AbstractSearchQueryBuilder.Comparison;
 import mil.dds.anet.utils.DaoUtils;
+import mil.dds.anet.utils.Utils;
 import ru.vyarus.guicey.jdbi3.tx.InTransaction;
 
 public abstract class AbstractPersonSearcher extends AbstractSearcher<Person, PersonSearchQuery>
@@ -49,7 +50,7 @@ public abstract class AbstractPersonSearcher extends AbstractSearcher<Person, Pe
     qb.addFromClause("people");
 
     if (query.getOrgUuid() != null || query.getLocationUuid() != null
-        || query.getMatchPositionName()) {
+        || query.getMatchPositionName() || !Utils.isEmptyOrNull(query.getPositionType())) {
       qb.addFromClause("LEFT JOIN positions ON people.uuid = positions.\"currentPersonUuid\"");
     }
 
@@ -91,6 +92,8 @@ public abstract class AbstractPersonSearcher extends AbstractSearcher<Person, Pe
         qb.addWhereClause("people.biography IS NULL");
       }
     }
+
+    qb.addInClause("types", "positions.type", query.getPositionType());
 
     if (Boolean.TRUE.equals(query.isInMyReports())) {
       qb.addSelectClause("\"inMyReports\".max AS \"inMyReports_max\"");

--- a/src/test/java/mil/dds/anet/test/resources/PersonResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/PersonResourceTest.java
@@ -40,6 +40,8 @@ import mil.dds.anet.test.client.Status;
 import mil.dds.anet.test.utils.UtilsTest;
 import mil.dds.anet.utils.DaoUtils;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 public class PersonResourceTest extends AbstractResourceTest {
 
@@ -315,6 +317,19 @@ public class PersonResourceTest extends AbstractResourceTest {
     searchResults =
         withCredentials(jackUser, t -> queryExecutor.personList(getListFields(FIELDS), query4));
     assertThat(searchResults.getList()).isNotEmpty();
+  }
+
+  @ParameterizedTest
+  @EnumSource(value = PositionType.class, names = {"_PLACEHOLDER_1_"},
+      mode = EnumSource.Mode.EXCLUDE)
+  void searchUsersByPositionType(PositionType positionType) {
+    final PersonSearchQueryInput query = PersonSearchQueryInput.builder().withPageSize(0)
+        .withPositionType(List.of(positionType)).build();
+    final AnetBeanList_Person people =
+        withCredentials(adminUser, t -> queryExecutor.personList(getListFields(FIELDS), query));
+    assertThat(people).isNotNull();
+    assertThat(people.getList()).isNotEmpty()
+        .allMatch(p -> p.getPosition().getType() == positionType);
   }
 
   @Test

--- a/src/test/resources/anet.graphql
+++ b/src/test/resources/anet.graphql
@@ -691,6 +691,7 @@ input PersonSearchQueryInput {
   pageNum: Int
   pageSize: Int
   pendingVerification: Boolean
+  positionType: [PositionType]
   rank: String
   sortBy: PersonSearchSortBy
   sortOrder: SortOrder


### PR DESCRIPTION
To be able to e.g. email all superusers, add an advanced search filter on people's current position type.

Closes [AB#1006](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1006), [AB#1073](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1073)

#### User changes
- Users can now search for people currently holding a position of a specific type (regular, superuser or administrator).

#### Superuser changes
- None

#### Admin changes
- None

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [x] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [x] Added and/or updated unit tests
  - [x] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here