### PR TITLE
Allow links to Attachments

### DIFF
--- a/src/main/resources/anet-schema.yml
+++ b/src/main/resources/anet-schema.yml
@@ -239,7 +239,7 @@ $defs:
               uniqueItems: true
               items:
                 type: string
-                enum: [AuthorizationGroup, Location, Organization, Person, Position, Report, Task]
+                enum: [Attachment, AuthorizationGroup, Location, Organization, Person, Position, Report, Task]
           required: [types]
         - properties:
             type:


### PR DESCRIPTION
Allow custom fields defined in the dictionary to also link to Attachments.

Closes [AB#995](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/995)

#### User changes
- None

#### Superuser changes
- None

#### Admin changes
- None

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
  A custom field in the dictionary could now be defined as:
  ```yaml
        attachment:
          type: anet_object
          label: Picture of ID
          helpText: Here you can link to a scan of the person's ID
          types:
            - Attachment
  ```
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here