### PR TITLE
Fix error when adding a location as a user without a position

### DIFF
--- a/client/src/pages/locations/Form.js
+++ b/client/src/pages/locations/Form.js
@@ -129,7 +129,7 @@ const LocationForm = ({
       }
     }
   }
-  if (currentUser.position) {
+  if (currentUser.position?.organization?.uuid) {
     approversFilters.myColleagues = {
       label: "My colleagues",
       queryVars: {


### PR DESCRIPTION
Adding a new location through a report as a regular user (when allowed in the dictionary) now also works when the user doesn't have a position yet.

Closes [AB#996](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/996)

#### User changes
- Users without a position can now also add a new location when creating a new report (when allowed in the dictionary).

#### Superuser changes
- None.

#### Admin changes
- None.

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here