### PR TITLE
Inherit APP6 Symbol Set from parent organization

### DIFF
--- a/client/src/components/graphs/OrganizationalChart.js
+++ b/client/src/components/graphs/OrganizationalChart.js
@@ -52,6 +52,7 @@ const GQL_GET_CHART_DATA = gql`
         uuid
         app6context
         app6standardIdentity
+        app6symbolSet
         parentOrg {
           uuid
         }
@@ -128,7 +129,11 @@ const determineSymbol = (org, allAscendantOrgs) => {
     "app6standardIdentity",
     "1"
   )
-  const symbolSet = org?.app6symbolSet || "00"
+  const symbolSet = utils.determineApp6field(
+    ascendantOrgs,
+    "app6symbolSet",
+    "00"
+  )
   const hq = org?.app6hq || "0"
   const amplifier = org?.app6amplifier || "00"
   const version = "14" // APP-6E

--- a/client/src/components/previews/OrganizationPreview.js
+++ b/client/src/components/previews/OrganizationPreview.js
@@ -83,6 +83,7 @@ const GQL_GET_ORGANIZATION = gql`
         ...organizationFields
         app6context
         app6standardIdentity
+        app6symbolSet
         parentOrg {
           uuid
         }
@@ -135,7 +136,7 @@ const OrganizationPreview = ({ className, uuid }) => {
   const organization = new Organization(
     data.organization ? data.organization : {}
   )
-  const { parentContext, parentStandardIdentity } =
+  const { parentContext, parentStandardIdentity, parentSymbolSet } =
     Organization.getApp6ParentFields(organization, organization)
 
   return (
@@ -281,6 +282,16 @@ const OrganizationPreview = ({ className, uuid }) => {
           wrappedComponent={PreviewField}
           dictProps={Settings.fields.organization.app6symbolSet}
           value={
+            (parentSymbolSet && (
+              <em>
+                {
+                  Settings.fields.organization.app6symbolSet.choices[
+                    parentSymbolSet
+                  ]
+                }{" "}
+                (inherited from parent)
+              </em>
+            )) ||
             Settings.fields.organization.app6symbolSet.choices[
               organization.app6symbolSet
             ]

--- a/client/src/models/Organization.js
+++ b/client/src/models/Organization.js
@@ -241,7 +241,10 @@ export default class Organization extends Model {
     const parentStandardIdentity = organizationValues.app6standardIdentity
       ? undefined
       : utils.determineApp6field(ascendantOrgs, "app6standardIdentity")
-    return { parentContext, parentStandardIdentity }
+    const parentSymbolSet = organizationValues.app6symbolSet
+      ? undefined
+      : utils.determineApp6field(ascendantOrgs, "app6symbolSet")
+    return { parentContext, parentStandardIdentity, parentSymbolSet }
   }
 
   static FILTERED_CLIENT_SIDE_FIELDS = [

--- a/client/src/pages/organizations/Edit.js
+++ b/client/src/pages/organizations/Edit.js
@@ -54,6 +54,7 @@ const GQL_GET_ORGANIZATION = gql`
           uuid
           app6context
           app6standardIdentity
+          app6symbolSet
           parentOrg {
             uuid
           }

--- a/client/src/pages/organizations/Form.js
+++ b/client/src/pages/organizations/Form.js
@@ -57,7 +57,7 @@ const GQL_UPDATE_ORGANIZATION = gql`
   }
 `
 
-const autocompleteQuery = `${Organization.autocompleteQuery} ascendantOrgs { uuid app6context app6standardIdentity parentOrg { uuid } }`
+const autocompleteQuery = `${Organization.autocompleteQuery} ascendantOrgs { uuid app6context app6standardIdentity app6symbolSet parentOrg { uuid } }`
 
 const OrganizationForm = ({ edit, title, initialValues, notesComponent }) => {
   const { loadAppData, currentUser } = useContext(AppContext)
@@ -124,7 +124,7 @@ const OrganizationForm = ({ edit, title, initialValues, notesComponent }) => {
           ]
           orgSearchQuery.orgRecurseStrategy = RECURSE_STRATEGY.CHILDREN
         }
-        const { parentContext, parentStandardIdentity } =
+        const { parentContext, parentStandardIdentity, parentSymbolSet } =
           Organization.getApp6ParentFields(values.parentOrg, values)
         const action = canAdministrateOrg && (
           <>
@@ -476,6 +476,20 @@ const OrganizationForm = ({ edit, title, initialValues, notesComponent }) => {
                     Settings.fields.organization.app6symbolSet.choices
                   )}
                   onChange={value => setFieldValue("app6symbolSet", value)}
+                  extraColElem={
+                    parentSymbolSet && (
+                      <div style={{ paddingTop: "9px" }}>
+                        <em>
+                          {
+                            Settings.fields.organization.app6symbolSet.choices[
+                              parentSymbolSet
+                            ]
+                          }{" "}
+                          (inherited from parent)
+                        </em>
+                      </div>
+                    )
+                  }
                 />
                 <DictionaryField
                   wrappedComponent={Field}

--- a/client/src/pages/organizations/New.js
+++ b/client/src/pages/organizations/New.js
@@ -28,6 +28,7 @@ const GQL_GET_ORGANIZATION = gql`
         uuid
         app6context
         app6standardIdentity
+        app6symbolSet
         parentOrg {
           uuid
         }

--- a/client/src/pages/organizations/Show.js
+++ b/client/src/pages/organizations/Show.js
@@ -120,6 +120,7 @@ const GQL_GET_ORGANIZATION = gql`
         ...organizationFields
         app6context
         app6standardIdentity
+        app6symbolSet
         parentOrg {
           uuid
         }
@@ -229,7 +230,7 @@ const OrganizationShow = ({ pageDispatchers }) => {
   const canAdministrateOrg =
     currentUser?.hasAdministrativePermissionsForOrganization(organization)
   const attachmentsEnabled = !Settings.fields.attachment.featureDisabled
-  const { parentContext, parentStandardIdentity } =
+  const { parentContext, parentStandardIdentity, parentSymbolSet } =
     Organization.getApp6ParentFields(organization, organization)
 
   const myOrg =
@@ -582,6 +583,16 @@ const OrganizationShow = ({ pageDispatchers }) => {
                   name="app6symbolSet"
                   component={FieldHelper.ReadonlyField}
                   humanValue={
+                    (parentSymbolSet && (
+                      <em>
+                        {
+                          Settings.fields.organization.app6symbolSet.choices[
+                            parentSymbolSet
+                          ]
+                        }{" "}
+                        (inherited from parent)
+                      </em>
+                    )) ||
                     Settings.fields.organization.app6symbolSet.choices[
                       organization.app6symbolSet
                     ]

--- a/client/tests/webdriver/baseSpecs/createNewOrganization.spec.js
+++ b/client/tests/webdriver/baseSpecs/createNewOrganization.spec.js
@@ -112,12 +112,10 @@ describe("When creating an organization", () => {
         await CreateOrganization.getApp6standardIdentityExtraColumn()
       ).getText()
     ).to.equal(`${topLevelOrg.app6standardIdentity} (inherited from parent)`)
-    /* eslint-disable no-unused-expressions */
     expect(
-      await (
-        await CreateOrganization.getApp6symbolSetExtraColumn()
-      ).isExisting()
-    ).to.be.false
+      await (await CreateOrganization.getApp6symbolSetExtraColumn()).getText()
+    ).to.equal(`${topLevelOrg.app6symbolSet} (inherited from parent)`)
+    /* eslint-disable no-unused-expressions */
     expect(await (await CreateOrganization.getApp6hqExtraColumn()).isExisting())
       .to.be.false
     expect(
@@ -185,12 +183,10 @@ describe("When creating an organization", () => {
         await CreateOrganization.getApp6standardIdentityExtraColumn()
       ).getText()
     ).to.equal(`${secondLevelOrg.app6standardIdentity} (inherited from parent)`)
-    /* eslint-disable no-unused-expressions */
     expect(
-      await (
-        await CreateOrganization.getApp6symbolSetExtraColumn()
-      ).isExisting()
-    ).to.be.false
+      await (await CreateOrganization.getApp6symbolSetExtraColumn()).getText()
+    ).to.equal(`${secondLevelOrg.app6symbolSet} (inherited from parent)`)
+    /* eslint-disable no-unused-expressions */
     expect(await (await CreateOrganization.getApp6hqExtraColumn()).isExisting())
       .to.be.false
     expect(
@@ -228,6 +224,9 @@ describe("When creating an organization", () => {
         await CreateOrganization.getApp6standardIdentityExtraColumn()
       ).getText()
     ).to.equal(`${secondLevelOrg.app6standardIdentity} (inherited from parent)`)
+    expect(
+      await (await CreateOrganization.getApp6symbolSetExtraColumn()).getText()
+    ).to.equal(`${secondLevelOrg.app6symbolSet} (inherited from parent)`)
 
     await CreateOrganization.submitForm()
     await ShowOrganization.waitForAlertSuccessToLoad()
@@ -255,9 +254,10 @@ describe("When creating an organization", () => {
     ).to.equal(
       `${testOrgs.secondLevel.app6standardIdentity} (inherited from parent)`
     )
+    expect(
+      await (await ShowOrganization.getApp6symbolSet()).getText()
+    ).to.equal(`${testOrgs.secondLevel.app6symbolSet} (inherited from parent)`)
     /* eslint-disable no-unused-expressions */
-    expect(await (await ShowOrganization.getApp6symbolSet()).getText()).to.be
-      .empty
     expect(await (await ShowOrganization.getApp6hq()).getText()).to.be.empty
     expect(await (await ShowOrganization.getApp6amplifier()).getText()).to.be
       .empty

--- a/insertBaseData-psql.sql
+++ b/insertBaseData-psql.sql
@@ -440,21 +440,21 @@ INSERT INTO organizations(uuid, "shortName", "longName", app6context, "app6stand
   (uuid_generate_v4(), 'TAAC Air', '', '0', NULL, NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
 
 -- Sub-organizations
-INSERT INTO organizations(uuid, "shortName", "longName", "parentOrgUuid", "app6symbolSet", "createdAt", "updatedAt") VALUES
-  ('04614b0f-7e8e-4bf1-8bc5-13abaffeab8a', 'EF 1.1', '', (SELECT uuid from organizations WHERE "shortName" ='EF 1'), '10', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
-  (uuid_generate_v4(), 'EF 1.2', '', (SELECT uuid from organizations WHERE "shortName" ='EF 1'), '10', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
-  (uuid_generate_v4(), 'EF 2.1', '', (SELECT uuid from organizations WHERE "shortName" ='EF 2'), '10', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
-  ('ccbee4bb-08b8-42df-8cb5-65e8172f657b', 'EF 2.2', '', (SELECT uuid from organizations WHERE "shortName" ='EF 2'), '10', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
-  (uuid_generate_v4(), 'EF 4.1', '', (SELECT uuid FROM organizations WHERE "shortName" = 'EF 4'), '11', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
-  (uuid_generate_v4(), 'EF 4.2', '', (SELECT uuid FROM organizations WHERE "shortName" = 'EF 4'), '11', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
-  (uuid_generate_v4(), 'EF 4.3', '', (SELECT uuid FROM organizations WHERE "shortName" = 'EF 4'), '11', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
-  (uuid_generate_v4(), 'EF 4.4', '', (SELECT uuid FROM organizations WHERE "shortName" = 'EF 4'), '11', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
-  (N'7f939a44-b9e4-48e0-98f5-7d0ea38a6ecf', 'EF 5.1', '', (SELECT uuid FROM organizations WHERE "shortName" = 'EF 5'), '10', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
-  (uuid_generate_v4(), 'EF 5.2', '', (SELECT uuid FROM organizations WHERE "shortName" = 'EF 5'), '10', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
-  (uuid_generate_v4(), 'EF 5.3', '', (SELECT uuid FROM organizations WHERE "shortName" = 'EF 5'), '10', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
-  (uuid_generate_v4(), 'EF 5.4', '', (SELECT uuid FROM organizations WHERE "shortName" = 'EF 5'), '10', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
-  (uuid_generate_v4(), 'EF 6.1', '', (SELECT uuid FROM organizations WHERE "shortName" = 'EF 6'), '10', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
-  (uuid_generate_v4(), 'EF 6.2', '', (SELECT uuid FROM organizations WHERE "shortName" = 'EF 6'), '10', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+INSERT INTO organizations(uuid, "shortName", "longName", "parentOrgUuid", "createdAt", "updatedAt") VALUES
+  ('04614b0f-7e8e-4bf1-8bc5-13abaffeab8a', 'EF 1.1', '', (SELECT uuid from organizations WHERE "shortName" ='EF 1'), CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+  (uuid_generate_v4(), 'EF 1.2', '', (SELECT uuid from organizations WHERE "shortName" ='EF 1'), CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+  (uuid_generate_v4(), 'EF 2.1', '', (SELECT uuid from organizations WHERE "shortName" ='EF 2'), CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+  ('ccbee4bb-08b8-42df-8cb5-65e8172f657b', 'EF 2.2', '', (SELECT uuid from organizations WHERE "shortName" ='EF 2'), CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+  (uuid_generate_v4(), 'EF 4.1', '', (SELECT uuid FROM organizations WHERE "shortName" = 'EF 4'), CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+  (uuid_generate_v4(), 'EF 4.2', '', (SELECT uuid FROM organizations WHERE "shortName" = 'EF 4'), CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+  (uuid_generate_v4(), 'EF 4.3', '', (SELECT uuid FROM organizations WHERE "shortName" = 'EF 4'), CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+  (uuid_generate_v4(), 'EF 4.4', '', (SELECT uuid FROM organizations WHERE "shortName" = 'EF 4'), CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+  (N'7f939a44-b9e4-48e0-98f5-7d0ea38a6ecf', 'EF 5.1', '', (SELECT uuid FROM organizations WHERE "shortName" = 'EF 5'), CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+  (uuid_generate_v4(), 'EF 5.2', '', (SELECT uuid FROM organizations WHERE "shortName" = 'EF 5'), CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+  (uuid_generate_v4(), 'EF 5.3', '', (SELECT uuid FROM organizations WHERE "shortName" = 'EF 5'), CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+  (uuid_generate_v4(), 'EF 5.4', '', (SELECT uuid FROM organizations WHERE "shortName" = 'EF 5'), CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+  (uuid_generate_v4(), 'EF 6.1', '', (SELECT uuid FROM organizations WHERE "shortName" = 'EF 6'), CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+  (uuid_generate_v4(), 'EF 6.2', '', (SELECT uuid FROM organizations WHERE "shortName" = 'EF 6'), CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
 
 UPDATE organizations
 SET "locationUuid"='9c982685-5946-4dad-a7ee-0f5a12f5e170'
@@ -671,8 +671,8 @@ INSERT INTO organizations (uuid, "shortName", "longName", "identificationCode", 
   (uuid_generate_v4(), 'MoI', 'Ministry of Interior', 'P12345', (SELECT uuid FROM locations WHERE type = 'PAC' AND name = 'Afghanistan'), '0', '4', '11', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
 
 -- Sub-organizations
-INSERT INTO organizations (uuid, "shortName", "longName", "parentOrgUuid", "identificationCode", "locationUuid", "app6symbolSet", "createdAt", "updatedAt") VALUES
-  (uuid_generate_v4(), 'MOD-F', 'Ministry of Defense Finances', (SELECT uuid from organizations where "shortName" = 'MoD'), NULL, (SELECT uuid FROM locations WHERE type = 'PAC' AND name = 'Afghanistan'), '11', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+INSERT INTO organizations (uuid, "shortName", "longName", "parentOrgUuid", "identificationCode", "locationUuid", "createdAt", "updatedAt") VALUES
+  (uuid_generate_v4(), 'MOD-F', 'Ministry of Defense Finances', (SELECT uuid from organizations where "shortName" = 'MoD'), NULL, (SELECT uuid FROM locations WHERE type = 'PAC' AND name = 'Afghanistan'), CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
 
 -- Test for Merging
 INSERT INTO organizations (uuid, "shortName", "longName", "identificationCode", "parentOrgUuid", "locationUuid", app6context, "app6standardIdentity", "app6symbolSet", "app6hq", "app6amplifier", "createdAt", "updatedAt") VALUES

--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -5195,6 +5195,7 @@
 						WHEN chu."user" THEN '3'
 					END AS "app6standardIdentity",
 					CASE
+						WHEN org."parentOrgUuid" IS NOT NULL THEN NULL
 						WHEN chu."user" THEN '10'
 					END AS "app6symbolSet"
 				FROM organizations org


### PR DESCRIPTION
In addition to the Context and Standard Identity, also inherit the Symbol Set from the parent organization.

Closes [AB#1184](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1184)

#### User changes
- When not explicitly set for an organization, the APP6 Symbol Set is inherited from the parent organization.

#### Superuser changes
- Superusers can leave the APP6 Symbol Set for an organization empty, in which case it will be inherited from the parent organization.

#### Admin changes
- None.

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [x] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [x] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here