### PR TITLE
Migrate custom report field "securityMarkings" to standard "classification"

### DIFF
--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -5848,4 +5848,17 @@
 		</sql>
 	</changeSet>
 
+	<changeSet id="migrate-custom-security-marking-to-report-classification" author="midmarch">
+		<sql>
+			<!-- Migrate report.customFields.securityMarking to report.classification -->
+			UPDATE reports
+			SET classification = "customFields"::jsonb->>'securityMarking';
+
+			<!-- Replace report.classification empty strings with NULL -->
+			UPDATE reports
+			SET classification = NULL
+			WHERE classification = '';
+		</sql>
+	</changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
DB migration of `report.customFields.securityMarking` to `report.classification`

Related to #4690


