### PR TITLE
Show all recent tasks

### DIFF
--- a/client/src/pages/reports/Form.js
+++ b/client/src/pages/reports/Form.js
@@ -249,18 +249,10 @@ const ReportForm = ({
   let recentTasksVarUser
   if (currentUser.isAdmin()) {
     recentTasksVarUser = recentTasksVarCommon
-  } else if (currentUser.position?.organization) {
-    recentTasksVarUser = {
-      ...recentTasksVarCommon,
-      inMyReports: true,
-      taskedOrgUuid: currentUser.position?.organization?.uuid,
-      orgRecurseStrategy: RECURSE_STRATEGY.PARENTS
-    }
   } else {
     recentTasksVarUser = {
-      pageSize: 1,
-      status: Model.STATUS.ACTIVE,
-      text: "__should_not_match_anything__" // TODO: Do this more gracefully
+      ...recentTasksVarCommon,
+      inMyReports: true
     }
   }
   const { loading, error, data } = API.useApiQuery(GQL_GET_RECENTS, {


### PR DESCRIPTION
In the engagement report form, show all recent tasks from a user, not just the ones from the user's organization hierarchy.

Closes [AB#978](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/978) (updates #4731)

#### User changes
- In the "Recent Tasks", all tasks recently assigned to an engagement report by the user are shown.

#### Superuser changes
- None.

#### Admin changes
- None.

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
