### PR TITLE
Simplify dictionary for tasks

### DIFF
--- a/anet-dictionary.yml
+++ b/anet-dictionary.yml
@@ -52,245 +52,228 @@ classification:
 fields:
 
   task:
+    shortLabel: Objective
+    longLabel: Objectives
     status:
       label: Status
-    shortLabel: Objective / Effort
     shortName:
-      label: Objective / Effort number
-      placeholder: Enter an objective / effort name, example …
-    longLabel: Objectives and Efforts
+      label: Short name
+      placeholder: Primary name or abbreviation
     longName:
-      label: Objective / Effort long name
-      placeholder: Enter an objective / effort long name, example …
+      label: Long name
+      placeholder: Full form name of objective
+      asA: textarea
     description:
-      label: Objective / Effort description
-      placeholder: Fill in the description of this objective / effort
-    topLevel:
-      shortLabel: Objective
-      shortName:
-        label: Name of this Objective
-        placeholder: Enter a Name for this Objective name, example …
-      longLabel: Objectives
-      longName:
-        label: Long Name of this Objective
-        placeholder: Enter a long name for this Objective, example …
-      assessments:
-        topTaskOnceReport:
-          label: Engagement assessment of objective
-          recurrence: once
-          relatedObjectType: report
-          authorizationGroupUuids:
-            read: ['c21e7321-7ec5-4837-8805-a302f9575754']
-            write: ['39a78d51-c351-452c-9206-4305ec8dd76d']
-          questions:
-            question1:
-              type: special_field
-              widget: likertScale
-              label: Instant assessment Question 1
-              helpText: Please provide assessment for something important
-              levels:
-                - color: red
-                  endValue: 2
-                  label: test
-                - color: "#FFBF00"
-                  endValue: 8
-                  label: mid
-                - color: green
-                  endValue: 10
-                  label: high
-              aggregation:
-                widget: likertScale
-            question2:
-              type: number
-              label: Instant assessment Question 2
-            question3:
-              type: number
-              label: Instant assessment Question 3
-        topTaskSemiannually:
-          label: Semi-annual assessment of objective
-          recurrence: semiannually
-          test: $.subject[?(@property === "shortName" && @.match(/^EF/i))]
-          authorizationGroupUuids:
-            read: ['c21e7321-7ec5-4837-8805-a302f9575754']
-            write: ['39a78d51-c351-452c-9206-4305ec8dd76d']
-          questions:
-            issues:
-              type: special_field
-              label: Top 3 issues
-              placeholder: Enter the top 3 issues
-              widget: richTextEditor
-              style:
-                height: 300px
-              validations:
-                - type: required
-                  params: [You must provide the Top 3 issues]
-        topTaskSemiannuallyNoWrite:
-          label: Semi-annual assessment of objective, no write
-          recurrence: semiannually
-          test: $.subject[?(@property === "noSuchProperty" && @.match(/^willNeverMatch/i))]
-          authorizationGroupUuids:
-            write: []
-          questions:
-            question1:
-              type: number
-              label: Test Question 1
-        topTaskOnceReportNoWrite:
-          label: Engagement assessment of objective, no write
-          recurrence: once
-          relatedObjectType: report
-          test: $.subject[?(@property === "noSuchProperty" && @.match(/^willNeverMatch/i))]
-          authorizationGroupUuids:
-            write: []
-          questions:
-            question1:
-              type: number
-              label: Test Question 1
+      label: Objective description
+      placeholder: Description of this objective
 
-    subLevel:
-      shortLabel: Effort
-      shortName:
-        label: Effort name
-        placeholder: Enter an effort name, example …
-      longLabel: Efforts
-      longName:
-        label: Effort Long Name
-        placeholder: Enter an effort Long Name, example …
-      assessments:
-        subTaskMonthly:
-          label: Monthly assessment of effort
-          recurrence: monthly
-          allowFutureAssessments: true
-          questions:
-            requiredButFilteredOutQuestion:
-              test: $.subject[?(@property === "noSuchProperty" && @.match(/^willNeverMatch/i))]
-              type: text
-              label: This question is required but will be filtered out
-              validations:
-                - type: required
-                  params: [You must provide the answer to subTaskMonthly.requiredButFilteredOutQuestion]
-            questionFor11B:
-              test: $.subject[?(@property === "shortName" && @ === "1.1.B")]
-              type: text
-              label: This question applies only to 1.1.B
-              validations:
-                - type: required
-                  params: [You must provide the answer to subTaskMonthly.questionFor11B]
-            issues:
-              type: special_field
-              label: Top 3 issues
-              placeholder: Enter the top 3 issues
-              widget: richTextEditor
-              style:
-                height: 300px
-              validations:
-                - type: required
-                  params: [You must provide the Top 3 issues]
-            status:
-              type: enum
-              label: Project status
-              helpText: Select an assessment status for objective
-              choices:
-                GREEN:
-                  label: Green
-                  color: '#c2ffb3'
-                AMBER:
-                  label: Amber
-                  color: '#ffe396'
-                RED:
-                  label: Red
-                  color: '#ff8279'
-              validations:
-                - type: required
-                  params: [You must provide the Project status]
-        subTaskWeekly:
-          label: Weekly assessment of effort
-          recurrence: weekly
-          questions:
-            issues:
-              type: special_field
-              label: Top 3 issues
-              placeholder: Enter the top 3 issues
-              widget: richTextEditor
-              style:
-                height: 300px
-              validations:
-                - type: required
-                  params: [You must provide the Top 3 issues]
-        subTaskOnceReport:
-          label: Engagement assessment of effort
-          recurrence: once
-          relatedObjectType: report
-          questions:
-            requiredButFilteredOutQuestion:
-              test: $.subject[?(@property === "noSuchProperty" && @.match(/^willNeverMatch/i))]
-              type: text
-              label: This question is required but will be filtered out
-              validations:
-                - type: required
-                  params: [You must provide the answer to subTaskOnceReport.requiredButFilteredOutQuestion]
-            questionFor11B:
-              test: $.subject[?(@property === "shortName" && @ === "1.1.B")]
-              type: text
-              label: This question applies only to 1.1.B
-              validations:
-                - type: required
-                  params: [You must provide the answer to subTaskOnceReport.questionFor11B]
-            questionForNegative:
-              test: $.relatedObject[?(@property === "atmosphere" && @ === "NEGATIVE")]
-              type: text
-              label: This question applies only to Negative engagements
-              validations:
-                - type: required
-                  params: [You must provide the answer to subTaskOnceReport.questionForNegative]
-            question1:
-              type: special_field
+    assessments:
+      taskOnceReportRestricted:
+        label: Engagement assessment of objective
+        recurrence: once
+        relatedObjectType: report
+        authorizationGroupUuids:
+          read: ['c21e7321-7ec5-4837-8805-a302f9575754']
+          write: ['39a78d51-c351-452c-9206-4305ec8dd76d']
+        questions:
+          question1:
+            type: special_field
+            widget: likertScale
+            label: Instant assessment Question 1
+            helpText: Please provide assessment for something important
+            levels:
+              - color: red
+                endValue: 2
+                label: test
+              - color: "#FFBF00"
+                endValue: 8
+                label: mid
+              - color: green
+                endValue: 10
+                label: high
+            aggregation:
               widget: likertScale
-              label: Instant assessment Question 1
-              helpText: Please provide assessment for something important
-              levels:
-                - color: red
-                  endValue: 2
-                  label: test
-                - color: "#FFBF00"
-                  endValue: 8
-                  label: mid
-                - color: green
-                  endValue: 10
-                  label: high
-              aggregation:
-                widget: likertScale
-            question2:
-              type: number
-              label: Instant assessment Question 2
-            question3:
-              type: number
-              label: Instant assessment Question 3
-        subTask11COnceReport:
-          label: Engagement assessment of effort 1.1.C
-          recurrence: once
-          relatedObjectType: report
-          test: $.subject[?(@property === "shortName" && @ === "1.1.C")]
-          questions:
-            requiredButFilteredOutQuestion:
-              test: $.subject[?(@property === "noSuchProperty" && @.match(/^willNeverMatch/i))]
-              type: text
-              label: This question is required but will be filtered out
-              validations:
-                - type: required
-                  params: [You must provide the answer to subTask11COnceReport.requiredButFilteredOutQuestion]
-            requiredQuestion:
-              type: text
-              label: This question is required
-              validations:
-                - type: required
-                  params: [You must provide the answer to subTask11COnceReport.requiredQuestion]
-            questionForNegative:
-              test: $.relatedObject[?(@property === "atmosphere" && @ === "NEGATIVE")]
-              type: text
-              label: This question applies only to Negative engagements
-              validations:
-                - type: required
-                  params: [You must provide the answer to subTask11COnceReport.questionForNegative]
+          question2:
+            type: number
+            label: Instant assessment Question 2
+          question3:
+            type: number
+            label: Instant assessment Question 3
+      taskSemiannuallyRestricted:
+        label: Semi-annual assessment of objective
+        recurrence: semiannually
+        test: $.subject[?(@property === "shortName" && @.match(/^EF/i))]
+        authorizationGroupUuids:
+          read: ['c21e7321-7ec5-4837-8805-a302f9575754']
+          write: ['39a78d51-c351-452c-9206-4305ec8dd76d']
+        questions:
+          issues:
+            type: special_field
+            label: Top 3 issues
+            placeholder: Enter the top 3 issues
+            widget: richTextEditor
+            style:
+              height: 300px
+            validations:
+              - type: required
+                params: [You must provide the Top 3 issues]
+      taskSemiannuallyNoWrite:
+        label: Semi-annual assessment of objective, no write
+        recurrence: semiannually
+        test: $.subject[?(@property === "noSuchProperty" && @.match(/^willNeverMatch/i))]
+        authorizationGroupUuids:
+          write: []
+        questions:
+          question1:
+            type: number
+            label: Test Question 1
+      taskOnceReportNoWrite:
+        label: Engagement assessment of objective, no write
+        recurrence: once
+        relatedObjectType: report
+        test: $.subject[?(@property === "noSuchProperty" && @.match(/^willNeverMatch/i))]
+        authorizationGroupUuids:
+          write: []
+        questions:
+          question1:
+            type: number
+            label: Test Question 1
+
+      taskMonthly:
+        label: Monthly assessment of objective
+        recurrence: monthly
+        allowFutureAssessments: true
+        questions:
+          requiredButFilteredOutQuestion:
+            test: $.subject[?(@property === "noSuchProperty" && @.match(/^willNeverMatch/i))]
+            type: text
+            label: This question is required but will be filtered out
+            validations:
+              - type: required
+                params: [You must provide the answer to taskMonthly.requiredButFilteredOutQuestion]
+          questionFor11B:
+            test: $.subject[?(@property === "shortName" && @ === "1.1.B")]
+            type: text
+            label: This question applies only to 1.1.B
+            validations:
+              - type: required
+                params: [You must provide the answer to taskMonthly.questionFor11B]
+          issues:
+            type: special_field
+            label: Top 3 issues
+            placeholder: Enter the top 3 issues
+            widget: richTextEditor
+            style:
+              height: 300px
+            validations:
+              - type: required
+                params: [You must provide the Top 3 issues]
+          status:
+            type: enum
+            label: Project status
+            helpText: Select an assessment status for objective
+            choices:
+              GREEN:
+                label: Green
+                color: '#c2ffb3'
+              AMBER:
+                label: Amber
+                color: '#ffe396'
+              RED:
+                label: Red
+                color: '#ff8279'
+            validations:
+              - type: required
+                params: [You must provide the Project status]
+      taskWeekly:
+        label: Weekly assessment of objective
+        recurrence: weekly
+        questions:
+          issues:
+            type: special_field
+            label: Top 3 issues
+            placeholder: Enter the top 3 issues
+            widget: richTextEditor
+            style:
+              height: 300px
+            validations:
+              - type: required
+                params: [You must provide the Top 3 issues]
+      taskOnceReport:
+        label: Engagement assessment of objective
+        recurrence: once
+        relatedObjectType: report
+        questions:
+          requiredButFilteredOutQuestion:
+            test: $.subject[?(@property === "noSuchProperty" && @.match(/^willNeverMatch/i))]
+            type: text
+            label: This question is required but will be filtered out
+            validations:
+              - type: required
+                params: [You must provide the answer to taskOnceReport.requiredButFilteredOutQuestion]
+          questionFor11B:
+            test: $.subject[?(@property === "shortName" && @ === "1.1.B")]
+            type: text
+            label: This question applies only to 1.1.B
+            validations:
+              - type: required
+                params: [You must provide the answer to taskOnceReport.questionFor11B]
+          questionForNegative:
+            test: $.relatedObject[?(@property === "atmosphere" && @ === "NEGATIVE")]
+            type: text
+            label: This question applies only to Negative engagements
+            validations:
+              - type: required
+                params: [You must provide the answer to taskOnceReport.questionForNegative]
+          question1:
+            type: special_field
+            widget: likertScale
+            label: Instant assessment Question 1
+            helpText: Please provide assessment for something important
+            levels:
+              - color: red
+                endValue: 2
+                label: test
+              - color: "#FFBF00"
+                endValue: 8
+                label: mid
+              - color: green
+                endValue: 10
+                label: high
+            aggregation:
+              widget: likertScale
+          question2:
+            type: number
+            label: Instant assessment Question 2
+          question3:
+            type: number
+            label: Instant assessment Question 3
+      task11COnceReport:
+        label: Engagement assessment of objective 1.1.C
+        recurrence: once
+        relatedObjectType: report
+        test: $.subject[?(@property === "shortName" && @ === "1.1.C")]
+        questions:
+          requiredButFilteredOutQuestion:
+            test: $.subject[?(@property === "noSuchProperty" && @.match(/^willNeverMatch/i))]
+            type: text
+            label: This question is required but will be filtered out
+            validations:
+              - type: required
+                params: [You must provide the answer to task11COnceReport.requiredButFilteredOutQuestion]
+          requiredQuestion:
+            type: text
+            label: This question is required
+            validations:
+              - type: required
+                params: [You must provide the answer to task11COnceReport.requiredQuestion]
+          questionForNegative:
+            test: $.relatedObject[?(@property === "atmosphere" && @ === "NEGATIVE")]
+            type: text
+            label: This question applies only to Negative engagements
+            validations:
+              - type: required
+                params: [You must provide the answer to task11COnceReport.questionForNegative]
 
     projectedCompletion:
       label: Projected Completion
@@ -299,10 +282,10 @@ fields:
       label: Planned Completion
       exclude: true
     parentTask:
-      label: Parent objective / effort
-      placeholder: Start typing to search for a higher level objective / effort
+      label: Parent objective
+      placeholder: Start typing to search for a higher level objective
     childrenTasks:
-      label: Sub efforts
+      label: Sub objectives
     taskedOrganizations:
       label: Tasked organizations
       placeholder: Search for an organization…

--- a/client/src/components/NoPaginationTaskTable.js
+++ b/client/src/components/NoPaginationTaskTable.js
@@ -33,7 +33,6 @@ const NoPaginationTaskTable = ({
           </thead>
           <tbody>
             {Task.map(tasks, task => {
-              const fieldSettings = task.fieldSettings()
               return (
                 <tr key={task.uuid}>
                   <td className="taskName">
@@ -63,7 +62,7 @@ const NoPaginationTaskTable = ({
                   {showDelete && (
                     <td id={"taskDelete_" + task.uuid}>
                       <RemoveButton
-                        title={`Remove ${fieldSettings.shortLabel}`}
+                        title={`Remove ${Settings.fields.task.shortLabel}`}
                         onClick={() => onDelete(task)}
                       />
                     </td>

--- a/client/src/components/ReportStatistics.js
+++ b/client/src/components/ReportStatistics.js
@@ -65,7 +65,7 @@ const REPORT_FIELDS_FOR_STATISTICS = {
       aggregationType: AGGREGATION_TYPE.REPORTS_BY_TASK,
       widget: AGGREGATION_WIDGET_TYPE.REPORTS_BY_TASK
     },
-    label: pluralize(Settings.fields.task.subLevel.shortLabel)
+    label: pluralize(Settings.fields.task.shortLabel)
   },
   atmosphere: {
     type: CUSTOM_FIELD_TYPE.ENUM,

--- a/client/src/components/ReportSummary.js
+++ b/client/src/components/ReportSummary.js
@@ -352,9 +352,7 @@ const ReportSummaryRow = ({ report }) => {
         <Col md={12}>
           {report.tasks.length > 0 && (
             <span>
-              <strong>
-                {pluralize(Settings.fields.task.subLevel.shortLabel)}:
-              </strong>{" "}
+              <strong>{pluralize(Settings.fields.task.shortLabel)}:</strong>{" "}
               {report.tasks.map((task, i) => (
                 <React.Fragment key={task.uuid}>
                   {i > 0 && (

--- a/client/src/components/ReportsByTask.js
+++ b/client/src/components/ReportsByTask.js
@@ -143,9 +143,9 @@ Map.propTypes = {
  */
 const ReportsByTask = ({ pageDispatchers, queryParams, style }) => {
   const [focusedSelection, setFocusedSelection] = useState(null)
-  usePageTitle(`Reports by ${Settings.fields.task.subLevel.shortLabel}`)
+  usePageTitle(`Reports by ${Settings.fields.task.shortLabel}`)
 
-  const taskShortLabel = Settings.fields.task.subLevel.shortLabel
+  const taskShortLabel = Settings.fields.task.shortLabel
   const chartId = "reports_by_task"
   const selectedBarClass = "selected-bar"
   const VISUALIZATIONS = [

--- a/client/src/components/aggregations/utils.js
+++ b/client/src/components/aggregations/utils.js
@@ -114,7 +114,7 @@ export const numbersListAggregation = (fieldName, fieldConfig, data) => {
   return { values: numberValues }
 }
 
-const noTaskMessage = `No ${Settings.fields.task.subLevel.shortLabel}`
+const noTaskMessage = `No ${Settings.fields.task.shortLabel}`
 const noTask = {
   uuid: "-1",
   shortName: noTaskMessage,

--- a/client/src/components/previews/ReportPreview.js
+++ b/client/src/components/previews/ReportPreview.js
@@ -120,7 +120,7 @@ const ReportPreview = ({ className, uuid }) => {
   )
   report = new Report(data.report)
   const reportType = report.isFuture() ? "planned engagement" : "report"
-  const tasksLabel = pluralize(Settings.fields.task.subLevel.shortLabel)
+  const tasksLabel = pluralize(Settings.fields.task.shortLabel)
 
   // Get initial tasks/people instant assessments values
   const hasAssessments = report.engagementDate && !report.isFuture()
@@ -309,7 +309,7 @@ const ReportPreview = ({ className, uuid }) => {
           </div>
         </>
       )}
-      <h4>{Settings.fields.task.subLevel.longLabel}</h4>
+      <h4>{Settings.fields.task.longLabel}</h4>
       <div className="preview-section">
         <NoPaginationTaskTable
           tasks={report.tasks}

--- a/client/src/components/previews/TaskPreview.js
+++ b/client/src/components/previews/TaskPreview.js
@@ -124,16 +124,15 @@ const TaskPreview = ({ className, uuid }) => {
   }
   const task = new Task(data.task ? data.task : {})
 
-  const fieldSettings = task.fieldSettings()
   return (
     <div className={`${className} preview-content-scroll`}>
       <div className="preview-sticky-title">
-        <h4 className="ellipsized-text">{`${fieldSettings.shortLabel} ${task.shortName}`}</h4>
+        <h4 className="ellipsized-text">{`${Settings.fields.task.shortLabel} ${task.shortName}`}</h4>
       </div>
       <div className="preview-section">
         <DictionaryField
           wrappedComponent={PreviewField}
-          dictProps={fieldSettings.longName}
+          dictProps={Settings.fields.task.longName}
           value={task.longName}
         />
         <DictionaryField

--- a/client/src/models/Report.js
+++ b/client/src/models/Report.js
@@ -200,7 +200,7 @@ export default class Report extends Model {
         .test("tasks", "tasks error", (tasks, testContext) =>
           _isEmpty(tasks)
             ? testContext.createError({
-              message: `You must provide at least one ${Settings.fields.task.subLevel.shortLabel}`
+              message: `You must provide at least one ${Settings.fields.task.shortLabel}`
             })
             : true
         )

--- a/client/src/models/Task.js
+++ b/client/src/models/Task.js
@@ -3,7 +3,6 @@ import Model, {
   GRAPHQL_NOTES_FIELDS,
   yupDate
 } from "components/Model"
-import _isEmpty from "lodash/isEmpty"
 import TASKS_ICON from "resources/tasks.png"
 import Settings from "settings"
 import utils from "utils"
@@ -33,8 +32,7 @@ export default class Task extends Model {
     REPORT_APPROVAL: "REPORT_APPROVAL"
   }
 
-  static topLevelAssessmentDictionaryPath = "fields.task.topLevel.assessments"
-  static subLevelAssessmentDictionaryPath = "fields.task.subLevel.assessments"
+  static assessmentDictionaryPath = "fields.task.assessments"
 
   // create yup schema for the customFields, based on the customFields config
   static customFieldsSchema = createCustomFieldsSchema(
@@ -148,20 +146,8 @@ export default class Task extends Model {
     super(Model.fillObject(props, Task.yupSchema))
   }
 
-  isTopLevelTask() {
-    return _isEmpty(this.parentTask)
-  }
-
-  fieldSettings() {
-    return this.isTopLevelTask()
-      ? Settings.fields.task.topLevel
-      : Settings.fields.task.subLevel
-  }
-
   getAssessmentDictionaryPath() {
-    return this.isTopLevelTask()
-      ? Task.topLevelAssessmentDictionaryPath
-      : Task.subLevelAssessmentDictionaryPath
+    return Task.assessmentDictionaryPath
   }
 
   iconUrl() {
@@ -173,7 +159,7 @@ export default class Task extends Model {
   }
 
   getAssessmentsConfig() {
-    return this.fieldSettings().assessments || {}
+    return Settings.fields.task.assessments || {}
   }
 
   static FILTERED_CLIENT_SIDE_FIELDS = ["ascendantTasks"]

--- a/client/src/pages/HopscotchTour.js
+++ b/client/src/pages/HopscotchTour.js
@@ -4,8 +4,6 @@ import Settings from "settings"
 
 const taskShortLabelSingular = Settings.fields.task.shortLabel
 const taskShortLabelPlural = pluralize(taskShortLabelSingular)
-const subLevelTaskShortLabelSingular = Settings.fields.task.subLevel.shortLabel
-const subLevelTaskShortLabelPlural = pluralize(subLevelTaskShortLabelSingular)
 const personSingular = Settings.fields.regular.person.name
 const advisorSingular = Settings.fields.advisor.person.name
 const advisorPlural = pluralize(advisorSingular)
@@ -163,7 +161,7 @@ const reportTour = (currentUser, navigate) => {
       },
       {
         title: "Recents",
-        content: `If you've written reports in the past, your recent selections of attendees, ${subLevelTaskShortLabelPlural}, and locations will display to the right in a section called "Recents". You can click on one of the shortcuts to quickly add it to your report.`,
+        content: `If you've written reports in the past, your recent selections of attendees, ${taskShortLabelPlural}, and locations will display to the right in a section called "Recents". You can click on one of the shortcuts to quickly add it to your report.`,
         target: "#attendees",
         placement: "bottom"
       },
@@ -174,8 +172,8 @@ const reportTour = (currentUser, navigate) => {
         placement: "bottom"
       },
       {
-        title: subLevelTaskShortLabelPlural,
-        content: `Search for the ${subLevelTaskShortLabelPlural} that apply to this engagement. You can search for ${subLevelTaskShortLabelPlural} in any organization, including your organization and its sub-organizations. ${subLevelTaskShortLabelPlural} are required.`,
+        title: taskShortLabelPlural,
+        content: `Search for the ${taskShortLabelPlural} that apply to this engagement. You can search for ${taskShortLabelPlural} in any organization, including your organization and its sub-organizations. ${taskShortLabelPlural} are required.`,
         target: "#tasks",
         placement: "right"
       },

--- a/client/src/pages/insights/Show.js
+++ b/client/src/pages/insights/Show.js
@@ -77,7 +77,7 @@ export const INSIGHT_DETAILS = {
   [REPORTS_BY_TASK]: {
     searchProps: REPORT_SEARCH_PROPS,
     component: ReportsByTask,
-    navTitle: `Reports by ${Settings.fields.task.subLevel.shortLabel}`,
+    navTitle: `Reports by ${Settings.fields.task.shortLabel}`,
     title: ""
   },
   [REPORTS_BY_DAY_OF_WEEK]: {

--- a/client/src/pages/reports/Compact.js
+++ b/client/src/pages/reports/Compact.js
@@ -370,7 +370,7 @@ const CompactReportView = ({ pageDispatchers }) => {
                 />
                 <CompactRow
                   id="tasks"
-                  label={Settings.fields.task.subLevel.longLabel}
+                  label={Settings.fields.task.longLabel}
                   content={getTasksAndAssessments()}
                   className="reportField"
                 />

--- a/client/src/pages/reports/Form.js
+++ b/client/src/pages/reports/Form.js
@@ -267,7 +267,7 @@ const ReportForm = ({
     return result
   }
   const submitText = "Save Report"
-  const tasksLabel = pluralize(Settings.fields.task.subLevel.shortLabel)
+  const tasksLabel = pluralize(Settings.fields.task.shortLabel)
   const showAssignedPositionWarning = !currentUser.hasAssignedPosition()
   const showActivePositionWarning =
     currentUser.hasAssignedPosition() && !currentUser.hasActivePosition()
@@ -778,12 +778,12 @@ const ReportForm = ({
 
               {!_isEmpty(tasksFilters) && (
                 <Fieldset
-                  title={Settings.fields.task.subLevel.longLabel}
+                  title={Settings.fields.task.longLabel}
                   className="tasks-selector"
                 >
                   <Field
                     name="tasks"
-                    label={Settings.fields.task.subLevel.longLabel}
+                    label={Settings.fields.task.longLabel}
                     component={FieldHelper.SpecialField}
                     onChange={value => {
                       // validation will be done by setFieldValue
@@ -802,12 +802,10 @@ const ReportForm = ({
                             tasks={values.tasks}
                             showDelete
                             showDescription
-                            noTasksMessage={`No ${tasksLabel} selected; click in the efforts box to view your organization's efforts`}
+                            noTasksMessage={`No ${tasksLabel} selected; click in the ${tasksLabel} box to view your organization's ${tasksLabel}`}
                           />
                         }
-                        overlayColumns={[
-                          Settings.fields.task.subLevel.shortLabel
-                        ]}
+                        overlayColumns={[Settings.fields.task.shortLabel]}
                         overlayRenderRow={TaskOverlayRow}
                         filterDefs={tasksFilters}
                         objectType={Task}
@@ -1153,7 +1151,7 @@ const ReportForm = ({
                   </Fieldset>
 
                   <Fieldset
-                    title={`${Settings.fields.task.subLevel.longLabel} engagement assessments`}
+                    title={`${Settings.fields.task.longLabel} engagement assessments`}
                     id="tasks-engagement-assessments"
                   >
                     <InstantAssessmentsContainerField

--- a/client/src/pages/reports/Show.js
+++ b/client/src/pages/reports/Show.js
@@ -354,7 +354,7 @@ const ReportShow = ({ setSearchQuery, pageDispatchers }) => {
   const isAttending = report.reportPeople?.some(rp =>
     Person.isEqual(currentUser, rp)
   )
-  const tasksLabel = pluralize(Settings.fields.task.subLevel.shortLabel)
+  const tasksLabel = pluralize(Settings.fields.task.shortLabel)
 
   // User can approve when admin,
   // or if report is pending approval and user is one of the approvers in the current approval step
@@ -716,7 +716,7 @@ const ReportShow = ({ setSearchQuery, pageDispatchers }) => {
               >
                 <ReportPeople report={report} disabled />
               </Fieldset>
-              <Fieldset title={Settings.fields.task.subLevel.longLabel}>
+              <Fieldset title={Settings.fields.task.longLabel}>
                 <NoPaginationTaskTable
                   tasks={report.tasks}
                   noTasksMessage={`No ${tasksLabel} selected`}
@@ -781,7 +781,7 @@ const ReportShow = ({ setSearchQuery, pageDispatchers }) => {
                   </Fieldset>
 
                   <Fieldset
-                    title={`${Settings.fields.task.subLevel.longLabel} engagement assessments`}
+                    title={`${Settings.fields.task.longLabel} engagement assessments`}
                     id="tasks-engagement-assessments"
                   >
                     <InstantAssessmentsContainerField

--- a/client/src/pages/tasks/Form.js
+++ b/client/src/pages/tasks/Form.js
@@ -130,7 +130,6 @@ const TaskForm = ({ edit, title, initialValues, notesComponent }) => {
       }) => {
         const isAdmin = currentUser && currentUser.isAdmin()
         const disabled = !isAdmin
-        const fieldSettings = values.fieldSettings()
         const action = (
           <>
             <Button
@@ -139,7 +138,7 @@ const TaskForm = ({ edit, title, initialValues, notesComponent }) => {
               onClick={submitForm}
               disabled={isSubmitting}
             >
-              Save {fieldSettings.shortLabel}
+              Save {Settings.fields.task.shortLabel}
             </Button>
             {notesComponent}
           </>
@@ -153,7 +152,7 @@ const TaskForm = ({ edit, title, initialValues, notesComponent }) => {
               <Fieldset>
                 <DictionaryField
                   wrappedComponent={Field}
-                  dictProps={fieldSettings.shortName}
+                  dictProps={Settings.fields.task.shortName}
                   name="shortName"
                   component={FieldHelper.InputField}
                   disabled={disabled}
@@ -161,7 +160,7 @@ const TaskForm = ({ edit, title, initialValues, notesComponent }) => {
 
                 <DictionaryField
                   wrappedComponent={Field}
-                  dictProps={fieldSettings.longName}
+                  dictProps={Settings.fields.task.longName}
                   name="longName"
                   component={FieldHelper.InputField}
                 />
@@ -341,7 +340,7 @@ const TaskForm = ({ edit, title, initialValues, notesComponent }) => {
 
               {Settings.fields.task.customFields && !disabled && (
                 <Fieldset
-                  title={`${fieldSettings.shortLabel} information`}
+                  title={`${Settings.fields.task.shortLabel} information`}
                   id="custom-fields"
                 >
                   <CustomFieldsContainer
@@ -391,7 +390,7 @@ const TaskForm = ({ edit, title, initialValues, notesComponent }) => {
                     onClick={submitForm}
                     disabled={isSubmitting}
                   >
-                    Save {fieldSettings.shortLabel}
+                    Save {Settings.fields.task.shortLabel}
                   </Button>
                 </div>
               </div>

--- a/client/src/pages/tasks/Show.js
+++ b/client/src/pages/tasks/Show.js
@@ -188,8 +188,6 @@ const TaskShow = ({ pageDispatchers }) => {
     ? []
     : task.descendantTasks?.map(task => new Task(task))
 
-  const fieldSettings = task.fieldSettings()
-
   // Admins can edit tasks or users in positions related to the task
   const isAdmin = currentUser && currentUser.isAdmin()
   const canEdit =
@@ -245,7 +243,7 @@ const TaskShow = ({ pageDispatchers }) => {
                         persistent
                       />
                     }{" "}
-                    {fieldSettings.shortLabel} {task.shortName}
+                    {Settings.fields.task.shortLabel} {task.shortName}
                   </>
                 }
                 action={action}
@@ -261,7 +259,7 @@ const TaskShow = ({ pageDispatchers }) => {
                 <Fieldset style={{ flex: "1 1 0" }}>
                   <DictionaryField
                     wrappedComponent={Field}
-                    dictProps={fieldSettings.longName}
+                    dictProps={Settings.fields.task.longName}
                     name="longName"
                     component={FieldHelper.ReadonlyField}
                   />
@@ -307,7 +305,7 @@ const TaskShow = ({ pageDispatchers }) => {
                       <DictionaryField
                         wrappedComponent={Field}
                         dictProps={Settings.fields.task.childrenTasks}
-                        name="subEfforts"
+                        name="subTasks"
                         component={FieldHelper.ReadonlyField}
                         humanValue={
                           <ListGroup>
@@ -374,7 +372,7 @@ const TaskShow = ({ pageDispatchers }) => {
 
             {Settings.fields.task.customFields && (
               <Fieldset
-                title={`${fieldSettings.shortLabel} information`}
+                title={`${Settings.fields.task.shortLabel} information`}
                 id="custom-fields"
               >
                 <ReadonlyCustomFields
@@ -393,7 +391,9 @@ const TaskShow = ({ pageDispatchers }) => {
               relatedObject={task}
             />
 
-            <Fieldset title={`Reports for this ${fieldSettings.shortLabel}`}>
+            <Fieldset
+              title={`Reports for this ${Settings.fields.task.shortLabel}`}
+            >
               <ReportCollection
                 paginationKey={`r_${uuid}`}
                 queryParams={{

--- a/client/tests/e2e/report.js
+++ b/client/tests/e2e/report.js
@@ -139,7 +139,7 @@ test.serial("Draft and submit a report", async t => {
   )
 
   const $tasksTitle = await t.context.driver.findElement(
-    By.xpath('//h4/span[text()="Efforts"]')
+    By.xpath('//h4/span[text()="Objectives"]')
   )
   await $tasksTitle.click()
 

--- a/client/tests/webdriver/baseSpecs/advancedSearch.spec.js
+++ b/client/tests/webdriver/baseSpecs/advancedSearch.spec.js
@@ -19,7 +19,7 @@ const ANET_OBJECT_TYPES = {
   Locations: {
     sampleFilters: ["Type"]
   },
-  "Objective / Efforts": {
+  Objectives: {
     sampleFilters: ["Within Organization"]
   },
   "Authorization Groups": {

--- a/client/tests/webdriver/baseSpecs/assessmentsForTasks.spec.js
+++ b/client/tests/webdriver/baseSpecs/assessmentsForTasks.spec.js
@@ -31,20 +31,20 @@ describe("For the periodic task assessments", () => {
 
     it("Should allow advisor to successfully add an assessment", async() => {
       await (
-        await ShowTask.getAssessmentsTable("subTaskMonthly", "monthly")
+        await ShowTask.getAssessmentsTable("taskMonthly", "monthly")
       ).waitForExist()
       await (
-        await ShowTask.getAssessmentsTable("subTaskMonthly", "monthly")
+        await ShowTask.getAssessmentsTable("taskMonthly", "monthly")
       ).waitForDisplayed()
       await (
-        await ShowTask.getAddAssessmentButton("subTaskMonthly", "monthly")
+        await ShowTask.getAddAssessmentButton("taskMonthly", "monthly")
       ).click()
       await ShowTask.waitForAssessmentModalForm()
 
       // NOTE: assuming assessment question content here, may change in future
       await ShowTask.fillAssessmentQuestion(ADVISOR_1_TASK_CREATE_DETAILS)
       await ShowTask.saveAssessmentAndWaitForModalClose(
-        "subTaskMonthly",
+        "taskMonthly",
         "monthly",
         ADVISOR_1_TASK_CREATE_DETAILS[0]
       )
@@ -52,7 +52,7 @@ describe("For the periodic task assessments", () => {
 
     it("Should show the same assessment details with the details just created", async() => {
       await assertAssessmentDetails(
-        "subTaskMonthly",
+        "taskMonthly",
         "monthly",
         ADVISOR_1_TASK_CREATE_DETAILS
       )
@@ -60,13 +60,13 @@ describe("For the periodic task assessments", () => {
 
     it("Should allow the author of the assessment to successfully edit it", async() => {
       await (
-        await ShowTask.getEditAssessmentButton("subTaskMonthly", "monthly")
+        await ShowTask.getEditAssessmentButton("taskMonthly", "monthly")
       ).waitForExist()
       await (
-        await ShowTask.getEditAssessmentButton("subTaskMonthly", "monthly")
+        await ShowTask.getEditAssessmentButton("taskMonthly", "monthly")
       ).waitForDisplayed()
       await (
-        await ShowTask.getEditAssessmentButton("subTaskMonthly", "monthly")
+        await ShowTask.getEditAssessmentButton("taskMonthly", "monthly")
       ).click()
       await ShowTask.waitForAssessmentModalForm()
 
@@ -75,7 +75,7 @@ describe("For the periodic task assessments", () => {
         ADVISOR_1_TASK_CREATE_DETAILS[0]
       )
       await ShowTask.saveAssessmentAndWaitForModalClose(
-        "subTaskMonthly",
+        "taskMonthly",
         "monthly",
         ADVISOR_1_TASK_EDIT_DETAILS[0]
       )
@@ -83,38 +83,36 @@ describe("For the periodic task assessments", () => {
 
     it("Should show the same assessment details with the details just edited", async() => {
       await assertAssessmentDetails(
-        "subTaskMonthly",
+        "taskMonthly",
         "monthly",
         ADVISOR_1_TASK_EDIT_DETAILS
       )
     })
 
-    it("Should see an add button for subTaskMonthly assessments in the future", async() => {
+    it("Should see an add button for taskMonthly assessments in the future", async() => {
       await (
-        await ShowTask.getNextPeriodButton("subTaskMonthly", "monthly")
+        await ShowTask.getNextPeriodButton("taskMonthly", "monthly")
       ).waitForExist()
 
       await (
-        await ShowTask.getNextPeriodButton("subTaskMonthly", "monthly")
+        await ShowTask.getNextPeriodButton("taskMonthly", "monthly")
       ).click()
 
       await (
-        await ShowTask.getFutureAddAssessmentButton("subTaskMonthly", "monthly")
+        await ShowTask.getFutureAddAssessmentButton("taskMonthly", "monthly")
       ).waitForExist()
     })
 
-    it("Should not see an add button for subTaskWeekly assessments in the future", async() => {
+    it("Should not see an add button for taskWeekly assessments in the future", async() => {
       await (
-        await ShowTask.getNextPeriodButton("subTaskWeekly", "weekly")
+        await ShowTask.getNextPeriodButton("taskWeekly", "weekly")
       ).waitForExist()
 
-      await (
-        await ShowTask.getNextPeriodButton("subTaskWeekly", "weekly")
-      ).click()
+      await (await ShowTask.getNextPeriodButton("taskWeekly", "weekly")).click()
 
       expect(
         await (
-          await ShowTask.getFutureAddAssessmentButton("subTaskWeekly", "weekly")
+          await ShowTask.getFutureAddAssessmentButton("taskWeekly", "weekly")
         ).isExisting()
       ).to.equal(false)
 
@@ -135,20 +133,20 @@ describe("For the periodic task assessments", () => {
     it("Should not show make assessment button when there is an assessment on that period", async() => {
       expect(
         await (
-          await ShowTask.getAddAssessmentButton("subTaskMonthly", "monthly")
+          await ShowTask.getAddAssessmentButton("taskMonthly", "monthly")
         ).isExisting()
       ).to.equal(false)
     })
 
     it("Should allow admins to successfully edit existing assessment", async() => {
       await (
-        await ShowTask.getAssessmentsTable("subTaskMonthly", "monthly")
+        await ShowTask.getAssessmentsTable("taskMonthly", "monthly")
       ).waitForExist()
       await (
-        await ShowTask.getAssessmentsTable("subTaskMonthly", "monthly")
+        await ShowTask.getAssessmentsTable("taskMonthly", "monthly")
       ).waitForDisplayed()
       await (
-        await ShowTask.getEditAssessmentButton("subTaskMonthly", "monthly")
+        await ShowTask.getEditAssessmentButton("taskMonthly", "monthly")
       ).click()
       await ShowTask.waitForAssessmentModalForm()
 
@@ -158,7 +156,7 @@ describe("For the periodic task assessments", () => {
         ADVISOR_1_TASK_EDIT_DETAILS[0]
       )
       await ShowTask.saveAssessmentAndWaitForModalClose(
-        "subTaskMonthly",
+        "taskMonthly",
         "monthly",
         ADMIN_TASK_EDIT_DETAILS[0]
       )
@@ -166,7 +164,7 @@ describe("For the periodic task assessments", () => {
 
     it("Should show the same assessment details with the details just edited", async() => {
       await assertAssessmentDetails(
-        "subTaskMonthly",
+        "taskMonthly",
         "monthly",
         ADMIN_TASK_EDIT_DETAILS
       )
@@ -187,20 +185,20 @@ describe("For the periodic task assessments", () => {
     it("Should not show make assessment button when there is an assessment on that period", async() => {
       expect(
         await (
-          await ShowTask.getAddAssessmentButton("subTaskMonthly", "monthly")
+          await ShowTask.getAddAssessmentButton("taskMonthly", "monthly")
         ).isExisting()
       ).to.equal(false)
     })
 
     it("Should allow the other advisor to successfully edit existing assessment", async() => {
       await (
-        await ShowTask.getAssessmentsTable("subTaskMonthly", "monthly")
+        await ShowTask.getAssessmentsTable("taskMonthly", "monthly")
       ).waitForExist()
       await (
-        await ShowTask.getAssessmentsTable("subTaskMonthly", "monthly")
+        await ShowTask.getAssessmentsTable("taskMonthly", "monthly")
       ).waitForDisplayed()
       await (
-        await ShowTask.getEditAssessmentButton("subTaskMonthly", "monthly")
+        await ShowTask.getEditAssessmentButton("taskMonthly", "monthly")
       ).click()
       await ShowTask.waitForAssessmentModalForm()
 
@@ -210,7 +208,7 @@ describe("For the periodic task assessments", () => {
         ADMIN_TASK_EDIT_DETAILS[0]
       )
       await ShowTask.saveAssessmentAndWaitForModalClose(
-        "subTaskMonthly",
+        "taskMonthly",
         "monthly",
         ADVISOR_2_TASK_EDIT_DETAILS[0]
       )
@@ -218,7 +216,7 @@ describe("For the periodic task assessments", () => {
 
     it("Should show the same assessment details with the details just edited", async() => {
       await assertAssessmentDetails(
-        "subTaskMonthly",
+        "taskMonthly",
         "monthly",
         ADVISOR_2_TASK_EDIT_DETAILS
       )
@@ -228,7 +226,7 @@ describe("For the periodic task assessments", () => {
       await (await ShowTask.getDeleteAssessmentButton()).click()
       await ShowTask.confirmDelete()
       await ShowTask.waitForDeletedAssessmentToDisappear(
-        "subTaskMonthly",
+        "taskMonthly",
         "monthly"
       )
       await ShowTask.logout()

--- a/client/tests/webdriver/baseSpecs/createNewTask.spec.js
+++ b/client/tests/webdriver/baseSpecs/createNewTask.spec.js
@@ -23,7 +23,7 @@ describe("When creating an task", () => {
     await CreateTask.submitForm()
     await ShowTask.waitForAlertSuccessToLoad()
     expect(await (await ShowTask.getAlertSuccess()).getText()).to.equal(
-      "Objective / Effort saved"
+      "Objective saved"
     )
   })
 

--- a/client/tests/webdriver/baseSpecs/myReports.spec.js
+++ b/client/tests/webdriver/baseSpecs/myReports.spec.js
@@ -119,7 +119,7 @@ describe("Show My Reports page", () => {
         await (
           await MyReports.getReportsSummarySpan(reportNoAttachments, 8, 1)
         ).getText()
-      ).to.equal("Efforts: EF 1 » EF 1.2 » 1.2.AEF 1 » EF 1.2 » 1.2.B")
+      ).to.equal("Objectives: EF 1 » EF 1.2 » 1.2.AEF 1 » EF 1.2 » 1.2.B")
       // eslint-disable-next-line no-unused-expressions
       expect(
         await (

--- a/client/tests/webdriver/baseSpecs/printReport.spec.js
+++ b/client/tests/webdriver/baseSpecs/printReport.spec.js
@@ -48,7 +48,7 @@ describe("Show print report page", () => {
         "Next steps",
         "Interlocutors",
         "Advisors",
-        "Efforts"
+        "Objectives"
       ]
       const fields = await ShowReport.getCompactReportFields()
       const fieldTexts = await fields.map(async field => await field.getText())

--- a/client/tests/webdriver/baseSpecs/showReport.spec.js
+++ b/client/tests/webdriver/baseSpecs/showReport.spec.js
@@ -15,20 +15,20 @@ describe("Show report page", () => {
       await (
         await ShowReport.getTasksEngagementAssessments()
       ).waitForDisplayed()
-      // Both 1.2.A as 1.2.B tasks on the page have an svg type of assessment (LikertScale widgets)
+      // The tasks on the page have an svg type of assessment (LikertScale widgets)
       // and two other questions
       const svgAssessments = await (
         await ShowReport.getTasksEngagementAssessments()
       ).$$("svg")
-      expect(svgAssessments).to.have.length(2)
+      expect(svgAssessments).to.have.length(4)
       const question2Assessments = await (
         await ShowReport.getTasksEngagementAssessments()
       ).$$("[name*=question2]")
-      expect(question2Assessments).to.have.length(2)
+      expect(question2Assessments).to.have.length(4)
       const question3Assessments = await (
         await ShowReport.getTasksEngagementAssessments()
       ).$$("[name*=question3]")
-      expect(question3Assessments).to.have.length(2)
+      expect(question3Assessments).to.have.length(4)
     })
   })
   describe("When on the show page of a report with attachment(s)", () => {

--- a/client/tests/webdriver/customFieldsSpecs/pendingAssessments.spec.js
+++ b/client/tests/webdriver/customFieldsSpecs/pendingAssessments.spec.js
@@ -152,7 +152,7 @@ describe("In my tasks page", () => {
       await (await MyTasks.getMyPendingTasks()).waitForDisplayed()
       expect(
         await (await MyTasks.getMyPendingTasksContent()).getText()
-      ).to.equal("No Objective / Efforts found")
+      ).to.equal("No Objectives found")
       await MyTasks.logout()
     })
   })
@@ -169,14 +169,11 @@ describe("In my tasks page", () => {
     it("Should be able to add a monthly assessment with 2 questions for the task", async() => {
       await (await MyTasks.getMyPendingTask("2.B")).click()
       await (
-        await AssessmentsSection.getAssessmentsSection(
-          "subTaskMonthly",
-          "monthly"
-        )
+        await AssessmentsSection.getAssessmentsSection("taskMonthly", "monthly")
       ).waitForDisplayed()
       const newAssessmentButton =
         await AssessmentsSection.getNewAssessmentButton(
-          "subTaskMonthly",
+          "taskMonthly",
           "monthly"
         )
       await newAssessmentButton.waitForDisplayed()
@@ -207,16 +204,10 @@ describe("In my tasks page", () => {
     })
     it("Should be able to add a weekly assessment with 1 question for the task", async() => {
       await (
-        await AssessmentsSection.getAssessmentsSection(
-          "subTaskWeekly",
-          "weekly"
-        )
+        await AssessmentsSection.getAssessmentsSection("taskWeekly", "weekly")
       ).waitForDisplayed()
       const newAssessmentButton =
-        await AssessmentsSection.getNewAssessmentButton(
-          "subTaskWeekly",
-          "weekly"
-        )
+        await AssessmentsSection.getNewAssessmentButton("taskWeekly", "weekly")
       await newAssessmentButton.waitForDisplayed()
       await newAssessmentButton.click()
       await browser.pause(SHORT_WAIT_MS) // wait for the modal to slide in (transition is 300 ms)
@@ -275,7 +266,7 @@ describe("In new report page", () => {
       await browser.pause(SHORT_WAIT_MS) // wait for assessment questions to be updated
       await (await CreateReport.getTasksAssessments()).scrollIntoView()
       const taskAssessmentRows = await CreateReport.getTaskAssessmentRows()
-      expect(taskAssessmentRows).to.have.length(2)
+      expect(taskAssessmentRows).to.have.length(3) // a heading and two assessments
       for (let i = 0; i < 2; i += 2) {
         const task = taskAssessmentRows[i]
         const assessment = taskAssessmentRows[i + 1]

--- a/client/tests/webdriver/customFieldsSpecs/showTask.spec.js
+++ b/client/tests/webdriver/customFieldsSpecs/showTask.spec.js
@@ -12,10 +12,10 @@ describe("Show task page", () => {
   describe("When on the show page of a task with assessments", () => {
     it("We should see a table of assessments related to the current task", async() => {
       await (
-        await ShowTask.getAssessmentResults("subTaskOnceReport", "monthly")
+        await ShowTask.getAssessmentResults("taskOnceReport", "monthly")
       ).waitForDisplayed()
       const question1AssessmentMonthly = await (
-        await ShowTask.getAssessmentResults("subTaskOnceReport", "monthly")
+        await ShowTask.getAssessmentResults("taskOnceReport", "monthly")
       ).$("[id*=question1-assessment]")
       // eslint-disable-next-line no-unused-expressions
       expect(await question1AssessmentMonthly.isExisting()).to.be.true

--- a/client/tests/webdriver/pages/home.page.js
+++ b/client/tests/webdriver/pages/home.page.js
@@ -61,7 +61,7 @@ class Home extends Page {
   }
 
   async getMyTasksLink() {
-    return browser.$('//a//span[text()="My Objective / Efforts"]')
+    return browser.$('//a//span[text()="My Objectives"]')
   }
 
   async getMyCounterpartsLink() {

--- a/client/tests/webdriver/pages/report/createReport.page.js
+++ b/client/tests/webdriver/pages/report/createReport.page.js
@@ -138,7 +138,7 @@ class CreateReport extends cr.CreateReport {
 
   async getAllUnassignedTasksFilterButton() {
     return (await this.getTaskSearchFilters()).$(
-      ".btn-link=All unassigned Efforts"
+      ".btn-link=All unassigned Objectives"
     )
   }
 

--- a/client/tests/webdriver/pages/showTask.page.js
+++ b/client/tests/webdriver/pages/showTask.page.js
@@ -24,15 +24,15 @@ class ShowTask extends Page {
   }
 
   async getChildrenTasks() {
-    return browser.$('div[id="subEfforts"]')
+    return browser.$('div[id="subTasks"]')
   }
 
   async getChildrenTasksField() {
-    return browser.$("#fg-subEfforts")
+    return browser.$("#fg-subTasks")
   }
 
   async getFirstItemFromChildrenTasks() {
-    return browser.$("#subEfforts > .list-group .list-group-item:first-child")
+    return browser.$("#subTasks > .list-group .list-group-item:first-child")
   }
 
   async getAssessmentResults(assessmentKey, recurrence) {

--- a/insertBaseData-psql.sql
+++ b/insertBaseData-psql.sql
@@ -1240,7 +1240,7 @@ INSERT INTO "noteRelatedObjects" ("noteUuid", "relatedObjectType", "relatedObjec
 -- Add instant assessments to tasks related to reports
 SELECT ('''' || uuid_generate_v4() || '''') AS "noteUuid" \gset
 INSERT INTO notes (uuid, "authorUuid", type, "assessmentKey", text, "createdAt", "updatedAt") VALUES
-  (:noteUuid, :authorUuid, 3, 'fields.task.subLevel.assessments.subTaskOnceReport', '{"__recurrence":"once","__relatedObjectType":"report","question1":4.462819020045945,"question2":"1","question3":"22"}', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+  (:noteUuid, :authorUuid, 3, 'fields.task.assessments.taskOnceReport', '{"__recurrence":"once","__relatedObjectType":"report","question1":4.462819020045945,"question2":"1","question3":"22"}', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
 INSERT INTO "noteRelatedObjects" ("noteUuid", "relatedObjectType", "relatedObjectUuid")
   SELECT :noteUuid, 'reports', r.uuid
   FROM reports r
@@ -1252,7 +1252,7 @@ INSERT INTO "noteRelatedObjects" ("noteUuid", "relatedObjectType", "relatedObjec
 
 SELECT ('''' || uuid_generate_v4() || '''') AS "noteUuid" \gset
 INSERT INTO notes (uuid, "authorUuid", type, "assessmentKey", text, "createdAt", "updatedAt") VALUES
-  (:noteUuid, :authorUuid, 3, 'fields.task.subLevel.assessments.subTaskOnceReport', '{"__recurrence":"once","__relatedObjectType":"report","question1":3.141592653589793,"question2":"3","question3":"14"}', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+  (:noteUuid, :authorUuid, 3, 'fields.task.assessments.taskOnceReport', '{"__recurrence":"once","__relatedObjectType":"report","question1":3.141592653589793,"question2":"3","question3":"14"}', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
 INSERT INTO "noteRelatedObjects" ("noteUuid", "relatedObjectType", "relatedObjectUuid")
   SELECT :noteUuid, 'reports', r.uuid
   FROM reports r
@@ -1266,7 +1266,7 @@ INSERT INTO "noteRelatedObjects" ("noteUuid", "relatedObjectType", "relatedObjec
 SELECT ('''' || uuid || '''') AS "authorUuid" FROM people WHERE name = 'ANDERSON, Andrew' \gset
 SELECT ('''' || uuid_generate_v4() || '''') AS "noteUuid" \gset
 INSERT INTO notes (uuid, "authorUuid", type, "assessmentKey", text, "createdAt", "updatedAt") VALUES
-  (:noteUuid, :authorUuid, 3, 'fields.task.subLevel.assessments.subTaskMonthly', '{"status":"GREEN","issues":"<ol><li>one</li><li>two</li><li>three</li></ol>","__recurrence":"monthly","__periodStart":"' || to_char(date_trunc('month', CURRENT_TIMESTAMP) + INTERVAL '-1 month', 'YYYY-MM-DD') || '"}', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+  (:noteUuid, :authorUuid, 3, 'fields.task.assessments.taskMonthly', '{"status":"GREEN","issues":"<ol><li>one</li><li>two</li><li>three</li></ol>","__recurrence":"monthly","__periodStart":"' || to_char(date_trunc('month', CURRENT_TIMESTAMP) + INTERVAL '-1 month', 'YYYY-MM-DD') || '"}', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
 INSERT INTO "noteRelatedObjects" ("noteUuid", "relatedObjectType", "relatedObjectUuid")
   SELECT :noteUuid, 'tasks', t.uuid
   FROM tasks t

--- a/src/main/java/mil/dds/anet/utils/PendingAssessmentsHelper.java
+++ b/src/main/java/mil/dds/anet/utils/PendingAssessmentsHelper.java
@@ -211,8 +211,7 @@ public class PendingAssessmentsHelper {
 
   // Dictionary lookup keys we use
   public static final String PERSON_ASSESSMENTS = "fields.regular.person.assessments";
-  public static final String TASK_SUB_LEVEL_ASSESSMENTS = "fields.task.subLevel.assessments";
-  public static final String TASK_TOP_LEVEL_ASSESSMENTS = "fields.task.topLevel.assessments";
+  public static final String TASK_ASSESSMENTS = "fields.task.assessments";
   public static final String ASSESSMENT_RECURRENCE = "recurrence";
   // JSON fields in note.text we use
   public static final String NOTE_RECURRENCE = "__recurrence";
@@ -244,8 +243,7 @@ public class PendingAssessmentsHelper {
 
     // Look up periodic assessment definitions for all tasks
     final Map<Task, Set<Recurrence>> taskAssessmentRecurrence = new HashMap<>();
-    addTaskDefinitions(recurrenceSet, taskAssessmentRecurrence, true);
-    addTaskDefinitions(recurrenceSet, taskAssessmentRecurrence, false);
+    addTaskDefinitions(recurrenceSet, taskAssessmentRecurrence);
     logger.trace("taskAssessmentRecurrence={}", taskAssessmentRecurrence);
 
     // Prepare maps of positions and tasks linked to active advisor positions
@@ -334,14 +332,14 @@ public class PendingAssessmentsHelper {
   }
 
   private void addTaskDefinitions(final Set<Recurrence> recurrenceSet,
-      final Map<Task, Set<Recurrence>> taskAssessmentRecurrence, boolean topLevel) {
+      final Map<Task, Set<Recurrence>> taskAssessmentRecurrence) {
     // Look up periodic assessment definitions for all tasks in the dictionary
-    final Set<Recurrence> assessmentRecurrence = getAssessmentRecurrence(recurrenceSet,
-        topLevel ? TASK_TOP_LEVEL_ASSESSMENTS : TASK_SUB_LEVEL_ASSESSMENTS);
+    final Set<Recurrence> assessmentRecurrence =
+        getAssessmentRecurrence(recurrenceSet, TASK_ASSESSMENTS);
 
     if (!assessmentRecurrence.isEmpty()) {
       // Look up periodic assessment definitions for each active task
-      final List<Task> tasks = getActiveTasks(topLevel);
+      final List<Task> tasks = getActiveTasks();
       tasks.forEach(t ->
       // Add all recurrence definitions for this task
       taskAssessmentRecurrence.computeIfAbsent(t, task -> new HashSet<>(assessmentRecurrence)));
@@ -413,12 +411,11 @@ public class PendingAssessmentsHelper {
     return positionDao.search(psq).getList();
   }
 
-  private List<Task> getActiveTasks(boolean topLevel) {
+  private List<Task> getActiveTasks() {
     // Get all active tasks with a non-empty customFields
     final TaskSearchQuery tsq = new TaskSearchQuery();
     tsq.setPageSize(0);
     tsq.setStatus(Position.Status.ACTIVE);
-    tsq.setHasParentTask(!topLevel);
     return taskDao.search(tsq).getList();
   }
 

--- a/src/main/resources/anet-schema.yml
+++ b/src/main/resources/anet-schema.yml
@@ -600,7 +600,7 @@ properties:
       task:
         type: object
         additionalProperties: false
-        required: [status, shortLabel, shortName, longLabel, longName, description, topLevel, subLevel,
+        required: [status, shortLabel, shortName, longLabel, longName, description,
                    projectedCompletion, plannedCompletion, parentTask, childrenTasks,
                    taskedOrganizations, responsiblePositions]
         properties:
@@ -620,25 +620,6 @@ properties:
             "$ref": "#/$defs/inputField"
           description:
             "$ref": "#/$defs/inputField"
-          topLevel:
-            type: object
-            additionalProperties: false
-            required: [shortLabel, shortName, longLabel, longName]
-            properties:
-              shortLabel:
-                "$ref": "#/properties/fields/properties/task/properties/shortLabel"
-              shortName:
-                "$ref": "#/properties/fields/properties/task/properties/shortName"
-              longLabel:
-                "$ref": "#/properties/fields/properties/task/properties/longLabel"
-              longName:
-                "$ref": "#/properties/fields/properties/task/properties/longName"
-              assessments:
-                type: object
-                additionalProperties:
-                  "$ref": "#/$defs/assessmentDef"
-          subLevel:
-            "$ref": "#/properties/fields/properties/task/properties/topLevel"
           projectedCompletion:
             "$ref": "#/$defs/excludableInputField"
           plannedCompletion:
@@ -651,6 +632,10 @@ properties:
             "$ref": "#/$defs/inputField"
           responsiblePositions:
             "$ref": "#/$defs/inputField"
+          assessments:
+            type: object
+            additionalProperties:
+              "$ref": "#/$defs/assessmentDef"
           customFields:
             type: object
             additionalProperties:

--- a/src/main/resources/emails/approvalNeeded.ftlh
+++ b/src/main/resources/emails/approvalNeeded.ftlh
@@ -121,7 +121,7 @@ Dear ${approvalStepName},
 <div class="row">
   <div class="col-xs-12">
     <#-- <a href="${serverUrl}/tasks/${task.uuid}"> -->
-    <strong>${fields.task.subLevel.shortLabel}:</strong> ${(task.longName)!}
+    <strong>${fields.task.shortLabel}:</strong> ${(task.longName)!}
     <#-- </a> -->
   </div>
 </div>

--- a/src/main/resources/emails/emailReport.ftlh
+++ b/src/main/resources/emails/emailReport.ftlh
@@ -417,7 +417,7 @@ ${sender.name} sent you a report from ANET:
     <#assign tasks = report.getTasks()>
     <div>
       <h2 class="legend">
-        <span class="title-text">${fields.task.subLevel.longLabel}</span>
+        <span class="title-text">${fields.task.longLabel}</span>
       </h2>
       <fieldset>
         <table class="table">

--- a/src/main/resources/emails/rollup.ftlh
+++ b/src/main/resources/emails/rollup.ftlh
@@ -145,7 +145,7 @@ a {
     <div class="row">
         <div class="col-xs-12">
             <#-- <a href="${serverUrl}/tasks/${task.uuid}"> -->
-                <strong>${fields.task.subLevel.shortLabel}:</strong> ${(task.shortName)!} ${(task.longName)!}
+                <strong>${fields.task.shortLabel}:</strong> ${(task.shortName)!} ${(task.longName)!}
             <#-- </a> -->
         </div>
     </div>

--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -5822,4 +5822,17 @@
 		</createIndex>
 	</changeSet>
 
+	<changeSet id="update-task-assessmentKey" author="gjvoosten">
+		<sql>
+			UPDATE notes
+			SET "assessmentKey" = regexp_replace("assessmentKey", '\.topLevel\.', '.')
+			WHERE "assessmentKey" LIKE 'fields.task.topLevel.assessments.%';
+
+			UPDATE notes
+			SET "assessmentKey" = regexp_replace("assessmentKey", '\.subLevel\.', '.')
+			WHERE "assessmentKey" LIKE 'fields.task.subLevel.assessments.%';
+		</sql>
+		<!-- Rolling back is not useful anymore -->
+	</changeSet>
+
 </databaseChangeLog>

--- a/src/test/java/mil/dds/anet/test/resources/NoteResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/NoteResourceTest.java
@@ -59,12 +59,12 @@ public class NoteResourceTest extends AbstractResourceTest {
 
   // The authorization groups defined in the dictionary give Erin read access and Jack write access;
   // these test objects can be used for the assessments authorization tests
-  // Top-level task EF 2
-  private static final String TEST_TOPTASK_UUID = "cd35abe7-a5c9-4b3e-885b-4c72bf564ed7";
-  // Sub-level task 2.B
-  private static final String TEST_SUBTASK_UUID = "2200a820-c4c7-4c9c-946c-f0c9c9e045c5";
-  // Sub-level task 1.2.A, Andrew is responsible
-  private static final String TEST_RESPONSIBLE_TASK_UUID = "953e0b0b-25e6-44b6-bc77-ef98251d046a";
+  // Task EF 2
+  private static final String TEST_TASK_EF2_UUID = "cd35abe7-a5c9-4b3e-885b-4c72bf564ed7";
+  // Task 2.B
+  private static final String TEST_TASK_2B_UUID = "2200a820-c4c7-4c9c-946c-f0c9c9e045c5";
+  // Task 1.2.A, Andrew is responsible
+  private static final String TEST_TASK_12A_UUID = "953e0b0b-25e6-44b6-bc77-ef98251d046a";
   // Person Christopf, Erin is counterpart
   private static final String TEST_COUNTERPART_PERSON_UUID = "237e8bf7-2ae4-4d49-b7c8-eca6a92d4767";
   // Report "Discuss improvements in Annual Budgeting process"
@@ -291,7 +291,7 @@ public class NoteResourceTest extends AbstractResourceTest {
     invalidNoteInput.setAssessmentKey("unknown");
     failNoteCreate(jackUser, invalidNoteInput);
     // Assessment without text
-    invalidNoteInput.setAssessmentKey("fields.task.subLevel.assessments.subTaskOnceReport");
+    invalidNoteInput.setAssessmentKey("fields.task.assessments.taskOnceReport");
     failNoteCreate(jackUser, invalidNoteInput);
     // Assessment with different recurrence from dictionary key
     invalidNoteInput.setText(createAssessmentText("test", "ondemand"));
@@ -395,7 +395,7 @@ public class NoteResourceTest extends AbstractResourceTest {
   void testInstantPersonAssessments() {
     // Instant ('once') ASSESSMENT note tests for person through the NoteResource methods
     testInstantAssessments("testInstantPersonAssessments",
-        "fields.regular.person.assessments.personOnceReportLinguist", true, TEST_SUBTASK_UUID);
+        "fields.regular.person.assessments.personOnceReportLinguist", true, TEST_TASK_2B_UUID);
   }
 
   @Test
@@ -403,7 +403,7 @@ public class NoteResourceTest extends AbstractResourceTest {
     // Instant ('once') ASSESSMENT note tests for person through the NoteResource methods, with
     // empty write authorization groups defined in the dictionary
     testInstantAssessmentsEmptyWriteAuthGroups("testInstantPersonAssessmentsNoAuthGroups",
-        "fields.regular.person.assessments.advisorOnceReportNoWrite", true, TEST_SUBTASK_UUID);
+        "fields.regular.person.assessments.advisorOnceReportNoWrite", true, TEST_TASK_2B_UUID);
   }
 
   @Test
@@ -411,7 +411,7 @@ public class NoteResourceTest extends AbstractResourceTest {
     // Instant ('once') ASSESSMENT note tests for person through the NoteResource methods, with no
     // authorization groups defined in the dictionary
     testInstantAssessmentsNoAuthGroups("testInstantPersonAssessmentsNoAuthGroups",
-        "fields.regular.person.assessments.interlocutorOnceReport", true, TEST_SUBTASK_UUID);
+        "fields.regular.person.assessments.interlocutorOnceReport", true, TEST_TASK_2B_UUID);
   }
 
   @Test
@@ -419,7 +419,7 @@ public class NoteResourceTest extends AbstractResourceTest {
     // Instant ('once') ASSESSMENT note tests for person through
     // ReportResource::updateReportAssessments
     testInstantAssessmentsViaReport("testInstantPersonAssessmentsViaReport",
-        "fields.regular.person.assessments.personOnceReportLinguist", true, TEST_SUBTASK_UUID);
+        "fields.regular.person.assessments.personOnceReportLinguist", true, TEST_TASK_2B_UUID);
   }
 
   @Test
@@ -428,7 +428,7 @@ public class NoteResourceTest extends AbstractResourceTest {
     // ReportResource::updateReportAssessments, with empty write authorization groups defined in the
     // dictionary
     testInstantAssessmentsViaReportEmptyWriteAuthGroups("testInstantPersonAssessmentsNoAuthGroups",
-        "fields.regular.person.assessments.advisorOnceReportNoWrite", true, TEST_SUBTASK_UUID);
+        "fields.regular.person.assessments.advisorOnceReportNoWrite", true, TEST_TASK_2B_UUID);
   }
 
   @Test
@@ -437,14 +437,14 @@ public class NoteResourceTest extends AbstractResourceTest {
     // ReportResource::updateReportAssessments, with no authorization groups defined in the
     // dictionary
     testInstantAssessmentsViaReportNoAuthGroups("testInstantPersonAssessmentsNoAuthGroups",
-        "fields.regular.person.assessments.interlocutorOnceReport", true, TEST_SUBTASK_UUID);
+        "fields.regular.person.assessments.interlocutorOnceReport", true, TEST_TASK_2B_UUID);
   }
 
   @Test
   void testInstantTaskAssessments() {
     // Instant ('once') ASSESSMENT note tests for task through the NoteResource methods
     testInstantAssessments("testInstantTaskAssessments",
-        "fields.task.topLevel.assessments.topTaskOnceReport", false, TEST_TOPTASK_UUID);
+        "fields.task.assessments.taskOnceReportRestricted", false, TEST_TASK_EF2_UUID);
   }
 
   @Test
@@ -452,7 +452,7 @@ public class NoteResourceTest extends AbstractResourceTest {
     // Instant ('once') ASSESSMENT note tests for task through the NoteResource methods, with empty
     // write authorization groups defined in the dictionary
     testInstantAssessmentsEmptyWriteAuthGroups("testInstantTaskAssessmentsNoAuthGroups",
-        "fields.task.topLevel.assessments.topTaskOnceReportNoWrite", false, TEST_SUBTASK_UUID);
+        "fields.task.assessments.taskOnceReportNoWrite", false, TEST_TASK_2B_UUID);
   }
 
   @Test
@@ -460,7 +460,7 @@ public class NoteResourceTest extends AbstractResourceTest {
     // Instant ('once') ASSESSMENT note tests for task through the NoteResource methods, with no
     // authorization groups defined in the dictionary
     testInstantAssessmentsNoAuthGroups("testInstantTaskAssessmentsNoAuthGroups",
-        "fields.task.subLevel.assessments.subTaskOnceReport", false, TEST_SUBTASK_UUID);
+        "fields.task.assessments.taskOnceReport", false, TEST_TASK_2B_UUID);
   }
 
   @Test
@@ -468,7 +468,7 @@ public class NoteResourceTest extends AbstractResourceTest {
     // Instant ('once') ASSESSMENT note tests for task through
     // ReportResource::updateReportAssessments
     testInstantAssessmentsViaReport("testInstantTaskAssessmentsViaReport",
-        "fields.task.topLevel.assessments.topTaskOnceReport", false, TEST_TOPTASK_UUID);
+        "fields.task.assessments.taskOnceReportRestricted", false, TEST_TASK_EF2_UUID);
   }
 
   @Test
@@ -478,7 +478,7 @@ public class NoteResourceTest extends AbstractResourceTest {
     // dictionary
     testInstantAssessmentsViaReportEmptyWriteAuthGroups(
         "testInstantTaskAssessmentsViaReportNoAuthGroups",
-        "fields.task.topLevel.assessments.topTaskOnceReportNoWrite", false, TEST_SUBTASK_UUID);
+        "fields.task.assessments.taskOnceReportNoWrite", false, TEST_TASK_2B_UUID);
   }
 
   @Test
@@ -487,7 +487,7 @@ public class NoteResourceTest extends AbstractResourceTest {
     // ReportResource::updateReportAssessments, with no authorization groups defined in the
     // dictionary
     testInstantAssessmentsViaReportNoAuthGroups("testInstantTaskAssessmentsViaReportNoAuthGroups",
-        "fields.task.subLevel.assessments.subTaskOnceReport", false, TEST_SUBTASK_UUID);
+        "fields.task.assessments.taskOnceReport", false, TEST_TASK_2B_UUID);
   }
 
   @Test
@@ -509,7 +509,7 @@ public class NoteResourceTest extends AbstractResourceTest {
 
     // - F: create for a task
     final GenericRelatedObjectInput testTaskNroInput =
-        createNoteRelatedObject(TaskDao.TABLE_NAME, TEST_SUBTASK_UUID);
+        createNoteRelatedObject(TaskDao.TABLE_NAME, TEST_TASK_2B_UUID);
     testNoteInputFail = createAssessment(assessmentKey, "test", recurrence, testTaskNroInput);
     failNoteCreate(jackUser, testNoteInputFail);
 
@@ -883,7 +883,7 @@ public class NoteResourceTest extends AbstractResourceTest {
   @Test
   void testPeriodicTaskAssessments() {
     // Periodic ASSESSMENT note tests for task
-    final String assessmentKey = "fields.task.topLevel.assessments.topTaskSemiannually";
+    final String assessmentKey = "fields.task.assessments.taskSemiannuallyRestricted";
     final String recurrence = "semiannually";
     final Person taskResponsible = getAndrewAnderson();
 
@@ -899,7 +899,7 @@ public class NoteResourceTest extends AbstractResourceTest {
 
     // - F: create for a report and a task
     final GenericRelatedObjectInput testTaskNroInput =
-        createNoteRelatedObject(TaskDao.TABLE_NAME, TEST_RESPONSIBLE_TASK_UUID);
+        createNoteRelatedObject(TaskDao.TABLE_NAME, TEST_TASK_12A_UUID);
     testNoteInputFail =
         createAssessment(assessmentKey, "test", recurrence, testReportNroInput, testTaskNroInput);
     failNoteCreate(taskResponsible.getDomainUsername(), testNoteInputFail);
@@ -928,17 +928,17 @@ public class NoteResourceTest extends AbstractResourceTest {
 
     // - F: read it as someone not in the read and write auth.groups
     final Task bobTask = withCredentials(getBobBobtown().getDomainUsername(),
-        t -> queryExecutor.task(TASK_FIELDS, TEST_RESPONSIBLE_TASK_UUID));
+        t -> queryExecutor.task(TASK_FIELDS, TEST_TASK_12A_UUID));
     assertNotes(bobTask.getNotes(), Collections.emptyList(), assessmentKey, 1);
 
     // - S: read it as someone in the read auth.groups
     final Task erinTask = withCredentials(getRegularUser().getDomainUsername(),
-        t -> queryExecutor.task(TASK_FIELDS, TEST_RESPONSIBLE_TASK_UUID));
+        t -> queryExecutor.task(TASK_FIELDS, TEST_TASK_12A_UUID));
     assertNotes(erinTask.getNotes(), testNoteInputs, assessmentKey, 1);
 
     // - S: read it as admin
-    final Task adminTask = withCredentials(adminUser,
-        t -> queryExecutor.task(TASK_FIELDS, TEST_RESPONSIBLE_TASK_UUID));
+    final Task adminTask =
+        withCredentials(adminUser, t -> queryExecutor.task(TASK_FIELDS, TEST_TASK_12A_UUID));
     assertNotes(adminTask.getNotes(), testNoteInputs, assessmentKey, 1);
 
     // - S: update it as someone with task permission not in the write auth.groups
@@ -974,7 +974,7 @@ public class NoteResourceTest extends AbstractResourceTest {
     assertThat(updatedNotesInput.remove(updatedNoteInput)).isTrue();
     assertNotes(
         withCredentials(getRegularUser().getDomainUsername(),
-            t -> queryExecutor.task(TASK_FIELDS, TEST_RESPONSIBLE_TASK_UUID)).getNotes(),
+            t -> queryExecutor.task(TASK_FIELDS, TEST_TASK_12A_UUID)).getNotes(),
         updatedNotesInput, assessmentKey, 1);
 
     // - S: delete it as someone without task permission in the write auth.groups
@@ -983,7 +983,7 @@ public class NoteResourceTest extends AbstractResourceTest {
     assertThat(updatedNotesInput.remove(updatedNoteInputAdmin)).isTrue();
     assertNotes(
         withCredentials(getRegularUser().getDomainUsername(),
-            t -> queryExecutor.task(TASK_FIELDS, TEST_RESPONSIBLE_TASK_UUID)).getNotes(),
+            t -> queryExecutor.task(TASK_FIELDS, TEST_TASK_12A_UUID)).getNotes(),
         updatedNotesInput, assessmentKey, 1);
 
     // - S: delete it as admin
@@ -991,7 +991,7 @@ public class NoteResourceTest extends AbstractResourceTest {
     assertThat(updatedNotesInput.remove(updatedNoteInputJack)).isTrue();
     assertNotes(
         withCredentials(getRegularUser().getDomainUsername(),
-            t -> queryExecutor.task(TASK_FIELDS, TEST_RESPONSIBLE_TASK_UUID)).getNotes(),
+            t -> queryExecutor.task(TASK_FIELDS, TEST_TASK_12A_UUID)).getNotes(),
         updatedNotesInput, assessmentKey, 1);
   }
 
@@ -999,14 +999,14 @@ public class NoteResourceTest extends AbstractResourceTest {
   void testPeriodicTaskAssessmentsEmptyWriteAuthGroups() {
     // Periodic ASSESSMENT note tests for task, with empty write authorization groups defined in the
     // dictionary
-    final String assessmentKey = "fields.task.topLevel.assessments.topTaskSemiannuallyNoWrite";
+    final String assessmentKey = "fields.task.assessments.taskSemiannuallyNoWrite";
     final String recurrence = "semiannually";
     final Person taskResponsible = getAndrewAnderson();
 
     // - F: create for a task as someone without task permission and empty write auth.groups defined
     // in the dictionary
     final GenericRelatedObjectInput testTaskNroInput =
-        createNoteRelatedObject(TaskDao.TABLE_NAME, TEST_RESPONSIBLE_TASK_UUID);
+        createNoteRelatedObject(TaskDao.TABLE_NAME, TEST_TASK_12A_UUID);
     final NoteInput testNoteInputFail =
         createAssessment(assessmentKey, "erin", recurrence, testTaskNroInput);
     failNoteCreate("erin", testNoteInputFail);
@@ -1020,7 +1020,7 @@ public class NoteResourceTest extends AbstractResourceTest {
 
     // - S: read it with no read auth.groups defined in the dictionary
     final Task erinTask = withCredentials(getRegularUser().getDomainUsername(),
-        t -> queryExecutor.task(TASK_FIELDS, TEST_RESPONSIBLE_TASK_UUID));
+        t -> queryExecutor.task(TASK_FIELDS, TEST_TASK_12A_UUID));
     assertNotes(erinTask.getNotes(), testNoteInputs, assessmentKey, 1);
 
     // - F: update it as someone without task permission and with empty write auth.groups defined in
@@ -1047,7 +1047,7 @@ public class NoteResourceTest extends AbstractResourceTest {
     assertThat(updatedNotesInput.remove(updatedNoteInput)).isTrue();
     assertNotes(
         withCredentials(getRegularUser().getDomainUsername(),
-            t -> queryExecutor.task(TASK_FIELDS, TEST_RESPONSIBLE_TASK_UUID)).getNotes(),
+            t -> queryExecutor.task(TASK_FIELDS, TEST_TASK_12A_UUID)).getNotes(),
         updatedNotesInput, assessmentKey, 1);
   }
 
@@ -1055,13 +1055,13 @@ public class NoteResourceTest extends AbstractResourceTest {
   void testPeriodicTaskAssessmentsNoAuthGroups() {
     // Periodic ASSESSMENT note tests for task, with no authorization groups defined in the
     // dictionary
-    final String assessmentKey = "fields.task.subLevel.assessments.subTaskMonthly";
+    final String assessmentKey = "fields.task.assessments.taskMonthly";
     final String recurrence = "monthly";
 
     // - S: create for a task as someone without task permission and no auth.groups defined in
     // the dictionary
     final GenericRelatedObjectInput testTaskNroInput =
-        createNoteRelatedObject(TaskDao.TABLE_NAME, TEST_RESPONSIBLE_TASK_UUID);
+        createNoteRelatedObject(TaskDao.TABLE_NAME, TEST_TASK_12A_UUID);
     final NoteInput testNoteInput =
         createAssessment(assessmentKey, "erin", recurrence, testTaskNroInput);
     final List<NoteInput> testNoteInputs = Lists.newArrayList(testNoteInput);
@@ -1069,7 +1069,7 @@ public class NoteResourceTest extends AbstractResourceTest {
 
     // - S: read it with no auth.groups defined in the dictionary
     final Task erinTask = withCredentials(getRegularUser().getDomainUsername(),
-        t -> queryExecutor.task(TASK_FIELDS, TEST_RESPONSIBLE_TASK_UUID));
+        t -> queryExecutor.task(TASK_FIELDS, TEST_TASK_12A_UUID));
     assertNotes(erinTask.getNotes(), testNoteInputs, assessmentKey, 1);
 
     // - S: update it as someone without task permission and with no auth.groups defined in
@@ -1086,7 +1086,7 @@ public class NoteResourceTest extends AbstractResourceTest {
     assertThat(updatedNotesInput.remove(updatedNoteInput)).isTrue();
     assertNotes(
         withCredentials(getRegularUser().getDomainUsername(),
-            t -> queryExecutor.task(TASK_FIELDS, TEST_RESPONSIBLE_TASK_UUID)).getNotes(),
+            t -> queryExecutor.task(TASK_FIELDS, TEST_TASK_12A_UUID)).getNotes(),
         updatedNotesInput, assessmentKey, 1);
   }
 

--- a/testDictionaries/no-custom-fields.yml
+++ b/testDictionaries/no-custom-fields.yml
@@ -51,245 +51,228 @@ classification:
 fields:
 
   task:
+    shortLabel: Objective
+    longLabel: Objectives
     status:
       label: Status
-    shortLabel: Objective / Effort
     shortName:
-      label: Objective / Effort number
-      placeholder: Enter an objective / effort name, example …
-    longLabel: Objectives and Efforts
+      label: Short name
+      placeholder: Primary name or abbreviation
     longName:
-      label: Objective / Effort long name
-      placeholder: Enter an objective / effort long name, example …
+      label: Long name
+      placeholder: Full form name of objective
+      asA: textarea
     description:
-      label: Objective / Effort description
-      placeholder: Fill in the description of this objective / effort
-    topLevel:
-      shortLabel: Objective
-      shortName:
-        label: Name of this Objective
-        placeholder: Enter a Name for this Objective name, example …
-      longLabel: Objectives
-      longName:
-        label: Long Name of this Objective
-        placeholder: Enter a long name for this Objective, example …
-      assessments:
-        topTaskOnceReport:
-          label: Engagement assessment of objective
-          recurrence: once
-          relatedObjectType: report
-          authorizationGroupUuids:
-            read: ['c21e7321-7ec5-4837-8805-a302f9575754']
-            write: ['39a78d51-c351-452c-9206-4305ec8dd76d']
-          questions:
-            question1:
-              type: special_field
-              widget: likertScale
-              label: Instant assessment Question 1
-              helpText: Please provide assessment for something important
-              levels:
-                - color: red
-                  endValue: 2
-                  label: test
-                - color: "#FFBF00"
-                  endValue: 8
-                  label: mid
-                - color: green
-                  endValue: 10
-                  label: high
-              aggregation:
-                widget: likertScale
-            question2:
-              type: number
-              label: Instant assessment Question 2
-            question3:
-              type: number
-              label: Instant assessment Question 3
-        topTaskSemiannually:
-          label: Semi-annual assessment of objective
-          recurrence: semiannually
-          test: $.subject[?(@property === "shortName" && @.match(/^EF/i))]
-          authorizationGroupUuids:
-            read: ['c21e7321-7ec5-4837-8805-a302f9575754']
-            write: ['39a78d51-c351-452c-9206-4305ec8dd76d']
-          questions:
-            issues:
-              type: special_field
-              label: Top 3 issues
-              placeholder: Enter the top 3 issues
-              widget: richTextEditor
-              style:
-                height: 300px
-              validations:
-                - type: required
-                  params: [You must provide the Top 3 issues]
-        topTaskSemiannuallyNoWrite:
-          label: Semi-annual assessment of objective, no write
-          recurrence: semiannually
-          test: $.subject[?(@property === "noSuchProperty" && @.match(/^willNeverMatch/i))]
-          authorizationGroupUuids:
-            write: []
-          questions:
-            question1:
-              type: number
-              label: Test Question 1
-        topTaskOnceReportNoWrite:
-          label: Engagement assessment of objective, no write
-          recurrence: once
-          relatedObjectType: report
-          test: $.subject[?(@property === "noSuchProperty" && @.match(/^willNeverMatch/i))]
-          authorizationGroupUuids:
-            write: []
-          questions:
-            question1:
-              type: number
-              label: Test Question 1
+      label: Objective description
+      placeholder: Description of this objective
 
-    subLevel:
-      shortLabel: Effort
-      shortName:
-        label: Effort name
-        placeholder: Enter an effort name, example …
-      longLabel: Efforts
-      longName:
-        label: Effort Long Name
-        placeholder: Enter an effort Long Name, example …
-      assessments:
-        subTaskMonthly:
-          label: Monthly assessment of effort
-          recurrence: monthly
-          allowFutureAssessments: true
-          questions:
-            requiredButFilteredOutQuestion:
-              test: $.subject[?(@property === "noSuchProperty" && @.match(/^willNeverMatch/i))]
-              type: text
-              label: This question is required but will be filtered out
-              validations:
-                - type: required
-                  params: [You must provide the answer to subTaskMonthly.requiredButFilteredOutQuestion]
-            questionFor11B:
-              test: $.subject[?(@property === "shortName" && @ === "1.1.B")]
-              type: text
-              label: This question applies only to 1.1.B
-              validations:
-                - type: required
-                  params: [You must provide the answer to subTaskMonthly.questionFor11B]
-            issues:
-              type: special_field
-              label: Top 3 issues
-              placeholder: Enter the top 3 issues
-              widget: richTextEditor
-              style:
-                height: 300px
-              validations:
-                - type: required
-                  params: [You must provide the Top 3 issues]
-            status:
-              type: enum
-              label: Project status
-              helpText: Select an assessment status for objective
-              choices:
-                GREEN:
-                  label: Green
-                  color: '#c2ffb3'
-                AMBER:
-                  label: Amber
-                  color: '#ffe396'
-                RED:
-                  label: Red
-                  color: '#ff8279'
-              validations:
-                - type: required
-                  params: [You must provide the Project status]
-        subTaskWeekly:
-          label: Weekly assessment of effort
-          recurrence: weekly
-          questions:
-            issues:
-              type: special_field
-              label: Top 3 issues
-              placeholder: Enter the top 3 issues
-              widget: richTextEditor
-              style:
-                height: 300px
-              validations:
-                - type: required
-                  params: [You must provide the Top 3 issues]
-        subTaskOnceReport:
-          label: Engagement assessment of effort
-          recurrence: once
-          relatedObjectType: report
-          questions:
-            requiredButFilteredOutQuestion:
-              test: $.subject[?(@property === "noSuchProperty" && @.match(/^willNeverMatch/i))]
-              type: text
-              label: This question is required but will be filtered out
-              validations:
-                - type: required
-                  params: [You must provide the answer to subTaskOnceReport.requiredButFilteredOutQuestion]
-            questionFor11B:
-              test: $.subject[?(@property === "shortName" && @ === "1.1.B")]
-              type: text
-              label: This question applies only to 1.1.B
-              validations:
-                - type: required
-                  params: [You must provide the answer to subTaskOnceReport.questionFor11B]
-            questionForNegative:
-              test: $.relatedObject[?(@property === "atmosphere" && @ === "NEGATIVE")]
-              type: text
-              label: This question applies only to Negative engagements
-              validations:
-                - type: required
-                  params: [You must provide the answer to subTaskOnceReport.questionForNegative]
-            question1:
-              type: special_field
+    assessments:
+      taskOnceReportRestricted:
+        label: Engagement assessment of objective
+        recurrence: once
+        relatedObjectType: report
+        authorizationGroupUuids:
+          read: ['c21e7321-7ec5-4837-8805-a302f9575754']
+          write: ['39a78d51-c351-452c-9206-4305ec8dd76d']
+        questions:
+          question1:
+            type: special_field
+            widget: likertScale
+            label: Instant assessment Question 1
+            helpText: Please provide assessment for something important
+            levels:
+              - color: red
+                endValue: 2
+                label: test
+              - color: "#FFBF00"
+                endValue: 8
+                label: mid
+              - color: green
+                endValue: 10
+                label: high
+            aggregation:
               widget: likertScale
-              label: Instant assessment Question 1
-              helpText: Please provide assessment for something important
-              levels:
-                - color: red
-                  endValue: 2
-                  label: test
-                - color: "#FFBF00"
-                  endValue: 8
-                  label: mid
-                - color: green
-                  endValue: 10
-                  label: high
-              aggregation:
-                widget: likertScale
-            question2:
-              type: number
-              label: Instant assessment Question 2
-            question3:
-              type: number
-              label: Instant assessment Question 3
-        subTask11COnceReport:
-          label: Engagement assessment of effort 1.1.C
-          recurrence: once
-          relatedObjectType: report
-          test: $.subject[?(@property === "shortName" && @ === "1.1.C")]
-          questions:
-            requiredButFilteredOutQuestion:
-              test: $.subject[?(@property === "noSuchProperty" && @.match(/^willNeverMatch/i))]
-              type: text
-              label: This question is required but will be filtered out
-              validations:
-                - type: required
-                  params: [You must provide the answer to subTask11COnceReport.requiredButFilteredOutQuestion]
-            requiredQuestion:
-              type: text
-              label: This question is required
-              validations:
-                - type: required
-                  params: [You must provide the answer to subTask11COnceReport.requiredQuestion]
-            questionForNegative:
-              test: $.relatedObject[?(@property === "atmosphere" && @ === "NEGATIVE")]
-              type: text
-              label: This question applies only to Negative engagements
-              validations:
-                - type: required
-                  params: [You must provide the answer to subTask11COnceReport.questionForNegative]
+          question2:
+            type: number
+            label: Instant assessment Question 2
+          question3:
+            type: number
+            label: Instant assessment Question 3
+      taskSemiannuallyRestricted:
+        label: Semi-annual assessment of objective
+        recurrence: semiannually
+        test: $.subject[?(@property === "shortName" && @.match(/^EF/i))]
+        authorizationGroupUuids:
+          read: ['c21e7321-7ec5-4837-8805-a302f9575754']
+          write: ['39a78d51-c351-452c-9206-4305ec8dd76d']
+        questions:
+          issues:
+            type: special_field
+            label: Top 3 issues
+            placeholder: Enter the top 3 issues
+            widget: richTextEditor
+            style:
+              height: 300px
+            validations:
+              - type: required
+                params: [You must provide the Top 3 issues]
+      taskSemiannuallyNoWrite:
+        label: Semi-annual assessment of objective, no write
+        recurrence: semiannually
+        test: $.subject[?(@property === "noSuchProperty" && @.match(/^willNeverMatch/i))]
+        authorizationGroupUuids:
+          write: []
+        questions:
+          question1:
+            type: number
+            label: Test Question 1
+      taskOnceReportNoWrite:
+        label: Engagement assessment of objective, no write
+        recurrence: once
+        relatedObjectType: report
+        test: $.subject[?(@property === "noSuchProperty" && @.match(/^willNeverMatch/i))]
+        authorizationGroupUuids:
+          write: []
+        questions:
+          question1:
+            type: number
+            label: Test Question 1
+
+      taskMonthly:
+        label: Monthly assessment of objective
+        recurrence: monthly
+        allowFutureAssessments: true
+        questions:
+          requiredButFilteredOutQuestion:
+            test: $.subject[?(@property === "noSuchProperty" && @.match(/^willNeverMatch/i))]
+            type: text
+            label: This question is required but will be filtered out
+            validations:
+              - type: required
+                params: [You must provide the answer to taskMonthly.requiredButFilteredOutQuestion]
+          questionFor11B:
+            test: $.subject[?(@property === "shortName" && @ === "1.1.B")]
+            type: text
+            label: This question applies only to 1.1.B
+            validations:
+              - type: required
+                params: [You must provide the answer to taskMonthly.questionFor11B]
+          issues:
+            type: special_field
+            label: Top 3 issues
+            placeholder: Enter the top 3 issues
+            widget: richTextEditor
+            style:
+              height: 300px
+            validations:
+              - type: required
+                params: [You must provide the Top 3 issues]
+          status:
+            type: enum
+            label: Project status
+            helpText: Select an assessment status for objective
+            choices:
+              GREEN:
+                label: Green
+                color: '#c2ffb3'
+              AMBER:
+                label: Amber
+                color: '#ffe396'
+              RED:
+                label: Red
+                color: '#ff8279'
+            validations:
+              - type: required
+                params: [You must provide the Project status]
+      taskWeekly:
+        label: Weekly assessment of objective
+        recurrence: weekly
+        questions:
+          issues:
+            type: special_field
+            label: Top 3 issues
+            placeholder: Enter the top 3 issues
+            widget: richTextEditor
+            style:
+              height: 300px
+            validations:
+              - type: required
+                params: [You must provide the Top 3 issues]
+      taskOnceReport:
+        label: Engagement assessment of objective
+        recurrence: once
+        relatedObjectType: report
+        questions:
+          requiredButFilteredOutQuestion:
+            test: $.subject[?(@property === "noSuchProperty" && @.match(/^willNeverMatch/i))]
+            type: text
+            label: This question is required but will be filtered out
+            validations:
+              - type: required
+                params: [You must provide the answer to taskOnceReport.requiredButFilteredOutQuestion]
+          questionFor11B:
+            test: $.subject[?(@property === "shortName" && @ === "1.1.B")]
+            type: text
+            label: This question applies only to 1.1.B
+            validations:
+              - type: required
+                params: [You must provide the answer to taskOnceReport.questionFor11B]
+          questionForNegative:
+            test: $.relatedObject[?(@property === "atmosphere" && @ === "NEGATIVE")]
+            type: text
+            label: This question applies only to Negative engagements
+            validations:
+              - type: required
+                params: [You must provide the answer to taskOnceReport.questionForNegative]
+          question1:
+            type: special_field
+            widget: likertScale
+            label: Instant assessment Question 1
+            helpText: Please provide assessment for something important
+            levels:
+              - color: red
+                endValue: 2
+                label: test
+              - color: "#FFBF00"
+                endValue: 8
+                label: mid
+              - color: green
+                endValue: 10
+                label: high
+            aggregation:
+              widget: likertScale
+          question2:
+            type: number
+            label: Instant assessment Question 2
+          question3:
+            type: number
+            label: Instant assessment Question 3
+      task11COnceReport:
+        label: Engagement assessment of objective 1.1.C
+        recurrence: once
+        relatedObjectType: report
+        test: $.subject[?(@property === "shortName" && @ === "1.1.C")]
+        questions:
+          requiredButFilteredOutQuestion:
+            test: $.subject[?(@property === "noSuchProperty" && @.match(/^willNeverMatch/i))]
+            type: text
+            label: This question is required but will be filtered out
+            validations:
+              - type: required
+                params: [You must provide the answer to task11COnceReport.requiredButFilteredOutQuestion]
+          requiredQuestion:
+            type: text
+            label: This question is required
+            validations:
+              - type: required
+                params: [You must provide the answer to task11COnceReport.requiredQuestion]
+          questionForNegative:
+            test: $.relatedObject[?(@property === "atmosphere" && @ === "NEGATIVE")]
+            type: text
+            label: This question applies only to Negative engagements
+            validations:
+              - type: required
+                params: [You must provide the answer to task11COnceReport.questionForNegative]
 
     projectedCompletion:
       label: Projected Completion
@@ -298,10 +281,10 @@ fields:
       label: Planned Completion
       exclude: true
     parentTask:
-      label: Parent objective / effort
-      placeholder: Start typing to search for a higher level objective / effort
+      label: Parent objective
+      placeholder: Start typing to search for a higher level objective
     childrenTasks:
-      label: Sub efforts
+      label: Sub objectives
     taskedOrganizations:
       label: Tasked organizations
       placeholder: Search for an organization…


### PR DESCRIPTION
Drop the distinction between topLevel and subLevel tasks in the dictionary.

Closes [AB#855](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/855)

#### User changes
- None.

#### Superuser changes
- None.

#### Admin changes
- None.

#### System admin changes
- [x] anet.yml or anet-dictionary.yml needs change
  If before you had something like this in your dictionary:
  ```yaml
  fields:
    task:
      status:
        label: Status
      description:
        label: Objective / Effort description
        placeholder: Fill in the description of this objective / effort
      shortLabel: Objective / Effort
      longLabel: Objectives and Efforts
      shortName:
        label: Objective / Effort number
        placeholder: Enter an objective / effort name, example …
      longName:
        label: Objective / Effort long name
        placeholder: Enter an objective / effort long name, example …

      topLevel:
        shortLabel: Objective
        longLabel: Objectives
        shortName:
          label: Name of this Objective
          placeholder: Enter a Name for this Objective name, example …
        longName:
          label: Long Name of this Objective
          placeholder: Enter a long name for this Objective, example …
          asA: textarea

      subLevel:
        shortLabel: Effort
        longLabel: Efforts
        shortName:
          label: Effort name
          placeholder: Enter an effort name, example …
        longName:
          label: Effort Long Name
          placeholder: Enter an effort Long Name, example …
          asA: textarea

        assessments:
          assessmentDefinitionOne:
            …
          assessmentDefinitionTwo:
            …
  ```
  you should change that to:
  ```yaml
  fields:
    task:
      shortLabel: Objective
      longLabel: Objectives
      status:
        label: Status
      description:
        label: Objective description
        placeholder: Description of this objective
      shortName:
        label: Short name
        placeholder: Primary name or abbreviation
      longName:
        label: Long name
        placeholder: Full form name of objective
        asA: textarea

      assessments:
        assessmentDefinitionOne:
          …
        assessmentDefinitionTwo:
          …
  ```
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [x] Added and/or updated unit tests
  - [x] Added and/or updated e2e tests
  - [x] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
