### PR TITLE
Add a new custom field type geo_location

### DIFF
--- a/anet-dictionary.yml
+++ b/anet-dictionary.yml
@@ -408,6 +408,9 @@ fields:
           filter:
             orgUuid: 70193ee9-05b4-4aac-80b5-75609825db9f
     customFields:
+      gridLocation:
+        type: geo_location
+        label: Grid location
       relatedReport:
         type: anet_object
         label: Related report

--- a/client/src/components/CustomFields.js
+++ b/client/src/components/CustomFields.js
@@ -322,12 +322,14 @@ const GeoLocationField = fieldProps => {
         {...formikProps}
         {...otherFieldProps}
       />
-      <Row style={{ marginTop: "-1rem" }}>
-        <Col sm={2} />
-        <Col sm={7}>
-          <Leaflet markers={[marker]} mapId={name} {...leafletProps} />
-        </Col>
-      </Row>
+      {(editable || Location.hasCoordinates(coordinates)) && (
+        <Row style={{ marginTop: "-1rem" }}>
+          <Col sm={2} />
+          <Col sm={7}>
+            <Leaflet markers={[marker]} mapId={name} {...leafletProps} />
+          </Col>
+        </Row>
+      )}
     </>
   )
 

--- a/client/src/components/GeoLocation.js
+++ b/client/src/components/GeoLocation.js
@@ -469,7 +469,7 @@ const AllFormatsInfo = ({ name, coordinates, setLocationFormat, inForm }) => {
               <tr>
                 <td style={{ whiteSpace: "nowrap" }}>
                   <Button
-                    name={name}
+                    name={`${name}.${Location.LOCATION_FORMATS.LAT_LON}`}
                     onClick={() =>
                       setLocationFormat(Location.LOCATION_FORMATS.LAT_LON)}
                     variant="outline-secondary"
@@ -488,7 +488,7 @@ const AllFormatsInfo = ({ name, coordinates, setLocationFormat, inForm }) => {
               <tr>
                 <td style={{ whiteSpace: "nowrap" }}>
                   <Button
-                    name={name}
+                    name={`${name}.${Location.LOCATION_FORMATS.MGRS}`}
                     onClick={() =>
                       setLocationFormat(Location.LOCATION_FORMATS.MGRS)}
                     variant="outline-secondary"

--- a/client/src/components/Model.js
+++ b/client/src/components/Model.js
@@ -180,6 +180,7 @@ export const CUSTOM_FIELD_TYPE = {
   DATE: "date",
   DATETIME: "datetime",
   JSON: "json",
+  GEO_LOCATION: "geo_location",
   ENUM: "enum",
   ENUMSET: "enumset",
   ARRAY_OF_OBJECTS: "array_of_objects",
@@ -194,6 +195,7 @@ export const CUSTOM_FIELD_TYPE_DEFAULTS = {
   [CUSTOM_FIELD_TYPE.DATE]: null,
   [CUSTOM_FIELD_TYPE.DATETIME]: null,
   [CUSTOM_FIELD_TYPE.JSON]: null,
+  [CUSTOM_FIELD_TYPE.GEO_LOCATION]: {},
   [CUSTOM_FIELD_TYPE.ENUM]: "",
   [CUSTOM_FIELD_TYPE.ENUMSET]: [],
   [CUSTOM_FIELD_TYPE.ARRAY_OF_OBJECTS]: [],
@@ -230,6 +232,10 @@ const CUSTOM_FIELD_TYPE_SCHEMA = {
         : testContext.createError({ message: "Invalid JSON" })
     )
     .default(CUSTOM_FIELD_TYPE_DEFAULTS[CUSTOM_FIELD_TYPE.JSON]),
+  [CUSTOM_FIELD_TYPE.GEO_LOCATION]: yup
+    .object()
+    .nullable()
+    .default(CUSTOM_FIELD_TYPE_DEFAULTS[CUSTOM_FIELD_TYPE.GEO_LOCATION]),
   [CUSTOM_FIELD_TYPE.ENUM]: yup
     .string()
     .nullable()

--- a/client/tests/jest/models/geoLocation.test.js
+++ b/client/tests/jest/models/geoLocation.test.js
@@ -1,4 +1,4 @@
-import { act, fireEvent, render, screen } from "@testing-library/react"
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react"
 import { Form, Formik } from "formik"
 import React from "react"
 import GeoLocation from "../../../src/components/GeoLocation"
@@ -30,15 +30,16 @@ const GeoLocationTest = () => {
 
 describe("In the location form", () => {
   it("We should be able to see Latitude, Longitude label and input field", () => {
-    render(GeoLocationTest())
+    render(<GeoLocationTest />)
     // LAT_LON is default
     const latLngLabel = screen.getByText(/Latitude, Longitude/)
     expect(latLngLabel).toBeInTheDocument()
     const latLngInput = screen.getByLabelText(/Latitude, Longitude/)
     expect(latLngInput).toBeInTheDocument()
+    cleanup()
   })
   it("We should be able to see MGRS label and input field", () => {
-    render(GeoLocationTest())
+    render(<GeoLocationTest />)
     const infoButton = screen.getByTestId("info-button")
     expect(infoButton).toBeInTheDocument()
     act(() => {
@@ -59,5 +60,6 @@ describe("In the location form", () => {
       /Military Grid Reference System \(MGRS\)/
     )
     expect(mrgsInput).toBeInTheDocument()
+    cleanup()
   })
 })

--- a/client/tests/webdriver/customFieldsSpecs/createReport.spec.js
+++ b/client/tests/webdriver/customFieldsSpecs/createReport.spec.js
@@ -1,6 +1,12 @@
 import { expect } from "chai"
 import CreateReport from "../pages/createReport.page"
 
+const GRID_LOCATION = {
+  lat: "52.1178",
+  lng: "4.28",
+  displayedCoordinate: "31UET8764074913"
+}
+
 const REPORT = "Interior"
 const REPORT_VALUE = "Talk to the Interior about things"
 const REPORT_COMPLETE = `${REPORT_VALUE}`
@@ -39,6 +45,36 @@ describe("Create report form page", () => {
       await browser.pause(500) // wait for the page transition and rendering of custom fields
       await (await CreateReport.getForm()).waitForExist()
       await (await CreateReport.getForm()).waitForDisplayed()
+    })
+
+    it("Should be able to set the grid location", async() => {
+      await (
+        await CreateReport.getGridLocationLatField()
+      ).setValue(GRID_LOCATION.lat)
+      await (
+        await CreateReport.getGridLocationLngField()
+      ).setValue(GRID_LOCATION.lng)
+      await (await CreateReport.getGridLocationInfoButton()).click()
+      await (await CreateReport.getGridLocationMgrsButton()).waitForExist()
+      await (await CreateReport.getGridLocationMgrsButton()).waitForDisplayed()
+      await (await CreateReport.getGridLocationMgrsButton()).click()
+      expect(
+        await (
+          await CreateReport.getGridLocationDisplayedCoordinateField()
+        ).getValue()
+      ).to.equal(GRID_LOCATION.displayedCoordinate)
+      await (await CreateReport.getGridLocationInfoButton()).click()
+      await (await CreateReport.getGridLocationLatLonButton()).waitForExist()
+      await (
+        await CreateReport.getGridLocationLatLonButton()
+      ).waitForDisplayed()
+      await (await CreateReport.getGridLocationLatLonButton()).click()
+      expect(
+        await (await CreateReport.getGridLocationLatField()).getValue()
+      ).to.equal(GRID_LOCATION.lat)
+      expect(
+        await (await CreateReport.getGridLocationLngField()).getValue()
+      ).to.equal(GRID_LOCATION.lng)
     })
 
     it("Should be able to prevent invalid duration values", async() => {

--- a/client/tests/webdriver/pages/createReport.page.js
+++ b/client/tests/webdriver/pages/createReport.page.js
@@ -2,6 +2,7 @@ import Page from "./page"
 
 const PAGE_URL = "/reports/new"
 
+const GRID_LOCATION_ID = "formCustomFields.gridLocation"
 const RELATED_REPORT_ID = "formCustomFields.relatedReport"
 const ADDITIONAL_ENGAGEMENTS_ID = "formCustomFields.additionalEngagementNeeded"
 const ENGAGEMENT_TYPES_ID = "formCustomFields.multipleButtons"
@@ -50,6 +51,32 @@ export class CreateReport extends Page {
 
   async getEngagementInformationTitle() {
     return browser.$('//span[text()="Engagement information"]')
+  }
+
+  async getGridLocationLatField() {
+    return browser.$(`input[id="${GRID_LOCATION_ID}.lat"]`)
+  }
+
+  async getGridLocationLngField() {
+    return browser.$(`input[id="${GRID_LOCATION_ID}.lng"]`)
+  }
+
+  async getGridLocationDisplayedCoordinateField() {
+    return browser.$(`input[id="${GRID_LOCATION_ID}.displayedCoordinate"]`)
+  }
+
+  async getGridLocationInfoButton() {
+    return browser
+      .$(`div[id="fg-${GRID_LOCATION_ID}"]`)
+      .$('button[data-testid="info-button"]')
+  }
+
+  async getGridLocationLatLonButton() {
+    return browser.$(`button[name="${GRID_LOCATION_ID}.LAT_LON"]`)
+  }
+
+  async getGridLocationMgrsButton() {
+    return browser.$(`button[name="${GRID_LOCATION_ID}.MGRS"]`)
   }
 
   async getTestReferenceFieldFormGroup() {

--- a/insertBaseData-psql.sql
+++ b/insertBaseData-psql.sql
@@ -10,8 +10,6 @@ TRUNCATE TABLE "comments" CASCADE;
 TRUNCATE TABLE "customSensitiveInformation" CASCADE;
 TRUNCATE TABLE "emailAddresses" CASCADE;
 TRUNCATE TABLE "jobHistory" CASCADE;
--- Countries are inserted by the migrations!
-DELETE FROM "locations" WHERE type != 'PAC';
 TRUNCATE TABLE "noteRelatedObjects" CASCADE;
 TRUNCATE TABLE "notes" CASCADE;
 TRUNCATE TABLE "organizationAdministrativePositions" CASCADE;
@@ -34,6 +32,9 @@ TRUNCATE TABLE "taskResponsiblePositions" CASCADE;
 TRUNCATE TABLE "taskTaskedOrganizations" CASCADE;
 TRUNCATE TABLE "tasks" CASCADE;
 TRUNCATE TABLE "userActivities" CASCADE;
+
+-- Countries are inserted by the migrations!
+DELETE FROM "locations" WHERE type != 'PAC';
 
 -- Create people
 INSERT INTO people (uuid, name, status, "phoneNumber", rank, biography, "user", "domainUsername", "openIdSubject", "countryUuid", gender, "endOfTourDate", "createdAt", "updatedAt") VALUES

--- a/src/main/resources/anet-schema.yml
+++ b/src/main/resources/anet-schema.yml
@@ -144,7 +144,19 @@ $defs:
       type:
         title: value type field
         type: string
-        enum: [text, number, date, datetime, json, enum, enumset, array_of_objects, anet_object, array_of_anet_objects, special_field]
+        enum:
+          - text
+          - number
+          - date
+          - datetime
+          - json
+          - geo_location
+          - enum
+          - enumset
+          - array_of_objects
+          - anet_object
+          - array_of_anet_objects
+          - special_field
       typeError:
         title: custom value for type error
         type: string
@@ -200,7 +212,7 @@ $defs:
         oneOf:
         - properties:
             type:
-              enum: [text, number, date, datetime, json]
+              enum: [text, number, date, datetime, json, geo_location]
         - properties:
             type:
               enum: [enum, enumset]


### PR DESCRIPTION
A new type of custom field is introduced: `geo_location`. When such a field is defined in the dictionary, users can fill in the coordinates of a geographic location, or set these by dragging a marker on a map.

Closes [AB#1095](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1095), [AB#1111](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1111)

#### User changes
- Users can now fill in custom fields of type `geo_location` if these are defined in the dictionary.

#### Superuser changes
- None.

#### Admin changes
- None.

#### System admin changes
- [x] anet.yml or anet-dictionary.yml needs change
  You can add something like this to the dictionary:
  ```yaml
  fields:
    report:
      customFields:
        gridLocation:
          type: geo_location
          label: Grid location
  ```
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [x] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
