### PR TITLE
Add description to positions

### DIFF
--- a/anet-dictionary.yml
+++ b/anet-dictionary.yml
@@ -898,6 +898,9 @@ fields:
         member: Member
         deputy: Deputy
         leader: Leader
+    description:
+      label: Description
+      placeholder: Fill in the description of this position
     emailAddresses:
       label: Email addresses
       authorizationGroupUuids: ['ab1a7d99-4529-44b1-a118-bdee3ca8296b']

--- a/client/src/components/previews/PositionPreview.js
+++ b/client/src/components/previews/PositionPreview.js
@@ -5,6 +5,7 @@ import EmailAddressTable from "components/EmailAddressTable"
 import { PreviewField } from "components/FieldHelper"
 import LinkTo from "components/LinkTo"
 import { GRAPHQL_ENTITY_AVATAR_FIELDS } from "components/Model"
+import RichTextEditor from "components/RichTextEditor"
 import { Location, Position } from "models"
 import moment from "moment"
 import PropTypes from "prop-types"
@@ -21,6 +22,7 @@ const GQL_GET_POSITION = gql`
       role
       status
       code
+      description
       emailAddresses {
         network
         address
@@ -157,6 +159,14 @@ const PositionPreview = ({ className, uuid }) => {
           dictProps={Settings.fields.position.role}
           value={Position.humanNameOfRole(position.role)}
         />
+
+        {position.description && (
+          <DictionaryField
+            wrappedComponent={PreviewField}
+            dictProps={Settings.fields.position.description}
+            value={<RichTextEditor readOnly value={position.description} />}
+          />
+        )}
       </div>
 
       <h4>Current assigned person</h4>

--- a/client/src/models/Position.js
+++ b/client/src/models/Position.js
@@ -69,6 +69,7 @@ export default class Position extends Model {
         .string()
         .required()
         .default(() => PositionRole.MEMBER.toString()),
+      description: yup.string().nullable().default(""),
       associatedPositions: yup.array().nullable().default([]),
       previousPeople: yup.array().nullable().default([]),
       organization: yup
@@ -111,6 +112,7 @@ export default class Position extends Model {
     isSubscribed
     updatedAt
     code
+    description
     emailAddresses {
       network
       address

--- a/client/src/pages/admin/merge/MergePositions.js
+++ b/client/src/pages/admin/merge/MergePositions.js
@@ -25,6 +25,7 @@ import {
   useBoilerplate,
   usePageTitle
 } from "components/Page"
+import RichTextEditor from "components/RichTextEditor"
 import useMergeObjects, {
   ALIGN_OPTIONS,
   areAllSet,
@@ -193,6 +194,17 @@ const MergePositions = ({ pageDispatchers }) => {
                 value={mergedPosition.code}
                 align={ALIGN_OPTIONS.CENTER}
                 fieldName="code"
+                mergeState={mergeState}
+                dispatchMergeActions={dispatchMergeActions}
+              />
+              <DictionaryField
+                wrappedComponent={MergeField}
+                dictProps={Settings.fields.position.description}
+                value={
+                  <RichTextEditor readOnly value={mergedPosition.description} />
+                }
+                align={ALIGN_OPTIONS.CENTER}
+                fieldName="description"
                 mergeState={mergeState}
                 dispatchMergeActions={dispatchMergeActions}
               />
@@ -535,6 +547,21 @@ const PositionColumn = ({
               dispatchMergeActions(
                 setAMergedField("code", position.code, align)
               )}
+            mergeState={mergeState}
+            autoMerge
+            dispatchMergeActions={dispatchMergeActions}
+          />
+          <DictionaryField
+            wrappedComponent={MergeField}
+            dictProps={Settings.fields.position.description}
+            fieldName="description"
+            value={<RichTextEditor readOnly value={position.description} />}
+            align={align}
+            action={() => {
+              dispatchMergeActions(
+                setAMergedField("description", position.description, align)
+              )
+            }}
             mergeState={mergeState}
             autoMerge
             dispatchMergeActions={dispatchMergeActions}

--- a/client/src/pages/positions/Edit.js
+++ b/client/src/pages/positions/Edit.js
@@ -32,6 +32,7 @@ const GQL_GET_POSITION = gql`
       status
       type
       role
+      description
       emailAddresses {
         network
         address

--- a/client/src/pages/positions/Form.js
+++ b/client/src/pages/positions/Form.js
@@ -23,8 +23,10 @@ import Messages from "components/Messages"
 import Model from "components/Model"
 import NavigationWarning from "components/NavigationWarning"
 import { jumpToTop } from "components/Page"
+import RichTextEditor from "components/RichTextEditor"
 import SimilarObjectsModal from "components/SimilarObjectsModal"
 import { FastField, Field, Form, Formik } from "formik"
+import _isEqual from "lodash/isEqual"
 import { Location, Organization, Position } from "models"
 import { PositionRole } from "models/Position"
 import PropTypes from "prop-types"
@@ -369,6 +371,31 @@ const PositionForm = ({ edit, title, initialValues, notesComponent }) => {
                   component={FieldHelper.RadioButtonToggleGroupField}
                   buttons={positionRoleButtons}
                   onChange={value => setFieldValue("role", value)}
+                />
+
+                <DictionaryField
+                  wrappedComponent={FastField}
+                  dictProps={Settings.fields.position.description}
+                  name="description"
+                  component={FieldHelper.SpecialField}
+                  onChange={value => {
+                    // prevent initial unnecessary render of RichTextEditor
+                    if (!_isEqual(values.description, value)) {
+                      setFieldValue("description", value, true)
+                    }
+                  }}
+                  onHandleBlur={() => {
+                    // validation will be done by setFieldValue
+                    setFieldTouched("description", true, false)
+                  }}
+                  widget={
+                    <RichTextEditor
+                      className="description"
+                      placeholder={
+                        Settings.fields.position.description?.placeholder
+                      }
+                    />
+                  }
                 />
               </Fieldset>
 

--- a/client/src/pages/positions/Show.js
+++ b/client/src/pages/positions/Show.js
@@ -29,6 +29,7 @@ import {
   usePageTitle
 } from "components/Page"
 import RelatedObjectNotes from "components/RelatedObjectNotes"
+import RichTextEditor from "components/RichTextEditor"
 import { Field, Form, Formik } from "formik"
 import { Location, Position } from "models"
 import { positionTour } from "pages/HopscotchTour"
@@ -292,6 +293,16 @@ const PositionShow = ({ pageDispatchers }) => {
                   name="role"
                   component={FieldHelper.ReadonlyField}
                   humanValue={Position.humanNameOfRole}
+                />
+
+                <DictionaryField
+                  wrappedComponent={Field}
+                  dictProps={Settings.fields.position.description}
+                  name="description"
+                  component={FieldHelper.ReadonlyField}
+                  humanValue={
+                    <RichTextEditor readOnly value={position.description} />
+                  }
                 />
               </Fieldset>
 

--- a/client/tests/sim/stories/PositionStories.js
+++ b/client/tests/sim/stories/PositionStories.js
@@ -2,8 +2,10 @@ import { faker } from "@faker-js/faker"
 import Model from "components/Model"
 import _isEmpty from "lodash/isEmpty"
 import { Location, Position } from "models"
+import { PositionRole } from "models/Position"
 import {
   createEmailAddresses,
+  createHtmlParagraphs,
   fuzzy,
   getRandomObject,
   identity,
@@ -138,7 +140,9 @@ function randomPositionTemplate(organizations) {
     organization: () => faker.helpers.arrayElement(organizations),
     name: () => faker.person.jobTitle(),
     location: identity,
+    role: () => getPositionRole(),
     code: identity,
+    description: async() => await createHtmlParagraphs(),
     associatedPositions: identity
   }
 }
@@ -149,6 +153,14 @@ function getPositionType() {
     : fuzzy.withProbability(0.9)
       ? Position.TYPE.SUPERUSER
       : Position.TYPE.ADMINISTRATOR
+}
+
+function getPositionRole() {
+  return fuzzy.withProbability(0.9)
+    ? PositionRole.MEMBER.toString()
+    : fuzzy.withProbability(0.9)
+      ? PositionRole.DEPUTY.toString()
+      : PositionRole.LEADER.toString()
 }
 
 /**
@@ -193,6 +205,8 @@ const _createPosition = async function(user) {
     organization,
     person,
     location,
+    role: () => getPositionRole(),
+    description: async() => await createHtmlParagraphs(),
     emailAddresses
   }
 
@@ -204,6 +218,8 @@ const _createPosition = async function(user) {
   await positionGenerator.person.always()
   await positionGenerator.organization.always()
   await positionGenerator.location.always()
+  await positionGenerator.role.always()
+  await positionGenerator.description.always()
   await positionGenerator.emailAddresses.always()
 
   console.debug(`Creating position ${position.name.green}`)

--- a/src/main/java/mil/dds/anet/beans/Position.java
+++ b/src/main/java/mil/dds/anet/beans/Position.java
@@ -51,6 +51,9 @@ public class Position extends AbstractEmailableAnetBean
   @GraphQLQuery
   @GraphQLInputField
   private PositionRole role;
+  @GraphQLQuery
+  @GraphQLInputField
+  private String description;
   // Lazy Loaded
   // annotated below
   private ForeignObjectHolder<Organization> organization = new ForeignObjectHolder<>();
@@ -102,6 +105,11 @@ public class Position extends AbstractEmailableAnetBean
     return status;
   }
 
+  @Override
+  public void setStatus(Status status) {
+    this.status = status;
+  }
+
   public PositionRole getRole() {
     return role;
   }
@@ -110,9 +118,12 @@ public class Position extends AbstractEmailableAnetBean
     this.role = role;
   }
 
-  @Override
-  public void setStatus(Status status) {
-    this.status = status;
+  public String getDescription() {
+    return description;
+  }
+
+  public void setDescription(String description) {
+    this.description = description;
   }
 
   @GraphQLQuery(name = "organization")
@@ -358,12 +369,15 @@ public class Position extends AbstractEmailableAnetBean
     return super.equals(o) && Objects.equals(uuid, other.getUuid())
         && Objects.equals(name, other.getName()) && Objects.equals(code, other.getCode())
         && Objects.equals(type, other.getType()) && Objects.equals(status, other.getStatus())
+        && Objects.equals(role, other.getRole())
+        && Objects.equals(description, other.getDescription())
         && Objects.equals(getOrganizationUuid(), other.getOrganizationUuid());
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(super.hashCode(), uuid, name, code, type, status, organization);
+    return Objects.hash(super.hashCode(), uuid, name, code, type, status, role, organization,
+        description);
   }
 
   @Override

--- a/src/main/java/mil/dds/anet/database/PositionDao.java
+++ b/src/main/java/mil/dds/anet/database/PositionDao.java
@@ -44,7 +44,7 @@ public class PositionDao extends AnetSubscribableObjectDao<Position, PositionSea
 
   public static final String[] fields =
       {"uuid", "name", "code", "createdAt", "updatedAt", "organizationUuid", "currentPersonUuid",
-          "type", "status", "locationUuid", "customFields", "role"};
+          "type", "status", "locationUuid", "customFields", "role", "description"};
   public static final String TABLE_NAME = "positions";
   public static final String POSITION_FIELDS = DaoUtils.buildFieldAliases(TABLE_NAME, fields, true);
   public static final String DUPLICATE_POSITION_CODE =
@@ -67,8 +67,9 @@ public class PositionDao extends AnetSubscribableObjectDao<Position, PositionSea
       try {
         handle.createUpdate("/* positionInsert */ INSERT INTO positions (uuid, name, code, type, "
             + "status, \"organizationUuid\", \"locationUuid\", \"createdAt\", \"updatedAt\", "
-            + "\"customFields\", \"role\") VALUES (:uuid, :name, :code, :type, :status, :organizationUuid, "
-            + ":locationUuid, :createdAt, :updatedAt, :customFields, :role)").bindBean(p)
+            + "\"customFields\", role, description) VALUES (:uuid, :name, :code, :type, :status, "
+            + ":organizationUuid, :locationUuid, :createdAt, :updatedAt, :customFields, :role, "
+            + ":description)").bindBean(p)
             .bind("createdAt", DaoUtils.asLocalDateTime(p.getCreatedAt()))
             .bind("updatedAt", DaoUtils.asLocalDateTime(p.getUpdatedAt()))
             .bind("type", DaoUtils.getEnumId(p.getType()))
@@ -167,7 +168,8 @@ public class PositionDao extends AnetSubscribableObjectDao<Position, PositionSea
             .createUpdate("/* positionUpdate */ UPDATE positions SET name = :name, code = :code, "
                 + "\"organizationUuid\" = :organizationUuid, type = :type, status = :status, "
                 + "\"locationUuid\" = :locationUuid, \"updatedAt\" = :updatedAt, "
-                + "\"customFields\" = :customFields, \"role\" = :role WHERE uuid = :uuid")
+                + "\"customFields\" = :customFields, role = :role, description = :description "
+                + "WHERE uuid = :uuid")
             .bindBean(p).bind("updatedAt", DaoUtils.asLocalDateTime(p.getUpdatedAt()))
             .bind("type", DaoUtils.getEnumId(p.getType()))
             .bind("status", DaoUtils.getEnumId(p.getStatus()))

--- a/src/main/java/mil/dds/anet/database/mappers/PositionMapper.java
+++ b/src/main/java/mil/dds/anet/database/mappers/PositionMapper.java
@@ -32,6 +32,7 @@ public class PositionMapper implements RowMapper<Position> {
     p.setType(MapperUtils.getEnumIdx(rs, "positions_type", PositionType.class));
     p.setStatus(MapperUtils.getEnumIdx(rs, "positions_status", Position.Status.class));
     p.setRole(MapperUtils.getEnumIdx(rs, "positions_role", PositionRole.class));
+    p.setDescription(MapperUtils.getOptionalString(rs, "positions_description"));
 
     p.setOrganizationUuid(rs.getString("positions_organizationUuid"));
     p.setPersonUuid(rs.getString("positions_currentPersonUuid"));

--- a/src/main/java/mil/dds/anet/resources/PositionResource.java
+++ b/src/main/java/mil/dds/anet/resources/PositionResource.java
@@ -80,6 +80,8 @@ public class PositionResource {
   public Position createPosition(@GraphQLRootContext GraphQLContext context,
       @GraphQLArgument(name = "position") Position pos) {
     pos.checkAndFixCustomFields();
+    pos.setDescription(
+        Utils.isEmptyHtml(pos.getDescription()) ? null : Utils.sanitizeHtml(pos.getDescription()));
     final Person user = DaoUtils.getUserFromContext(context);
     assertPermission(user, pos);
     validatePosition(user, pos);
@@ -131,6 +133,8 @@ public class PositionResource {
   public Integer updatePosition(@GraphQLRootContext GraphQLContext context,
       @GraphQLArgument(name = "position") Position pos) {
     pos.checkAndFixCustomFields();
+    pos.setDescription(
+        Utils.isEmptyHtml(pos.getDescription()) ? null : Utils.sanitizeHtml(pos.getDescription()));
     final Person user = DaoUtils.getUserFromContext(context);
     assertPermission(user, pos);
     validatePosition(user, pos);

--- a/src/main/java/mil/dds/anet/threads/MergedEntityWorker.java
+++ b/src/main/java/mil/dds/anet/threads/MergedEntityWorker.java
@@ -28,6 +28,7 @@ public class MergedEntityWorker extends AbstractWorker {
       new FieldWithEntityReference("organizations", "customFields"), // -
       new FieldWithEntityReference("people", "biography"), // -
       new FieldWithEntityReference("people", "customFields"), // -
+      new FieldWithEntityReference("positions", "description"), // -
       new FieldWithEntityReference("positions", "customFields"), // -
       new FieldWithEntityReference("reports", "text"), // -
       new FieldWithEntityReference("reports", "customFields"), // -

--- a/src/main/resources/anet-schema.yml
+++ b/src/main/resources/anet-schema.yml
@@ -890,7 +890,7 @@ properties:
       position:
         type: object
         additionalProperties: false
-        required: [status, name, type, code, organization, location, organizationsAdministrated, role, emailAddresses, authorizationGroups]
+        required: [status, name, type, code, organization, location, organizationsAdministrated, role, description, emailAddresses, authorizationGroups]
         properties:
           status:
             "$ref": "#/$defs/labeledField"
@@ -943,6 +943,8 @@ properties:
                       leader:
                         type: string
                         description: UI label of leader position
+          description:
+            "$ref": "#/$defs/inputField"
           customFields:
             type: object
             additionalProperties:

--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -5940,6 +5940,12 @@
 		/>
 	</changeSet>
 
+	<changeSet id="add-description-field-to-positions" author="gjvoosten">
+		<addColumn tableName="positions">
+			<column name="description" type="text"/>
+		</addColumn>
+	</changeSet>
+
 	<!-- Keep this change set as the last one in the change log;
 	     it will be re-run whenever it changes. -->
 	<changeSet id="set-up-full-text-search" runOnChange="true" author="gjvoosten">
@@ -6249,6 +6255,8 @@
 
 			ALTER TABLE positions
 				ADD COLUMN more_text tsvector GENERATED ALWAYS AS (
+					setweight(to_tsvector(${fts_config}, coalesce(positions.description, ''))
+						|| to_tsvector('simple', coalesce(positions.description, '')), ${fts_low}) ||
 					setweight(to_tsvector(${fts_config}, jsonb_value_agg(positions."customFields"::jsonb))
 						|| to_tsvector('simple', jsonb_value_agg(positions."customFields"::jsonb)), ${fts_lower})
 				) STORED;
@@ -6375,15 +6383,31 @@
 			CREATE UNIQUE INDEX "UQ_mv_lts_people_uuid" ON mv_lts_people(uuid);
 
 			CREATE MATERIALIZED VIEW IF NOT EXISTS mv_lts_positions(uuid, link_text) AS
-			WITH cf_links AS (
+			WITH rt_links AS (
+				SELECT * FROM get_rt_referenced_objects('positions', 'description')
+			),
+			cf_links AS (
 				SELECT * FROM get_cf_referenced_objects('positions', 'customFields')
 			)
 			SELECT
-				positions.uuid,
-				setweight(coalesce(tsvector_agg(get_core_text(cf_links.object_table, cf_links.object_uuid)), ''::tsvector), ${fts_low})
-			FROM positions
-			LEFT JOIN cf_links ON cf_links.uuid = positions.uuid
-			GROUP BY positions.uuid
+				links.uuid,
+				setweight(coalesce(tsvector_agg(links.agg), ''::tsvector), ${fts_low})
+			FROM (
+				SELECT
+					positions.uuid,
+					coalesce(tsvector_agg(get_core_text(rt_links.object_table, rt_links.object_uuid)), ''::tsvector) AS agg
+				FROM positions
+				LEFT JOIN rt_links ON rt_links.uuid = positions.uuid
+				GROUP BY positions.uuid
+			UNION ALL
+				SELECT
+					positions.uuid,
+					coalesce(tsvector_agg(get_core_text(cf_links.object_table, cf_links.object_uuid)), ''::tsvector) AS agg
+				FROM positions
+				LEFT JOIN cf_links ON cf_links.uuid = positions.uuid
+				GROUP BY positions.uuid
+			) AS links
+			GROUP BY links.uuid
 			WITH DATA;
 			CREATE UNIQUE INDEX "UQ_mv_lts_positions_uuid" ON mv_lts_positions(uuid);
 

--- a/src/test/java/mil/dds/anet/test/integration/db/MergedEntityWorkerTest.java
+++ b/src/test/java/mil/dds/anet/test/integration/db/MergedEntityWorkerTest.java
@@ -264,8 +264,10 @@ class MergedEntityWorkerTest extends AbstractResourceTest {
     input.setType(Position.PositionType.REGULAR);
     input.setRole(Position.PositionRole.MEMBER);
     input.setName("testPosition");
+    input.setDescription(getRichText(PositionDao.TABLE_NAME, testOldUuid));
     input.setCustomFields(getJsonString(PositionDao.TABLE_NAME, testOldUuid));
     final Position created = positionDao.insert(input);
+    assertContains(created.getDescription(), testOldUuid);
     assertContains(created.getCustomFields(), testOldUuid);
 
     // run the worker
@@ -273,7 +275,9 @@ class MergedEntityWorkerTest extends AbstractResourceTest {
 
     // assert that the entity refs have been updated
     final Position updated = positionDao.getByUuid(created.getUuid());
+    assertDoesNotContain(updated.getDescription(), testOldUuid);
     assertDoesNotContain(updated.getCustomFields(), testOldUuid);
+    assertContains(updated.getDescription(), testNewUuid);
     assertContains(updated.getCustomFields(), testNewUuid);
 
     // clean up

--- a/src/test/java/mil/dds/anet/test/resources/PositionResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/PositionResourceTest.java
@@ -39,8 +39,8 @@ public class PositionResourceTest extends AbstractResourceTest {
       String.format("uuid shortName %1$s", _EMAIL_ADDRESSES_FIELDS);
   private static final String _PERSON_FIELDS =
       String.format("uuid name %1$s", _EMAIL_ADDRESSES_FIELDS);
-  private static final String _POSITION_FIELDS =
-      String.format("uuid name code type role status customFields %1$s", _EMAIL_ADDRESSES_FIELDS);
+  private static final String _POSITION_FIELDS = String.format(
+      "uuid name code type role status description customFields %1$s", _EMAIL_ADDRESSES_FIELDS);
   public static final String ORGANIZATION_FIELDS =
       String.format("{ %1$s positions { %2$s organization { uuid } location { uuid } } }",
           _ORGANIZATION_FIELDS, _POSITION_FIELDS);
@@ -510,12 +510,14 @@ public class PositionResourceTest extends AbstractResourceTest {
     final PositionInput newbPositionInput = PositionInput.builder()
         .withName("PositionTest Position for Newb").withType(PositionType.REGULAR)
         .withRole(PositionRole.MEMBER).withOrganization(getOrganizationInput(orgs.getList().get(0)))
-        .withStatus(Status.ACTIVE).withPerson(getPersonInput(newb1)).withCode(positionCode).build();
+        .withStatus(Status.ACTIVE).withPerson(getPersonInput(newb1)).withCode(positionCode)
+        .withDescription("<p>This position has no description.</p>").build();
 
     final Position newbPosition =
         withCredentials(adminUser, t -> mutationExecutor.createPosition(FIELDS, newbPositionInput));
     assertThat(newbPosition).isNotNull();
     assertThat(newbPosition.getUuid()).isNotNull();
+    assertThat(newbPositionInput.getDescription()).isEqualTo(newbPosition.getDescription());
     // Ensure that the position contains the person
     final Person returnedPerson = newbPosition.getPerson();
     assertThat(returnedPerson).isNotNull();

--- a/src/test/resources/anet.graphql
+++ b/src/test/resources/anet.graphql
@@ -800,6 +800,7 @@ type Position {
   createdAt: Instant
   customFields: String
   customSensitiveInformation: [CustomSensitiveInformation]
+  description: String
   emailAddresses(network: String): [EmailAddress]
   isApprover: Boolean
   isSubscribed: Boolean
@@ -825,6 +826,7 @@ input PositionInput {
   createdAt: Instant
   customFields: String
   customSensitiveInformation: [CustomSensitiveInformationInput]
+  description: String
   emailAddresses: [EmailAddressInput]
   location: LocationInput
   name: String

--- a/testDictionaries/no-custom-fields.yml
+++ b/testDictionaries/no-custom-fields.yml
@@ -561,6 +561,9 @@ fields:
         member: Member
         deputy: Deputy
         leader: Leader
+    description:
+      label: Description
+      placeholder: Fill in the description of this position
     emailAddresses:
       label: Email addresses
       authorizationGroupUuids: ['ab1a7d99-4529-44b1-a118-bdee3ca8296b']


### PR DESCRIPTION
Add a description field to positions, that can hold rich-text content.

Closes [AB#1194](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1194)

#### User changes
- Users can see a description of positions.

#### Superuser changes
- Superusers can fill in rich-text in the new description field of positions.

#### Admin changes
- Admins can merge descriptions when merging positions.

#### System admin changes
- [x] anet.yml or anet-dictionary.yml needs change
- [x] db needs migration
- [ ] documentation has changed
- [x] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [x] Added and/or updated unit tests
  - [ ] Added and/or updated e2e tests
  - [x] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
