### PR TITLE
Fix error when changing dates in the position history

### DIFF
--- a/client/src/components/EditHistory.js
+++ b/client/src/components/EditHistory.js
@@ -264,9 +264,11 @@ function EditHistory({
                                     label={null}
                                     value={values.history[idx].startTime}
                                     onChange={value => {
+                                      const startTime =
+                                        value && moment(value).valueOf()
                                       setFieldValue(
                                         startTimeFieldName,
-                                        value?.valueOf()
+                                        startTime
                                       )
                                       setFinalHistory(
                                         sortHistory(
@@ -275,7 +277,7 @@ function EditHistory({
                                             index === idx
                                               ? {
                                                 ...item,
-                                                startTime: value?.valueOf()
+                                                startTime
                                               }
                                               : item
                                           ),
@@ -302,7 +304,7 @@ function EditHistory({
                                       onChange={value =>
                                         setFieldValue(
                                           endTimeFieldName,
-                                          value?.valueOf()
+                                          value && moment(value).valueOf()
                                         )}
                                       component={FieldHelper.SpecialField}
                                       widget={

--- a/client/tests/webdriver/baseSpecs/editHistory.spec.js
+++ b/client/tests/webdriver/baseSpecs/editHistory.spec.js
@@ -1,0 +1,87 @@
+import { expect } from "chai"
+import moment from "moment"
+import ShowPerson from "../pages/showPerson.page"
+import ShowPosition from "../pages/showPosition.page"
+
+const PERSON_UUID = "39d02d26-49eb-43b5-9cec-344777213a67"
+const DATE_FORMAT = "DD-MM-YYYY"
+const HISTORY_INDEX = 0
+let origStartDate
+let origEndDate
+
+describe("As admin we should be able to edit position history", () => {
+  it("We should be able to edit position history for a person", async() => {
+    await ShowPerson.openAsAdminUser(PERSON_UUID)
+    await (await ShowPerson.getEditHistoryButton()).click()
+    await (await ShowPerson.getEditHistoryDialog()).waitForExist()
+    await (await ShowPerson.getEditHistoryDialog()).waitForDisplayed()
+    await (
+      await ShowPerson.getEditHistoryStartDate(HISTORY_INDEX)
+    ).waitForExist()
+    await (
+      await ShowPerson.getEditHistoryStartDate(HISTORY_INDEX)
+    ).waitForDisplayed()
+    origStartDate = await (
+      await ShowPerson.getEditHistoryStartDate(HISTORY_INDEX)
+    ).getValue()
+    const newStartDate = moment(origStartDate, DATE_FORMAT)
+      .subtract(1, "day")
+      .format(DATE_FORMAT)
+    await ShowPerson.deleteInput(
+      ShowPerson.getEditHistoryStartDate(HISTORY_INDEX)
+    )
+    await (
+      await ShowPerson.getEditHistoryStartDate(HISTORY_INDEX)
+    ).setValue(newStartDate)
+    origEndDate = await (
+      await ShowPerson.getEditHistoryEndDate(HISTORY_INDEX)
+    ).getValue()
+    const newEndDate = moment(origEndDate, DATE_FORMAT)
+      .subtract(1, "day")
+      .format(DATE_FORMAT)
+    await ShowPerson.deleteInput(
+      ShowPerson.getEditHistoryEndDate(HISTORY_INDEX)
+    )
+    await (
+      await ShowPerson.getEditHistoryEndDate(HISTORY_INDEX)
+    ).setValue(newEndDate)
+    await (await ShowPerson.getEditHistorySubmitButton()).click()
+    await (
+      await ShowPerson.getEditHistoryDialog()
+    ).waitForExist({ reverse: true })
+    // eslint-disable-next-line no-unused-expressions
+    expect(await (await ShowPerson.getAlertDanger()).isExisting()).to.be.false
+  })
+  it("We should be able to edit position history for a position", async() => {
+    await (await ShowPerson.getPreviousPositionLink(HISTORY_INDEX)).click()
+    await (await ShowPosition.getEditHistoryButton()).waitForExist()
+    await (await ShowPosition.getEditHistoryButton()).waitForDisplayed()
+    await (await ShowPosition.getEditHistoryButton()).click()
+    await (await ShowPerson.getEditHistoryDialog()).waitForExist()
+    await (await ShowPerson.getEditHistoryDialog()).waitForDisplayed()
+    await (
+      await ShowPerson.getEditHistoryStartDate(HISTORY_INDEX)
+    ).waitForExist()
+    await (
+      await ShowPerson.getEditHistoryStartDate(HISTORY_INDEX)
+    ).waitForDisplayed()
+    await ShowPerson.deleteInput(
+      ShowPerson.getEditHistoryStartDate(HISTORY_INDEX)
+    )
+    await (
+      await ShowPerson.getEditHistoryStartDate(HISTORY_INDEX)
+    ).setValue(origStartDate)
+    await ShowPerson.deleteInput(
+      ShowPerson.getEditHistoryEndDate(HISTORY_INDEX)
+    )
+    await (
+      await ShowPerson.getEditHistoryEndDate(HISTORY_INDEX)
+    ).setValue(origEndDate)
+    await (await ShowPerson.getEditHistorySubmitButton()).click()
+    await (
+      await ShowPerson.getEditHistoryDialog()
+    ).waitForExist({ reverse: true })
+    // eslint-disable-next-line no-unused-expressions
+    expect(await (await ShowPosition.getAlertDanger()).isExisting()).to.be.false
+  })
+})

--- a/client/tests/webdriver/pages/page.js
+++ b/client/tests/webdriver/pages/page.js
@@ -141,6 +141,10 @@ class Page {
     }
   }
 
+  async getAlertDanger() {
+    return browser.$(".alert-danger")
+  }
+
   async getRandomOption(select) {
     const options = await select.$$("option")
     // Ignore the first option, it is always the empty one

--- a/client/tests/webdriver/pages/showPerson.page.js
+++ b/client/tests/webdriver/pages/showPerson.page.js
@@ -69,6 +69,30 @@ class ShowPerson extends Page {
     return (await this.getCompactView()).$$(".left-table > tr")
   }
 
+  async getEditHistoryButton() {
+    return browser.$("button.edit-history")
+  }
+
+  async getEditHistoryDialog() {
+    return browser.$("div.edit-history-dialog")
+  }
+
+  async getEditHistoryStartDate(i) {
+    return browser.$(`input[id="history[${i}].startTime"]`)
+  }
+
+  async getEditHistoryEndDate(i) {
+    return browser.$(`input[id="history[${i}].endTime"]`)
+  }
+
+  async getEditHistorySubmitButton() {
+    return browser.$("button#editHistoryModalSubmitButton")
+  }
+
+  async getPreviousPositionLink(i) {
+    return browser.$(`tr#previousPosition_${i} a`)
+  }
+
   async getAssessmentsTable(assessmentKey, recurrence) {
     return (await this.getAssessmentContainer(assessmentKey, recurrence)).$(
       "table.assessments-table"

--- a/client/tests/webdriver/pages/showPosition.page.js
+++ b/client/tests/webdriver/pages/showPosition.page.js
@@ -19,6 +19,10 @@ class ShowPosition extends Page {
     const agTable = await this.getAuthorizationGroupsTable()
     return agTable.$(`tbody tr:nth-child(${i}) td:first-child a`)
   }
+
+  async getEditHistoryButton() {
+    return browser.$("div.edit-history button")
+  }
 }
 
 export default new ShowPosition()

--- a/insertBaseData-psql.sql
+++ b/insertBaseData-psql.sql
@@ -320,15 +320,16 @@ UPDATE positions SET "currentPersonUuid" = (SELECT uuid from people where "domai
 
 -- Rotate advisors through billets ending up with Dvisor in the EF 2.2 Advisor Sewing Facilities Billet and Selena in the EF 1.2 Advisor Billet
 INSERT INTO "peoplePositions" ("positionUuid", "personUuid", "createdAt") VALUES
+  ((SELECT uuid from positions where name = 'EF 1.2 Advisor'), (SELECT uuid from people where "domainUsername" = 'advisor'), CURRENT_TIMESTAMP);
+INSERT INTO "peoplePositions" ("positionUuid", "personUuid", "createdAt") VALUES
   ((SELECT uuid from positions where name = 'EF 2.2 Advisor Sewing Facilities'), (SELECT uuid from people where "domainUsername" = 'selena'), CURRENT_TIMESTAMP);
+
+UPDATE "peoplePositions" SET "endedAt" = CURRENT_TIMESTAMP + INTERVAL '1 millisecond' WHERE "positionUuid" = (SELECT uuid from positions where name = 'EF 1.2 Advisor');
 UPDATE "peoplePositions" SET "endedAt" = CURRENT_TIMESTAMP + INTERVAL '1 millisecond' WHERE "positionUuid" = (SELECT uuid from positions where name = 'EF 2.2 Advisor Sewing Facilities');
+
 INSERT INTO "peoplePositions" ("positionUuid", "personUuid", "createdAt") VALUES
   ((SELECT uuid from positions where name = 'EF 2.2 Advisor Sewing Facilities'), (SELECT uuid from people where "domainUsername" = 'advisor'), CURRENT_TIMESTAMP + INTERVAL '1 millisecond');
 UPDATE positions SET "currentPersonUuid" = (SELECT uuid from people where "domainUsername" = 'advisor') WHERE name = 'EF 2.2 Advisor Sewing Facilities';
-
-INSERT INTO "peoplePositions" ("positionUuid", "personUuid", "createdAt") VALUES
-  ((SELECT uuid from positions where name = 'EF 1.2 Advisor'), (SELECT uuid from people where "domainUsername" = 'advisor'), CURRENT_TIMESTAMP);
-UPDATE "peoplePositions" SET "endedAt" = CURRENT_TIMESTAMP + INTERVAL '1 millisecond' WHERE "positionUuid" = (SELECT uuid from positions where name = 'EF 1.2 Advisor');
 INSERT INTO "peoplePositions" ("positionUuid", "personUuid", "createdAt") VALUES
   ((SELECT uuid from positions where name = 'EF 1.2 Advisor'), (SELECT uuid from people where "domainUsername" = 'selena'), CURRENT_TIMESTAMP + INTERVAL '1 millisecond');
 UPDATE positions SET "currentPersonUuid" = (SELECT uuid from people where "domainUsername" = 'selena') WHERE name = 'EF 1.2 Advisor';


### PR DESCRIPTION
Closes [AB#722](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/722)

#### User changes
- None.

#### Superuser changes
- Changing start or end dates when manually editing position history works correctly again.

#### Admin changes
- None.

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [x] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
