### PR TITLE
Allow advanced search for various types within multiple organizations

### DIFF
--- a/client/src/components/SearchFilters.js
+++ b/client/src/components/SearchFilters.js
@@ -517,8 +517,8 @@ export const searchFilters = function(includeAdminFilters) {
         }
       },
       "Within Organization": {
-        component: OrganizationFilter,
-        deserializer: deserializeOrganizationFilter,
+        component: OrganizationMultiFilter,
+        deserializer: deserializeOrganizationMultiFilter,
         props: {
           queryKey: "organizationUuid",
           queryRecurseStrategyKey: "orgRecurseStrategy",

--- a/client/src/components/SearchFilters.js
+++ b/client/src/components/SearchFilters.js
@@ -11,7 +11,9 @@ import DateRangeFilter, {
   deserialize as deserializeDateRangeFilter
 } from "components/advancedSearch/DateRangeFilter"
 import OrganizationFilter, {
-  deserialize as deserializeOrganizationFilter
+  deserialize as deserializeOrganizationFilter,
+  deserializeMulti as deserializeOrganizationMultiFilter,
+  OrganizationMultiFilter
 } from "components/advancedSearch/OrganizationFilter"
 import RadioButtonFilter, {
   deserialize as deserializeRadioButtonFilter
@@ -258,8 +260,8 @@ export const searchFilters = function(includeAdminFilters) {
         })
       },
       "Within Organization": {
-        component: OrganizationFilter,
-        deserializer: deserializeOrganizationFilter,
+        component: OrganizationMultiFilter,
+        deserializer: deserializeOrganizationMultiFilter,
         props: {
           queryKey: "orgUuid",
           queryRecurseStrategyKey: "orgRecurseStrategy",

--- a/client/src/components/SearchFilters.js
+++ b/client/src/components/SearchFilters.js
@@ -465,8 +465,8 @@ export const searchFilters = function(includeAdminFilters) {
   filters[SEARCH_OBJECT_TYPES.ORGANIZATIONS] = {
     filters: {
       "Within Organization": {
-        component: OrganizationFilter,
-        deserializer: deserializeOrganizationFilter,
+        component: OrganizationMultiFilter,
+        deserializer: deserializeOrganizationMultiFilter,
         props: {
           queryKey: "parentOrgUuid",
           queryRecurseStrategyKey: "orgRecurseStrategy",

--- a/client/src/components/SearchFilters.js
+++ b/client/src/components/SearchFilters.js
@@ -10,8 +10,7 @@ import CheckboxFilter, {
 import DateRangeFilter, {
   deserialize as deserializeDateRangeFilter
 } from "components/advancedSearch/DateRangeFilter"
-import OrganizationFilter, {
-  deserialize as deserializeOrganizationFilter,
+import {
   deserializeMulti as deserializeOrganizationMultiFilter,
   OrganizationMultiFilter
 } from "components/advancedSearch/OrganizationFilter"
@@ -591,8 +590,8 @@ export const searchFilters = function(includeAdminFilters) {
         }
       },
       "Within Organization": {
-        component: OrganizationFilter,
-        deserializer: deserializeOrganizationFilter,
+        component: OrganizationMultiFilter,
+        deserializer: deserializeOrganizationMultiFilter,
         props: {
           queryKey: "taskedOrgUuid",
           queryRecurseStrategyKey: "orgRecurseStrategy",

--- a/client/src/components/SearchFilters.js
+++ b/client/src/components/SearchFilters.js
@@ -383,8 +383,8 @@ export const searchFilters = function(includeAdminFilters) {
   filters[SEARCH_OBJECT_TYPES.PEOPLE] = {
     filters: {
       "Within Organization": {
-        component: OrganizationFilter,
-        deserializer: deserializeOrganizationFilter,
+        component: OrganizationMultiFilter,
+        deserializer: deserializeOrganizationMultiFilter,
         props: {
           queryKey: "orgUuid",
           queryRecurseStrategyKey: "orgRecurseStrategy",

--- a/client/src/pages/rollup/Show.js
+++ b/client/src/pages/rollup/Show.js
@@ -34,6 +34,7 @@ import {
   SearchQueryPropType
 } from "components/SearchFilters"
 import { Field, Form, Formik } from "formik"
+import _isEmpty from "lodash/isEmpty"
 import { Report, RollupGraph } from "models"
 import moment from "moment"
 import pluralize from "pluralize"
@@ -139,7 +140,7 @@ const Chart = ({
     }
     return generateChartDataFromAllReports(
       data.reportList.list,
-      queryParams.orgUuid
+      !_isEmpty(queryParams.orgUuid)
     )
   }, [data, queryParams.orgUuid])
 
@@ -273,13 +274,13 @@ const updateOrgReports = (
   return elem
 }
 
-const generateChartDataFromAllReports = (allReports, orgFilterUuid) => {
+const generateChartDataFromAllReports = (allReports, forFilteredOrg) => {
   return allReports.reduce(
     (acc, r) => {
       if (r.advisorOrg) {
         const topLevelAdvisorOrg = r.advisorOrg.ascendantOrgs[0]
         // If reports are not filtered for organization show reports under the top level organization
-        const displayedAdvisorOrg = orgFilterUuid
+        const displayedAdvisorOrg = forFilteredOrg
           ? r.advisorOrg
           : topLevelAdvisorOrg
         updateOrgReports(
@@ -291,7 +292,7 @@ const generateChartDataFromAllReports = (allReports, orgFilterUuid) => {
       }
       if (r.interlocutorOrg) {
         const topLevelInterlocutorOrg = r.interlocutorOrg.ascendantOrgs[0]
-        const displayedInterlocutorOrg = orgFilterUuid
+        const displayedInterlocutorOrg = forFilteredOrg
           ? r.interlocutorOrg
           : topLevelInterlocutorOrg
         updateOrgReports(

--- a/insertBaseData-psql.sql
+++ b/insertBaseData-psql.sql
@@ -376,8 +376,8 @@ UPDATE positions SET "currentPersonUuid" = (SELECT uuid from people where "domai
 INSERT INTO organizations(uuid, "shortName", "longName", app6context, "app6standardIdentity", "app6symbolSet", "createdAt", "updatedAt") VALUES
   (uuid_generate_v4(), 'ANET Administrators','', '0', '3', '10', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
   ('70193ee9-05b4-4aac-80b5-75609825db9f', 'LNG', 'Linguistic', '0', '3', '10', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
-  (uuid_generate_v4(), 'EF 1', 'Planning Programming, Budgeting and Execution', '0', '3', '10', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
-  (uuid_generate_v4(), 'EF 2', '', '0', '3', '10', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+  ('9a35caa7-a095-4963-ac7b-b784fde4d583', 'EF 1', 'Planning Programming, Budgeting and Execution', '0', '3', '10', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+  ('291abe56-e2c2-4a3a-8419-1661e5c5ac17', 'EF 2', '', '0', '3', '10', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
   (uuid_generate_v4(), 'EF 3', '', '0', NULL, NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
   (uuid_generate_v4(), 'EF 4', '', '0', '4', '11', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
   (uuid_generate_v4(), 'EF 5', '', '0', '3', '10', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),

--- a/src/main/java/mil/dds/anet/beans/search/PersonSearchQuery.java
+++ b/src/main/java/mil/dds/anet/beans/search/PersonSearchQuery.java
@@ -3,6 +3,7 @@ package mil.dds.anet.beans.search;
 import io.leangen.graphql.annotations.GraphQLInputField;
 import io.leangen.graphql.annotations.GraphQLQuery;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
 import mil.dds.anet.beans.Position.PositionType;
 
@@ -10,7 +11,7 @@ public class PersonSearchQuery extends SubscribableObjectSearchQuery<PersonSearc
 
   @GraphQLQuery
   @GraphQLInputField
-  String orgUuid;
+  List<String> orgUuid;
   @GraphQLQuery
   @GraphQLInputField
   RecurseStrategy orgRecurseStrategy;
@@ -58,11 +59,11 @@ public class PersonSearchQuery extends SubscribableObjectSearchQuery<PersonSearc
   }
 
   @GraphQLQuery
-  public String getOrgUuid() {
+  public List<String> getOrgUuid() {
     return orgUuid;
   }
 
-  public void setOrgUuid(String orgUuid) {
+  public void setOrgUuid(List<String> orgUuid) {
     this.orgUuid = orgUuid;
   }
 
@@ -148,7 +149,11 @@ public class PersonSearchQuery extends SubscribableObjectSearchQuery<PersonSearc
 
   @Override
   public PersonSearchQuery clone() throws CloneNotSupportedException {
-    return (PersonSearchQuery) super.clone();
+    final PersonSearchQuery clone = (PersonSearchQuery) super.clone();
+    if (orgUuid != null) {
+      clone.setOrgUuid(new ArrayList<>(orgUuid));
+    }
+    return clone;
   }
 
 }

--- a/src/main/java/mil/dds/anet/beans/search/ReportSearchQuery.java
+++ b/src/main/java/mil/dds/anet/beans/search/ReportSearchQuery.java
@@ -55,7 +55,7 @@ public class ReportSearchQuery extends SubscribableObjectSearchQuery<ReportSearc
   Atmosphere atmosphere;
   @GraphQLQuery
   @GraphQLInputField
-  String orgUuid;
+  List<String> orgUuid;
   @GraphQLQuery
   @GraphQLInputField
   private RecurseStrategy orgRecurseStrategy;
@@ -205,11 +205,11 @@ public class ReportSearchQuery extends SubscribableObjectSearchQuery<ReportSearc
     this.atmosphere = atmosphere;
   }
 
-  public String getOrgUuid() {
+  public List<String> getOrgUuid() {
     return orgUuid;
   }
 
-  public void setOrgUuid(String orgUuid) {
+  public void setOrgUuid(List<String> orgUuid) {
     this.orgUuid = orgUuid;
   }
 
@@ -373,6 +373,9 @@ public class ReportSearchQuery extends SubscribableObjectSearchQuery<ReportSearc
     }
     if (authorizationGroupUuid != null) {
       clone.setAuthorizationGroupUuid(new ArrayList<>(authorizationGroupUuid));
+    }
+    if (orgUuid != null) {
+      clone.setOrgUuid(new ArrayList<>(orgUuid));
     }
     return clone;
   }

--- a/src/main/java/mil/dds/anet/beans/search/TaskSearchQuery.java
+++ b/src/main/java/mil/dds/anet/beans/search/TaskSearchQuery.java
@@ -15,7 +15,7 @@ public class TaskSearchQuery extends SubscribableObjectSearchQuery<TaskSearchSor
   private Boolean isAssigned;
   @GraphQLQuery
   @GraphQLInputField
-  private String taskedOrgUuid;
+  private List<String> taskedOrgUuid;
   @GraphQLQuery
   @GraphQLInputField
   private RecurseStrategy orgRecurseStrategy;
@@ -64,11 +64,11 @@ public class TaskSearchQuery extends SubscribableObjectSearchQuery<TaskSearchSor
     this.isAssigned = isAssigned;
   }
 
-  public String getTaskedOrgUuid() {
+  public List<String> getTaskedOrgUuid() {
     return taskedOrgUuid;
   }
 
-  public void setTaskedOrgUuid(String taskedOrgUuid) {
+  public void setTaskedOrgUuid(List<String> taskedOrgUuid) {
     this.taskedOrgUuid = taskedOrgUuid;
   }
 
@@ -184,6 +184,9 @@ public class TaskSearchQuery extends SubscribableObjectSearchQuery<TaskSearchSor
     final TaskSearchQuery clone = (TaskSearchQuery) super.clone();
     if (parentTaskUuid != null) {
       clone.setParentTaskUuid(new ArrayList<>(parentTaskUuid));
+    }
+    if (taskedOrgUuid != null) {
+      clone.setTaskedOrgUuid(new ArrayList<>(taskedOrgUuid));
     }
     return clone;
   }

--- a/src/main/java/mil/dds/anet/emails/DailyRollupEmail.java
+++ b/src/main/java/mil/dds/anet/emails/DailyRollupEmail.java
@@ -65,7 +65,9 @@ public class DailyRollupEmail implements AnetEmailAction {
     query.setEngagementDateStart(engagementDateStart);
     query.setSortBy(ReportSearchSortBy.ENGAGEMENT_DATE);
     query.setSortOrder(SortOrder.DESC);
-    query.setOrgUuid(orgUuid);
+    if (orgUuid != null) {
+      query.setOrgUuid(List.of(orgUuid));
+    }
     query.setOrgRecurseStrategy(RecurseStrategy.CHILDREN);
 
     List<Report> reports = AnetObjectEngine.getInstance().getReportDao().search(query).getList();

--- a/src/main/java/mil/dds/anet/resources/OrganizationResource.java
+++ b/src/main/java/mil/dds/anet/resources/OrganizationResource.java
@@ -63,6 +63,11 @@ public class OrganizationResource {
     return org;
   }
 
+  @GraphQLQuery(name = "organizations")
+  public List<Organization> getByUuids(@GraphQLArgument(name = "uuids") List<String> uuids) {
+    return dao.getByIds(uuids);
+  }
+
   @GraphQLMutation(name = "createOrganization")
   public Organization createOrganization(@GraphQLRootContext Map<String, Object> context,
       @GraphQLArgument(name = "organization") Organization org) {

--- a/src/main/java/mil/dds/anet/search/AbstractOrganizationSearcher.java
+++ b/src/main/java/mil/dds/anet/search/AbstractOrganizationSearcher.java
@@ -9,6 +9,7 @@ import mil.dds.anet.beans.search.ISearchQuery.SortOrder;
 import mil.dds.anet.beans.search.OrganizationSearchQuery;
 import mil.dds.anet.database.OrganizationDao;
 import mil.dds.anet.database.mappers.OrganizationMapper;
+import mil.dds.anet.utils.Utils;
 import ru.vyarus.guicey.jdbi3.tx.InTransaction;
 
 public abstract class AbstractOrganizationSearcher extends
@@ -64,7 +65,7 @@ public abstract class AbstractOrganizationSearcher extends
       }
     }
 
-    if (query.getParentOrgUuid() != null) {
+    if (!Utils.isEmptyOrNull(query.getParentOrgUuid())) {
       addParentOrgUuidQuery(query);
     }
 

--- a/src/main/java/mil/dds/anet/search/AbstractPersonSearcher.java
+++ b/src/main/java/mil/dds/anet/search/AbstractPersonSearcher.java
@@ -71,14 +71,14 @@ public abstract class AbstractPersonSearcher extends AbstractSearcher<Person, Pe
     qb.addObjectEqualsClause("pendingVerification", "people.\"pendingVerification\"",
         query.getPendingVerification());
 
-    if (query.getOrgUuid() != null) {
+    if (!Utils.isEmptyOrNull(query.getOrgUuid())) {
       if (RecurseStrategy.CHILDREN.equals(query.getOrgRecurseStrategy())
           || RecurseStrategy.PARENTS.equals(query.getOrgRecurseStrategy())) {
         qb.addRecursiveClause(null, "positions", "\"organizationUuid\"", "parent_orgs",
             "organizations", "\"parentOrgUuid\"", "orgUuid", query.getOrgUuid(),
             RecurseStrategy.CHILDREN.equals(query.getOrgRecurseStrategy()));
       } else {
-        qb.addStringEqualsClause("orgUuid", "positions.\"organizationUuid\"", query.getOrgUuid());
+        qb.addInListClause("orgUuid", "positions.\"organizationUuid\"", query.getOrgUuid());
       }
     }
 

--- a/src/main/java/mil/dds/anet/search/AbstractPositionSearcher.java
+++ b/src/main/java/mil/dds/anet/search/AbstractPositionSearcher.java
@@ -15,6 +15,7 @@ import mil.dds.anet.database.PositionDao;
 import mil.dds.anet.database.mappers.PositionMapper;
 import mil.dds.anet.utils.DaoUtils;
 import mil.dds.anet.utils.PendingAssessmentsHelper;
+import mil.dds.anet.utils.Utils;
 import org.jdbi.v3.core.Handle;
 import ru.vyarus.guicey.jdbi3.tx.InTransaction;
 
@@ -79,7 +80,7 @@ public abstract class AbstractPositionSearcher
 
     qb.addInClause("types", "positions.type", query.getType());
 
-    if (query.getOrganizationUuid() != null) {
+    if (!Utils.isEmptyOrNull(query.getOrganizationUuid())) {
       if (RecurseStrategy.CHILDREN.equals(query.getOrgRecurseStrategy())
           || RecurseStrategy.PARENTS.equals(query.getOrgRecurseStrategy())) {
         qb.addRecursiveClause(null, "positions", "\"organizationUuid\"", "parent_orgs",

--- a/src/main/java/mil/dds/anet/search/AbstractReportSearcher.java
+++ b/src/main/java/mil/dds/anet/search/AbstractReportSearcher.java
@@ -182,7 +182,7 @@ public abstract class AbstractReportSearcher extends AbstractSearcher<Report, Re
       }
     }
 
-    if (query.getOrgUuid() != null) {
+    if (!Utils.isEmptyOrNull(query.getOrgUuid())) {
       addOrgUuidQuery(query);
     }
 
@@ -347,9 +347,9 @@ public abstract class AbstractReportSearcher extends AbstractSearcher<Report, Re
           "parent_orgs", "organizations", "\"parentOrgUuid\"", "orgUuid", query.getOrgUuid(),
           RecurseStrategy.CHILDREN.equals(query.getOrgRecurseStrategy()));
     } else {
-      qb.addWhereClause(
-          "(reports.\"advisorOrganizationUuid\" = :orgUuid OR reports.\"interlocutorOrganizationUuid\" = :orgUuid)");
-      qb.addSqlArg("orgUuid", query.getOrgUuid());
+      qb.addWhereClause("(reports.\"advisorOrganizationUuid\" IN ( <orgUuid> )"
+          + " OR reports.\"interlocutorOrganizationUuid\" IN ( <orgUuid> ))");
+      qb.addListArg("orgUuid", query.getOrgUuid());
     }
   }
 

--- a/src/main/java/mil/dds/anet/search/AbstractSearchQueryBuilder.java
+++ b/src/main/java/mil/dds/anet/search/AbstractSearchQueryBuilder.java
@@ -256,7 +256,7 @@ public abstract class AbstractSearchQueryBuilder<B, T extends AbstractSearchQuer
         findChildren ? "parent_uuid" : "uuid"));
   }
 
-  private final void addRecursiveClause(AbstractSearchQueryBuilder<B, T> outerQb, String tableName,
+  public final void addRecursiveClause(AbstractSearchQueryBuilder<B, T> outerQb, String tableName,
       String[] foreignKeys, String withTableName, String recursiveTableName,
       String recursiveForeignKey, String paramName, List<String> fieldValues,
       boolean findChildren) {

--- a/src/main/java/mil/dds/anet/search/AbstractTaskSearcher.java
+++ b/src/main/java/mil/dds/anet/search/AbstractTaskSearcher.java
@@ -11,6 +11,7 @@ import mil.dds.anet.database.TaskDao;
 import mil.dds.anet.database.mappers.TaskMapper;
 import mil.dds.anet.search.AbstractSearchQueryBuilder.Comparison;
 import mil.dds.anet.utils.DaoUtils;
+import mil.dds.anet.utils.Utils;
 import ru.vyarus.guicey.jdbi3.tx.InTransaction;
 
 public abstract class AbstractTaskSearcher extends AbstractSearcher<Task, TaskSearchQuery>
@@ -45,7 +46,7 @@ public abstract class AbstractTaskSearcher extends AbstractSearcher<Task, TaskSe
           AnetObjectEngine.getInstance().getTaskDao().getSubscriptionUpdate(null)));
     }
 
-    if (query.getTaskedOrgUuid() != null) {
+    if (!Utils.isEmptyOrNull(query.getTaskedOrgUuid())) {
       addTaskedOrgUuidQuery(query);
     }
 
@@ -117,7 +118,7 @@ public abstract class AbstractTaskSearcher extends AbstractSearcher<Task, TaskSe
           "parent_orgs", "organizations", "\"parentOrgUuid\"", "orgUuid", query.getTaskedOrgUuid(),
           RecurseStrategy.CHILDREN.equals(query.getOrgRecurseStrategy()));
     } else {
-      qb.addStringEqualsClause("orgUuid", "\"taskTaskedOrganizations\".\"organizationUuid\"",
+      qb.addInListClause("orgUuid", "\"taskTaskedOrganizations\".\"organizationUuid\"",
           query.getTaskedOrgUuid());
     }
   }

--- a/src/test/java/mil/dds/anet/test/resources/PersonResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/PersonResourceTest.java
@@ -219,7 +219,7 @@ public class PersonResourceTest extends AbstractResourceTest {
         .filter(o -> o.getShortName().equalsIgnoreCase("EF 1.1")).findFirst().get();
 
     query1.setText(null);
-    query1.setOrgUuid(org.getUuid());
+    query1.setOrgUuid(List.of(org.getUuid()));
     searchResults =
         withCredentials(jackUser, t -> queryExecutor.personList(getListFields(FIELDS), query1));
     assertThat(searchResults.getList()).isNotEmpty();
@@ -237,7 +237,7 @@ public class PersonResourceTest extends AbstractResourceTest {
     org = orgs.getList().stream().filter(o -> o.getShortName().equalsIgnoreCase("EF 1")).findFirst()
         .get();
     query1.setStatus(null);
-    query1.setOrgUuid(org.getUuid());
+    query1.setOrgUuid(List.of(org.getUuid()));
     // First don't include child orgs and then increase the scope and verify results increase.
     final AnetBeanList_Person parentOnlyResults =
         withCredentials(jackUser, t -> queryExecutor.personList(getListFields(FIELDS), query1));

--- a/src/test/java/mil/dds/anet/test/resources/TaskResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/TaskResourceTest.java
@@ -116,7 +116,7 @@ class TaskResourceTest extends AbstractResourceTest {
 
     // Fetch the tasks of the organization
     final TaskSearchQueryInput queryTasks =
-        TaskSearchQueryInput.builder().withTaskedOrgUuid(ef8.getUuid()).build();
+        TaskSearchQueryInput.builder().withTaskedOrgUuid(List.of(ef8.getUuid())).build();
     final AnetBeanList_Task tasks =
         withCredentials(jackUser, t -> queryExecutor.taskList(getListFields(FIELDS), queryTasks));
     assertThat(tasks.getList()).anyMatch(t -> t.getUuid().equals(returnedA.getUuid()));
@@ -153,7 +153,7 @@ class TaskResourceTest extends AbstractResourceTest {
     assertThat(ef2).isNotNull();
 
     query1.setText(null);
-    query1.setTaskedOrgUuid(ef2.getUuid());
+    query1.setTaskedOrgUuid(List.of(ef2.getUuid()));
     final AnetBeanList_Task searchObjects2 =
         withCredentials(jackUser, t -> queryExecutor.taskList(getListFields(FIELDS), query1));
     assertThat(searchObjects2).isNotNull();

--- a/src/test/resources/anet.graphql
+++ b/src/test/resources/anet.graphql
@@ -835,6 +835,7 @@ type Query {
   mySubscriptions(query: SubscriptionSearchQueryInput): AnetBeanList_Subscription
   organization(uuid: String): Organization
   organizationList(query: OrganizationSearchQueryInput): AnetBeanList_Organization
+  organizations(uuids: [String]): [Organization]
   person(uuid: String): Person
   personList(query: PersonSearchQueryInput): AnetBeanList_Person
   position(uuid: String): Position
@@ -1058,7 +1059,7 @@ input ReportSearchQueryInput {
   includeEngagementDayOfWeek: Boolean
   locationUuid: String
   orgRecurseStrategy: RecurseStrategy
-  orgUuid: String
+  orgUuid: [String]
   pageNum: Int
   pageSize: Int
   pendingApprovalOf: String

--- a/src/test/resources/anet.graphql
+++ b/src/test/resources/anet.graphql
@@ -704,7 +704,7 @@ input PersonSearchQueryInput {
   locationUuid: String
   matchPositionName: Boolean
   orgRecurseStrategy: RecurseStrategy
-  orgUuid: String
+  orgUuid: [String]
   pageNum: Int
   pageSize: Int
   pendingVerification: Boolean

--- a/src/test/resources/anet.graphql
+++ b/src/test/resources/anet.graphql
@@ -1312,7 +1312,7 @@ input TaskSearchQueryInput {
   sortOrder: SortOrder
   status: Status
   subscribed: Boolean
-  taskedOrgUuid: String
+  taskedOrgUuid: [String]
   text: String
 }
 


### PR DESCRIPTION
Improve the reports, people, organizations, positions and tasks search by allowing reports to be searched within multiple organizations.

Closes [AB#1007](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1007)

#### User changes
- The advanced search filter **Within Organization** for reports, people, organizations, positions and tasks now allows multiple organizations to be selected.

#### Superuser changes
- None.

#### Admin changes
- None.

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [x] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [x] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
