### PR TITLE
Swap the engagement information and details

### DIFF
--- a/client/src/pages/reports/Form.js
+++ b/client/src/pages/reports/Form.js
@@ -847,21 +847,6 @@ const ReportForm = ({
                 </Fieldset>
               )}
 
-              {showCustomFields && (
-                <Fieldset title="Engagement information" id="custom-fields">
-                  <CustomFieldsContainer
-                    fieldsConfig={Settings.fields.report.customFields}
-                    formikProps={{
-                      setFieldTouched,
-                      setFieldValue,
-                      values,
-                      validateForm
-                    }}
-                    setShowCustomFields={setShowCustomFields}
-                  />
-                </Fieldset>
-              )}
-
               <Fieldset title="Engagement details" id="meeting-details">
                 {!isFutureEngagement && !values.cancelled && (
                   <>
@@ -1133,6 +1118,21 @@ const ReportForm = ({
                   )}
                 </Collapse>
               </Fieldset>
+
+              {showCustomFields && (
+                <Fieldset title="Engagement information" id="custom-fields">
+                  <CustomFieldsContainer
+                    fieldsConfig={Settings.fields.report.customFields}
+                    formikProps={{
+                      setFieldTouched,
+                      setFieldValue,
+                      values,
+                      validateForm
+                    }}
+                    setShowCustomFields={setShowCustomFields}
+                  />
+                </Fieldset>
+              )}
 
               {hasAssessments && (
                 <>


### PR DESCRIPTION
In the report form, swap the engagement information and details sections.
This makes it more in line with the report show page.

Closes [AB#1092](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1092) 

#### User changes
- The **Engagement details** input section now comes before the **Engagement information** input section in the report form.

#### Superuser changes
- None.

#### Admin changes
- None.

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
