### PR TITLE
Replace deprecated querystring with modern URLSearchParams

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -153,7 +153,6 @@
     "paths-js": "0.4.11",
     "pluralize": "8.0.0",
     "prop-types": "15.8.1",
-    "querystring": "0.2.1",
     "react": "18.2.0",
     "react-advanced-cropper": "0.20.0",
     "react-bootstrap": "2.10.2",

--- a/client/src/components/Model.js
+++ b/client/src/components/Model.js
@@ -10,7 +10,6 @@ import {
   RECURRENCE_TYPE
 } from "periodUtils"
 import PropTypes from "prop-types"
-import encodeQuery from "querystring/encode"
 import utils from "utils"
 import * as yup from "yup"
 
@@ -512,7 +511,7 @@ export default class Model {
     )
   }
 
-  static pathFor(instance, query, resourceOverride) {
+  static pathFor(instance, query) {
     if (!instance) {
       return console.error(
         `You didn't pass anything to ${this.name}.pathFor. If you want a new route, you can pass null.`
@@ -520,7 +519,7 @@ export default class Model {
     }
 
     if (process.env.NODE_ENV !== "production") {
-      if (!resourceOverride && !this.resourceName) {
+      if (!this.resourceName) {
         return console.error(
           `You must specify a resourceName on model ${this.name}.`
         )
@@ -529,33 +528,21 @@ export default class Model {
 
     const resourceName = utils.resourceize(this.resourceName)
     const uuid = instance.uuid
-    let url = ["", resourceOverride || resourceName, uuid].join("/")
-
-    if (query) {
-      url += "?" + encodeQuery(query)
-    }
-
+    let url = ["", resourceName, uuid].join("/")
+    url += utils.formatQueryString(query)
     return url
   }
 
-  static pathForNew(query, resourceOverride) {
+  static pathForNew(query) {
     const resourceName = utils.resourceize(this.resourceName)
-    let url = ["", resourceOverride || resourceName, "new"].join("/")
-
-    if (query) {
-      url += "?" + encodeQuery(query)
-    }
-
+    let url = ["", resourceName, "new"].join("/")
+    url += utils.formatQueryString(query)
     return url
   }
 
   static pathForEdit(instance, query) {
     let url = this.pathFor(instance) + "/edit"
-
-    if (query) {
-      url += "?" + encodeQuery(query)
-    }
-
+    url += utils.formatQueryString(query)
     return url
   }
 

--- a/client/src/pages/organizations/New.js
+++ b/client/src/pages/organizations/New.js
@@ -40,10 +40,10 @@ const OrganizationNew = ({ pageDispatchers }) => {
   const routerLocation = useLocation()
   usePageTitle("New Organization")
   const qs = utils.parseQueryString(routerLocation.search)
-  if (qs.parentOrgUuid) {
+  if (qs.get("parentOrgUuid")) {
     return (
       <OrganizationNewFetchParentOrg
-        orgUuid={qs.parentOrgUuid}
+        orgUuid={qs.get("parentOrgUuid")}
         pageDispatchers={pageDispatchers}
       />
     )

--- a/client/src/pages/positions/New.js
+++ b/client/src/pages/positions/New.js
@@ -32,10 +32,10 @@ const PositionNew = ({ pageDispatchers }) => {
   const routerLocation = useLocation()
   usePageTitle("New Position")
   const qs = utils.parseQueryString(routerLocation.search)
-  if (qs.organizationUuid) {
+  if (qs.get("organizationUuid")) {
     return (
       <PositionNewFetchOrg
-        orgUuid={qs.organizationUuid}
+        orgUuid={qs.get("organizationUuid")}
         pageDispatchers={pageDispatchers}
       />
     )

--- a/client/src/pages/tasks/New.js
+++ b/client/src/pages/tasks/New.js
@@ -33,10 +33,10 @@ const TaskNew = ({ pageDispatchers }) => {
   const taskShortLabel = Settings.fields.task.shortLabel
   usePageTitle(`New ${taskShortLabel}`)
   const qs = utils.parseQueryString(routerLocation.search)
-  if (qs.taskedOrgUuid) {
+  if (qs.get("taskedOrgUuid")) {
     return (
       <TaskNewFetchTaskedOrg
-        taskedOrgUuid={qs.taskedOrgUuid}
+        taskedOrgUuid={qs.get("taskedOrgUuid")}
         pageDispatchers={pageDispatchers}
       />
     )

--- a/client/src/utils.js
+++ b/client/src/utils.js
@@ -5,8 +5,6 @@ import * as d3 from "d3"
 import parseAddressList from "email-addresses"
 import _isEmpty from "lodash/isEmpty"
 import pluralize from "pluralize"
-import decodeQuery from "querystring/decode"
-import encodeQuery from "querystring/encode"
 import React, { useCallback, useEffect } from "react"
 import absentIcon from "resources/icons/absent.svg"
 import binaryIcon from "resources/icons/binary.svg"
@@ -160,16 +158,16 @@ export default {
 
   parseQueryString: function(queryString) {
     if (!queryString) {
-      return {}
+      return new URLSearchParams()
     }
-    return decodeQuery(queryString.slice(1)) || {}
+    return new URLSearchParams(queryString.slice(1))
   },
 
   formatQueryString: function(queryParams) {
     if (!queryParams) {
       return ""
     }
-    return "?" + encodeQuery(queryParams)
+    return `?${new URLSearchParams(queryParams).toString()}`
   },
 
   formatBoolean: function(b, emptyForNullOrUndefined) {

--- a/client/tests/util/test.js
+++ b/client/tests/util/test.js
@@ -147,8 +147,6 @@ test.beforeEach(t => {
   }
 
   // This method is a helper so we don't have to keep repeating the hostname.
-  // Passing the authentication through the querystring is a hack so we can
-  // pass the information along via window.fetch.
   t.context.get = async(pathname, userPw) => {
     const credentials = userPw || "erin"
     const urlToGet = `${process.env.SERVER_URL}${pathname}`

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -6395,7 +6395,6 @@ __metadata:
     prettier: "npm:3.3.2"
     prettier-eslint-cli: "npm:8.0.1"
     prop-types: "npm:15.8.1"
-    querystring: "npm:0.2.1"
     react: "npm:18.2.0"
     react-advanced-cropper: "npm:0.20.0"
     react-bootstrap: "npm:2.10.2"
@@ -16753,13 +16752,6 @@ __metadata:
   version: 1.0.1
   resolution: "query-selector-shadow-dom@npm:1.0.1"
   checksum: 10c0/f36de03f170ff1da69c3eecfa7f8b01e450a46dd266c921e17f36076ec59862eee00179489f30cb17c118bb56e868436578c01ea66f671fb358750d6ae474125
-  languageName: node
-  linkType: hard
-
-"querystring@npm:0.2.1":
-  version: 0.2.1
-  resolution: "querystring@npm:0.2.1"
-  checksum: 10c0/6841b32bec4f16ffe7f5b5e4373b47ad451f079cde3a7f45e63e550f0ecfd8f8189ef81fb50079413b3fc1c59b06146e4c98192cb74ed7981aca72090466cd94
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
The querystring module was deprecated, this replaces it with the modern standard URLSearchParams.
Also resourceOverride is removed, it was no longer used.