### PR TITLE
Allow admins to edit attachments on all reports incl. published

### DIFF
--- a/src/main/java/mil/dds/anet/resources/ReportResource.java
+++ b/src/main/java/mil/dds/anet/resources/ReportResource.java
@@ -226,8 +226,9 @@ public class ReportResource {
     ResourceUtils.assertAllowedClassification(r.getClassification());
 
     // State should not change when report is being edited by an approver
-    // State should change to draft when the report is being edited by one of the existing authors
-    if (isAuthor) {
+    // State should change to draft when the report is being edited by one of the existing authors,
+    // except when the editor is admin and is editing their own published report
+    if (isAuthor && !(AuthUtils.isAdmin(editor) && r.getState() == ReportState.PUBLISHED)) {
       r.setState(ReportState.DRAFT);
       r.setApprovalStep(null);
     }

--- a/src/main/java/mil/dds/anet/resources/ReportResource.java
+++ b/src/main/java/mil/dds/anet/resources/ReportResource.java
@@ -92,6 +92,10 @@ public class ReportResource {
       return false;
     }
 
+    if (AuthUtils.isAdmin(user)) {
+      // Admins can do *anything*
+      return true;
+    }
     boolean isAuthor = report.isAuthor(user);
     return switch (report.getState()) {
       case DRAFT, REJECTED, APPROVED, CANCELLED ->
@@ -102,7 +106,7 @@ public class ReportResource {
         isAuthor || anetObjectEngine.canUserApproveStep(anetObjectEngine.getContext(),
             user.getUuid(), report.getApprovalStepUuid(), report.getAdvisorOrgUuid()).join();
       case PUBLISHED ->
-        // Published reports are immutable
+        // Must be admin
         false;
       default -> false;
     };


### PR DESCRIPTION
Admins can edit published reports, but adding attachments was forbidden. This is now allowed.
Also, when admins are editing their own published reports, these are no longer changed into Draft.

Closes [AB#1109](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1109)

#### User changes
- None.

#### Superuser changes
- None.

#### Admin changes
- Admins can add attachments to published reports.
- When admins edit their own published reports, they stay published.
  (Note that this was already the case when admins edited reports by other authors.)

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [x] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
