### PR TITLE
Improve possible duplicates warning

### DIFF
--- a/client/tests/webdriver/baseSpecs/createNewLocation.spec.js
+++ b/client/tests/webdriver/baseSpecs/createNewLocation.spec.js
@@ -6,6 +6,7 @@ import {
   LOCATION_COORDS,
   LOCATION_NAME,
   LOCATION_TYPE,
+  NOT_SIMILAR_LOCATION,
   SIMILAR_LOCATION
 } from "./locationUtils"
 
@@ -82,5 +83,17 @@ describe("When creating a new Location", () => {
     await (await CreateNewLocation.getCreateButton()).click()
     await (await CreateNewLocation.getSuccessMsg()).waitForExist()
     await (await CreateNewLocation.getSuccessMsg()).waitForDisplayed()
+  })
+
+  it("Should not display possible duplicates button", async() => {
+    await CreateNewLocation.open()
+    await (await CreateNewLocation.getForm()).waitForExist()
+    await (await CreateNewLocation.getForm()).waitForDisplayed()
+    await (
+      await CreateNewLocation.getNameField()
+    ).setValue(NOT_SIMILAR_LOCATION.name)
+    // eslint-disable-next-line no-unused-expressions
+    expect(await (await CreateNewLocation.getDuplicatesButton()).isExisting())
+      .to.be.false
   })
 })

--- a/client/tests/webdriver/baseSpecs/createNewPerson.spec.js
+++ b/client/tests/webdriver/baseSpecs/createNewPerson.spec.js
@@ -10,6 +10,10 @@ const VALID_PERSON_ADVISOR = {
   firstName: "Jane",
   emailAddresses: ["", "test@NATO.INT"]
 }
+const NOT_SIMILAR_PERSON_ADVISOR = {
+  lastName: "XXX",
+  firstName: "XXX"
+}
 
 const SIMILAR_PERSON_ADVISOR = {
   lastName: "ERINSON",
@@ -282,6 +286,23 @@ describe("Create new Person form page", () => {
       ).getText()
       expect(alertMessage).to.equal("Person saved")
       await CreatePerson.logout()
+    })
+
+    it("Should not display possible duplicates button", async() => {
+      await CreatePerson.openAsAdmin()
+      await (await CreatePerson.getForm()).waitForExist()
+      await (await CreatePerson.getForm()).waitForDisplayed()
+      await (await CreatePerson.getLastName()).waitForDisplayed()
+      await (
+        await CreatePerson.getLastName()
+      ).setValue(NOT_SIMILAR_PERSON_ADVISOR.lastName)
+      await (await CreatePerson.getFirstName()).waitForDisplayed()
+      await (
+        await CreatePerson.getFirstName()
+      ).setValue(NOT_SIMILAR_PERSON_ADVISOR.firstName)
+      // eslint-disable-next-line no-unused-expressions
+      expect(await (await CreatePerson.getDuplicatesButton()).isExisting()).to
+        .be.false
     })
   })
 })

--- a/client/tests/webdriver/baseSpecs/createNewPosition.spec.js
+++ b/client/tests/webdriver/baseSpecs/createNewPosition.spec.js
@@ -5,6 +5,7 @@ const ADMIN_ORG = "ANET Admin"
 const ADMIN_ORG_COMPLETE = "ANET Administrators"
 const INTERLOCUTOR_ORG = "MoI"
 const INTERLOCUTOR_ORG_COMPLETE = "MoI | Ministry of Interior"
+const NOT_SIMILAR_ADVISOR_POSITION_NAME = "XXX"
 const SIMILAR_ADVISOR_POSITION_NAME = "EF 1.1 Advisor for Agriculture"
 
 describe("Create position page", () => {
@@ -136,6 +137,18 @@ describe("Create position page", () => {
       await CreatePosition.submitForm()
       await CreatePosition.waitForAlertSuccessToLoad()
       await CreatePosition.logout()
+    })
+
+    it("Should not display possible duplicates button", async() => {
+      await CreatePosition.openAsAdminUser()
+      await (await CreatePosition.getForm()).waitForExist()
+      await (await CreatePosition.getForm()).waitForDisplayed()
+      await (
+        await CreatePosition.getPositionNameInput()
+      ).setValue(NOT_SIMILAR_ADVISOR_POSITION_NAME)
+      // eslint-disable-next-line no-unused-expressions
+      expect(await (await CreatePosition.getDuplicatesButton()).isExisting()).to
+        .be.false
     })
   })
 })

--- a/client/tests/webdriver/baseSpecs/locationUtils.js
+++ b/client/tests/webdriver/baseSpecs/locationUtils.js
@@ -10,6 +10,9 @@ export const NEW_COORDS = {
   lng: "32.75818",
   mgrs: "36SVK7932314682"
 }
+export const NOT_SIMILAR_LOCATION = {
+  name: "XXX"
+}
 export const SIMILAR_LOCATION = {
   name: "Kabul Hospital"
 }


### PR DESCRIPTION
The possible duplicates warning when creating locations, people or positions now will only appear when there are actually possible duplicates. A count query is run in the form to determine this and only when it returns results the button is displayed.

Closes [AB#992](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/992)

#### User changes
- If they are allowed to create locations they will only see the possible duplicates warning when creating locations if there are actually potential location duplicates.

#### Superuser changes
- Will only see the possible duplicates warning when creating locations, people or positions when there are actually possible duplicates.

#### Admin changes
- Will only see the possible duplicates warning when creating locations, people or positions when there are actually possible duplicates.

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [ ] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [x] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
