### PR TITLE
Remove zoom on hovering over attachment preview image

### DIFF
--- a/client/src/components/Attachment/Attachment.css
+++ b/client/src/components/Attachment/Attachment.css
@@ -101,11 +101,6 @@
   height: 100%;
   max-height: 450px;
   border-radius: 5px;
-  transition: transform .5s ease;
-}
-.img-hover-zoom:hover .attachment-image {
-  cursor: zoom-in;
-  transform: scale(1.5);
 }
 
 @media screen and (max-width: 768px) {

--- a/client/src/components/Attachment/AttachmentImage.js
+++ b/client/src/components/Attachment/AttachmentImage.js
@@ -1,4 +1,3 @@
-import classNames from "classnames"
 import PropTypes from "prop-types"
 import React from "react"
 
@@ -18,11 +17,7 @@ const AttachmentImage = ({
     />
   )
   return (
-    <div
-      className={classNames("img-container", {
-        "img-hover-zoom": !contentMissing
-      })}
-    >
+    <div className="img-container">
       {contentMissing ? (
         <>{image}</>
       ) : (


### PR DESCRIPTION
Hovering over attachment preview image doesn't zoom in anymore.

Closes [AB#1104](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1104)

#### User changes
- Hovering over attachment preview image doesn't zoom in anymore

#### Superuser changes
- None

#### Admin changes
- None

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
