### PR TITLE
Update entity links after merge

### DIFF
--- a/src/main/java/mil/dds/anet/AnetApplication.java
+++ b/src/main/java/mil/dds/anet/AnetApplication.java
@@ -59,6 +59,7 @@ import mil.dds.anet.threads.AccountDeactivationWorker;
 import mil.dds.anet.threads.AnetEmailWorker;
 import mil.dds.anet.threads.FutureEngagementWorker;
 import mil.dds.anet.threads.MaterializedViewRefreshWorker;
+import mil.dds.anet.threads.MergedEntityWorker;
 import mil.dds.anet.threads.PendingAssessmentsNotificationWorker;
 import mil.dds.anet.threads.ReportApprovalWorker;
 import mil.dds.anet.threads.ReportPublicationWorker;
@@ -344,31 +345,31 @@ public class AnetApplication extends Application<AnetConfiguration> {
       final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
 
       // Check for any reports that need to be published every 5 minutes.
-      // And run once in 5 seconds from boot-up. (give the server time to boot up).
+      // And run once 5 seconds from boot-up.
       final ReportPublicationWorker reportPublicationWorker =
           new ReportPublicationWorker(configuration, engine.getReportDao());
       scheduler.scheduleAtFixedRate(reportPublicationWorker, 5, 5, TimeUnit.MINUTES);
       scheduler.schedule(reportPublicationWorker, 5, TimeUnit.SECONDS);
 
       // Check for any emails that need to be sent every 5 minutes.
-      // And run once in 10 seconds from boot-up. (give the server time to boot up).
+      // And run once 10 seconds from boot-up.
       final AnetEmailWorker emailWorker = new AnetEmailWorker(configuration, engine.getEmailDao());
       scheduler.scheduleAtFixedRate(emailWorker, 5, 5, TimeUnit.MINUTES);
       scheduler.schedule(emailWorker, 10, TimeUnit.SECONDS);
 
       // Check for any future engagements every 3 hours.
-      // And run once in 15 seconds from boot-up. (give the server time to boot up).
+      // And run once 15 seconds from boot-up.
       final FutureEngagementWorker futureWorker =
           new FutureEngagementWorker(configuration, engine.getReportDao());
       scheduler.scheduleAtFixedRate(futureWorker, 0, 3, TimeUnit.HOURS);
       scheduler.schedule(futureWorker, 15, TimeUnit.SECONDS);
 
       // Check for any reports that need to be approved every 5 minutes.
-      // And run once in 20 seconds from boot-up. (give the server time to boot up).
+      // And run once 20 seconds from boot-up.
       final ReportApprovalWorker reportApprovalWorker =
           new ReportApprovalWorker(configuration, engine.getReportDao());
       scheduler.scheduleAtFixedRate(reportApprovalWorker, 5, 5, TimeUnit.MINUTES);
-      scheduler.schedule(reportApprovalWorker, 5, TimeUnit.SECONDS);
+      scheduler.schedule(reportApprovalWorker, 20, TimeUnit.SECONDS);
 
       runAccountDeactivationWorker(configuration, scheduler, engine);
 
@@ -384,6 +385,13 @@ public class AnetApplication extends Application<AnetConfiguration> {
       final MaterializedViewRefreshWorker materializedViewRefreshWorker =
           new MaterializedViewRefreshWorker(configuration, engine.getAdminDao());
       scheduler.scheduleWithFixedDelay(materializedViewRefreshWorker, 30, 60, TimeUnit.SECONDS);
+
+      // Check for merged entities that need to be updated every 5 minutes.
+      // And run once 60 seconds from boot-up.
+      final MergedEntityWorker mergedEntityWorker =
+          new MergedEntityWorker(configuration, engine.getAdminDao());
+      scheduler.scheduleAtFixedRate(mergedEntityWorker, 5, 5, TimeUnit.MINUTES);
+      scheduler.schedule(mergedEntityWorker, 60, TimeUnit.SECONDS);
     }
 
     // Create all of the HTTP Resources.

--- a/src/main/java/mil/dds/anet/beans/MergedEntity.java
+++ b/src/main/java/mil/dds/anet/beans/MergedEntity.java
@@ -1,0 +1,5 @@
+package mil.dds.anet.beans;
+
+import java.time.Instant;
+
+public record MergedEntity(String oldUuid, String newUuid, Instant mergeDate) {}

--- a/src/main/java/mil/dds/anet/database/AdminDao.java
+++ b/src/main/java/mil/dds/anet/database/AdminDao.java
@@ -6,7 +6,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import mil.dds.anet.beans.AdminSetting;
+import mil.dds.anet.beans.MergedEntity;
 import mil.dds.anet.database.mappers.AdminSettingMapper;
+import mil.dds.anet.database.mappers.MergedEntityMapper;
+import mil.dds.anet.utils.DaoUtils;
 import org.jdbi.v3.core.Handle;
 import ru.vyarus.guicey.jdbi3.tx.InTransaction;
 
@@ -72,5 +75,41 @@ public class AdminDao {
     // Can't use a prepared statement with a parameter here, alas
     getDbHandle()
         .execute(String.format("REFRESH MATERIALIZED VIEW CONCURRENTLY \"%1$s\"", viewName));
+  }
+
+  @InTransaction
+  public List<MergedEntity> getMergedEntities() {
+    return getDbHandle()
+        .createQuery("/* getMergedEntities */ SELECT \"oldUuid\", \"newUuid\" "
+            + "FROM \"mergedEntities\" ORDER BY \"createdAt\"")
+        .map(new MergedEntityMapper()).list();
+  }
+
+  @InTransaction
+  public int insertMergedEntity(final MergedEntity mergedEntity) {
+    final String sql = "/* insertMergedEntity */ INSERT INTO \"mergedEntities\" "
+        + "( \"oldUuid\", \"newUuid\", \"createdAt\" ) VALUES ( :oldUuid, :newUuid, :mergeDate )";
+    return getDbHandle().createUpdate(sql).bind("oldUuid", mergedEntity.oldUuid())
+        .bind("newUuid", mergedEntity.newUuid())
+        .bind("mergeDate", DaoUtils.asLocalDateTime(mergedEntity.mergeDate())).execute();
+  }
+
+  @InTransaction
+  public int updateMergedEntity(final String tableName, final String columnName,
+      final MergedEntity mergedEntity) {
+    final String sql = String.format(
+        "/* updateMergedEntity */ UPDATE \"%1$s\" "
+            + "SET \"%2$s\" = regexp_replace(\"%2$s\", %3$s, :newUuid, 'g') WHERE \"%2$s\" ~ %3$s",
+        tableName, columnName, "('\\m' || :oldUuid || '\\M')");
+    return getDbHandle().createUpdate(sql).bind("oldUuid", mergedEntity.oldUuid())
+        .bind("newUuid", mergedEntity.newUuid()).execute();
+  }
+
+  @InTransaction
+  public int deleteMergedEntity(final MergedEntity mergedEntity) {
+    return getDbHandle()
+        .createUpdate("/* deleteMergedEntity */ DELETE FROM \"mergedEntities\" "
+            + "WHERE \"oldUuid\" = :oldUuid AND \"newUuid\" = :newUuid")
+        .bind("oldUuid", mergedEntity.oldUuid()).bind("newUuid", mergedEntity.newUuid()).execute();
   }
 }

--- a/src/main/java/mil/dds/anet/database/AnetBaseDao.java
+++ b/src/main/java/mil/dds/anet/database/AnetBaseDao.java
@@ -78,4 +78,10 @@ public abstract class AnetBaseDao<T extends AbstractAnetBean, S extends Abstract
     return getDbHandle().createUpdate(String.format(sqlDeleteFormat, tableName, fieldName))
         .bind("loserUuid", loserUuid).execute();
   }
+
+  // For testing purposes only!
+  @InTransaction
+  public int _deleteByUuid(String tableName, String fieldName, String uuid) {
+    return deleteForMerge(tableName, fieldName, uuid);
+  }
 }

--- a/src/main/java/mil/dds/anet/database/LocationDao.java
+++ b/src/main/java/mil/dds/anet/database/LocationDao.java
@@ -1,9 +1,11 @@
 package mil.dds.anet.database;
 
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.List;
 import mil.dds.anet.AnetObjectEngine;
 import mil.dds.anet.beans.Location;
+import mil.dds.anet.beans.MergedEntity;
 import mil.dds.anet.beans.lists.AnetBeanList;
 import mil.dds.anet.beans.search.LocationSearchQuery;
 import mil.dds.anet.database.mappers.LocationMapper;
@@ -106,7 +108,12 @@ public class LocationDao extends AnetSubscribableObjectDao<Location, LocationSea
     deleteForMerge("customSensitiveInformation", "relatedObjectUuid", loserLocationUuid);
 
     // Finally, delete the location
-    return deleteForMerge("locations", "uuid", loserLocationUuid);
+    final int nrDeleted = deleteForMerge(LocationDao.TABLE_NAME, "uuid", loserLocationUuid);
+    if (nrDeleted > 0) {
+      AnetObjectEngine.getInstance().getAdminDao().insertMergedEntity(
+          new MergedEntity(loserLocationUuid, winnerLocationUuid, Instant.now()));
+    }
+    return nrDeleted;
   }
 
   // TODO: Don't delete any location if any references exist.

--- a/src/main/java/mil/dds/anet/database/mappers/MergedEntityMapper.java
+++ b/src/main/java/mil/dds/anet/database/mappers/MergedEntityMapper.java
@@ -1,0 +1,17 @@
+package mil.dds.anet.database.mappers;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import mil.dds.anet.beans.MergedEntity;
+import org.jdbi.v3.core.mapper.RowMapper;
+import org.jdbi.v3.core.statement.StatementContext;
+
+public class MergedEntityMapper implements RowMapper<MergedEntity> {
+
+  @Override
+  public MergedEntity map(ResultSet rs, StatementContext ctx) throws SQLException {
+    return new MergedEntity(rs.getString("oldUuid"), rs.getString("newUuid"),
+        MapperUtils.getInstantAsLocalDateTime(rs, "createdAt"));
+  }
+
+}

--- a/src/main/java/mil/dds/anet/threads/MergedEntityWorker.java
+++ b/src/main/java/mil/dds/anet/threads/MergedEntityWorker.java
@@ -1,0 +1,48 @@
+package mil.dds.anet.threads;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import mil.dds.anet.beans.JobHistory;
+import mil.dds.anet.config.AnetConfiguration;
+import mil.dds.anet.database.AdminDao;
+
+public class MergedEntityWorker extends AbstractWorker {
+
+  private record FieldWithEntityReference(String tableName, String columnName) {}
+
+  private static final List<FieldWithEntityReference> fieldsWithEntityReference = List.of(// -
+      new FieldWithEntityReference("attachments", "description"), // -
+      new FieldWithEntityReference("customSensitiveInformation", "customFieldValue"), // -
+      new FieldWithEntityReference("locations", "description"),
+      new FieldWithEntityReference("locations", "customFields"), // -
+      new FieldWithEntityReference("notes", "text"), // -
+      new FieldWithEntityReference("organizations", "profile"), // -
+      new FieldWithEntityReference("organizations", "customFields"), // -
+      new FieldWithEntityReference("people", "biography"), // -
+      new FieldWithEntityReference("people", "customFields"), // -
+      new FieldWithEntityReference("positions", "customFields"), // -
+      new FieldWithEntityReference("reports", "text"), // -
+      new FieldWithEntityReference("reports", "customFields"), // -
+      new FieldWithEntityReference("reportsSensitiveInformation", "text"), // -
+      new FieldWithEntityReference("tasks", "description"), // -
+      new FieldWithEntityReference("tasks", "customFields")// -
+  );
+
+  private final AdminDao dao;
+
+  public MergedEntityWorker(AnetConfiguration config, AdminDao dao) {
+    super(config, "Waking up to check for merged entities");
+    this.dao = dao;
+  }
+
+  @Override
+  protected void runInternal(Instant now, JobHistory jobHistory, Map<String, Object> context) {
+    final var mergedEntities = dao.getMergedEntities();
+    mergedEntities.forEach(mergedEntity -> {
+      fieldsWithEntityReference.forEach(
+          tuple -> dao.updateMergedEntity(tuple.tableName(), tuple.columnName(), mergedEntity));
+      dao.deleteMergedEntity(mergedEntity);
+    });
+  }
+}

--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -5759,4 +5759,23 @@
 		<!-- Rolling back is not useful anymore -->
 	</changeSet>
 
+	<changeSet id="add-mergedEntities" author="gjvoosten">
+		<createTable tableName="mergedEntities">
+			<column name="oldUuid" type="${uuid_type}">
+				<constraints nullable="false" />
+			</column>
+			<column name="newUuid" type="${uuid_type}">
+				<constraints nullable="false" />
+			</column>
+			<column name="createdAt" type="datetime" />
+		</createTable>
+
+		<!-- Entities can be merged only once -->
+		<addUniqueConstraint
+			tableName="mergedEntities"
+			columnNames="oldUuid, newUuid"
+			constraintName="UQ_MergedEntitiesOldUuidNewUuid"
+		/>
+	</changeSet>
+
 </databaseChangeLog>

--- a/src/test/java/mil/dds/anet/test/integration/db/MergedEntityWorkerTest.java
+++ b/src/test/java/mil/dds/anet/test/integration/db/MergedEntityWorkerTest.java
@@ -1,0 +1,365 @@
+package mil.dds.anet.test.integration.db;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.dropwizard.testing.junit5.DropwizardAppExtension;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import mil.dds.anet.AnetObjectEngine;
+import mil.dds.anet.beans.Attachment;
+import mil.dds.anet.beans.CustomSensitiveInformation;
+import mil.dds.anet.beans.Location;
+import mil.dds.anet.beans.MergedEntity;
+import mil.dds.anet.beans.Note;
+import mil.dds.anet.beans.Organization;
+import mil.dds.anet.beans.Person;
+import mil.dds.anet.beans.Position;
+import mil.dds.anet.beans.Task;
+import mil.dds.anet.beans.WithStatus;
+import mil.dds.anet.config.AnetConfiguration;
+import mil.dds.anet.database.AdminDao;
+import mil.dds.anet.database.AttachmentDao;
+import mil.dds.anet.database.CustomSensitiveInformationDao;
+import mil.dds.anet.database.LocationDao;
+import mil.dds.anet.database.NoteDao;
+import mil.dds.anet.database.OrganizationDao;
+import mil.dds.anet.database.PersonDao;
+import mil.dds.anet.database.PositionDao;
+import mil.dds.anet.database.ReportDao;
+import mil.dds.anet.database.TaskDao;
+import mil.dds.anet.test.client.Atmosphere;
+import mil.dds.anet.test.client.Report;
+import mil.dds.anet.test.client.ReportInput;
+import mil.dds.anet.test.client.ReportSensitiveInformationInput;
+import mil.dds.anet.test.resources.AbstractResourceTest;
+import mil.dds.anet.test.resources.ReportResourceTest;
+import mil.dds.anet.threads.MergedEntityWorker;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class MergedEntityWorkerTest extends AbstractResourceTest {
+
+  @Autowired
+  protected DropwizardAppExtension<AnetConfiguration> dropwizardApp;
+
+  private AnetObjectEngine engine;
+  private AdminDao adminDao;
+  private MergedEntityWorker mergedEntityWorker;
+
+  @BeforeAll
+  void setUpClass() {
+    engine = AnetObjectEngine.getInstance();
+    adminDao = engine.getAdminDao();
+    mergedEntityWorker = new MergedEntityWorker(dropwizardApp.getConfiguration(), adminDao);
+
+    // Flush all merged entities from previous tests
+    mergedEntityWorker.run();
+  }
+
+  @Test
+  void testAttachment() {
+    final String testOldUuid = UUID.randomUUID().toString();
+    final String testNewUuid = UUID.randomUUID().toString();
+    final AttachmentDao dao = engine.getAttachmentDao();
+
+    // set things up
+    final Attachment input = new Attachment();
+    input.setAuthor(getRegularUserBean());
+    input.setDescription(getRichText(AttachmentDao.TABLE_NAME, testOldUuid));
+    final Attachment created = dao.insert(input);
+    assertContains(created.getDescription(), testOldUuid);
+
+    // run the worker
+    runMergedEntityWorker(testOldUuid, testNewUuid);
+
+    // assert that the entity refs have been updated
+    final Attachment updated = dao.getByUuid(created.getUuid());
+    assertDoesNotContain(updated.getDescription(), testOldUuid);
+    assertContains(updated.getDescription(), testNewUuid);
+
+    // clean up
+    dao.delete(updated.getUuid());
+  }
+
+  @Test
+  void testCustomSensitiveInformation() {
+    final String testOldUuid = UUID.randomUUID().toString();
+    final String testNewUuid = UUID.randomUUID().toString();
+    final CustomSensitiveInformationDao dao = engine.getCustomSensitiveInformationDao();
+
+    // set things up
+    final CustomSensitiveInformation input = new CustomSensitiveInformation();
+    input.setRelatedObjectType(PersonDao.TABLE_NAME);
+    final String relatedObjectUuid = getRegularUserBean().getUuid();
+    input.setRelatedObjectUuid(relatedObjectUuid);
+    input.setCustomFieldName("testCustomField");
+    input.setCustomFieldValue(getRichText(PersonDao.TABLE_NAME, testOldUuid));
+    final CustomSensitiveInformation created = dao.insert(input);
+    assertContains(created.getCustomFieldValue(), testOldUuid);
+
+    // run the worker
+    runMergedEntityWorker(testOldUuid, testNewUuid);
+
+    // assert that the entity refs have been updated
+    final CustomSensitiveInformation updated = dao.getByUuid(created.getUuid());
+    assertDoesNotContain(updated.getCustomFieldValue(), testOldUuid);
+    assertContains(updated.getCustomFieldValue(), testNewUuid);
+
+    // clean up
+    dao.deleteFor(relatedObjectUuid);
+  }
+
+  @Test
+  void testLocation() {
+    final String testOldUuid = UUID.randomUUID().toString();
+    final String testNewUuid = UUID.randomUUID().toString();
+    final LocationDao dao = engine.getLocationDao();
+
+    // set things up
+    final Location input = new Location();
+    input.setStatus(WithStatus.Status.ACTIVE);
+    input.setType(Location.LocationType.POINT_LOCATION);
+    input.setName("testLocation");
+    input.setDescription(getRichText(LocationDao.TABLE_NAME, testOldUuid));
+    input.setCustomFields(getJsonString(LocationDao.TABLE_NAME, testOldUuid));
+    final Location created = dao.insert(input);
+    assertContains(created.getDescription(), testOldUuid);
+    assertContains(created.getCustomFields(), testOldUuid);
+
+    // run the worker
+    runMergedEntityWorker(testOldUuid, testNewUuid);
+
+    // assert that the entity refs have been updated
+    final Location updated = dao.getByUuid(created.getUuid());
+    assertDoesNotContain(updated.getDescription(), testOldUuid);
+    assertDoesNotContain(updated.getCustomFields(), testOldUuid);
+    assertContains(updated.getDescription(), testNewUuid);
+    assertContains(updated.getCustomFields(), testNewUuid);
+
+    // clean up (through internal method)
+    dao._deleteByUuid(LocationDao.TABLE_NAME, "uuid", updated.getUuid());
+  }
+
+  @Test
+  void testNote() {
+    final String testOldUuid = UUID.randomUUID().toString();
+    final String testNewUuid = UUID.randomUUID().toString();
+    final NoteDao dao = engine.getNoteDao();
+
+    // set things up
+    final Note input = new Note();
+    input.setType(Note.NoteType.FREE_TEXT);
+    input.setAuthor(getRegularUserBean());
+    input.setText(getRichText(NoteDao.TABLE_NAME, testOldUuid));
+    input.setNoteRelatedObjects(List.of());
+    final Note created = dao.insert(input);
+    assertContains(created.getText(), testOldUuid);
+
+    // run the worker
+    runMergedEntityWorker(testOldUuid, testNewUuid);
+
+    // assert that the entity refs have been updated
+    final Note updated = dao.getByUuid(created.getUuid());
+    assertDoesNotContain(updated.getText(), testOldUuid);
+    assertContains(updated.getText(), testNewUuid);
+
+    // clean up
+    dao.delete(updated.getUuid());
+  }
+
+  @Test
+  void testOrganization() {
+    final String testOldUuid = UUID.randomUUID().toString();
+    final String testNewUuid = UUID.randomUUID().toString();
+    final OrganizationDao dao = engine.getOrganizationDao();
+
+    // set things up
+    final Organization input = new Organization();
+    input.setStatus(WithStatus.Status.ACTIVE);
+    input.setShortName("testOrganization");
+    input.setProfile(getRichText(OrganizationDao.TABLE_NAME, testOldUuid));
+    input.setCustomFields(getJsonString(OrganizationDao.TABLE_NAME, testOldUuid));
+    final Organization created = dao.insert(input);
+    assertContains(created.getProfile(), testOldUuid);
+    assertContains(created.getCustomFields(), testOldUuid);
+
+    // run the worker
+    runMergedEntityWorker(testOldUuid, testNewUuid);
+
+    // assert that the entity refs have been updated
+    final Organization updated = dao.getByUuid(created.getUuid());
+    assertDoesNotContain(updated.getProfile(), testOldUuid);
+    assertDoesNotContain(updated.getCustomFields(), testOldUuid);
+    assertContains(updated.getProfile(), testNewUuid);
+    assertContains(updated.getCustomFields(), testNewUuid);
+
+    // clean up (through internal method)
+    dao._deleteByUuid(OrganizationDao.TABLE_NAME, "uuid", updated.getUuid());
+  }
+
+  @Test
+  void testPerson() {
+    final String testOldUuid = UUID.randomUUID().toString();
+    final String testNewUuid = UUID.randomUUID().toString();
+    final PersonDao dao = engine.getPersonDao();
+
+    // set things up
+    final Person input = new Person();
+    input.setStatus(WithStatus.Status.ACTIVE);
+    input.setName("testPerson");
+    input.setBiography(getRichText(PersonDao.TABLE_NAME, testOldUuid));
+    input.setCustomFields(getJsonString(PersonDao.TABLE_NAME, testOldUuid));
+    final Person created = dao.insert(input);
+    assertContains(created.getBiography(), testOldUuid);
+    assertContains(created.getCustomFields(), testOldUuid);
+
+    // run the worker
+    runMergedEntityWorker(testOldUuid, testNewUuid);
+
+    // assert that the entity refs have been updated
+    final Person updated = dao.getByUuid(created.getUuid());
+    assertDoesNotContain(updated.getBiography(), testOldUuid);
+    assertDoesNotContain(updated.getCustomFields(), testOldUuid);
+    assertContains(updated.getBiography(), testNewUuid);
+    assertContains(updated.getCustomFields(), testNewUuid);
+
+    // clean up
+    dao.delete(updated.getUuid());
+  }
+
+  @Test
+  void testPosition() {
+    final String testOldUuid = UUID.randomUUID().toString();
+    final String testNewUuid = UUID.randomUUID().toString();
+    final PositionDao dao = engine.getPositionDao();
+
+    // set things up
+    final Position input = new Position();
+    input.setStatus(WithStatus.Status.ACTIVE);
+    input.setType(Position.PositionType.REGULAR);
+    input.setRole(Position.PositionRole.MEMBER);
+    input.setName("testPosition");
+    input.setCustomFields(getJsonString(PositionDao.TABLE_NAME, testOldUuid));
+    final Position created = dao.insert(input);
+    assertContains(created.getCustomFields(), testOldUuid);
+
+    // run the worker
+    runMergedEntityWorker(testOldUuid, testNewUuid);
+
+    // assert that the entity refs have been updated
+    final Position updated = dao.getByUuid(created.getUuid());
+    assertDoesNotContain(updated.getCustomFields(), testOldUuid);
+    assertContains(updated.getCustomFields(), testNewUuid);
+
+    // clean up
+    dao.delete(updated.getUuid());
+  }
+
+  @Test
+  void testReport() {
+    final String testOldUuid = UUID.randomUUID().toString();
+    final String testNewUuid = UUID.randomUUID().toString();
+
+    // set things up (through GraphQL, so we can include report sensitive information)
+    final mil.dds.anet.test.client.Person author = getRegularUser();
+    final ReportSensitiveInformationInput rsiInput = ReportSensitiveInformationInput.builder()
+        .withText(getRichText(ReportDao.TABLE_NAME, testOldUuid)).build();
+    final ReportInput input = ReportInput.builder().withIntent("testReport")
+        .withEngagementDate(Instant.now()).withAtmosphere(Atmosphere.NEUTRAL)
+        .withReportPeople(getReportPeopleInput(List.of(personToReportAuthor(author))))
+        .withReportText(getRichText(ReportDao.TABLE_NAME, testOldUuid))
+        .withCustomFields(getJsonString(ReportDao.TABLE_NAME, testOldUuid))
+        .withReportSensitiveInformation(rsiInput).build();
+    final Report created = withCredentials(author.getDomainUsername(),
+        t -> mutationExecutor.createReport(ReportResourceTest.FIELDS, input));
+    assertContains(created.getReportText(), testOldUuid);
+    assertContains(created.getCustomFields(), testOldUuid);
+    assertContains(created.getReportSensitiveInformation().getText(), testOldUuid);
+
+    // run the worker
+    runMergedEntityWorker(testOldUuid, testNewUuid);
+
+    // assert that the entity refs have been updated
+    final Report updated = withCredentials(author.getDomainUsername(),
+        t -> queryExecutor.report(ReportResourceTest.FIELDS, created.getUuid()));
+    assertDoesNotContain(updated.getReportText(), testOldUuid);
+    assertDoesNotContain(updated.getCustomFields(), testOldUuid);
+    assertDoesNotContain(updated.getReportSensitiveInformation().getText(), testOldUuid);
+    assertContains(updated.getReportText(), testNewUuid);
+    assertContains(updated.getCustomFields(), testNewUuid);
+    assertContains(updated.getReportSensitiveInformation().getText(), testNewUuid);
+
+    // clean up
+    withCredentials(author.getDomainUsername(),
+        t -> mutationExecutor.deleteReport("", updated.getUuid()));
+  }
+
+  @Test
+  void testTask() {
+    final String testOldUuid = UUID.randomUUID().toString();
+    final String testNewUuid = UUID.randomUUID().toString();
+    final TaskDao dao = engine.getTaskDao();
+
+    // set things up
+    final Task input = new Task();
+    input.setStatus(WithStatus.Status.ACTIVE);
+    input.setShortName("testTask");
+    input.setDescription(getRichText(TaskDao.TABLE_NAME, testOldUuid));
+    input.setCustomFields(getJsonString(TaskDao.TABLE_NAME, testOldUuid));
+    final Task created = dao.insert(input);
+    assertContains(created.getDescription(), testOldUuid);
+    assertContains(created.getCustomFields(), testOldUuid);
+
+    // run the worker
+    runMergedEntityWorker(testOldUuid, testNewUuid);
+
+    // assert that the entity refs have been updated
+    final Task updated = dao.getByUuid(created.getUuid());
+    assertDoesNotContain(updated.getDescription(), testOldUuid);
+    assertDoesNotContain(updated.getCustomFields(), testOldUuid);
+    assertContains(updated.getDescription(), testNewUuid);
+    assertContains(updated.getCustomFields(), testNewUuid);
+
+    // clean up (through internal method)
+    dao._deleteByUuid(TaskDao.TABLE_NAME, "uuid", updated.getUuid());
+  }
+
+  private void assertContains(String field, String uuid) {
+    assertThat(field).containsPattern(getPattern(uuid));
+  }
+
+  private void assertDoesNotContain(String field, String uuid) {
+    assertThat(field).doesNotContainPattern(getPattern(uuid));
+  }
+
+  private String getRichText(String tableName, String uuid) {
+    return String.format("<p><a href=\"urn:anet:%1$s:%2$s\" rel=\"nofollow\">%1$s:%2$s</a></p>",
+        tableName, uuid);
+  }
+
+  private String getJsonString(String tableName, String uuid) {
+    return String.format("{\"relatedObject1\":{\"type\":\"%1$s\",\"uuid\":\"%2$s\"},"
+        + "\"relatedObject2\":{\"type\":\"%1$s\",\"uuid\":\"%2$s\"}}", tableName, uuid);
+  }
+
+  private String getPattern(String testOldUuid) {
+    return String.format("\\b%1$s\\b", testOldUuid);
+  }
+
+  private void runMergedEntityWorker(String testOldUuid, String testNewUuid) {
+    final int nrBefore =
+        adminDao.insertMergedEntity(new MergedEntity(testOldUuid, testNewUuid, Instant.now()));
+    assertThat(nrBefore).isOne();
+    mergedEntityWorker.run();
+    final int nrAfter = adminDao.getMergedEntities().size();
+    assertThat(nrAfter).isZero();
+  }
+
+}

--- a/src/test/java/mil/dds/anet/test/resources/ReportResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/ReportResourceTest.java
@@ -78,7 +78,7 @@ import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-class ReportResourceTest extends AbstractResourceTest {
+public class ReportResourceTest extends AbstractResourceTest {
 
   private static final Logger logger =
       LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
@@ -109,7 +109,7 @@ class ReportResourceTest extends AbstractResourceTest {
   private static final String _TASK_FIELDS = "uuid shortName longName category";
   private static final String TASK_FIELDS =
       String.format("{ %1$s parentTask { %1$s } }", _TASK_FIELDS);
-  protected static final String FIELDS = String.format(
+  public static final String FIELDS = String.format(
       "{ %1$s advisorOrg %2$s interlocutorOrg %2$s authors %3$s attendees %3$s"
           + " reportPeople %3$s tasks %4$s approvalStep { uuid relatedObjectUuid } location %5$s"
           + " comments %6$s notes %7$s authorizationGroups { uuid name }"


### PR DESCRIPTION
Various (database) fields can _contain_ references to other ANET entities, e.g. rich-text fields or custom fields. When merging entities (e.g. people or positions), these references were not updated. This change makes sure that all such fields are checked and updated if necessary. And because this can potentially be a lengthy operation, it is done periodically in the background, and not directly with the merge itself.

Closes [AB#917](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/917)

#### User changes
- None.

#### Superuser changes
- None.

#### Admin changes
- After merging two entities, any references to the 'losing' entity of the merge will be updated in the background to the 'winning' entity. Note that this background task runs every 5 minutes, so the changes may not be immediately visible.

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [x] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [x] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [x] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
