### PR TITLE
Show organizations and positions at a location

### DIFF
--- a/client/src/components/EditAdministratingPositionsModal.js
+++ b/client/src/components/EditAdministratingPositionsModal.js
@@ -99,6 +99,7 @@ const EditAdministratingPositionsModal = ({
                             renderSelected={
                               <PositionTable
                                 positions={values.administratingPositions || []}
+                                showLocation
                                 showDelete
                               />
                             }

--- a/client/src/components/OrganizationTable.js
+++ b/client/src/components/OrganizationTable.js
@@ -30,6 +30,10 @@ const GQL_GET_ORGANIZATION_LIST = gql`
         shortName
         longName
         identificationCode
+        location {
+          uuid
+          name
+        }
       }
     }
   }
@@ -92,6 +96,7 @@ PaginatedOrganizations.propTypes = {
 
 const BaseOrganizationTable = ({
   id,
+  showLocation,
   showDelete,
   onDelete,
   organizations,
@@ -136,6 +141,7 @@ const BaseOrganizationTable = ({
                 </>
               )}
               <th>Name</th>
+              {showLocation && <th>Location</th>}
               {showDelete && <th />}
             </tr>
           </thead>
@@ -168,6 +174,11 @@ const BaseOrganizationTable = ({
                 <td>
                   <LinkTo modelType="Organization" model={org} />
                 </td>
+                {showLocation && (
+                  <td>
+                    <LinkTo modelType="Location" model={org.location} />
+                  </td>
+                )}
                 {showDelete && (
                   <td id={"organizationDelete_" + org.uuid}>
                     <RemoveButton
@@ -187,6 +198,7 @@ const BaseOrganizationTable = ({
 
 BaseOrganizationTable.propTypes = {
   id: PropTypes.string,
+  showLocation: PropTypes.bool,
   showDelete: PropTypes.bool,
   onDelete: PropTypes.func,
   // list of organizations:

--- a/client/src/components/PositionTable.js
+++ b/client/src/components/PositionTable.js
@@ -111,6 +111,7 @@ PaginatedPositions.propTypes = {
 
 const BasePositionTable = ({
   id,
+  showLocation,
   showDelete,
   onDelete,
   positions,
@@ -155,7 +156,7 @@ const BasePositionTable = ({
                 </>
               )}
               <th>Name</th>
-              <th>Location</th>
+              {showLocation && <th>Location</th>}
               <th>Organization</th>
               {showOrganizationsAdministrated && <th>Superuser of</th>}
               <th>Current Occupant</th>
@@ -196,9 +197,11 @@ const BasePositionTable = ({
                       {nameComponents.join(" - ")}
                     </LinkTo>
                   </td>
-                  <td>
-                    <LinkTo modelType="Location" model={pos.location} />
-                  </td>
+                  {showLocation && (
+                    <td>
+                      <LinkTo modelType="Location" model={pos.location} />
+                    </td>
+                  )}
                   <td>
                     {pos.organization && (
                       <LinkTo
@@ -243,6 +246,7 @@ const BasePositionTable = ({
 
 BasePositionTable.propTypes = {
   id: PropTypes.string,
+  showLocation: PropTypes.bool,
   showDelete: PropTypes.bool,
   onDelete: PropTypes.func,
   // list of positions:

--- a/client/src/components/previews/AuthorizationGroupPreview.js
+++ b/client/src/components/previews/AuthorizationGroupPreview.js
@@ -116,7 +116,10 @@ const AuthorizationGroupPreview = ({ className, uuid }) => {
         {Settings.fields.authorizationGroup.administrativePositions?.label}
       </h4>
       <div className="preview-section">
-        <PositionTable positions={authorizationGroup.administrativePositions} />
+        <PositionTable
+          positions={authorizationGroup.administrativePositions}
+          showLocation
+        />
       </div>
 
       <h4>

--- a/client/src/components/previews/TaskPreview.js
+++ b/client/src/components/previews/TaskPreview.js
@@ -238,7 +238,7 @@ const TaskPreview = ({ className, uuid }) => {
 
       <h4>{Settings.fields.task.responsiblePositions?.label}</h4>
       <div className="preview-section">
-        <PositionTable positions={task.responsiblePositions} />
+        <PositionTable positions={task.responsiblePositions} showLocation />
       </div>
     </div>
   )

--- a/client/src/pages/authorizationGroups/Form.js
+++ b/client/src/pages/authorizationGroups/Form.js
@@ -157,6 +157,7 @@ const AuthorizationGroupForm = ({ edit, title, initialValues }) => {
                       renderSelected={
                         <PositionTable
                           positions={values.administrativePositions}
+                          showLocation
                           showDelete={currentUser?.isAdmin()}
                         />
                       }

--- a/client/src/pages/authorizationGroups/Show.js
+++ b/client/src/pages/authorizationGroups/Show.js
@@ -190,6 +190,7 @@ const AuthorizationGroupShow = ({ pageDispatchers }) => {
               >
                 <PositionTable
                   positions={authorizationGroup.administrativePositions}
+                  showLocation
                 />
               </Fieldset>
 

--- a/client/src/pages/locations/Show.js
+++ b/client/src/pages/locations/Show.js
@@ -53,10 +53,8 @@ const LocationShow = ({ pageDispatchers }) => {
   const { currentUser } = useContext(AppContext)
   const { uuid } = useParams()
   const routerLocation = useLocation()
-  const stateSuccess = routerLocation.state && routerLocation.state.success
-  const [stateError, setStateError] = useState(
-    routerLocation.state && routerLocation.state.error
-  )
+  const stateSuccess = routerLocation.state?.success
+  const [stateError, setStateError] = useState(routerLocation.state?.error)
   const { loading, error, data, refetch } = API.useApiQuery(GQL_GET_LOCATION, {
     uuid
   })

--- a/client/src/pages/locations/Show.js
+++ b/client/src/pages/locations/Show.js
@@ -14,6 +14,7 @@ import LinkTo from "components/LinkTo"
 import LocationTable from "components/LocationTable"
 import Messages from "components/Messages"
 import { DEFAULT_CUSTOM_FIELDS_PARENT } from "components/Model"
+import OrganizationTable from "components/OrganizationTable"
 import {
   jumpToTop,
   mapPageDispatchersToProps,
@@ -22,6 +23,7 @@ import {
   useBoilerplate,
   usePageTitle
 } from "components/Page"
+import PositionTable from "components/PositionTable"
 import RelatedObjectNotes from "components/RelatedObjectNotes"
 import ReportCollection from "components/ReportCollection"
 import RichTextEditor from "components/RichTextEditor"
@@ -274,6 +276,14 @@ const LocationShow = ({ pageDispatchers }) => {
             </Form>
 
             <Approvals relatedObject={location} />
+
+            <Fieldset title="Organizations at this Location">
+              <OrganizationTable queryParams={{ locationUuid: uuid }} />
+            </Fieldset>
+
+            <Fieldset title="Positions at this Location">
+              <PositionTable queryParams={{ locationUuid: uuid }} />
+            </Fieldset>
 
             <Fieldset title="Reports at this Location">
               <ReportCollection

--- a/client/src/pages/organizations/Laydown.js
+++ b/client/src/pages/organizations/Laydown.js
@@ -135,6 +135,7 @@ const OrganizationLaydown = ({ organization, refetch, readOnly }) => {
         <PositionTable
           id="superuser-table"
           positions={allAdministratingPositions}
+          showLocation
           showOrganizationsAdministrated
         />
         <EditAdministratingPositionsModal

--- a/client/src/pages/positions/MyCounterparts.js
+++ b/client/src/pages/positions/MyCounterparts.js
@@ -26,13 +26,19 @@ const MyCounterparts = ({ pageDispatchers }) => {
   return (
     <div>
       <Fieldset id="my-counterparts" title="My Counterparts">
-        <PositionTable positions={currentUser.position.associatedPositions} />
+        <PositionTable
+          positions={currentUser.position.associatedPositions}
+          showLocation
+        />
       </Fieldset>
       <Fieldset
         id="my-counterparts-with-pending-assessments"
         title="My Counterparts that have pending assessments"
       >
-        <PositionTable positions={counterpartsWithPendingAssessments} />
+        <PositionTable
+          positions={counterpartsWithPendingAssessments}
+          showLocation
+        />
       </Fieldset>
     </div>
   )

--- a/client/src/pages/searches/Search.js
+++ b/client/src/pages/searches/Search.js
@@ -102,6 +102,10 @@ const GQL_GET_ORGANIZATION_LIST = gql`
         longName
         identificationCode
         ${GQL_EMAIL_ADDRESSES}
+        location {
+          uuid
+          name
+        }
       }
     }
   }
@@ -372,6 +376,7 @@ const Organizations = ({
   return (
     <OrganizationTable
       organizations={organizations}
+      showLocation
       pageSize={pageSize}
       pageNum={curPage}
       totalCount={totalCount}

--- a/client/src/pages/searches/Search.js
+++ b/client/src/pages/searches/Search.js
@@ -607,6 +607,7 @@ const Positions = ({
   return (
     <PositionTable
       positions={positions}
+      showLocation
       pageSize={pageSize}
       pageNum={curPage}
       totalCount={totalCount}

--- a/client/src/pages/tasks/Form.js
+++ b/client/src/pages/tasks/Form.js
@@ -350,6 +350,7 @@ const TaskForm = ({ edit, title, initialValues, notesComponent }) => {
                       renderSelected={
                         <PositionTable
                           positions={values.responsiblePositions}
+                          showLocation
                           showDelete
                         />
                       }

--- a/client/src/pages/tasks/Show.js
+++ b/client/src/pages/tasks/Show.js
@@ -392,7 +392,10 @@ const TaskShow = ({ pageDispatchers }) => {
             )}
 
             <Fieldset title={Settings.fields.task.responsiblePositions?.label}>
-              <PositionTable positions={task.responsiblePositions} />
+              <PositionTable
+                positions={task.responsiblePositions}
+                showLocation
+              />
             </Fieldset>
 
             <Approvals

--- a/client/tests/webdriver/baseSpecs/showLocation.spec.js
+++ b/client/tests/webdriver/baseSpecs/showLocation.spec.js
@@ -1,12 +1,15 @@
 import { expect } from "chai"
 import ShowLocation from "../pages/location/showLocation.page"
 
-const LOCATION_UUID = "e5b3a4b9-acf7-4c79-8224-f248b9a7215d"
+const LOCATION_WITH_ATTACHMENTS_UUID = "e5b3a4b9-acf7-4c79-8224-f248b9a7215d" // Antarctica
+const LOCATION_WITH_ORGANIZATIONS_UUID = "9c982685-5946-4dad-a7ee-0f5a12f5e170" // Wishingwells Park
+const LOCATION_WITH_POSITIONS_UUID = "cc49bb27-4d8f-47a8-a9ee-af2b68b992ac" // St Johns Airport
+const LOCATION_WITH_REPORTS_UUID = "0855fb0a-995e-4a79-a132-4024ee2983ff" // General Hospital
 
 describe("Show location page", () => {
   describe("When on the show page of a location with attachment(s)", () => {
     it("We should see a container for Attachment List", async() => {
-      await ShowLocation.open(LOCATION_UUID)
+      await ShowLocation.open(LOCATION_WITH_ATTACHMENTS_UUID)
       await (await ShowLocation.getAttachments()).waitForExist()
       await (await ShowLocation.getAttachments()).waitForDisplayed()
     })
@@ -20,6 +23,39 @@ describe("Show location page", () => {
       await expect(await browser.getUrl()).to.include(
         "/attachments/f7cd5b02-ef73-4ee8-814b-c5a7a916685d"
       )
+    })
+  })
+
+  describe("When on the show page of a location with organizations", () => {
+    it("We should see rows in the organizations table", async() => {
+      await ShowLocation.open(LOCATION_WITH_ORGANIZATIONS_UUID)
+      await (await ShowLocation.getTable("organizations_table")).waitForExist()
+      await (
+        await ShowLocation.getTable("organizations_table")
+      ).waitForDisplayed()
+      expect(
+        await ShowLocation.getTableRows("organizations_table")
+      ).to.have.lengthOf.above(0)
+    })
+  })
+
+  describe("When on the show page of a location with positions", () => {
+    it("We should see rows in the positions table", async() => {
+      await ShowLocation.open(LOCATION_WITH_POSITIONS_UUID)
+      await (await ShowLocation.getTable("positions_table")).waitForExist()
+      await (await ShowLocation.getTable("positions_table")).waitForDisplayed()
+      expect(
+        await ShowLocation.getTableRows("positions_table")
+      ).to.have.lengthOf.above(0)
+    })
+  })
+
+  describe("When on the show page of a location with reports", () => {
+    it("We should see rows in the reports table", async() => {
+      await ShowLocation.open(LOCATION_WITH_REPORTS_UUID)
+      await (await ShowLocation.getReportCollection()).waitForExist()
+      await (await ShowLocation.getReportCollection()).waitForDisplayed()
+      expect(await ShowLocation.getReportSummaries()).to.have.lengthOf.above(0)
     })
   })
 })

--- a/client/tests/webdriver/pages/location/showLocation.page.js
+++ b/client/tests/webdriver/pages/location/showLocation.page.js
@@ -22,5 +22,21 @@ class ShowLocation extends Page {
   async getLngField() {
     return browser.$('div[name="location"] span:nth-child(3)')
   }
+
+  async getTable(tableName) {
+    return browser.$(`table.${tableName}`)
+  }
+
+  async getTableRows(tableName) {
+    return (await this.getTable(tableName)).$$("tbody tr")
+  }
+
+  async getReportCollection() {
+    return browser.$("div.report-collection")
+  }
+
+  async getReportSummaries() {
+    return (await this.getReportCollection()).$$("div.report-summary")
+  }
 }
 export default new ShowLocation()

--- a/insertBaseData-psql.sql
+++ b/insertBaseData-psql.sql
@@ -447,6 +447,10 @@ INSERT INTO organizations(uuid, "shortName", "longName", "parentOrgUuid", "app6s
   (uuid_generate_v4(), 'EF 6.2', '', (SELECT uuid FROM organizations WHERE "shortName" = 'EF 6'), '10', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
 
 UPDATE organizations
+SET "locationUuid"='9c982685-5946-4dad-a7ee-0f5a12f5e170'
+WHERE "shortName" LIKE 'EF 4%';
+
+UPDATE organizations
 SET "customFields"='{"invisibleCustomFields":["formCustomFields.textareaFieldName","formCustomFields.numberFieldName"],"arrayFieldName":[],"nlt_dt":null,"nlt":null,"colourOptions":"","inputFieldName":"quis nostrud exercitation ullamco laboris","multipleButtons":[]}'
 WHERE "shortName"='LNG';
 


### PR DESCRIPTION
The location details page now has sections showing the organizations and positions at this location.

Closes [AB#1164](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1164)

#### User changes
- A user can see the organizations and positions at a location.
- The search results for organizations now also show the organization's location.

#### Superuser changes
- None.

#### Admin changes
- None.

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [x] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here