### PR TITLE
Update Chromedriver options for version 128

### DIFF
--- a/client/config/wdio.config.js
+++ b/client/config/wdio.config.js
@@ -1,3 +1,5 @@
+const path = require("path")
+
 const config = {
   //
   // ====================
@@ -70,7 +72,15 @@ const config = {
         // Note: it is important to have a big window height as otherwise
         // while scrolling some form fields might go under the header and
         // therefore we would get failing tests related to these fields.
-        args: ["--headless", "--disable-gpu", "--window-size=1600,1200"]
+        args: [
+          "--headless=old",
+          "--disable-gpu",
+          "--disable-search-engine-choice-screen",
+          "--window-size=1600,1200"
+        ],
+        prefs: {
+          "download.default_directory": path.dirname(__dirname)
+        }
       }
       // If outputDir is provided WebdriverIO can capture driver session logs
       // it is possible to configure which logTypes to include/exclude.

--- a/client/tests/e2e/report.js
+++ b/client/tests/e2e/report.js
@@ -54,11 +54,10 @@ test.serial("Draft and submit a report", async t => {
       "topferness, christopf"
     )
 
-  const $attendeesTitle = await t.context.driver.findElement(
-    // if future "People who will be involved in this planned engagement"
-    By.xpath('//h4/span[text()="People involved in this engagement"]')
+  const $newReportTitle = await t.context.driver.findElement(
+    By.xpath('//h4/span[text()="Create a new Report"]')
   )
-  await $attendeesTitle.click()
+  await $newReportTitle.click()
 
   t.is(
     await $attendeesAdvancedSelect1.getAttribute("value"),
@@ -96,7 +95,7 @@ test.serial("Draft and submit a report", async t => {
       "#reportPeople",
       "steveson, steve"
     )
-  await $attendeesTitle.click()
+  await $newReportTitle.click()
 
   t.is(
     await $attendeesAdvancedSelect2.getAttribute("value"),

--- a/client/tests/util/test.js
+++ b/client/tests/util/test.js
@@ -90,7 +90,10 @@ test.beforeEach(t => {
   let builder = new webdriver.Builder()
   if (testEnv === "local") {
     const chrome = require("selenium-webdriver/chrome")
-    const options = new chrome.Options(capabilities).addArguments("--headless")
+    const options = new chrome.Options(capabilities).addArguments([
+      "--headless=old",
+      "--disable-search-engine-choice-screen"
+    ])
     builder = builder
       .forBrowser(webdriver.Browser.CHROME)
       .setChromeOptions(options)

--- a/client/tests/webdriver/baseSpecs/myCounterparts.spec.js
+++ b/client/tests/webdriver/baseSpecs/myCounterparts.spec.js
@@ -30,7 +30,7 @@ describe("My counterparts page", () => {
   })
 
   describe("When Erin is checking the content of the page", () => {
-    it("Should see an empty table of the counterparts", async() => {
+    it("Should see a table of the counterparts", async() => {
       await MyCounterparts.open()
       await (await MyCounterparts.getMyCounterparts()).waitForDisplayed()
       const myCounterpartsItems = await (
@@ -42,7 +42,7 @@ describe("My counterparts page", () => {
   })
 
   describe("When Rebecca is checking the content of the page", () => {
-    it("Should see a table of the counterparts", async() => {
+    it("Should see an empty table of the counterparts", async() => {
       await MyCounterparts.openAsSuperuser()
       await (await MyCounterparts.getMyCounterparts()).waitForDisplayed()
       const myCounterpartsItems = await (


### PR DESCRIPTION
With the release of Chromedriver 128, several client-side tests started failing. Update the driver options to accommodate the changed behaviour.