### PR TITLE
Display correct classification in report print view footer

### DIFF
--- a/client/src/components/Compact.js
+++ b/client/src/components/Compact.js
@@ -127,7 +127,10 @@ export const CompactHeaderContent = ({
     <HeaderContentS bgc={appSettings[SETTING_KEY_COLOR]}>
       <img src={anetLogo} alt="logo" width="50" height="12" />
       <ClassificationBoxS>
-        <ClassificationBanner classification={classification} />
+        <ClassificationBanner
+          classification={classification}
+          bannerId="header-banner"
+        />
         {sensitiveInformation && <SensitivityInformation />}
       </ClassificationBoxS>
     </HeaderContentS>
@@ -150,7 +153,10 @@ export const CompactFooterContent = ({ object, classification }) => {
           {object.uuid}
         </Link>
       </span>
-      <ClassificationBanner classification={classification} />
+      <ClassificationBanner
+        classification={classification}
+        bannerId="footer-banner"
+      />
       <PrintedByBoxS>
         <div>
           printed by{" "}
@@ -270,16 +276,20 @@ const FooterContentS = styled.div`
   background-color: ${props => props.bgc} !important;
 `
 
-const ClassificationBanner = ({ classification }) => {
+const ClassificationBanner = ({ classification, bannerId }) => {
   return (
     <ClassificationBannerS>
-      <CompactSecurityBanner classification={classification} />
+      <CompactSecurityBanner
+        classification={classification}
+        bannerId={bannerId}
+      />
     </ClassificationBannerS>
   )
 }
 
 ClassificationBanner.propTypes = {
-  classification: PropTypes.string
+  classification: PropTypes.string,
+  bannerId: PropTypes.string
 }
 
 const ClassificationBannerS = styled.div`

--- a/client/src/components/Compact.js
+++ b/client/src/components/Compact.js
@@ -139,7 +139,7 @@ CompactHeaderContent.propTypes = {
   sensitiveInformation: PropTypes.bool
 }
 
-export const CompactFooterContent = ({ object }) => {
+export const CompactFooterContent = ({ object, classification }) => {
   const location = useLocation()
   const { currentUser, appSettings } = useContext(AppContext)
   return (
@@ -150,7 +150,7 @@ export const CompactFooterContent = ({ object }) => {
           {object.uuid}
         </Link>
       </span>
-      <ClassificationBanner />
+      <ClassificationBanner classification={classification} />
       <PrintedByBoxS>
         <div>
           printed by{" "}
@@ -169,7 +169,8 @@ export const CompactFooterContent = ({ object }) => {
 }
 
 CompactFooterContent.propTypes = {
-  object: PropTypes.object
+  object: PropTypes.object,
+  classification: PropTypes.string
 }
 
 const SensitivityInformation = () => {

--- a/client/src/components/SecurityBanner.js
+++ b/client/src/components/SecurityBanner.js
@@ -208,15 +208,17 @@ ConnectionBanner.propTypes = {
   connection: PropTypes.object.isRequired
 }
 
-export const CompactSecurityBanner = ({ classification }) => {
+export const CompactSecurityBanner = ({ classification, bannerId }) => {
   const { appSettings } = useContext(AppContext)
   return (
     <CompactBannerS className="banner" bgc={appSettings[SETTING_KEY_COLOR]}>
       {(classification && (
-        <span className="classificationText">{classification}</span>
+        <span className="classificationText" id={bannerId}>
+          {classification}
+        </span>
       )) || (
         <>
-          <span className="classificationText">
+          <span className="classificationText" id={bannerId}>
             {appSettings[SETTING_KEY_CLASSIFICATION]?.toUpperCase() || ""}
           </span>{" "}
           <span className="releasabilityText">
@@ -229,7 +231,8 @@ export const CompactSecurityBanner = ({ classification }) => {
 }
 
 CompactSecurityBanner.propTypes = {
-  classification: PropTypes.string
+  classification: PropTypes.string,
+  bannerId: PropTypes.string
 }
 
 const CompactBannerS = styled.div`

--- a/client/src/pages/reports/Compact.js
+++ b/client/src/pages/reports/Compact.js
@@ -409,7 +409,12 @@ const CompactReportView = ({ pageDispatchers }) => {
                 )}
               </FullColumn>
             </CompactTable>
-            <CompactFooterContent object={report} />
+            <CompactFooterContent
+              object={report}
+              classification={
+                Settings.classification.choices[report.classification]
+              }
+            />
           </CompactView>
         </>
       )}

--- a/client/tests/webdriver/baseSpecs/printReport.spec.js
+++ b/client/tests/webdriver/baseSpecs/printReport.spec.js
@@ -13,6 +13,8 @@ const ADVISORS = ["CIV DMIN, Arthur", "CIV GUIST, Lin"]
 
 const TASKS = ["EF 1 » EF 1.2 » 1.2.A", "EF 1 » EF 1.2 » 1.2.B"]
 
+const DEFAULT_REPORT_CLASSIFICATION = "DEMO USE ONLY"
+
 describe("Show print report page", () => {
   beforeEach("Open the show report page", async() => {
     await MyReports.open("arthur")
@@ -122,6 +124,48 @@ describe("Show print report page", () => {
       for (const task of TASKS) {
         expect(displayedTasks).to.contain(task)
       }
+    })
+  })
+  describe("When on the print page of a report without classification", () => {
+    it("We should see the default text for classification in the header and footer banners", async() => {
+      await (await ShowReport.getClassificationHeader()).waitForExist()
+      await (await ShowReport.getClassificationHeader()).waitForDisplayed()
+      expect(
+        await (await ShowReport.getClassificationHeader()).getText()
+      ).to.equal(DEFAULT_REPORT_CLASSIFICATION)
+      await (await ShowReport.getClassificationFooter()).waitForExist()
+      await (await ShowReport.getClassificationFooter()).waitForDisplayed()
+      expect(
+        await (await ShowReport.getClassificationFooter()).getText()
+      ).to.equal(DEFAULT_REPORT_CLASSIFICATION)
+    })
+  })
+})
+
+const REPORT_CLASSIFICATION = "NATO UNCLASSIFIED"
+describe("Show print report page with classification", () => {
+  beforeEach("Open the show report page", async() => {
+    await MyReports.open("arthur")
+    await MyReports.selectReport(
+      "A classified report from Arthur",
+      REPORT_STATES.DRAFT
+    )
+    await (await ShowReport.getCompactViewButton()).click()
+    await (await ShowReport.getCompactView()).waitForExist()
+    await (await ShowReport.getCompactView()).waitForDisplayed()
+  })
+  describe("When on the print page of a report with classification", () => {
+    it("We should see the classification in the header and footer banners", async() => {
+      await (await ShowReport.getClassificationHeader()).waitForExist()
+      await (await ShowReport.getClassificationHeader()).waitForDisplayed()
+      expect(
+        await (await ShowReport.getClassificationHeader()).getText()
+      ).to.equal(REPORT_CLASSIFICATION)
+      await (await ShowReport.getClassificationFooter()).waitForExist()
+      await (await ShowReport.getClassificationFooter()).waitForDisplayed()
+      expect(
+        await (await ShowReport.getClassificationFooter()).getText()
+      ).to.equal(REPORT_CLASSIFICATION)
     })
   })
 })

--- a/client/tests/webdriver/pages/report/showReport.page.js
+++ b/client/tests/webdriver/pages/report/showReport.page.js
@@ -211,6 +211,14 @@ class ShowReport extends Page {
       await fieldCheckbox.click()
     }
   }
+
+  async getClassificationHeader() {
+    return browser.$("#header-banner")
+  }
+
+  async getClassificationFooter() {
+    return browser.$("#footer-banner")
+  }
 }
 
 export default new ShowReport()


### PR DESCRIPTION
The classification banner in the report print view's footer will now display the classification correctly instead of the default defined in the dictionary.

Closes [AB#1114](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1114)
(relates to [AB#1053](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1053))

#### User changes
- User will now see the correct classification displayed

#### Superuser changes
- None

#### Admin changes
- None

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [x] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
