### PR TITLE
Fix cancelledReason selection in report form

### DIFF
--- a/client/src/pages/reports/Form.js
+++ b/client/src/pages/reports/Form.js
@@ -672,6 +672,7 @@ const ReportForm = ({
                   <DictionaryField
                     wrappedComponent={Field}
                     dictProps={Settings.fields.report.cancelledReason}
+                    name="cancelledReason"
                     component={FieldHelper.SpecialField}
                     onChange={event => {
                       // validation will be done by setFieldValue


### PR DESCRIPTION
After selecting a reason for cancellation in the engagement report form, it would always show the first selection. It now shows the correct selection.

Closes [AB#1108](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1108) 

#### User changes
- When selecting a reason for cancellation in the engagement report form, the correct selection is shown.

#### Superuser changes
- None.

#### Admin changes
- None.

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
