### PR TITLE
Add options "last 3 months", "last 6 months", "last year" for calendar periods

### DIFF
--- a/client/src/components/advancedSearch/DateRangeFilter.js
+++ b/client/src/components/advancedSearch/DateRangeFilter.js
@@ -7,9 +7,12 @@ import {
   dateRangeEndKey,
   dateRangeStartKey,
   dateToQuery,
+  LAST_3_MONTHS,
+  LAST_6_MONTHS,
   LAST_DAY,
   LAST_MONTH,
   LAST_WEEK,
+  LAST_YEAR,
   ON,
   RANGE_TYPE_LABELS
 } from "dateUtils"
@@ -82,6 +85,15 @@ const DateRangeFilter = ({
       </option>,
       <option key="last_month" value={LAST_MONTH}>
         {RANGE_TYPE_LABELS[LAST_MONTH]}
+      </option>,
+      <option key="last_3_months" value={LAST_3_MONTHS}>
+        {RANGE_TYPE_LABELS[LAST_3_MONTHS]}
+      </option>,
+      <option key="last_6_months" value={LAST_6_MONTHS}>
+        {RANGE_TYPE_LABELS[LAST_6_MONTHS]}
+      </option>,
+      <option key="last_year" value={LAST_YEAR}>
+        {RANGE_TYPE_LABELS[LAST_YEAR]}
       </option>
     ]
     const options = onlyBetween
@@ -196,7 +208,14 @@ export const deserialize = ({ queryKey }, query, key) => {
 
   if (query[startKey]) {
     toQueryValue[startKey] = query[startKey]
-    const lastValues = [LAST_DAY, LAST_WEEK, LAST_MONTH]
+    const lastValues = [
+      LAST_DAY,
+      LAST_WEEK,
+      LAST_MONTH,
+      LAST_3_MONTHS,
+      LAST_6_MONTHS,
+      LAST_YEAR
+    ]
     if (lastValues.indexOf(+query[startKey]) !== -1) {
       filterValue.relative = query[startKey]
     } else {

--- a/client/src/dateUtils.js
+++ b/client/src/dateUtils.js
@@ -7,6 +7,9 @@ export const ON = "3"
 export const LAST_DAY = -1 * 1000 * 60 * 60 * 24
 export const LAST_WEEK = LAST_DAY * 7
 export const LAST_MONTH = LAST_DAY * 30
+export const LAST_3_MONTHS = LAST_MONTH * 3
+export const LAST_6_MONTHS = LAST_MONTH * 6
+export const LAST_YEAR = LAST_MONTH * 12
 
 export const RANGE_TYPE_LABELS = {
   [BETWEEN]: "Between",
@@ -15,7 +18,10 @@ export const RANGE_TYPE_LABELS = {
   [ON]: "On",
   [LAST_DAY]: "Last 24 hours",
   [LAST_WEEK]: "Last 7 days",
-  [LAST_MONTH]: "Last 30 days"
+  [LAST_MONTH]: "Last 30 days",
+  [LAST_3_MONTHS]: "Last 90 days",
+  [LAST_6_MONTHS]: "Last 180 dsys",
+  [LAST_YEAR]: "Last 360 days"
 }
 
 export function dateRangeStartKey(queryKey) {
@@ -56,9 +62,9 @@ export function dateToQuery(queryKey, value) {
       [endKey]: startDateEnd
     }
   } else {
-    // LAST_DAY, LAST_WEEK, LAST_MONTH => Time relative to now, up till now
+    // LAST_* => Time relative to now, up till now
     return {
-      [startKey]: parseInt(value.relative)
+      [startKey]: parseInt(value.relative, 10)
     }
   }
 }


### PR DESCRIPTION
Added calendar option "last 3 months", "last 6 months", "last year".

Closes [AB#1086](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1086)

#### User changes
- 3 more selection options available in calendar filter.

#### Superuser changes
- None

#### Admin changes
- None

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
