### PR TITLE
Add 2- and 3-letter code fields to location merge

### DIFF
--- a/client/src/pages/admin/merge/MergeLocations.js
+++ b/client/src/pages/admin/merge/MergeLocations.js
@@ -230,6 +230,30 @@ const MergeLocations = ({ pageDispatchers }) => {
                 mergeState={mergeState}
                 dispatchMergeActions={dispatchMergeActions}
               />
+              <DictionaryField
+                wrappedComponent={MergeField}
+                dictProps={Settings.fields.location.digram}
+                value={mergedLocation.digram}
+                align={ALIGN_OPTIONS.CENTER}
+                action={getClearButton(() =>
+                  dispatchMergeActions(setAMergedField("digram", "", null))
+                )}
+                fieldName="digram"
+                mergeState={mergeState}
+                dispatchMergeActions={dispatchMergeActions}
+              />
+              <DictionaryField
+                wrappedComponent={MergeField}
+                dictProps={Settings.fields.location.trigram}
+                value={mergedLocation.trigram}
+                align={ALIGN_OPTIONS.CENTER}
+                action={getClearButton(() =>
+                  dispatchMergeActions(setAMergedField("trigram", "", null))
+                )}
+                fieldName="trigram"
+                mergeState={mergeState}
+                dispatchMergeActions={dispatchMergeActions}
+              />
               <MergeField
                 label="Planning Approval Steps"
                 fieldName="planningApprovalSteps"
@@ -527,6 +551,44 @@ const LocationColumn = ({
               align,
               mergeState,
               "description"
+            )}
+            mergeState={mergeState}
+            dispatchMergeActions={dispatchMergeActions}
+          />
+          <DictionaryField
+            wrappedComponent={MergeField}
+            dictProps={Settings.fields.location.digram}
+            fieldName="digram"
+            value={location.digram}
+            align={align}
+            action={getActionButton(
+              () => {
+                dispatchMergeActions(
+                  setAMergedField("digram", location.digram, align)
+                )
+              },
+              align,
+              mergeState,
+              "digram"
+            )}
+            mergeState={mergeState}
+            dispatchMergeActions={dispatchMergeActions}
+          />
+          <DictionaryField
+            wrappedComponent={MergeField}
+            dictProps={Settings.fields.location.trigram}
+            fieldName="trigram"
+            value={location.trigram}
+            align={align}
+            action={getActionButton(
+              () => {
+                dispatchMergeActions(
+                  setAMergedField("trigram", location.trigram, align)
+                )
+              },
+              align,
+              mergeState,
+              "trigram"
             )}
             mergeState={mergeState}
             dispatchMergeActions={dispatchMergeActions}


### PR DESCRIPTION
Location merge allows selections of 2- and 3-letter codes.

Closes [AB#1110](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1110)

#### User changes
- None

#### Superuser changes
- None

#### Admin changes
- Admin can select 2- and 3-letter codes when merging locations.

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [ ] Referenced/updated all related issues
  - [ ] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [ ] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
