### PR TITLE
Improve Sim

### DIFF
--- a/client/tests/sim/scenarios/buildup/lotsOfData.js
+++ b/client/tests/sim/scenarios/buildup/lotsOfData.js
@@ -54,10 +54,18 @@ const buildupLotsOfData = [
     }
   },
   {
-    name: "Create position",
-    number: TEST_RUN ? 1 : 20000,
+    name: "Create position #1",
+    number: TEST_RUN ? 1 : 10000,
     runnable: createPosition,
-    preDelay: TEST_RUN ? 3 : 300,
+    preDelay: TEST_RUN ? 1 : 100,
+    userTypes: ["existingAdmin"],
+    arguments: {}
+  },
+  {
+    name: "Create position #2",
+    number: TEST_RUN ? 1 : 10000,
+    runnable: createPosition,
+    preDelay: TEST_RUN ? 2 : 200,
     userTypes: ["existingAdmin"],
     arguments: {}
   },
@@ -65,7 +73,7 @@ const buildupLotsOfData = [
     name: "Create published report #1",
     number: TEST_RUN ? 1 : 25000,
     runnable: createReport,
-    preDelay: TEST_RUN ? 6 : 600,
+    preDelay: TEST_RUN ? 3 : 300,
     userTypes: ["existingAdmin"],
     arguments: { state: Report.STATE.PUBLISHED }
   },
@@ -73,7 +81,7 @@ const buildupLotsOfData = [
     name: "Create published report #2",
     number: TEST_RUN ? 1 : 25000,
     runnable: createReport,
-    preDelay: TEST_RUN ? 6 : 600,
+    preDelay: TEST_RUN ? 4 : 400,
     userTypes: ["existingAdmin"],
     arguments: { state: Report.STATE.PUBLISHED }
   },
@@ -81,7 +89,7 @@ const buildupLotsOfData = [
     name: "Create published report #3",
     number: TEST_RUN ? 1 : 25000,
     runnable: createReport,
-    preDelay: TEST_RUN ? 6 : 600,
+    preDelay: TEST_RUN ? 5 : 500,
     userTypes: ["existingAdmin"],
     arguments: { state: Report.STATE.PUBLISHED }
   },
@@ -97,7 +105,7 @@ const buildupLotsOfData = [
     name: "Create published report #5",
     number: TEST_RUN ? 1 : 25000,
     runnable: createReport,
-    preDelay: TEST_RUN ? 6 : 600,
+    preDelay: TEST_RUN ? 7 : 700,
     userTypes: ["existingAdmin"],
     arguments: { state: Report.STATE.PUBLISHED }
   },
@@ -105,7 +113,7 @@ const buildupLotsOfData = [
     name: "Create published report #6",
     number: TEST_RUN ? 1 : 25000,
     runnable: createReport,
-    preDelay: TEST_RUN ? 6 : 600,
+    preDelay: TEST_RUN ? 8 : 800,
     userTypes: ["existingAdmin"],
     arguments: { state: Report.STATE.PUBLISHED }
   },
@@ -113,7 +121,7 @@ const buildupLotsOfData = [
     name: "Create published report #7",
     number: TEST_RUN ? 1 : 25000,
     runnable: createReport,
-    preDelay: TEST_RUN ? 6 : 600,
+    preDelay: TEST_RUN ? 9 : 900,
     userTypes: ["existingAdmin"],
     arguments: { state: Report.STATE.PUBLISHED }
   },
@@ -121,7 +129,7 @@ const buildupLotsOfData = [
     name: "Create published report #8",
     number: TEST_RUN ? 1 : 25000,
     runnable: createReport,
-    preDelay: TEST_RUN ? 6 : 600,
+    preDelay: TEST_RUN ? 10 : 1000,
     userTypes: ["existingAdmin"],
     arguments: { state: Report.STATE.PUBLISHED }
   },

--- a/client/tests/sim/stories/LocationStories.js
+++ b/client/tests/sim/stories/LocationStories.js
@@ -3,7 +3,7 @@ import Model from "components/Model"
 import { Location } from "models"
 import { createHtmlParagraphs, fuzzy, populate, runGQL } from "../simutils"
 
-async function populateLocation(location, user) {
+async function populateLocation(location) {
   const template = {
     status: () => Model.STATUS.ACTIVE,
     type: () =>
@@ -27,21 +27,21 @@ async function populateLocation(location, user) {
           precision: 10
         })
       ),
-    description: () => createHtmlParagraphs()
+    description: async() => await createHtmlParagraphs()
   }
-  populate(location, template)
-    .status.always()
-    .type.always()
-    .name.always()
-    .lat.always()
-    .lng.always()
-    .description.always()
+  const locationGenerator = await populate(location, template)
+  await locationGenerator.status.always()
+  await locationGenerator.type.always()
+  await locationGenerator.name.always()
+  await locationGenerator.lat.always()
+  await locationGenerator.lng.always()
+  await locationGenerator.description.always()
   return location
 }
 
 const _createLocation = async function(user) {
   const location = Location.filterClientSideFields(new Location())
-  if (await populateLocation(location, user)) {
+  if (await populateLocation(location)) {
     console.debug(`Creating location ${location.name}`)
 
     return (

--- a/client/tests/sim/stories/OrganizationStories.js
+++ b/client/tests/sim/stories/OrganizationStories.js
@@ -46,7 +46,7 @@ function randomOrganization() {
     identificationCode: () => faker.helpers.replaceSymbols("??????"),
     parentOrg: identity,
     status: () => faker.helpers.objectValue(Organization.STATUS),
-    profile: () => createHtmlParagraphs()
+    profile: async() => await createHtmlParagraphs()
   }
 
   // approvalSteps: [],
@@ -123,7 +123,7 @@ async function createHierarchy(user, grow, args) {
     org.shortName = (shortName + " " + path.join(".")).trim()
     org.identificationCode = faker.helpers.replaceSymbols("??????")
     org.status = status
-    org.profile = createHtmlParagraphs()
+    org.profile = await createHtmlParagraphs()
     if (fuzzy.withProbability(0.5)) {
       const orgSlug = org.shortName.replace(/[ .]/g, "")
       org.emailAddresses = createEmailAddresses(
@@ -204,13 +204,13 @@ const createOrganization = async function(user, parentOrg, path) {
   }
   randomOrg.status = Model.STATUS.ACTIVE
 
-  populate(org, randomOrg)
-    .shortName.always()
-    .longName.always()
-    .identificationCode.always()
-    .parentOrg.always()
-    .status.always()
-    .profile.always()
+  const orgGenerator = await populate(org, randomOrg)
+  await orgGenerator.shortName.always()
+  await orgGenerator.longName.always()
+  await orgGenerator.identificationCode.always()
+  await orgGenerator.parentOrg.always()
+  await orgGenerator.status.always()
+  await orgGenerator.profile.always()
 
   if (path.length === 1 && org.longName) {
     path[0] = abbreviateCompanyName(org.longName)

--- a/client/tests/sim/stories/PersonStories.js
+++ b/client/tests/sim/stories/PersonStories.js
@@ -194,6 +194,18 @@ const updatePerson = async function(user) {
         }) {
           list {
             uuid
+            biography
+            country {
+              uuid
+            }
+            endOfTourDate
+            gender
+            name
+            domainUsername
+            phoneNumber
+            rank
+            role
+            status
           }
         }
       }
@@ -202,32 +214,7 @@ const updatePerson = async function(user) {
     })
   ).data.personList.list
 
-  let person = people && people[0]
-  person = (
-    await runGQL(user, {
-      query: `
-      query {
-        person (uuid:"${person.uuid}") {
-          uuid
-          biography
-          country {
-            uuid
-          }
-          endOfTourDate
-          gender
-          name
-          domainUsername
-          phoneNumber
-          rank
-          role
-          status
-        }
-      }
-    `,
-      variables: {}
-    })
-  ).data.person
-
+  const person = people && people[0]
   const personGenerator = await populate(person, modifiedPerson())
   await personGenerator.name.rarely()
   await personGenerator.domainUsername.never()
@@ -268,7 +255,7 @@ const _deletePerson = async function(user) {
   if (totalCount === 0) {
     return null
   }
-  let person0
+  let person
   for (let i = 0; i < Math.max(totalCount, 10); i++) {
     const random = faker.number.int({ max: totalCount - 1 })
     const people = (
@@ -283,6 +270,15 @@ const _deletePerson = async function(user) {
           list {
             uuid
             name
+            biography
+            country {
+              uuid
+            }
+            endOfTourDate
+            gender
+            phoneNumber
+            rank
+            status
             position {
               uuid
             }
@@ -293,34 +289,12 @@ const _deletePerson = async function(user) {
         variables: {}
       })
     ).data.personList.list.filter(p => !p.position)
-    person0 = people && people[0]
-    if (person0) {
+    person = people && people[0]
+    if (person) {
       break
     }
   }
-  if (person0) {
-    const person = (
-      await runGQL(user, {
-        query: `
-        query {
-          person(uuid: "${person0.uuid}") {
-              biography
-              country {
-                uuid
-              }
-              endOfTourDate
-              gender
-              name
-              phoneNumber
-              rank
-              status
-              uuid
-          }
-        }
-      `,
-        variables: {}
-      })
-    ).data.person
+  if (person) {
     person.status = Model.STATUS.INACTIVE
 
     console.debug(`Deleting/Deactivating ${person.name.green}`)

--- a/client/tests/sim/stories/PersonStories.js
+++ b/client/tests/sim/stories/PersonStories.js
@@ -1,6 +1,7 @@
 import { allFakers, allLocales, faker } from "@faker-js/faker"
 import Model from "components/Model"
 import { countries, getCountryCode } from "countries-list"
+import _isEmpty from "lodash/isEmpty"
 import { Location, Person } from "models"
 import Settings from "settings"
 import {
@@ -65,9 +66,9 @@ async function randomPerson(isUser, status) {
   }
   const langCode =
     fakerHacks[countryCode] ||
-    (countryByCode
-      ? faker.helpers.arrayElement(countryByCode.languages)
-      : defaultLangCode)
+    (_isEmpty(countryByCode?.languages)
+      ? defaultLangCode
+      : faker.helpers.arrayElement(countryByCode.languages))
   const locale = availableLocales.includes(langCode)
     ? langCode
     : defaultLangCode


### PR DESCRIPTION
Improve Sim:

- When generating HTML for rich-text fields, also include a random list of links to other ANET objects
- Make sure report primaries and author are set
- Remove unnecessary extra query
- Reduce the number of queries for getting random objects by caching the results for 90 seconds
- Change lotsOfData buildup by splitting creating positions in two separate threads, and changing the timings of the threads a bit
- Fix picking random language code