### PR TITLE
Update the JSON aggregation function to also handle empty values

### DIFF
--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -5725,4 +5725,39 @@
 		<!-- Rolling back is not useful anymore -->
 	</changeSet>
 
+	<changeSet id="update-jsonb-aggregation-functions" author="gjvoosten" runInTransaction="false">
+		<sql>
+			<!-- Update the function for aggregating JSON values to also handle empty values -->
+			CREATE OR REPLACE FUNCTION jsonb_value_agg(p_json jsonb, ignore_key text default 'invisibleCustomFields')
+				RETURNS text
+			AS
+			'
+			BEGIN
+				RETURN CASE
+					WHEN jsonb_typeof(p_json) = ''array'' THEN coalesce(public.jsonb_array_value_agg(p_json, ignore_key), '''')
+					WHEN jsonb_typeof(p_json) = ''object'' THEN coalesce(public.jsonb_object_value_agg(p_json, ignore_key), '''')
+					WHEN jsonb_typeof(p_json) = ''string''
+						AND p_json #>> ''{}'' !~ ''^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{1,3}Z$''
+						THEN coalesce(p_json #>> ''{}'', '''')
+					ELSE ''''
+				END;
+			EXCEPTION
+				WHEN OTHERS THEN
+				RETURN NULL;
+			END;
+			'
+			LANGUAGE plpgsql
+			IMMUTABLE;
+
+			<!-- Forcefully update all computed full_text columns for tables that have a customFields column -->
+			UPDATE locations SET "customFields" = "customFields";
+			UPDATE organizations SET "customFields" = "customFields";
+			UPDATE people SET "customFields" = "customFields";
+			UPDATE positions SET "customFields" = "customFields";
+			UPDATE reports SET "customFields" = "customFields";
+			UPDATE tasks SET "customFields" = "customFields";
+		</sql>
+		<!-- Rolling back is not useful anymore -->
+	</changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
Migrated data could contain customFields columns that would lead to an empty full-text index for that object.

Closes [AB#1009](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1009)

#### User changes
- None.

#### Superuser changes
- None.

#### Admin changes
- None.

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [x] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [x] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here