### PR TITLE
Fix display of atmospherics in report print view

### DIFF
--- a/client/src/pages/reports/Compact.js
+++ b/client/src/pages/reports/Compact.js
@@ -261,6 +261,7 @@ const CompactReportView = ({ pageDispatchers }) => {
   if (!data) {
     report = new Report()
   } else {
+    data.report.cancelled = !!data.report.cancelledReason
     data.report.tasks = Task.fromArray(data.report.tasks)
     data.report.attendees = Person.fromArray(data.report.attendees)
     data.report.to = ""
@@ -338,13 +339,13 @@ const CompactReportView = ({ pageDispatchers }) => {
                     <DictionaryField
                       wrappedComponent={CompactRow}
                       dictProps={Settings.fields.report.atmosphere}
-                      value={utils.sentenceCase(report.atmosphere)}
+                      content={utils.sentenceCase(report.atmosphere)}
                       className="reportField"
                     />
                     <DictionaryField
                       wrappedComponent={CompactRow}
                       dictProps={Settings.fields.report.atmosphereDetails}
-                      value={report.atmosphereDetails}
+                      content={report.atmosphereDetails}
                       className="reportField"
                     />
                   </>


### PR DESCRIPTION
Properly show the actual values of the atmospherics and details. But don't show them for cancelled reports.

Closes AB#1106

#### User changes
- Atmospherics and details are now properly shown in the report print view.

#### Superuser changes
- None.

#### Admin changes
- None.

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [ ] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
