### PR TITLE
Add advanced select filter for "All unassigned tasks"

### DIFF
--- a/.run/createReportForTaskSearch.run.xml
+++ b/.run/createReportForTaskSearch.run.xml
@@ -1,0 +1,16 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="createReportForTaskSearch" type="WdioConfigurationType">
+    <node-interpreter>project</node-interpreter>
+    <node-options />
+    <wdio-package>$PROJECT_DIR$/client/node_modules/@wdio/cli</wdio-package>
+    <working-directory>$PROJECT_DIR$/client</working-directory>
+    <pass-parent-env>true</pass-parent-env>
+    <envs>
+      <env name="SERVER_URL" value="http://localhost:8180" />
+    </envs>
+    <wdio-config-file-path>$PROJECT_DIR$/client/config/wdio.config.js</wdio-config-file-path>
+    <wdio-framework>Mocha</wdio-framework>
+    <test-file>$PROJECT_DIR$/client/tests/webdriver/baseSpecs/createReportForTaskSearch.spec.js</test-file>
+    <method v="2" />
+  </configuration>
+</component>

--- a/client/src/components/SearchFilters.js
+++ b/client/src/components/SearchFilters.js
@@ -540,6 +540,16 @@ export const searchFilters = function(includeAdminFilters) {
 
   filters[SEARCH_OBJECT_TYPES.TASKS] = {
     filters: {
+      "Is Assigned?": {
+        component: RadioButtonFilter,
+        deserializer: deserializeRadioButtonFilter,
+        labelClass: "pt-0",
+        props: {
+          queryKey: "isAssigned",
+          options: [true, false],
+          labels: ["Yes", "No"]
+        }
+      },
       "Within Organization": {
         component: OrganizationFilter,
         deserializer: deserializeOrganizationFilter,

--- a/client/src/pages/reports/Form.js
+++ b/client/src/pages/reports/Form.js
@@ -441,8 +441,8 @@ const ReportForm = ({
         }
 
         tasksFilters.allUnassignedTasks = {
-          label: "All unassigned tasks",
-          queryVars: { taskedOrgUuid: null }
+          label: `All unassigned ${tasksLabel}`,
+          queryVars: { hasParentTask: true, taskedOrgUuid: "-1" }
         }
 
         const authorizationGroupsFilters = {

--- a/client/src/pages/reports/Form.js
+++ b/client/src/pages/reports/Form.js
@@ -435,7 +435,7 @@ const ReportForm = ({
 
         tasksFilters.allUnassignedTasks = {
           label: `All unassigned ${tasksLabel}`,
-          queryVars: { hasParentTask: true, taskedOrgUuid: "-1" }
+          queryVars: { hasParentTask: true, isAssigned: false }
         }
 
         if (currentUser.isAdmin()) {

--- a/client/src/pages/reports/Form.js
+++ b/client/src/pages/reports/Form.js
@@ -433,16 +433,16 @@ const ReportForm = ({
           }
         }
 
+        tasksFilters.allUnassignedTasks = {
+          label: `All unassigned ${tasksLabel}`,
+          queryVars: { hasParentTask: true, taskedOrgUuid: "-1" }
+        }
+
         if (currentUser.isAdmin()) {
           tasksFilters.allTasks = {
             label: `All ${tasksLabel}`,
             queryVars: { hasParentTask: true }
           }
-        }
-
-        tasksFilters.allUnassignedTasks = {
-          label: `All unassigned ${tasksLabel}`,
-          queryVars: { hasParentTask: true, taskedOrgUuid: "-1" }
         }
 
         const authorizationGroupsFilters = {

--- a/client/src/pages/reports/Form.js
+++ b/client/src/pages/reports/Form.js
@@ -440,6 +440,11 @@ const ReportForm = ({
           }
         }
 
+        tasksFilters.allUnassignedTasks = {
+          label: "All unassigned tasks",
+          queryVars: { taskedOrgUuid: null }
+        }
+
         const authorizationGroupsFilters = {
           allAuthorizationGroups: {
             label: "All authorization groups",

--- a/client/tests/webdriver/baseSpecs/createReportForTaskSearch.spec.js
+++ b/client/tests/webdriver/baseSpecs/createReportForTaskSearch.spec.js
@@ -1,0 +1,37 @@
+import { expect } from "chai"
+import CreateReport from "../pages/report/createReport.page"
+
+describe("When creating a report with tasks", () => {
+  it("should offer option to search for all unassigned tasks", async() => {
+    await CreateReport.open()
+    await (await CreateReport.getTasks()).click()
+    await (await CreateReport.getTaskSearchPopover()).waitForExist()
+    await (await CreateReport.getTaskSearchPopover()).waitForDisplayed()
+    await (await CreateReport.getTaskSearchFilters()).waitForExist()
+    await (await CreateReport.getTaskSearchFilters()).waitForDisplayed()
+    const allUnassignedButton =
+      await CreateReport.getAllUnassignedTasksFilterButton()
+    // eslint-disable-next-line no-unused-expressions
+    expect(await allUnassignedButton.isExisting()).to.be.true
+  })
+  it("should return one option 1.3.C", async() => {
+    await CreateReport.open()
+    await (await CreateReport.getTasks()).click()
+    await (await CreateReport.getTaskSearchPopover()).waitForExist()
+    await (await CreateReport.getTaskSearchPopover()).waitForDisplayed()
+    await (await CreateReport.getTaskSearchFilters()).waitForExist()
+    await (await CreateReport.getTaskSearchFilters()).waitForDisplayed()
+    await (
+      await CreateReport.getAllUnassignedTasksFilterButton()
+    ).waitForExist()
+    await (
+      await CreateReport.getAllUnassignedTasksFilterButton()
+    ).waitForDisplayed()
+    await (await CreateReport.getAllUnassignedTasksFilterButton()).click()
+    const task13C = (await CreateReport.getTasksTable()).$(
+      ".bp4-popover2-target=1.3.C"
+    )
+    // eslint-disable-next-line no-unused-expressions
+    expect(await task13C.isExisting()).to.be.true
+  })
+})

--- a/client/tests/webdriver/pages/report/createReport.page.js
+++ b/client/tests/webdriver/pages/report/createReport.page.js
@@ -121,8 +121,22 @@ class CreateReport extends cr.CreateReport {
     return browser.$("#tasks")
   }
 
+  async getTaskSearchPopover() {
+    return browser.$("#tasks-popover")
+  }
+
+  async getTaskSearchFilters() {
+    return (await this.getTaskSearchPopover()).$(".advanced-select-filters")
+  }
+
   async getTasksTable() {
-    return browser.$("#tasks-popover .table-responsive table")
+    return (await this.getTaskSearchPopover()).$(".table-responsive table")
+  }
+
+  async getAllUnassignedTasksFilterButton() {
+    return (await this.getTaskSearchFilters()).$(
+      ".btn-link=All unassigned Efforts"
+    )
   }
 
   async selectTaskByName(name) {

--- a/src/main/java/mil/dds/anet/beans/search/TaskSearchQuery.java
+++ b/src/main/java/mil/dds/anet/beans/search/TaskSearchQuery.java
@@ -9,6 +9,10 @@ import java.util.Objects;
 
 public class TaskSearchQuery extends SubscribableObjectSearchQuery<TaskSearchSortBy> {
 
+  // Find tasks that are (not) assigned to one or more Organizations
+  @GraphQLQuery
+  @GraphQLInputField
+  private Boolean isAssigned;
   @GraphQLQuery
   @GraphQLInputField
   private String taskedOrgUuid;
@@ -50,6 +54,14 @@ public class TaskSearchQuery extends SubscribableObjectSearchQuery<TaskSearchSor
 
   public TaskSearchQuery() {
     super(TaskSearchSortBy.NAME);
+  }
+
+  public Boolean getIsAssigned() {
+    return isAssigned;
+  }
+
+  public void setIsAssigned(final Boolean isAssigned) {
+    this.isAssigned = isAssigned;
   }
 
   public String getTaskedOrgUuid() {
@@ -142,7 +154,7 @@ public class TaskSearchQuery extends SubscribableObjectSearchQuery<TaskSearchSor
 
   @Override
   public int hashCode() {
-    return Objects.hash(super.hashCode(), taskedOrgUuid, orgRecurseStrategy, category,
+    return Objects.hash(super.hashCode(), isAssigned, taskedOrgUuid, orgRecurseStrategy, category,
         plannedCompletionEnd, plannedCompletionStart, projectedCompletionEnd,
         projectedCompletionStart, parentTaskUuid, parentTaskRecurseStrategy,
         responsiblePositionUuid);
@@ -154,7 +166,8 @@ public class TaskSearchQuery extends SubscribableObjectSearchQuery<TaskSearchSor
       return false;
     }
     final TaskSearchQuery other = (TaskSearchQuery) obj;
-    return super.equals(obj) && Objects.equals(getTaskedOrgUuid(), other.getTaskedOrgUuid())
+    return super.equals(obj) && Objects.equals(getIsAssigned(), other.getIsAssigned())
+        && Objects.equals(getTaskedOrgUuid(), other.getTaskedOrgUuid())
         && Objects.equals(getOrgRecurseStrategy(), other.getOrgRecurseStrategy())
         && Objects.equals(getCategory(), other.getCategory())
         && Objects.equals(getPlannedCompletionEnd(), other.getPlannedCompletionEnd())

--- a/src/main/java/mil/dds/anet/search/AbstractTaskSearcher.java
+++ b/src/main/java/mil/dds/anet/search/AbstractTaskSearcher.java
@@ -1,6 +1,7 @@
 package mil.dds.anet.search;
 
 import mil.dds.anet.AnetObjectEngine;
+import mil.dds.anet.beans.Organization;
 import mil.dds.anet.beans.Task;
 import mil.dds.anet.beans.lists.AnetBeanList;
 import mil.dds.anet.beans.search.AbstractBatchParams;
@@ -45,7 +46,9 @@ public abstract class AbstractTaskSearcher extends AbstractSearcher<Task, TaskSe
           AnetObjectEngine.getInstance().getTaskDao().getSubscriptionUpdate(null)));
     }
 
-    addTaskedOrgUuidQuery(query);
+    if (query.getTaskedOrgUuid() != null) {
+      addTaskedOrgUuidQuery(query);
+    }
 
     qb.addStringEqualsClause("category", "tasks.category", query.getCategory());
     qb.addEnumEqualsClause("status", "tasks.status", query.getStatus());
@@ -101,7 +104,7 @@ public abstract class AbstractTaskSearcher extends AbstractSearcher<Task, TaskSe
 
   protected void addTaskedOrgUuidQuery(TaskSearchQuery query) {
     final var taskedOrgUuid = query.getTaskedOrgUuid();
-    if (taskedOrgUuid == null) {
+    if (Organization.DUMMY_ORG_UUID.equals(taskedOrgUuid)) {
       qb.addWhereClause(
           "tasks.uuid NOT IN (SELECT DISTINCT \"taskUuid\" FROM \"taskTaskedOrganizations\")");
     } else {

--- a/src/test/java/mil/dds/anet/test/resources/TaskResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/TaskResourceTest.java
@@ -212,6 +212,18 @@ class TaskResourceTest extends AbstractResourceTest {
   }
 
   @Test
+  void shouldFindOnlyUnassignedTasks() {
+    final var query = TaskSearchQueryInput.builder().withIsAssigned(false).build();
+    final var searchObjects =
+        withCredentials(jackUser, t -> queryExecutor.taskList(getListFields(FIELDS), query));
+    assertThat(searchObjects).isNotNull();
+    assertThat(searchObjects.getList()).isNotEmpty();
+    final var searchResults = searchObjects.getList();
+    assertThat(searchResults).isNotEmpty()
+        .allSatisfy(result -> assertThat(result.getTaskedOrganizations()).isNullOrEmpty());
+  }
+
+  @Test
   void duplicateTaskTest() {
     final Task taskEF7 = withCredentials(adminUser,
         t -> queryExecutor.task(FIELDS, "19364d81-3203-483d-a6bf-461d58888c76"));

--- a/src/test/resources/anet.graphql
+++ b/src/test/resources/anet.graphql
@@ -1276,6 +1276,7 @@ input TaskSearchQueryInput {
   emailNetwork: String
   hasParentTask: Boolean
   inMyReports: Boolean
+  isAssigned: Boolean
   orgRecurseStrategy: RecurseStrategy
   pageNum: Int
   pageSize: Int


### PR DESCRIPTION
Add filter "All unassigned tasks" that allows users when editing an engagement report to select tasks that are not assigned to any specific organisation.

Closes [AB#978](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/978)

#### User changes
- When editing a report, the tasks input has got an additional filter option "All unassigned tasks".
- The advanced search for tasks has a new filter "Is Assigned?" that can search for (un)assigned tasks.

#### Superuser changes
- None

#### Admin changes
- None

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [x] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [x] Added and/or updated unit tests
  - [x] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
