### PR TITLE
Move dictionary keys to more logical place

### DIFF
--- a/anet-dictionary.yml
+++ b/anet-dictionary.yml
@@ -874,6 +874,10 @@ fields:
       label: Location
       placeholder: Search for the location where this Position will operate from…
       optional: false
+      filter: [POINT_LOCATION]
+    organizationsAdministrated:
+      label: Organizations administrated
+      placeholder: Search for an organization…
     role:
       label: Position Role
       types:
@@ -988,6 +992,10 @@ fields:
     location:
       label: Location
       placeholder: Search for the location where this Organization will operate from…
+      filter: [POINT_LOCATION, COUNTRY]
+    administratingPositions:
+      label: Assigned Superusers
+      placeholder: Search for a position…
     profile:
       label: Profile
       placeholder: Fill in the profile of this organization
@@ -1958,20 +1966,10 @@ fields:
     position:
       name: Regular
       type: Regular position
-      location:
-        filter: [POINT_LOCATION]
-      organizationsAdministrated:
-        label: Organizations administrated
-        placeholder: Search for an organization…
 
     org:
       name: Organization
       allOrgName: Top-level Organizations
-      location:
-        filter: [POINT_LOCATION, COUNTRY]
-      administratingPositions:
-        label: Assigned Superusers
-        placeholder: Search for a position…
 
 pinned_ORGs: [Key Leader Engagement]
 non_reporting_ORGs: [ANET Administrators]

--- a/client/src/components/EditAdministratingPositionsModal.js
+++ b/client/src/components/EditAdministratingPositionsModal.js
@@ -51,7 +51,6 @@ const EditAdministratingPositionsModal = ({
   return (
     <Formik enableReinitialize onSubmit={onSubmit} initialValues={organization}>
       {({ setFieldValue, values, submitForm, setFieldTouched }) => {
-        const orgSettings = Settings.fields.regular.org
         return (
           <Modal
             centered
@@ -61,7 +60,10 @@ const EditAdministratingPositionsModal = ({
           >
             <Modal.Header closeButton>
               <Modal.Title>
-                Edit {utils.noCase(orgSettings.administratingPositions.label)}
+                Edit{" "}
+                {utils.noCase(
+                  Settings.fields.organization.administratingPositions.label
+                )}
               </Modal.Title>
             </Modal.Header>
             <Modal.Body>
@@ -72,7 +74,9 @@ const EditAdministratingPositionsModal = ({
                     <Col md={12}>
                       <DictionaryField
                         wrappedComponent={FastField}
-                        dictProps={orgSettings.administratingPositions}
+                        dictProps={
+                          Settings.fields.organization.administratingPositions
+                        }
                         name="administratingPositions"
                         component={FieldHelper.SpecialField}
                         onChange={value => {

--- a/client/src/components/EditOrganizationsAdministratedModal.js
+++ b/client/src/components/EditOrganizationsAdministratedModal.js
@@ -44,7 +44,7 @@ const EditOrganizationsAdministratedModal = ({
     <Formik enableReinitialize onSubmit={onSubmit} initialValues={position}>
       {({ setFieldValue, values, submitForm, setFieldTouched }) => {
         const organizationsAdministratedSettings =
-          Settings.fields.regular.position.organizationsAdministrated
+          Settings.fields.position.organizationsAdministrated
         return (
           <Modal
             centered

--- a/client/src/models/Location.js
+++ b/client/src/models/Location.js
@@ -257,13 +257,13 @@ export default class Location extends Model {
 
   static getOrganizationLocationFilters() {
     return Location.getLocationFilters(
-      Settings?.fields.regular?.org?.location?.filter
+      Settings?.fields?.organization?.location?.filter
     )
   }
 
   static getPositionLocationFilters() {
     return Location.getLocationFilters(
-      Settings?.fields.regular?.position?.location?.filter
+      Settings?.fields?.position?.location?.filter
     )
   }
 

--- a/client/src/models/Position.js
+++ b/client/src/models/Position.js
@@ -8,10 +8,6 @@ import Settings from "settings"
 import utils from "utils"
 import * as yup from "yup"
 
-export const regularPosition = Settings.fields.regular.position
-export const administratorPosition = Settings.fields.administrator.position
-export const superuserPosition = Settings.fields.superuser.position
-
 export class PositionRole {
   // Static enumerations
   static MEMBER = new PositionRole("MEMBER", "member")
@@ -186,11 +182,11 @@ export default class Position extends Model {
 
   static humanNameOfType(type) {
     if (type === Position.TYPE.REGULAR) {
-      return regularPosition.type
+      return Settings.fields.regular.position.type
     } else if (type === Position.TYPE.SUPERUSER) {
-      return superuserPosition.type
+      return Settings.fields.superuser.position.type
     } else if (type === Position.TYPE.ADMINISTRATOR) {
-      return administratorPosition.type
+      return Settings.fields.administrator.position.type
     }
   }
 

--- a/client/src/pages/organizations/Laydown.js
+++ b/client/src/pages/organizations/Laydown.js
@@ -56,8 +56,6 @@ const OrganizationLaydown = ({ organization, refetch, readOnly }) => {
   )
   const allAdministratingPositions = getAllAdministratingPositions(organization)
 
-  const orgSettings = Settings.fields.regular.org
-
   return (
     <>
       <Fieldset id="orgChart" title="Organization Diagram">
@@ -116,7 +114,9 @@ const OrganizationLaydown = ({ organization, refetch, readOnly }) => {
       </Fieldset>
       <Fieldset
         id="administratingPositions"
-        title={utils.sentenceCase(orgSettings.administratingPositions.label)}
+        title={utils.sentenceCase(
+          Settings.fields.organization.administratingPositions.label
+        )}
         action={
           !readOnly &&
           isAdmin && (
@@ -124,7 +124,10 @@ const OrganizationLaydown = ({ organization, refetch, readOnly }) => {
               onClick={() => setShowAdministratingPositionsModal(true)}
               variant="outline-secondary"
             >
-              Edit {utils.noCase(orgSettings.administratingPositions.label)}
+              Edit{" "}
+              {utils.noCase(
+                Settings.fields.organization.administratingPositions.label
+              )}
             </Button>
           )
         }

--- a/client/src/pages/organizations/Show.js
+++ b/client/src/pages/organizations/Show.js
@@ -228,7 +228,6 @@ const OrganizationShow = ({ pageDispatchers }) => {
   const canAdministrateOrg =
     currentUser &&
     currentUser.hasAdministrativePermissionsForOrganization(organization)
-  const orgSettings = Settings.fields.regular.org
   const attachmentsEnabled = !Settings.fields.attachment.featureDisabled
   const { parentContext, parentStandardIdentity } =
     Organization.getApp6ParentFields(organization, organization)
@@ -254,7 +253,7 @@ const OrganizationShow = ({ pageDispatchers }) => {
         </Nav.Item>
         <Nav.Item>
           <AnchorNavItem to="administratingPositions">
-            {orgSettings.administratingPositions.label}
+            {Settings.fields.organization.administratingPositions.label}
           </AnchorNavItem>
         </Nav.Item>
         <Nav.Item>

--- a/client/src/pages/positions/Show.js
+++ b/client/src/pages/positions/Show.js
@@ -110,9 +110,6 @@ const PositionShow = ({ pageDispatchers }) => {
   const position = new Position(data ? data.position : {})
 
   const isSuperuser = position.type === Position.TYPE.SUPERUSER
-  const assignedRole = Settings.fields.regular.person.name
-  const positionSettings = Settings.fields.regular.position
-
   const canEdit =
     // Admins can edit anybody
     currentUser.isAdmin() ||
@@ -353,7 +350,7 @@ const PositionShow = ({ pageDispatchers }) => {
               </Fieldset>
 
               <Fieldset
-                title={`Assigned ${assignedRole}`}
+                title={`Assigned ${Settings.fields.regular.person.name}`}
                 id="assigned-counterpart"
                 action={
                   canEdit && (
@@ -361,7 +358,7 @@ const PositionShow = ({ pageDispatchers }) => {
                       onClick={() => setShowAssociatedPositionsModal(true)}
                       variant="outline-secondary"
                     >
-                      Change assigned {assignedRole}
+                      Change assigned {Settings.fields.regular.person.name}
                     </Button>
                   )
                 }
@@ -371,7 +368,8 @@ const PositionShow = ({ pageDispatchers }) => {
                 />
                 {position.associatedPositions.length === 0 && (
                   <em>
-                    {position.name} has no associated {assignedRole}
+                    {position.name} has no associated{" "}
+                    {Settings.fields.regular.person.name}
                   </em>
                 )}
 
@@ -413,7 +411,7 @@ const PositionShow = ({ pageDispatchers }) => {
                 <Fieldset
                   id="organizationsAdministrated"
                   title={utils.sentenceCase(
-                    positionSettings.organizationsAdministrated.label
+                    Settings.fields.position.organizationsAdministrated.label
                   )}
                   action={
                     currentUser.isAdmin() && (
@@ -424,7 +422,8 @@ const PositionShow = ({ pageDispatchers }) => {
                       >
                         Edit{" "}
                         {utils.noCase(
-                          positionSettings.organizationsAdministrated.label
+                          Settings.fields.position.organizationsAdministrated
+                            .label
                         )}
                       </Button>
                     )

--- a/src/main/resources/anet-schema.yml
+++ b/src/main/resources/anet-schema.yml
@@ -727,7 +727,7 @@ properties:
                   items:
                     type: string
                     enum:
-                      [VIRTUAL_LOCATION, PHYSICAL_LOCATION, GEOGRAPHICAL_AREA, POINT_LOCATION]
+                      [VIRTUAL_LOCATION, PHYSICAL_LOCATION, GEOGRAPHICAL_AREA, COUNTRY, POINT_LOCATION]
           reportPeople:
             required: [optionalAttendingAuthor, optionalPrimaryAdvisor, optionalPrimaryPrincipal]
             properties:
@@ -867,7 +867,7 @@ properties:
       position:
         type: object
         additionalProperties: false
-        required: [status, name, type, code, organization, role, emailAddresses, authorizationGroups]
+        required: [status, name, type, code, organization, location, organizationsAdministrated, role, emailAddresses, authorizationGroups]
         properties:
           status:
             "$ref": "#/$defs/labeledField"
@@ -880,7 +880,19 @@ properties:
           organization:
             "$ref": "#/$defs/inputField"
           location:
-            "$ref": "#/$defs/optionableInputField"
+            required: [filter]
+            allOf:
+            - "$ref": "#/$defs/extensibleInputField"
+            - properties:
+                filter:
+                  type: array
+                  uniqueItems: true
+                  items:
+                    type: string
+                    enum:
+                      [VIRTUAL_LOCATION, PHYSICAL_LOCATION, GEOGRAPHICAL_AREA, COUNTRY, POINT_LOCATION]
+          organizationsAdministrated:
+            "$ref": "#/$defs/inputField"
           emailAddresses:
             "$ref": "#/$defs/restrictableLabeledField"
           authorizationGroups:
@@ -917,7 +929,7 @@ properties:
         type: object
         additionalProperties: false
         required: [status, shortName, longName, identificationCode, type, parentOrg, childrenOrgs,
-                   location, profile, app6context, app6standardIdentity, app6symbolSet, app6hq,
+                   location, administratingPositions, profile, app6context, app6standardIdentity, app6symbolSet, app6hq,
                    app6amplifier, emailAddresses, authorizationGroups]
         properties:
           status:
@@ -935,6 +947,18 @@ properties:
           childrenOrgs:
             "$ref": "#/$defs/labeledField"
           location:
+            required: [filter]
+            allOf:
+            - "$ref": "#/$defs/extensibleInputField"
+            - properties:
+                filter:
+                  type: array
+                  uniqueItems: true
+                  items:
+                    type: string
+                    enum:
+                      [VIRTUAL_LOCATION, PHYSICAL_LOCATION, GEOGRAPHICAL_AREA, COUNTRY, POINT_LOCATION]
+          administratingPositions:
             "$ref": "#/$defs/inputField"
           profile:
             "$ref": "#/$defs/inputField"
@@ -1068,7 +1092,7 @@ properties:
           position:
             type: object
             additionalProperties: false
-            required: [name, type, location, organizationsAdministrated]
+            required: [name, type]
             properties:
               name:
                 type: string
@@ -1078,25 +1102,11 @@ properties:
                 type: string
                 title: The permissions type of this field
                 description: Used in the UI for the type/permissions of a position.
-              location:
-                type: object
-                additionalProperties: false
-                required: [filter]
-                properties:
-                  filter:
-                    type: array
-                    uniqueItems: true
-                    items:
-                      type: string
-                      enum:
-                        [VIRTUAL_LOCATION, PHYSICAL_LOCATION, GEOGRAPHICAL_AREA, POINT_LOCATION]
-              organizationsAdministrated:
-                "$ref": "#/$defs/inputField"
 
           org:
             type: object
             additionalProperties: false
-            required: [name, allOrgName, location, administratingPositions]
+            required: [name, allOrgName]
             properties:
               name:
                 type: string
@@ -1106,20 +1116,6 @@ properties:
                 type: string
                 title: The name used to represent 'all organizations'
                 description: Used in the UI to refer to all organizations collectively.
-              location:
-                type: object
-                additionalProperties: false
-                required: [filter]
-                properties:
-                  filter:
-                    type: array
-                    uniqueItems: true
-                    items:
-                      type: string
-                      enum:
-                        [VIRTUAL_LOCATION, PHYSICAL_LOCATION, GEOGRAPHICAL_AREA, COUNTRY, POINT_LOCATION]
-              administratingPositions:
-                "$ref": "#/$defs/inputField"
 
       superuser:
         type: object

--- a/testDictionaries/no-custom-fields.yml
+++ b/testDictionaries/no-custom-fields.yml
@@ -537,6 +537,10 @@ fields:
       label: Location
       placeholder: Search for the location where this Position will operate from…
       optional: false
+      filter: [POINT_LOCATION]
+    organizationsAdministrated:
+      label: Organizations administrated
+      placeholder: Search for an organization…
     role:
       label: Position Role
       types:
@@ -572,6 +576,10 @@ fields:
     location:
       label: Location
       placeholder: Search for the location where this Organization will operate from…
+      filter: [POINT_LOCATION, COUNTRY]
+    administratingPositions:
+      label: Assigned Superusers
+      placeholder: Search for a position…
     profile:
       label: Profile
       placeholder: Fill in the profile of this organization
@@ -1446,20 +1454,10 @@ fields:
     position:
       name: Regular
       type: Regular position
-      location:
-        filter: [POINT_LOCATION]
-      organizationsAdministrated:
-        label: Organizations administrated
-        placeholder: Search for an organization…
 
     org:
       name: Organization
       allOrgName: Top-level Organizations
-      location:
-        filter: [POINT_LOCATION, COUNTRY]
-      administratingPositions:
-        label: Assigned Superusers
-        placeholder: Search for a position…
 
 pinned_ORGs: [Key Leader Engagement]
 non_reporting_ORGs: [ANET Administrators]


### PR DESCRIPTION
Closes [AB#1165](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1165)

#### User changes
- None

#### Superuser changes
- None

#### Admin changes
- None

#### System admin changes
- [x] anet.yml or anet-dictionary.yml needs change
  - Move the key `fields.regular.position.location.filter` to `fields.position.location.filter`
  - Move the key `fields.regular.position.organizationsAdministrated` to `fields.position.organizationsAdministrated`
  - Move the key `fields.regular.org.location.filter` to `fields.organization.location.filter`
  - Move the key `fields.regular.org.administratingPositions` to `fields.organization.administratingPositions`
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
