### PR TITLE
Fix display of organization tasks

### DIFF
--- a/anet-dictionary.yml
+++ b/anet-dictionary.yml
@@ -2059,7 +2059,7 @@ fields:
 
 pinned_ORGs: [Key Leader Engagement]
 non_reporting_ORGs: [ANET Administrators]
-tasking_ORGs: [EF 2.2, EF 9]
+tasking_ORGs: [E 1.1, EF 1.2, EF 2, EF 4, EF 9]
 domainNames: [example.com, example.ns, cmil.mil, mission.ita, nato.int, "*.isaf.nato.int"]
 activeDomainNames: [example.com, example.ns, cmil.mil, mission.ita, nato.int, "*.isaf.nato.int"]
 emailNetworks:

--- a/client/src/pages/organizations/Edit.js
+++ b/client/src/pages/organizations/Edit.js
@@ -116,6 +116,17 @@ const GQL_GET_ORGANIZATION = gql`
         uuid
         shortName
         longName
+        parentTask {
+          uuid
+          shortName
+        }
+        ascendantTasks {
+          uuid
+          shortName
+          parentTask {
+            uuid
+          }
+        }
       }
       attachments {
         ${Attachment.basicFieldsQuery}

--- a/client/src/pages/organizations/OrganizationTasks.js
+++ b/client/src/pages/organizations/OrganizationTasks.js
@@ -29,6 +29,17 @@ const GQL_GET_TASK_LIST = gql`
         uuid
         shortName
         longName
+        parentTask {
+          uuid
+          shortName
+        }
+        ascendantTasks {
+          uuid
+          shortName
+          parentTask {
+            uuid
+          }
+        }
       }
     }
   }

--- a/client/tests/webdriver/baseSpecs/myTasks.spec.js
+++ b/client/tests/webdriver/baseSpecs/myTasks.spec.js
@@ -38,8 +38,8 @@ describe("My tasks page", () => {
       const myOrgAssignedTasksItems = await (
         await MyTasks.getMyOrgAssignedTasks()
       ).$$("tr")
-      // table has a header and 5 task rows
-      expect(myOrgAssignedTasksItems).to.have.length(6)
+      // table has a header and 4 task rows
+      expect(myOrgAssignedTasksItems).to.have.length(5)
     })
     it("Should see a table of the tasks being the responsibility of the current user", async() => {
       await (await MyTasks.getMyResponsibleTasks()).waitForDisplayed()

--- a/client/tests/webdriver/baseSpecs/showOrganization.spec.js
+++ b/client/tests/webdriver/baseSpecs/showOrganization.spec.js
@@ -7,6 +7,12 @@ import ShowOrganization from "../pages/showOrganization.page"
 const ORGANIZATION_UUID = "ccbee4bb-08b8-42df-8cb5-65e8172f657b" // EF 2.2
 const ORGANIZATION_WITH_AG_UUID = "7f939a44-b9e4-48e0-98f5-7d0ea38a6ecf" // EF 5.1
 const ORGANIZATION_EF2_SEARCH_STRING = "EF 2"
+const EF2_ASSIGNED_TASKS = [
+  "EF 2 » 2.A",
+  "EF 2 » 2.B",
+  "EF 2 » 2.C",
+  "EF 2 » 2.D"
+]
 const ORGANIZATION_EF22_SEARCH_STRING = "EF 2.2"
 const LEADER_POSITION_TEXT = "EF 2.2 Final Reviewer"
 const LEADER_PERSON_TEXT = "CTR BECCABON, Rebecca"
@@ -44,6 +50,30 @@ describe("Show organization page", () => {
       const deputyField = await ShowOrganization.getDeputies()
       // eslint-disable-next-line no-unused-expressions
       expect(await deputyField.isExisting()).to.be.false
+    })
+    it("Should see assigned tasks on the Show page", async() => {
+      const tasks = await ShowOrganization.getTasks()
+      await tasks.waitForExist()
+      await tasks.waitForDisplayed()
+      const assignedTasks = await ShowOrganization.getAssignedTasks()
+      const assignedTasksShortNames = await assignedTasks.map(
+        async at => await at.getText()
+      )
+      expect(assignedTasksShortNames).to.have.members(EF2_ASSIGNED_TASKS)
+    })
+    it("Should see assigned tasks on the Edit page", async() => {
+      await (await ShowOrganization.getEditOrganizationButton()).click()
+      const editableTasks = await ShowOrganization.getEditableTasks()
+      await editableTasks.waitForExist()
+      await editableTasks.waitForDisplayed()
+      const editableAssignedTasks =
+        await ShowOrganization.getEditableAssignedTasks()
+      const editableAssignedTasksShortNames = await editableAssignedTasks.map(
+        async at => await at.getText()
+      )
+      expect(editableAssignedTasksShortNames).to.have.members(
+        EF2_ASSIGNED_TASKS
+      )
 
       // Log out
       await ShowOrganization.logout()

--- a/client/tests/webdriver/pages/showOrganization.page.js
+++ b/client/tests/webdriver/pages/showOrganization.page.js
@@ -75,6 +75,26 @@ class ShowOrganization extends Page {
     return browser.$("div#Deputies span:nth-child(2)")
   }
 
+  async getTasks() {
+    return browser.$('div[id="tasks"]')
+  }
+
+  async getAssignedTasks() {
+    return (await this.getTasks()).$$("table tr td:first-child")
+  }
+
+  async getEditOrganizationButton() {
+    return browser.$("//a[text()='Edit']")
+  }
+
+  async getEditableTasks() {
+    return browser.$('div[id="fg-tasks"]')
+  }
+
+  async getEditableAssignedTasks() {
+    return (await this.getEditableTasks()).$$("table tr td:first-child")
+  }
+
   async waitForAlertSuccessToLoad() {
     if (!(await (await this.getAlertSuccess()).isDisplayed())) {
       await (await this.getAlertSuccess()).waitForExist()

--- a/insertBaseData-psql.sql
+++ b/insertBaseData-psql.sql
@@ -589,7 +589,6 @@ INSERT INTO "taskTaskedOrganizations" ("taskUuid", "organizationUuid") VALUES
   -- ((SELECT uuid from tasks where "shortName" = '1.3.A'), (SELECT uuid from organizations where "shortName"='EF 1.3')),
   -- ((SELECT uuid from tasks where "shortName" = '1.3.B'), (SELECT uuid from organizations where "shortName"='EF 1.3')),
   -- ((SELECT uuid from tasks where "shortName" = '1.3.C'), (SELECT uuid from organizations where "shortName"='EF 1.3')),
-  ((SELECT uuid from tasks where "shortName" = 'EF 2'), (SELECT uuid from organizations where "shortName"='EF 2')),
   ((SELECT uuid from tasks where "shortName" = '2.A'), (SELECT uuid from organizations where "shortName"='EF 2')),
   ((SELECT uuid from tasks where "shortName" = '2.B'), (SELECT uuid from organizations where "shortName"='EF 2')),
   ((SELECT uuid from tasks where "shortName" = '2.C'), (SELECT uuid from organizations where "shortName"='EF 2')),

--- a/testDictionaries/no-custom-fields.yml
+++ b/testDictionaries/no-custom-fields.yml
@@ -1547,7 +1547,7 @@ fields:
 
 pinned_ORGs: [Key Leader Engagement]
 non_reporting_ORGs: [ANET Administrators]
-tasking_ORGs: [EF 2.2, EF 9]
+tasking_ORGs: [E 1.1, EF 1.2, EF 2, EF 4, EF 9]
 domainNames: [example.com, example.ns, cmil.mil, mission.ita, nato.int, "*.isaf.nato.int"]
 activeDomainNames: [example.com, example.ns, cmil.mil, mission.ita, nato.int, "*.isaf.nato.int"]
 emailNetworks:


### PR DESCRIPTION
The table of tasks for organizations now correctly shows the breadcrumb trail of each task in the Name column.

Closes [AB#1196](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1196)

#### User changes
- On the Show page of an organization, users can now see the breadcrumb trail of the assigned tasks.

#### Superuser changes
- On the Edit page of an organization, superusers can now see the breadcrumb trail of the assigned tasks.

#### Admin changes
- On the Edit page of an organization, admins can now see the breadcrumb trail of the assigned tasks, also after (de)selecting tasks.

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [ ] Added and/or updated unit tests
  - [x] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
