### PR TITLE
Add merge buttons to the show pages for mergeable objects

### DIFF
--- a/client/src/components/Model.js
+++ b/client/src/components/Model.js
@@ -971,6 +971,14 @@ export default class Model {
     return Model.filterClientSideFields(this, ...additionalFields)
   }
 
+  fixupFields() {
+    if (this.customFields) {
+      this[DEFAULT_CUSTOM_FIELDS_PARENT] = utils.parseJsonSafe(
+        this.customFields
+      )
+    }
+  }
+
   static isAuthorized(user, customSensitiveInformationField) {
     // Admins are always allowed
     if (user?.isAdmin()) {

--- a/client/src/models/Location.js
+++ b/client/src/models/Location.js
@@ -308,4 +308,9 @@ export default class Location extends Model {
   filterClientSideFields(...additionalFields) {
     return Location.filterClientSideFields(this, ...additionalFields)
   }
+
+  fixupFields() {
+    super.fixupFields()
+    this.displayedCoordinate = convertLatLngToMGRS(this.lat, this.lng)
+  }
 }

--- a/client/src/models/Person.js
+++ b/client/src/models/Person.js
@@ -484,6 +484,15 @@ export default class Person extends Model {
     return Person.filterClientSideFields(this, ...additionalFields)
   }
 
+  fixupFields() {
+    super.fixupFields()
+    if (this.customSensitiveInformation) {
+      this[SENSITIVE_CUSTOM_FIELDS_PARENT] = utils.parseSensitiveFields(
+        this.customSensitiveInformation
+      )
+    }
+  }
+
   static isAuthorized(user, customSensitiveInformationField, position) {
     if (Model.isAuthorized(user, customSensitiveInformationField)) {
       return true

--- a/client/src/pages/admin/merge/MergeLocations.js
+++ b/client/src/pages/admin/merge/MergeLocations.js
@@ -119,6 +119,7 @@ const MergeLocations = ({ pageDispatchers }) => {
             locationFormat={locationFormat}
             setLocationFormat={setLocationFormat}
             locationFormatLabel={locationFormatLabel}
+            disabled={!!initialLeftUuid}
           />
         </Col>
         <Col md={4} id="mid-merge-loc-col">
@@ -386,6 +387,7 @@ function getLocationFilters() {
 const LocationColumn = ({
   align,
   label,
+  disabled,
   mergeState,
   dispatchMergeActions,
   locationFormat,
@@ -418,6 +420,8 @@ const LocationColumn = ({
           fields={Location.allFieldsQuery}
           addon={LOCATIONS_ICON}
           vertical
+          disabled={disabled}
+          showRemoveButton={!disabled}
         />
       </ColTitle>
       {areAllSet(location) && (
@@ -644,6 +648,7 @@ const LocationColumn = ({
 LocationColumn.propTypes = {
   align: PropTypes.oneOf(["left", "right"]).isRequired,
   label: PropTypes.string.isRequired,
+  disabled: PropTypes.bool,
   mergeState: PropTypes.object,
   dispatchMergeActions: PropTypes.func,
   locationFormat: PropTypes.oneOf(Object.keys(Location.LOCATION_FORMATS))

--- a/client/src/pages/admin/merge/MergeOrganizations.js
+++ b/client/src/pages/admin/merge/MergeOrganizations.js
@@ -108,6 +108,7 @@ const MergeOrganizations = ({ pageDispatchers }) => {
             dispatchMergeActions={dispatchMergeActions}
             align={ALIGN_OPTIONS.LEFT}
             label="Organization 1"
+            disabled={!!initialLeftUuid}
           />
         </Col>
         <Col md={4} id="mid-merge-org-col">
@@ -456,6 +457,7 @@ const organizationsFilters = {
 const OrganizationColumn = ({
   align,
   label,
+  disabled,
   mergeState,
   dispatchMergeActions
 }) => {
@@ -488,6 +490,8 @@ const OrganizationColumn = ({
           fields={Organization.allFieldsQuery}
           addon={ORGANIZATIONS_ICON}
           vertical
+          disabled={disabled}
+          showRemoveButton={!disabled}
         />
       </ColTitle>
       {areAllSet(organization) && (
@@ -856,6 +860,7 @@ const OrganizationCol = styled.div`
 OrganizationColumn.propTypes = {
   align: PropTypes.oneOf(["left", "right"]).isRequired,
   label: PropTypes.string.isRequired,
+  disabled: PropTypes.bool,
   mergeState: PropTypes.object,
   dispatchMergeActions: PropTypes.func
 }

--- a/client/src/pages/admin/merge/MergePeople.js
+++ b/client/src/pages/admin/merge/MergePeople.js
@@ -107,6 +107,7 @@ const MergePeople = ({ pageDispatchers }) => {
             dispatchMergeActions={dispatchMergeActions}
             align={ALIGN_OPTIONS.LEFT}
             label="Person 1"
+            disabled={!!initialLeftUuid}
           />
         </Col>
         <Col md={4} id="mid-merge-per-col">
@@ -469,7 +470,13 @@ const peopleFilters = {
   }
 }
 
-const PersonColumn = ({ align, label, mergeState, dispatchMergeActions }) => {
+const PersonColumn = ({
+  align,
+  label,
+  disabled,
+  mergeState,
+  dispatchMergeActions
+}) => {
   const person = mergeState[align]
   const idForPerson = label.replace(/\s+/g, "")
 
@@ -496,6 +503,8 @@ const PersonColumn = ({ align, label, mergeState, dispatchMergeActions }) => {
           fields={Person.allFieldsQuery}
           addon={PEOPLE_ICON}
           vertical
+          disabled={disabled}
+          showRemoveButton={!disabled}
         />
       </ColTitle>
       {areAllSet(person) && (
@@ -855,6 +864,7 @@ const PersonCol = styled.div`
 PersonColumn.propTypes = {
   align: PropTypes.oneOf(["left", "right"]).isRequired,
   label: PropTypes.string.isRequired,
+  disabled: PropTypes.bool,
   mergeState: PropTypes.object,
   dispatchMergeActions: PropTypes.func
 }

--- a/client/src/pages/admin/merge/MergePositions.js
+++ b/client/src/pages/admin/merge/MergePositions.js
@@ -108,6 +108,7 @@ const MergePositions = ({ pageDispatchers }) => {
             dispatchMergeActions={dispatchMergeActions}
             align={ALIGN_OPTIONS.LEFT}
             label="Position 1"
+            disabled={!!initialLeftUuid}
           />
         </Col>
         <Col md={4} id="mid-merge-pos-col">
@@ -429,7 +430,13 @@ function getPositionFilters(mergeState, align) {
   }
 }
 
-const PositionColumn = ({ align, label, mergeState, dispatchMergeActions }) => {
+const PositionColumn = ({
+  align,
+  label,
+  disabled,
+  mergeState,
+  dispatchMergeActions
+}) => {
   const position = mergeState[align]
   const hideWhenEmpty =
     !Location.hasCoordinates(mergeState[MERGE_SIDES.LEFT]?.location) &&
@@ -458,6 +465,8 @@ const PositionColumn = ({ align, label, mergeState, dispatchMergeActions }) => {
           fields={Position.allFieldsQuery}
           addon={POSITIONS_ICON}
           vertical
+          disabled={disabled}
+          showRemoveButton={!disabled}
         />
       </ColTitle>
       {areAllSet(position) && (
@@ -712,6 +721,7 @@ const PositionCol = styled.div`
 PositionColumn.propTypes = {
   align: PropTypes.oneOf(["left", "right"]).isRequired,
   label: PropTypes.string.isRequired,
+  disabled: PropTypes.bool,
   mergeState: PropTypes.object,
   dispatchMergeActions: PropTypes.func
 }

--- a/client/src/pages/locations/Show.js
+++ b/client/src/pages/locations/Show.js
@@ -34,7 +34,7 @@ import _isEmpty from "lodash/isEmpty"
 import { Attachment, Location } from "models"
 import React, { useContext, useState } from "react"
 import { connect } from "react-redux"
-import { useLocation, useParams } from "react-router-dom"
+import { Link, useLocation, useParams } from "react-router-dom"
 import Settings from "settings"
 import utils from "utils"
 
@@ -77,7 +77,8 @@ const LocationShow = ({ pageDispatchers }) => {
     )
   }
   const location = new Location(data ? data.location : {})
-  const canEdit = currentUser.isSuperuser()
+  const isAdmin = currentUser?.isAdmin()
+  const canEdit = currentUser?.isSuperuser()
   const attachmentsEnabled = !Settings.fields.attachment.featureDisabled
 
   return (
@@ -95,6 +96,15 @@ const LocationShow = ({ pageDispatchers }) => {
         }
         const action = (
           <>
+            {isAdmin && (
+              <Link
+                to="/admin/merge/locations"
+                state={{ initialLeftUuid: location.uuid }}
+                className="btn btn-outline-secondary"
+              >
+                Merge with other location
+              </Link>
+            )}
             {canEdit && (
               <LinkTo
                 modelType="Location"

--- a/client/src/pages/locations/Show.js
+++ b/client/src/pages/locations/Show.js
@@ -98,6 +98,7 @@ const LocationShow = ({ pageDispatchers }) => {
           <>
             {isAdmin && (
               <Link
+                id="mergeWithOther"
                 to="/admin/merge/locations"
                 state={{ initialLeftUuid: location.uuid }}
                 className="btn btn-outline-secondary"

--- a/client/src/pages/organizations/Show.js
+++ b/client/src/pages/organizations/Show.js
@@ -289,6 +289,7 @@ const OrganizationShow = ({ pageDispatchers }) => {
           <>
             {isAdmin && (
               <Link
+                id="mergeWithOther"
                 to="/admin/merge/organizations"
                 state={{ initialLeftUuid: organization.uuid }}
                 className="btn btn-outline-secondary"

--- a/client/src/pages/organizations/Show.js
+++ b/client/src/pages/organizations/Show.js
@@ -47,7 +47,7 @@ import {
   Nav
 } from "react-bootstrap"
 import { connect } from "react-redux"
-import { useLocation, useParams } from "react-router-dom"
+import { Link, useLocation, useParams } from "react-router-dom"
 import { RECURSE_STRATEGY } from "searchUtils"
 import Settings from "settings"
 import utils from "utils"
@@ -225,9 +225,9 @@ const OrganizationShow = ({ pageDispatchers }) => {
   }
   const organization = new Organization(data ? data.organization : {})
 
+  const isAdmin = currentUser?.isAdmin()
   const canAdministrateOrg =
-    currentUser &&
-    currentUser.hasAdministrativePermissionsForOrganization(organization)
+    currentUser?.hasAdministrativePermissionsForOrganization(organization)
   const attachmentsEnabled = !Settings.fields.attachment.featureDisabled
   const { parentContext, parentStandardIdentity } =
     Organization.getApp6ParentFields(organization, organization)
@@ -287,6 +287,15 @@ const OrganizationShow = ({ pageDispatchers }) => {
       {({ values }) => {
         const action = (
           <>
+            {isAdmin && (
+              <Link
+                to="/admin/merge/organizations"
+                state={{ initialLeftUuid: organization.uuid }}
+                className="btn btn-outline-secondary"
+              >
+                Merge with other organization
+              </Link>
+            )}
             {canAdministrateOrg && (
               <LinkTo
                 modelType="Organization"

--- a/client/src/pages/people/Show.js
+++ b/client/src/pages/people/Show.js
@@ -56,7 +56,7 @@ import {
   Tooltip
 } from "react-bootstrap"
 import { connect } from "react-redux"
-import { useLocation, useNavigate, useParams } from "react-router-dom"
+import { Link, useLocation, useNavigate, useParams } from "react-router-dom"
 import Settings from "settings"
 import utils from "utils"
 import PersonAvatar from "./Avatar"
@@ -196,8 +196,8 @@ const PersonShow = ({ pageDispatchers }) => {
   // User can always edit themselves
   // Admins can always edit anybody
   // Superusers can edit people in their org, their descendant orgs, or un-positioned people.
-  const isAdmin = currentUser && currentUser.isAdmin()
-  const hasPosition = position && position.uuid
+  const isAdmin = currentUser?.isAdmin()
+  const hasPosition = position?.uuid
   const canEdit =
     Person.isEqual(currentUser, person) ||
     isAdmin ||
@@ -220,6 +220,15 @@ const PersonShow = ({ pageDispatchers }) => {
 
   const action = (
     <>
+      {isAdmin && (
+        <Link
+          to="/admin/merge/people"
+          state={{ initialLeftUuid: person.uuid }}
+          className="btn btn-outline-secondary"
+        >
+          Merge with other person
+        </Link>
+      )}
       <Button value="compactView" variant="primary" onClick={onCompactClick}>
         Summary / Print
       </Button>

--- a/client/src/pages/people/Show.js
+++ b/client/src/pages/people/Show.js
@@ -222,6 +222,7 @@ const PersonShow = ({ pageDispatchers }) => {
     <>
       {isAdmin && (
         <Link
+          id="mergeWithOther"
           to="/admin/merge/people"
           state={{ initialLeftUuid: person.uuid }}
           className="btn btn-outline-secondary"

--- a/client/src/pages/positions/Show.js
+++ b/client/src/pages/positions/Show.js
@@ -128,6 +128,7 @@ const PositionShow = ({ pageDispatchers }) => {
           <>
             {isAdmin && (
               <Link
+                id="mergeWithOther"
                 to="/admin/merge/positions"
                 state={{ initialLeftUuid: position.uuid }}
                 className="btn btn-outline-secondary"

--- a/client/src/pages/positions/Show.js
+++ b/client/src/pages/positions/Show.js
@@ -34,7 +34,7 @@ import { positionTour } from "pages/HopscotchTour"
 import React, { useContext, useState } from "react"
 import { Badge, Button } from "react-bootstrap"
 import { connect } from "react-redux"
-import { useLocation, useNavigate, useParams } from "react-router-dom"
+import { Link, useLocation, useNavigate, useParams } from "react-router-dom"
 import Settings from "settings"
 import utils from "utils"
 import PreviousPeople from "./PreviousPeople"
@@ -43,10 +43,6 @@ const GQL_GET_POSITION = gql`
   query($uuid: String!) {
     position(uuid: $uuid) {
       ${Position.allFieldsQuery}
-      emailAddresses {
-        network
-        address
-      }
       authorizationGroups {
         uuid
         name
@@ -110,16 +106,17 @@ const PositionShow = ({ pageDispatchers }) => {
   const position = new Position(data ? data.position : {})
 
   const isSuperuser = position.type === Position.TYPE.SUPERUSER
+  const isAdmin = currentUser?.isAdmin()
   const canEdit =
     // Admins can edit anybody
-    currentUser.isAdmin() ||
+    isAdmin ||
     // Superusers can edit positions if they have administrative permissions for the organization of the position
     (position?.organization?.uuid &&
       currentUser.hasAdministrativePermissionsForOrganization(
         position.organization
       ))
   const canDelete =
-    currentUser.isAdmin() &&
+    isAdmin &&
     position.status === Model.STATUS.INACTIVE &&
     position.uuid &&
     (!position.person || !position.person.uuid)
@@ -129,6 +126,15 @@ const PositionShow = ({ pageDispatchers }) => {
       {({ values }) => {
         const action = (
           <>
+            {isAdmin && (
+              <Link
+                to="/admin/merge/positions"
+                state={{ initialLeftUuid: position.uuid }}
+                className="btn btn-outline-secondary"
+              >
+                Merge with other position
+              </Link>
+            )}
             {canEdit && (
               <LinkTo
                 modelType="Position"
@@ -414,7 +420,7 @@ const PositionShow = ({ pageDispatchers }) => {
                     Settings.fields.position.organizationsAdministrated.label
                   )}
                   action={
-                    currentUser.isAdmin() && (
+                    isAdmin && (
                       <Button
                         onClick={() =>
                           setShowOrganizationsAdministratedModal(true)}

--- a/client/tests/webdriver/baseSpecs/showLocation.spec.js
+++ b/client/tests/webdriver/baseSpecs/showLocation.spec.js
@@ -1,5 +1,6 @@
 import { expect } from "chai"
 import ShowLocation from "../pages/location/showLocation.page"
+import MergeLocations from "../pages/mergeLocations.page"
 
 const LOCATION_WITH_ATTACHMENTS_UUID = "e5b3a4b9-acf7-4c79-8224-f248b9a7215d" // Antarctica
 const LOCATION_WITH_ORGANIZATIONS_UUID = "9c982685-5946-4dad-a7ee-0f5a12f5e170" // Wishingwells Park
@@ -56,6 +57,21 @@ describe("Show location page", () => {
       await (await ShowLocation.getReportCollection()).waitForExist()
       await (await ShowLocation.getReportCollection()).waitForDisplayed()
       expect(await ShowLocation.getReportSummaries()).to.have.lengthOf.above(0)
+
+      await ShowLocation.logout()
+    })
+  })
+
+  describe("When on the show page of a location as admin", () => {
+    it("We can select to merge it with another location", async() => {
+      await ShowLocation.openAsAdminUser(LOCATION_WITH_ATTACHMENTS_UUID)
+      await (await ShowLocation.getMergeButton()).click()
+      await browser.pause(500) // wait for the merge page to render and load data
+      // eslint-disable-next-line no-unused-expressions
+      expect(await MergeLocations.getTitle()).to.exist
+      expect(
+        await (await MergeLocations.getLeftLocationField()).getValue()
+      ).to.contain("Antarctica")
     })
   })
 })

--- a/client/tests/webdriver/baseSpecs/showLocation.spec.js
+++ b/client/tests/webdriver/baseSpecs/showLocation.spec.js
@@ -72,6 +72,9 @@ describe("Show location page", () => {
       expect(
         await (await MergeLocations.getLeftLocationField()).getValue()
       ).to.contain("Antarctica")
+      // eslint-disable-next-line no-unused-expressions
+      expect(await (await MergeLocations.getLeftLocationField()).isEnabled()).to
+        .be.false
     })
   })
 })

--- a/client/tests/webdriver/baseSpecs/showOrganization.spec.js
+++ b/client/tests/webdriver/baseSpecs/showOrganization.spec.js
@@ -1,5 +1,6 @@
 import { expect } from "chai"
 import Home from "../pages/home.page"
+import MergeOrganizations from "../pages/mergeOrganizations.page"
 import Search from "../pages/search.page"
 import ShowOrganization from "../pages/showOrganization.page"
 
@@ -140,6 +141,21 @@ describe("Show organization page", () => {
       await expect(await browser.getUrl()).to.include(
         "/attachments/9ac41246-25ac-457c-b7d6-946c5f625f1f"
       )
+
+      await ShowOrganization.logout()
+    })
+  })
+
+  describe("When on the show page of an organization as admin", () => {
+    it("We can select to merge it with another organization", async() => {
+      await ShowOrganization.openAsAdminUser(ORGANIZATION_UUID)
+      await (await ShowOrganization.getMergeButton()).click()
+      await browser.pause(500) // wait for the merge page to render and load data
+      // eslint-disable-next-line no-unused-expressions
+      expect(await MergeOrganizations.getTitle()).to.exist
+      expect(
+        await (await MergeOrganizations.getLeftOrganizationField()).getValue()
+      ).to.contain("EF 2.2")
     })
   })
 })

--- a/client/tests/webdriver/baseSpecs/showOrganization.spec.js
+++ b/client/tests/webdriver/baseSpecs/showOrganization.spec.js
@@ -156,6 +156,10 @@ describe("Show organization page", () => {
       expect(
         await (await MergeOrganizations.getLeftOrganizationField()).getValue()
       ).to.contain("EF 2.2")
+      // eslint-disable-next-line no-unused-expressions
+      expect(
+        await (await MergeOrganizations.getLeftOrganizationField()).isEnabled()
+      ).to.be.false
     })
   })
 })

--- a/client/tests/webdriver/baseSpecs/showPerson.spec.js
+++ b/client/tests/webdriver/baseSpecs/showPerson.spec.js
@@ -1,4 +1,5 @@
 import { expect } from "chai"
+import MergePeople from "../pages/mergePeople.page"
 import ShowPerson from "../pages/showPerson.page"
 
 const PERSON_UUID = "df9c7381-56ac-4bc5-8e24-ec524bccd7e9"
@@ -38,6 +39,21 @@ describe("Show person page", () => {
       await expect(await browser.getUrl()).to.include(
         "/attachments/13318e42-a0a3-438f-8ed5-dc16b1ef17bc"
       )
+
+      await ShowPerson.logout()
+    })
+  })
+
+  describe("When on the show page of a person as admin", () => {
+    it("We can select to merge them with another person", async() => {
+      await ShowPerson.openAsAdminUser(PERSON_WITH_AG_UUID)
+      await (await ShowPerson.getMergeButton()).click()
+      await browser.pause(500) // wait for the merge page to render and load data
+      // eslint-disable-next-line no-unused-expressions
+      expect(await MergePeople.getTitle()).to.exist
+      expect(
+        await (await MergePeople.getLeftPersonField()).getValue()
+      ).to.contain("BRATTON, Creed")
     })
   })
 })

--- a/client/tests/webdriver/baseSpecs/showPerson.spec.js
+++ b/client/tests/webdriver/baseSpecs/showPerson.spec.js
@@ -54,6 +54,9 @@ describe("Show person page", () => {
       expect(
         await (await MergePeople.getLeftPersonField()).getValue()
       ).to.contain("BRATTON, Creed")
+      // eslint-disable-next-line no-unused-expressions
+      expect(await (await MergePeople.getLeftPersonField()).isEnabled()).to.be
+        .false
     })
   })
 })

--- a/client/tests/webdriver/baseSpecs/showPosition.spec.js
+++ b/client/tests/webdriver/baseSpecs/showPosition.spec.js
@@ -1,4 +1,5 @@
 import { expect } from "chai"
+import MergePositions from "../pages/mergePositions.page"
 import ShowPosition from "../pages/showPosition.page"
 
 const POSITION_WITH_AG_UUID = "05c42ce0-34a0-4391-8b2f-c4cd85ee6b47" // EF 5.1 Advisor Quality Assurance
@@ -20,6 +21,21 @@ describe("Show position page", () => {
       await expect(await browser.getUrl()).to.include(
         "/authorizationGroups/ab1a7d99-4529-44b1-a118-bdee3ca8296b"
       )
+
+      await ShowPosition.logout()
+    })
+  })
+
+  describe("When on the show page of a position as admin", () => {
+    it("We can select to merge it with another position", async() => {
+      await ShowPosition.openAsAdminUser(POSITION_WITH_AG_UUID)
+      await (await ShowPosition.getMergeButton()).click()
+      await browser.pause(500) // wait for the merge page to render and load data
+      // eslint-disable-next-line no-unused-expressions
+      expect(await MergePositions.getTitle()).to.exist
+      expect(
+        await (await MergePositions.getLeftPositionField()).getValue()
+      ).to.contain("EF 5.1 Advisor Quality Assurance")
     })
   })
 })

--- a/client/tests/webdriver/baseSpecs/showPosition.spec.js
+++ b/client/tests/webdriver/baseSpecs/showPosition.spec.js
@@ -36,6 +36,9 @@ describe("Show position page", () => {
       expect(
         await (await MergePositions.getLeftPositionField()).getValue()
       ).to.contain("EF 5.1 Advisor Quality Assurance")
+      // eslint-disable-next-line no-unused-expressions
+      expect(await (await MergePositions.getLeftPositionField()).isEnabled()).to
+        .be.false
     })
   })
 })

--- a/client/tests/webdriver/pages/location/showLocation.page.js
+++ b/client/tests/webdriver/pages/location/showLocation.page.js
@@ -7,6 +7,10 @@ class ShowLocation extends Page {
     await super.open(PAGE_URL.replace(":uuid", uuid))
   }
 
+  async openAsAdminUser(uuid) {
+    await super.openAsAdminUser(PAGE_URL.replace(":uuid", uuid))
+  }
+
   async getEditButton() {
     return browser.$('//a[text()="Edit"]')
   }

--- a/client/tests/webdriver/pages/page.js
+++ b/client/tests/webdriver/pages/page.js
@@ -219,6 +219,10 @@ class Page {
       await this.deleteText(await (await inputField).getValue())
     }
   }
+
+  async getMergeButton() {
+    return browser.$('a[id="mergeWithOther"]')
+  }
 }
 
 export default Page

--- a/client/tests/webdriver/pages/showOrganization.page.js
+++ b/client/tests/webdriver/pages/showOrganization.page.js
@@ -7,6 +7,10 @@ class ShowOrganization extends Page {
     await super.open(PAGE_URL.replace(":uuid", uuid))
   }
 
+  async openAsAdminUser(uuid) {
+    await super.openAsAdminUser(PAGE_URL.replace(":uuid", uuid))
+  }
+
   async getCreateSubOrganizationButton() {
     return browser.$('//a[text()="Create sub-organization"]')
   }

--- a/client/tests/webdriver/pages/showPerson.page.js
+++ b/client/tests/webdriver/pages/showPerson.page.js
@@ -7,6 +7,10 @@ class ShowPerson extends Page {
     await super.open(PAGE_URL.replace(":uuid", uuid))
   }
 
+  async openAsAdminUser(uuid) {
+    await super.openAsAdminUser(PAGE_URL.replace(":uuid", uuid))
+  }
+
   async getEditButton() {
     return browser.$("div a.edit-person")
   }

--- a/client/tests/webdriver/pages/showPosition.page.js
+++ b/client/tests/webdriver/pages/showPosition.page.js
@@ -7,6 +7,10 @@ class ShowPosition extends Page {
     await super.open(PAGE_URL.replace(":uuid", uuid))
   }
 
+  async openAsAdminUser(uuid) {
+    await super.openAsAdminUser(PAGE_URL.replace(":uuid", uuid))
+  }
+
   async getAuthorizationGroupsTable() {
     return browser.$("#authorizationGroups table")
   }


### PR DESCRIPTION
Details pages for mergeable objects now show a button for an admin to directly go to the merge page for that object.

Closes [AB#1163](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1163)

#### User changes
- None.

#### Superuser changes
- None.

#### Admin changes
- An admin can now click a button at the top of the page for an organization, position, person or location, to go directly to the merge page for that object.

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [x] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
