### PR TITLE
Fix attachmentRelatedObject deselection and ANET link deselection

### DIFF
--- a/client/src/components/editor/LinkSourceAnet.js
+++ b/client/src/components/editor/LinkSourceAnet.js
@@ -76,10 +76,12 @@ const LinkSourceAnet = ({ editor, showModal, setShowModal, external }) => {
             objectType={value?.objectType}
             entityTypes={ALL_ENTITY_TYPES}
             value={value?.object}
-            valueKey={value?.object && "uuid"}
+            valueKey="uuid"
             onConfirm={(value, objectType) => {
-              const anetLinkNode = createAnetLinkNode(objectType, value.uuid)
-              insertAnetLink(anetLinkNode)
+              if (value?.uuid) {
+                const anetLinkNode = createAnetLinkNode(objectType, value.uuid)
+                insertAnetLink(anetLinkNode)
+              }
             }}
           />
         )}

--- a/client/src/pages/attachments/Form.js
+++ b/client/src/pages/attachments/Form.js
@@ -1,8 +1,6 @@
 import { gql } from "@apollo/client"
 import API from "api"
-import MultiTypeAdvancedSelectComponent, {
-  ENTITY_TYPES
-} from "components/advancedSelectWidget/MultiTypeAdvancedSelectComponent"
+import { ENTITY_TYPES } from "components/advancedSelectWidget/MultiTypeAdvancedSelectComponent"
 import AppContext from "components/AppContext"
 import ConfirmDestructive from "components/ConfirmDestructive"
 import DictionaryField from "components/DictionaryField"
@@ -10,18 +8,16 @@ import * as FieldHelper from "components/FieldHelper"
 import Fieldset from "components/Fieldset"
 import LinkTo from "components/LinkTo"
 import Messages from "components/Messages"
-import { MODEL_TO_OBJECT_TYPE, OBJECT_TYPE_TO_MODEL } from "components/Model"
 import NavigationWarning from "components/NavigationWarning"
 import { jumpToTop } from "components/Page"
-import RemoveButton from "components/RemoveButton"
+import { RelatedObjectsTableInput } from "components/RelatedObjectsTable"
 import RichTextEditor from "components/RichTextEditor"
 import { FastField, Field, Form, Formik } from "formik"
-import _isEmpty from "lodash/isEmpty"
 import _isEqual from "lodash/isEqual"
 import { Attachment } from "models"
 import PropTypes from "prop-types"
 import React, { useContext, useState } from "react"
-import { Button, Col, Table } from "react-bootstrap"
+import { Button, Col } from "react-bootstrap"
 import { useNavigate } from "react-router-dom"
 import Settings from "settings"
 import utils from "utils"
@@ -155,88 +151,26 @@ const AttachmentForm = ({ edit, title, initialValues }) => {
 
                     {edit && (
                       <Field
-                        name="used in"
+                        label="Used in"
+                        name="attachmentRelatedObjects"
                         component={FieldHelper.SpecialField}
                         value={values.attachmentRelatedObjects}
                         widget={
-                          <MultiTypeAdvancedSelectComponent
-                            fieldName="attachmentRelatedObjects"
+                          <RelatedObjectsTableInput
+                            title=""
+                            relatedObjects={values.attachmentRelatedObjects}
                             entityTypes={[
                               ENTITY_TYPES.LOCATIONS,
                               ENTITY_TYPES.ORGANIZATIONS,
                               ENTITY_TYPES.PEOPLE,
                               ENTITY_TYPES.REPORTS
                             ]}
-                            valueKey="relatedObjectUuid"
-                            isMultiSelect
-                            onConfirm={(value, entityType) => {
-                              if (
-                                value.length >
-                                values.attachmentRelatedObjects?.length
-                              ) {
-                                // entity was added at the end, set correct value
-                                const addedEntity = value.pop()
-                                value.push({
-                                  relatedObjectType:
-                                    MODEL_TO_OBJECT_TYPE[entityType],
-                                  relatedObjectUuid: addedEntity.uuid,
-                                  relatedObject: addedEntity
-                                })
-                              }
-                              setFieldValue("attachmentRelatedObjects", value)
-                            }}
+                            setRelatedObjects={value =>
+                              setFieldValue("attachmentRelatedObjects", value)}
+                            showDelete
                           />
                         }
-                      >
-                        {!_isEmpty(values.attachmentRelatedObjects) && (
-                          <Table
-                            id="attachmentRelatedObjects-value"
-                            striped
-                            hover
-                            responsive
-                          >
-                            <tbody>
-                              {values.attachmentRelatedObjects.map(entity => (
-                                <tr key={entity.relatedObjectUuid}>
-                                  <td>
-                                    <LinkTo
-                                      modelType={entity.relatedObjectType}
-                                      model={{
-                                        uuid: entity.relatedObjectUuid,
-                                        ...entity.relatedObject
-                                      }}
-                                    />
-                                  </td>
-                                  <td className="col-1">
-                                    <RemoveButton
-                                      title={`Unlink this ${OBJECT_TYPE_TO_MODEL[entity.relatedObjectType]}`}
-                                      onClick={() => {
-                                        let found = false
-                                        const newValue =
-                                          values.attachmentRelatedObjects.filter(
-                                            e => {
-                                              if (_isEqual(e, entity)) {
-                                                found = true
-                                                return false
-                                              }
-                                              return true
-                                            }
-                                          )
-                                        if (found) {
-                                          setFieldValue(
-                                            "attachmentRelatedObjects",
-                                            newValue
-                                          )
-                                        }
-                                      }}
-                                    />
-                                  </td>
-                                </tr>
-                              ))}
-                            </tbody>
-                          </Table>
-                        )}
-                      </Field>
+                      />
                     )}
 
                     <DictionaryField


### PR DESCRIPTION
- Prevent deselect of ANET link in the rich-text editor throwing an error.
- Allow user to deselect attachmentRelatedObjects.

Relates to [AB#910](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/910), [AB#764](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/764)