### PR TITLE
Fix full-text search migration and report advisor organization label

### DIFF
--- a/.github/workflows/build-gradle.yml
+++ b/.github/workflows/build-gradle.yml
@@ -13,6 +13,7 @@ on:
 env:
   NODE_OPTIONS: '--max-old-space-size=8192'
   DB_DRIVER: postgresql
+  DB_VERSION: 15
 
 jobs:
   build:

--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,7 @@ if (!isTestEnv && file('localSettings.gradle').exists()) {
 
 // Defaults for development variables
 run.environment("DB_DRIVER", run.environment["DB_DRIVER"] ?: "postgresql")
+run.environment("DB_VERSION", run.environment["DB_VERSION"] ?: "latest")
 run.environment("ANET_DB_SERVER", run.environment["ANET_DB_SERVER"] ?: "localhost")
 run.environment("ANET_DB_NAME", run.environment["ANET_DB_NAME"] ?: isTestEnv ? "testAnet" : "devAnet")
 run.environment("ANET_DB_USERNAME", run.environment["ANET_DB_USERNAME"] ?: isTestEnv ? "anetTestUser" : "anetDevUser")
@@ -507,7 +508,7 @@ task dockerPushImage(type: DockerPushImage) {
 
 task dockerPullDB(type: DockerPullImage) {
 	group = "database container"
-	image = "postgres:latest"
+	image = "postgres:${run.environment['DB_VERSION']}"
 	description = "Pulls a docker image for the ANET DB from ${image}."
 }
 

--- a/client/src/components/ReportTable.js
+++ b/client/src/components/ReportTable.js
@@ -12,6 +12,7 @@ import moment from "moment"
 import PropTypes from "prop-types"
 import React, { useEffect, useRef, useState } from "react"
 import { Table } from "react-bootstrap"
+import Settings from "settings"
 
 const GQL_GET_REPORT_LIST = gql`
   query ($reportQuery: ReportSearchQueryInput) {
@@ -147,10 +148,10 @@ const ReportTable = ({
           <thead>
             <tr>
               <th>Authors</th>
-              <th>Organization</th>
-              <th>Summary</th>
-              {showStatus && <th>Status</th>}
-              <th>Engagement Date</th>
+              <th>{Settings.fields.advisor.org.name}</th>
+              <th>{Settings.fields.report.intent?.label}</th>
+              {showStatus && <th>State</th>}
+              <th>{Settings.fields.report.engagementDate?.label}</th>
               <th title="Does the report have attachments?">
                 <Icon icon={IconNames.PAPERCLIP} />
               </th>

--- a/client/src/pages/reports/Show.js
+++ b/client/src/pages/reports/Show.js
@@ -376,10 +376,10 @@ const ReportShow = ({ setSearchQuery, pageDispatchers }) => {
   // Non-attending authors can only edit if it is future
   let canEdit =
     isAuthor && !report.isPublished() && (report.isFuture() || isAttending)
-  // Approvers can also edit
-  canEdit = canEdit || canApprove
-  // Authors and approvers can always read assessments
-  const canReadAssessments = isAuthor || canApprove
+  // Approvers and admins can also edit
+  canEdit = canEdit || canApprove || isAdmin
+  // Authors, approvers and admins can always read assessments
+  const canReadAssessments = isAuthor || canApprove || isAdmin
 
   // Only an admin or an author can submit when report is in draft or rejected AND author has an active position
   const hasActivePosition = currentUser.hasActivePosition()

--- a/client/src/pages/reports/Show.js
+++ b/client/src/pages/reports/Show.js
@@ -630,7 +630,7 @@ const ReportShow = ({ setSearchQuery, pageDispatchers }) => {
 
                 <Field
                   name="advisorOrg"
-                  label={Settings.fields.regular.org.name}
+                  label={Settings.fields.advisor.org.name}
                   component={FieldHelper.ReadonlyField}
                   humanValue={
                     <LinkTo

--- a/insertBaseData-psql.sql
+++ b/insertBaseData-psql.sql
@@ -1279,14 +1279,14 @@ INSERT INTO "noteRelatedObjects" ("noteUuid", "relatedObjectType", "relatedObjec
   FROM reports r
   WHERE r.text LIKE 'Today%';
 
--- Add ondemand assessments to MOD-F
+-- Add ondemand assessments to MOD-F and EF 6.2
 SELECT ('''' || uuid_generate_v4() || '''') AS "noteUuid" \gset
 INSERT INTO notes (uuid, "authorUuid", type, "assessmentKey", text, "createdAt", "updatedAt") VALUES
   (:noteUuid, :authorUuid, 3, 'fields.organization.assessments.interactionPlan', '{"exercises":null,"interaction":"<p>Keep in constant contact</p>","plan":"<p>Organise a face to face meeting</p>","relation":"","priority":"","assessmentDate":"2021-01-01","__recurrence":"ondemand"}', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
 INSERT INTO "noteRelatedObjects" ("noteUuid", "relatedObjectType", "relatedObjectUuid")
   SELECT :noteUuid, 'organizations', o.uuid
   FROM organizations o
-  WHERE o."shortName" = 'MOD-F';
+  WHERE o."shortName" IN ('MOD-F', 'EF 6.2');
 
 SELECT ('''' || uuid_generate_v4() || '''') AS "noteUuid" \gset
 INSERT INTO notes (uuid, "authorUuid", type, "assessmentKey", text, "createdAt", "updatedAt") VALUES
@@ -1294,7 +1294,7 @@ INSERT INTO notes (uuid, "authorUuid", type, "assessmentKey", text, "createdAt",
 INSERT INTO "noteRelatedObjects" ("noteUuid", "relatedObjectType", "relatedObjectUuid")
   SELECT :noteUuid, 'organizations', o.uuid
   FROM organizations o
-  WHERE o."shortName" = 'MOD-F';
+  WHERE o."shortName" IN ('MOD-F', 'EF 6.2');
 
 SELECT ('''' || uuid_generate_v4() || '''') AS "noteUuid" \gset
 INSERT INTO notes (uuid, "authorUuid", type, "assessmentKey", text, "createdAt", "updatedAt") VALUES
@@ -1302,7 +1302,7 @@ INSERT INTO notes (uuid, "authorUuid", type, "assessmentKey", text, "createdAt",
 INSERT INTO "noteRelatedObjects" ("noteUuid", "relatedObjectType", "relatedObjectUuid")
   SELECT :noteUuid, 'organizations', o.uuid
   FROM organizations o
-  WHERE o."shortName" = 'MOD-F';
+  WHERE o."shortName" IN ('MOD-F', 'EF 6.2');
 
 SELECT ('''' || uuid_generate_v4() || '''') AS "noteUuid" \gset
 INSERT INTO notes (uuid, "authorUuid", type, "assessmentKey", text, "createdAt", "updatedAt") VALUES
@@ -1310,7 +1310,7 @@ INSERT INTO notes (uuid, "authorUuid", type, "assessmentKey", text, "createdAt",
 INSERT INTO "noteRelatedObjects" ("noteUuid", "relatedObjectType", "relatedObjectUuid")
   SELECT :noteUuid, 'organizations', o.uuid
   FROM organizations o
-  WHERE o."shortName" = 'MOD-F';
+  WHERE o."shortName" IN ('MOD-F', 'EF 6.2');
 
 SELECT ('''' || uuid_generate_v4() || '''') AS "noteUuid" \gset
 INSERT INTO notes (uuid, "authorUuid", type, "assessmentKey", text, "createdAt", "updatedAt") VALUES
@@ -1318,7 +1318,7 @@ INSERT INTO notes (uuid, "authorUuid", type, "assessmentKey", text, "createdAt",
 INSERT INTO "noteRelatedObjects" ("noteUuid", "relatedObjectType", "relatedObjectUuid")
   SELECT :noteUuid, 'organizations', o.uuid
   FROM organizations o
-  WHERE o."shortName" = 'MOD-F';
+  WHERE o."shortName" IN ('MOD-F', 'EF 6.2');
 
 SELECT ('''' || uuid_generate_v4() || '''') AS "noteUuid" \gset
 INSERT INTO notes (uuid, "authorUuid", type, "assessmentKey", text, "createdAt", "updatedAt") VALUES
@@ -1326,7 +1326,7 @@ INSERT INTO notes (uuid, "authorUuid", type, "assessmentKey", text, "createdAt",
 INSERT INTO "noteRelatedObjects" ("noteUuid", "relatedObjectType", "relatedObjectUuid")
   SELECT :noteUuid, 'organizations', o.uuid
   FROM organizations o
-  WHERE o."shortName" = 'MOD-F';
+  WHERE o."shortName" IN ('MOD-F', 'EF 6.2');
 
 -- Add ondemand assessments to Christopf
 SELECT ('''' || uuid_generate_v4() || '''') AS "noteUuid" \gset

--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -6024,7 +6024,7 @@
 			BEGIN
 				RETURN QUERY EXECUTE format(
 					''WITH links AS ('' ||
-					''  SELECT uuid, regexp_matches(%I, ''''"urn:anet:([^:]*):([^"]*)"'''', ''''g'''') AS arr FROM public.%I'' ||
+					''  SELECT uuid, regexp_matches(%I, ''''"urn:anet:(attachments|authorizationGroups|locations|organizations|people|positions|reports|tasks):([^"]*)"'''', ''''g'''') AS arr FROM public.%I'' ||
 					'')'' ||
 					''  SELECT uuid, arr[1], arr[2] FROM links'',
 					column_name, table_name
@@ -6041,7 +6041,7 @@
 			BEGIN
 				RETURN QUERY EXECUTE format(
 					''WITH links AS ('' ||
-					''  SELECT uuid, regexp_matches(%I, ''''\\"urn:anet:([^:]*):([^\\]*)\\"|{"type":"([^"]*)","uuid":"([^"]*)"}'''', ''''g'''') AS arr FROM public.%I'' ||
+					''  SELECT uuid, regexp_matches(%I, ''''\\"urn:anet:(attachments|authorizationGroups|locations|organizations|people|positions|reports|tasks):([^\\]*)\\"|{"type":"(Attachment|AuthorizationGroup|Location|Organization|Person|Position|Report|Task)","uuid":"([^"]*)"}'''', ''''g'''') AS arr FROM public.%I'' ||
 					'')'' ||
 					''  SELECT uuid,'' ||
 					''  CASE WHEN arr[1] IS NOT NULL THEN arr[1] ELSE'' ||

--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -5868,6 +5868,8 @@
 		</addColumn>
 	</changeSet>
 
+	<!-- Keep this change set as the last one in the change log;
+	     it will be re-run whenever it changes. -->
 	<changeSet id="set-up-full-text-search" runOnChange="true" author="gjvoosten">
 		<sql>
 			<!--
@@ -6221,8 +6223,8 @@
 				SELECT * FROM get_cf_referenced_objects('locations', 'customFields')
 			)
 			SELECT
-				uuid,
-				setweight(coalesce(tsvector_agg(agg), ''::tsvector), ${fts_low})
+				links.uuid,
+				setweight(coalesce(tsvector_agg(links.agg), ''::tsvector), ${fts_low})
 			FROM (
 				SELECT
 					locations.uuid,
@@ -6237,8 +6239,8 @@
 				FROM locations
 				LEFT JOIN cf_links ON cf_links.uuid = locations.uuid
 				GROUP BY locations.uuid
-			)
-			GROUP BY uuid
+			) AS links
+			GROUP BY links.uuid
 			WITH DATA;
 			CREATE UNIQUE INDEX "UQ_mv_lts_locations_uuid" ON mv_lts_locations(uuid);
 
@@ -6250,8 +6252,8 @@
 				SELECT * FROM get_cf_referenced_objects('organizations', 'customFields')
 			)
 			SELECT
-				uuid,
-				setweight(coalesce(tsvector_agg(agg), ''::tsvector), ${fts_low})
+				links.uuid,
+				setweight(coalesce(tsvector_agg(links.agg), ''::tsvector), ${fts_low})
 			FROM (
 				SELECT
 					organizations.uuid,
@@ -6266,8 +6268,8 @@
 				FROM organizations
 				LEFT JOIN cf_links ON cf_links.uuid = organizations.uuid
 				GROUP BY organizations.uuid
-			)
-			GROUP BY uuid
+			) AS links
+			GROUP BY links.uuid
 			WITH DATA;
 			CREATE UNIQUE INDEX "UQ_mv_lts_organizations_uuid" ON mv_lts_organizations(uuid);
 
@@ -6279,8 +6281,8 @@
 				SELECT * FROM get_cf_referenced_objects('people', 'customFields')
 			)
 			SELECT
-				uuid,
-				setweight(coalesce(tsvector_agg(agg), ''::tsvector), ${fts_low})
+				links.uuid,
+				setweight(coalesce(tsvector_agg(links.agg), ''::tsvector), ${fts_low})
 			FROM (
 				SELECT
 					people.uuid,
@@ -6295,8 +6297,8 @@
 				FROM people
 				LEFT JOIN cf_links ON cf_links.uuid = people.uuid
 				GROUP BY people.uuid
-			)
-			GROUP BY uuid
+			) AS links
+			GROUP BY links.uuid
 			WITH DATA;
 			CREATE UNIQUE INDEX "UQ_mv_lts_people_uuid" ON mv_lts_people(uuid);
 
@@ -6321,8 +6323,8 @@
 				SELECT * FROM get_cf_referenced_objects('reports', 'customFields')
 			)
 			SELECT
-				uuid,
-				setweight(coalesce(tsvector_agg(agg), ''::tsvector), ${fts_low})
+				links.uuid,
+				setweight(coalesce(tsvector_agg(links.agg), ''::tsvector), ${fts_low})
 			FROM (
 				SELECT
 					reports.uuid,
@@ -6337,8 +6339,8 @@
 				FROM reports
 				LEFT JOIN cf_links ON cf_links.uuid = reports.uuid
 				GROUP BY reports.uuid
-			)
-			GROUP BY uuid
+			) AS links
+			GROUP BY links.uuid
 			WITH DATA;
 			CREATE UNIQUE INDEX "UQ_mv_lts_reports_uuid" ON mv_lts_reports(uuid);
 
@@ -6350,8 +6352,8 @@
 				SELECT * FROM get_cf_referenced_objects('tasks', 'customFields')
 			)
 			SELECT
-				uuid,
-				setweight(coalesce(tsvector_agg(agg), ''::tsvector), ${fts_low})
+				links.uuid,
+				setweight(coalesce(tsvector_agg(links.agg), ''::tsvector), ${fts_low})
 			FROM (
 				SELECT
 					tasks.uuid,
@@ -6366,8 +6368,8 @@
 				FROM tasks
 				LEFT JOIN cf_links ON cf_links.uuid = tasks.uuid
 				GROUP BY tasks.uuid
-			)
-			GROUP BY uuid
+			) AS links
+			GROUP BY links.uuid
 			WITH DATA;
 			CREATE UNIQUE INDEX "UQ_mv_lts_tasks" ON mv_lts_tasks(uuid);
 

--- a/src/test/java/mil/dds/anet/test/resources/OrganizationResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/OrganizationResourceTest.java
@@ -412,41 +412,37 @@ public class OrganizationResourceTest extends AbstractResourceTest {
   @Test
   void searchAssessmentsTestForInteractionPlan() {
     final String assessmentKey = "interactionPlan";
-    final String matchingShortName = "MOD-F";
-    searchForAssessments(assessmentKey, null, matchingShortName);
-    searchForAssessments(assessmentKey, Map.of("priority", List.of("t2")), matchingShortName);
+    final List<String> matchingShortNames = List.of("EF 6.2", "MOD-F");
+    searchForAssessments(assessmentKey, null, matchingShortNames);
+    searchForAssessments(assessmentKey, Map.of("priority", List.of("t2")), matchingShortNames);
     searchForAssessments(assessmentKey, Map.of("priority", List.of("t1", "t2", "t3", "t4", "t5")),
-        matchingShortName);
-    searchForAssessments(assessmentKey, Map.of("priority", List.of("t4")), null);
+        matchingShortNames);
+    searchForAssessments(assessmentKey, Map.of("priority", List.of("t4")), List.of());
     searchForAssessments(assessmentKey,
-        Map.of("priority", List.of("t1"), "relation", List.of("maintain")), null);
+        Map.of("priority", List.of("t1"), "relation", List.of("maintain")), List.of());
   }
 
   @Test
   void searchAssessmentsTestForOrganizationOndemand() {
     final String assessmentKey = "organizationOndemand";
-    final String matchingShortName = "MOD-F";
-    searchForAssessments(assessmentKey, null, matchingShortName);
-    searchForAssessments(assessmentKey, Map.of("enumset", List.of("t2")), matchingShortName);
+    final List<String> matchingShortNames = List.of("EF 6.2", "MOD-F");
+    searchForAssessments(assessmentKey, null, matchingShortNames);
+    searchForAssessments(assessmentKey, Map.of("enumset", List.of("t2")), matchingShortNames);
     searchForAssessments(assessmentKey, Map.of("enumset", List.of("t1", "t2", "t3", "t4", "t5")),
-        matchingShortName);
-    searchForAssessments(assessmentKey, Map.of("enumset", List.of("t4")), null);
+        matchingShortNames);
+    searchForAssessments(assessmentKey, Map.of("enumset", List.of("t4")), List.of());
   }
 
   private void searchForAssessments(final String key, final Map<?, ?> filters,
-      final String matchingShortName) {
+      final List<String> matchingShortNames) {
     final AssessmentSearchQueryInput aq = AssessmentSearchQueryInput.builder().withKey(key)
         .withFilters(filters == null ? null : new HashMap<>(filters)).build();
     final OrganizationSearchQueryInput q =
         OrganizationSearchQueryInput.builder().withAssessment(aq).build();
     final AnetBeanList_Organization result =
         withCredentials(jackUser, t -> queryExecutor.organizationList(getListFields(FIELDS), q));
-    if (matchingShortName == null) {
-      assertThat(result.getList()).isEmpty();
-    } else {
-      assertThat(result.getList()).isNotEmpty()
-          .anyMatch(o -> matchingShortName.equals(o.getShortName()));
-    }
+    assertThat(result.getList()).map(Organization::getShortName)
+        .hasSameElementsAs(matchingShortNames);
   }
 
   @Test

--- a/src/test/java/mil/dds/anet/test/resources/PersonResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/PersonResourceTest.java
@@ -339,24 +339,20 @@ public class PersonResourceTest extends AbstractResourceTest {
   void searchAssessmentsTestForInterlocutorOndemandScreeningAndVetting() {
     // These have all expired!
     final String assessmentKey = "interlocutorOndemandScreeningAndVetting";
-    searchForAssessments(assessmentKey, null, null);
-    searchForAssessments(assessmentKey, Map.of("question1", List.of("fail1")), null);
-    searchForAssessments(assessmentKey, Map.of("question1", List.of("fail2")), null);
-    searchForAssessments(assessmentKey, Map.of("question1", List.of("fail3")), null);
+    searchForAssessments(assessmentKey, null, List.of());
+    searchForAssessments(assessmentKey, Map.of("question1", List.of("fail1")), List.of());
+    searchForAssessments(assessmentKey, Map.of("question1", List.of("fail2")), List.of());
+    searchForAssessments(assessmentKey, Map.of("question1", List.of("fail3")), List.of());
   }
 
   private void searchForAssessments(final String key, final Map<?, ?> filters,
-      final String matchingName) {
+      final List<String> matchingNames) {
     final AssessmentSearchQueryInput aq = AssessmentSearchQueryInput.builder().withKey(key)
         .withFilters(filters == null ? null : new HashMap<>(filters)).build();
     final PersonSearchQueryInput q = PersonSearchQueryInput.builder().withAssessment(aq).build();
     final AnetBeanList_Person results =
         withCredentials(jackUser, t -> queryExecutor.personList(getListFields(FIELDS), q));
-    if (matchingName == null) {
-      assertThat(results.getList()).isEmpty();
-    } else {
-      assertThat(results.getList()).isNotEmpty().anyMatch(p -> matchingName.equals(p.getName()));
-    }
+    assertThat(results.getList()).map(Person::getName).hasSameElementsAs(matchingNames);
   }
 
   @Test


### PR DESCRIPTION
- Make the full-text migration also work on PostgreSQL versions before 16.
- Correct the label for report advisor organization.

Closes [AB#1076](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1076), [AB#728](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/728)

#### User changes
- The report show page and report table now display a clear label for the advisor organization, and the report table also shows the proper label for the report intent.

#### Superuser changes
- None.

#### Admin changes
- None.

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [x] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [x] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [x] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
