### PR TITLE
Add the Sim to the GitHub Actions workflow

### DIFF
--- a/.github/workflows/build-gradle.yml
+++ b/.github/workflows/build-gradle.yml
@@ -162,3 +162,23 @@ jobs:
         name: ${{ matrix.client-tests }}-test-results for ${{ steps.strip-slashes.outputs.dictionary }}
         path: client/build/test-results/${{ matrix.client-tests }}-test-results.xml
       if: always()
+
+  test-sim:
+    needs: build
+    name: Test simulator
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - uses: ./.github/actions/build-cache
+    - run: ./gradlew dockerCreateDB dockerStartDB
+    - run: ./gradlew dockerConfigureKeycloak dockerStartKeycloak
+    - run: ./gradlew dbWait dbMigrate dbLoad
+    - run: |
+        ./gradlew run &
+        sleep 15
+    - run: ./gradlew yarn_run_sim
+      env:
+        TEST_RUN: true

--- a/client/tests/sim/Simulator.js
+++ b/client/tests/sim/Simulator.js
@@ -103,6 +103,7 @@ async function runBuildup(scenario) {
           console.log(
             colors.red(`Buildup '${buildup.name}' iteration ${i} failed: ${e}`)
           )
+          process.exitCode = 1
         }
       }
     }
@@ -236,5 +237,6 @@ async function runStories(scenario, cycle, runningTime) {
     await simulate(process.argv.slice(3))
   } catch (e) {
     console.error(e)
+    process.exitCode = 1
   }
 })()


### PR DESCRIPTION
Add a test run of the Simulator to the GitHub Actions workflow, so we can (potentially) catch breaking changes early.

Closes [AB#1061](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1061)

#### User changes
- None.

#### Superuser changes
- None.

#### Admin changes
- None.

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
