### PR TITLE
Include approved reports in default search

### DIFF
--- a/client/src/components/advancedSearch/ReportStateFilter.js
+++ b/client/src/components/advancedSearch/ReportStateFilter.js
@@ -30,7 +30,7 @@ const ReportStateFilter = ({
     return val.state.length === 1 && val.state[0] === Report.STATE.CANCELLED
   }
   const defaultValue = {
-    state: inputValue.state || [Report.STATE.PUBLISHED],
+    state: inputValue.state || [Report.STATE.APPROVED, Report.STATE.PUBLISHED],
     cancelledReason: inputValue.cancelledReason || ""
   }
   const toQuery = val => {

--- a/src/main/java/mil/dds/anet/search/AbstractReportSearcher.java
+++ b/src/main/java/mil/dds/anet/search/AbstractReportSearcher.java
@@ -202,11 +202,11 @@ public abstract class AbstractReportSearcher extends AbstractSearcher<Report, Re
       // When not otherwise specified, restrict search to specific report states
       final List<ReportState> reportStates;
       if (Utils.isEmptyOrNull(query.getEngagementStatus())) {
-        // just published
-        reportStates = List.of(ReportState.PUBLISHED);
+        // approved or published
+        reportStates = List.of(ReportState.APPROVED, ReportState.PUBLISHED);
       } else {
-        // published or cancelled
-        reportStates = List.of(ReportState.PUBLISHED, ReportState.CANCELLED);
+        // approved, published or cancelled
+        reportStates = List.of(ReportState.APPROVED, ReportState.PUBLISHED, ReportState.CANCELLED);
       }
       qb.addInClause("states", "reports.state", reportStates);
     } else {


### PR DESCRIPTION
Include Approved reports in the default report search filter (in addition to Published).

Closes [AB#1059](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1059)

#### User changes
- A default report search now also finds Approved reports.

#### Superuser changes
- None

#### Admin changes
- None

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
