### PR TITLE
Show report attendee positions at engagement date

### DIFF
--- a/client/src/components/advancedSelectWidget/AdvancedSelectOverlayRow.js
+++ b/client/src/components/advancedSelectWidget/AdvancedSelectOverlayRow.js
@@ -152,29 +152,32 @@ export const PersonSimpleOverlayRow = item => (
   </React.Fragment>
 )
 
-export const PersonDetailedOverlayRow = item => (
-  <React.Fragment key={item.uuid}>
-    <td>
-      <AsLink modelType="Person" model={item} />
-    </td>
-    <td>
-      <AsLink modelType="Position" model={item.position} />
-      {item.position && item.position.code ? `, ${item.position.code}` : ""}
-    </td>
-    <td>
-      <AsLink
-        modelType="Location"
-        model={item.position && item.position.location}
-        whenUnspecified=""
-      />
-    </td>
-    <td>
-      {item.position && item.position.organization && (
-        <AsLink modelType="Organization" model={item.position.organization} />
-      )}
-    </td>
-  </React.Fragment>
-)
+export const PersonDetailedOverlayRow = (item, date) => {
+  const position = utils.findPositionAtDate(item, date)
+  return (
+    <React.Fragment key={item.uuid}>
+      <td>
+        <AsLink modelType="Person" model={item} />
+      </td>
+      <td>
+        <AsLink modelType="Position" model={position} />
+        {position?.code ? `, ${position.code}` : ""}
+      </td>
+      <td>
+        <AsLink
+          modelType="Location"
+          model={position?.location}
+          whenUnspecified=""
+        />
+      </td>
+      <td>
+        {position?.organization && (
+          <AsLink modelType="Organization" model={position?.organization} />
+        )}
+      </td>
+    </React.Fragment>
+  )
+}
 
 export const ApproverOverlayRow = item => (
   <React.Fragment key={item.uuid}>

--- a/client/src/components/previews/ReportPreview.js
+++ b/client/src/components/previews/ReportPreview.js
@@ -72,6 +72,26 @@ const GQL_GET_REPORT = gql`
             name
           }
         }
+        previousPositions {
+          startTime
+          endTime
+          position {
+            uuid
+            name
+            code
+            organization {
+              uuid
+              shortName
+              longName
+              identificationCode
+              ${GRAPHQL_ENTITY_AVATAR_FIELDS}
+            }
+            location {
+              uuid
+              name
+            }
+          }
+        }
       }
       tasks {
         uuid

--- a/client/src/pages/App.js
+++ b/client/src/pages/App.js
@@ -142,6 +142,25 @@ const GQL_GET_APP_DATA = gql`
           uuid
         }
       }
+      previousPositions {
+        startTime
+        endTime
+        position {
+          uuid
+          name
+          code
+          organization {
+            uuid
+            shortName
+            longName
+            identificationCode
+          }
+          location {
+            uuid
+            name
+          }
+        }
+      }
     }
 
     adminSettings {

--- a/client/src/pages/reports/Edit.js
+++ b/client/src/pages/reports/Edit.js
@@ -79,6 +79,26 @@ const GQL_GET_REPORT = gql`
             name
           }
         }
+        previousPositions {
+          startTime
+          endTime
+          position {
+            uuid
+            name
+            code
+            organization {
+              uuid
+              shortName
+              longName
+              identificationCode
+              ${GRAPHQL_ENTITY_AVATAR_FIELDS}
+            }
+            location {
+              uuid
+              name
+            }
+          }
+        }
       }
       tasks {
         uuid

--- a/client/src/pages/reports/Form.js
+++ b/client/src/pages/reports/Form.js
@@ -24,6 +24,7 @@ import Fieldset from "components/Fieldset"
 import Messages from "components/Messages"
 import Model, {
   ASSESSMENTS_RELATED_OBJECT_TYPE,
+  GRAPHQL_ENTITY_AVATAR_FIELDS,
   NOTE_TYPE
 } from "components/Model"
 import NavigationWarning from "components/NavigationWarning"
@@ -72,6 +73,30 @@ import ReportPeople, {
   forceOnlyAttendingPersonPerRoleToPrimary
 } from "./ReportPeople"
 
+const reportPeopleAutocompleteQuery = `
+  ${Person.autocompleteQuery}
+  previousPositions {
+    startTime
+    endTime
+    position {
+      uuid
+      name
+      code
+      organization {
+        uuid
+        shortName
+        longName
+        identificationCode
+        ${GRAPHQL_ENTITY_AVATAR_FIELDS}
+      }
+      location {
+        uuid
+        name
+      }
+    }
+  }
+`
+
 const GQL_GET_RECENTS = gql`
   query($taskQuery: TaskSearchQueryInput) {
     locationList(
@@ -97,7 +122,7 @@ const GQL_GET_RECENTS = gql`
       }
     ) {
       list {
-        ${Person.autocompleteQuery}
+        ${reportPeopleAutocompleteQuery}
       }
     }
     taskList(query: $taskQuery) {
@@ -737,14 +762,15 @@ const ReportForm = ({
                         "Location",
                         "Organization"
                       ]}
-                      overlayRenderRow={PersonDetailedOverlayRow}
+                      overlayRenderRow={item =>
+                        PersonDetailedOverlayRow(item, values.engagementDate)}
                       filterDefs={reportPeopleFilters}
                       objectType={Person}
                       queryParams={{
                         status: Model.STATUS.ACTIVE,
                         pendingVerification: false
                       }}
-                      fields={Person.autocompleteQuery}
+                      fields={reportPeopleAutocompleteQuery}
                       addon={PEOPLE_ICON}
                     />
                   }

--- a/client/src/pages/reports/ReportPeople.js
+++ b/client/src/pages/reports/ReportPeople.js
@@ -6,14 +6,14 @@ import AppContext from "components/AppContext"
 import LinkTo from "components/LinkTo"
 import PlanningConflictForPerson from "components/PlanningConflictForPerson"
 import RemoveButton from "components/RemoveButton"
-import { Person } from "models"
-import Report from "models/Report"
+import { Person, Report } from "models"
 import pluralize from "pluralize"
 import PropTypes from "prop-types"
 import React, { useContext } from "react"
 import { Badge, Form, OverlayTrigger, Table, Tooltip } from "react-bootstrap"
 import { toast } from "react-toastify"
 import Settings from "settings"
+import utils from "utils"
 import "./ReportPeople.css"
 
 const ReportPeople = ({ report, disabled, onChange, showDelete, onDelete }) => {
@@ -78,6 +78,7 @@ const ReportPeople = ({ report, disabled, onChange, showDelete, onDelete }) => {
 
   function renderAttendeeRow(person) {
     const isCurrentEditor = Person.isEqual(person, currentUser)
+    const position = utils.findPositionAtDate(person, report.engagementDate)
     return (
       <tr key={person.uuid}>
         <td className="primary-attendee">
@@ -89,7 +90,7 @@ const ReportPeople = ({ report, disabled, onChange, showDelete, onDelete }) => {
               disabled={disabled}
             />
           )}
-          {/* // authors 0r non-attendees can't be interlocutors */}
+          {/* // authors or non-attendees can't be interlocutors */}
           {!person.author && person.attendee && (
             <ReportInterlocutorCheckbox
               person={person}
@@ -127,24 +128,20 @@ const ReportPeople = ({ report, disabled, onChange, showDelete, onDelete }) => {
           <LinkTo modelType="Person" model={person} showIcon={false} />
         </td>
         <td>
-          {person.position && person.position.uuid && (
-            <LinkTo modelType="Position" model={person.position} />
-          )}
-          {person.position && person.position.code
-            ? `, ${person.position.code}`
-            : ""}
+          {position?.uuid && <LinkTo modelType="Position" model={position} />}
+          {position?.code ? `, ${position.code}` : ""}
         </td>
         <td>
           <LinkTo
             modelType="Location"
-            model={person.position && person.position.location}
+            model={position?.location}
             whenUnspecified=""
           />
         </td>
         <td>
           <LinkTo
             modelType="Organization"
-            model={person.position && person.position.organization}
+            model={position?.organization}
             whenUnspecified=""
           />
         </td>

--- a/client/src/pages/reports/Show.js
+++ b/client/src/pages/reports/Show.js
@@ -127,6 +127,7 @@ const GQL_GET_REPORT = gql`
           uuid
           name
           type
+          role
           code
           status
           organization {
@@ -139,6 +140,26 @@ const GQL_GET_REPORT = gql`
           location {
             uuid
             name
+          }
+        }
+        previousPositions {
+          startTime
+          endTime
+          position {
+            uuid
+            name
+            code
+            organization {
+              uuid
+              shortName
+              longName
+              identificationCode
+              ${GRAPHQL_ENTITY_AVATAR_FIELDS}
+            }
+            location {
+              uuid
+              name
+            }
           }
         }
       }

--- a/client/src/utils.js
+++ b/client/src/utils.js
@@ -4,6 +4,7 @@ import * as changeCase from "change-case"
 import * as d3 from "d3"
 import parseAddressList from "email-addresses"
 import _isEmpty from "lodash/isEmpty"
+import moment from "moment/moment"
 import pluralize from "pluralize"
 import React, { useCallback, useEffect } from "react"
 import absentIcon from "resources/icons/absent.svg"
@@ -383,6 +384,16 @@ export default {
       }
     }
     return defaultValue
+  },
+
+  findPositionAtDate: function(person, date) {
+    if (!date) {
+      return person.position
+    }
+    const when = moment(date).valueOf()
+    return (person.previousPositions ?? []).find(p => {
+      return p.startTime <= when && (!p.endTime || p.endTime > when)
+    })?.position
   },
 
   getButtonsFromChoices: function(choices) {

--- a/client/tests/webdriver/baseSpecs/createNewReport.spec.js
+++ b/client/tests/webdriver/baseSpecs/createNewReport.spec.js
@@ -1,0 +1,173 @@
+import { expect } from "chai"
+import moment from "moment"
+import CreateReport from "../pages/report/createReport.page"
+import ShowReport from "../pages/report/showReport.page"
+
+const AUTHOR_NAME = "ERINSON, Erin"
+const AUTHOR = `CIV ${AUTHOR_NAME}`
+const ADVISOR_NAME = "DVISOR, A"
+const ADVISOR = `OF-2 ${ADVISOR_NAME}`
+const INTERLOCUTOR_NAME = "SOLENOID, Selena"
+const INTERLOCUTOR = `CIV ${INTERLOCUTOR_NAME}`
+const REPORT_FIELDS = {
+  intent: "Show attendee positions based on engagement date",
+  engagementDate: moment().subtract(1, "day"),
+  duration: "60",
+  location: "Fort Amherst",
+  atmosphere: "Positive",
+  advisors: [ADVISOR],
+  interlocutors: [INTERLOCUTOR],
+  tasks: ["2.A"],
+  keyOutcomes: "It works",
+  nextSteps: "Run some tests",
+  reportText:
+    "The attendees' positions change based on the engagement date:\n" +
+    "- when the engagement is in 2020 the attendees' positions are different from when the engagement is in 2021 or later\n" +
+    "- when the engagement is before 2020, none of the attendees have a position\n" +
+    "- when saving the report, the advisor organization and interlocutor organization change, based on the primary attendees' current positions"
+}
+const EXPECTED_DATA = {
+  now: {
+    positions: {
+      author: "EF 2.2 Advisor D",
+      advisor: "EF 2.2 Advisor Sewing Facilities",
+      interlocutor: "EF 1.2 Advisor"
+    },
+    locations: {
+      author: "Murray's Hotel",
+      advisor: "Murray's Hotel",
+      interlocutor: "St Johns Airport"
+    },
+    organizations: {
+      author: "EF 2.2",
+      advisor: "EF 2.2",
+      interlocutor: "EF 1.2"
+    }
+  },
+  in_2020: {
+    positions: {
+      author: "EF 2.1 Advisor B",
+      advisor: "EF 1.2 Advisor",
+      interlocutor: "EF 2.2 Advisor Sewing Facilities"
+    },
+    locations: {
+      author: "Murray's Hotel",
+      advisor: "St Johns Airport",
+      interlocutor: "Murray's Hotel"
+    },
+    organizations: {
+      author: "EF 2.1",
+      advisor: "EF 1.2",
+      interlocutor: "EF 2.2"
+    }
+  },
+  in_2019: {
+    positions: {
+      author: "",
+      advisor: "",
+      interlocutor: ""
+    },
+    locations: {
+      author: "",
+      advisor: "",
+      interlocutor: ""
+    },
+    organizations: {
+      author: "",
+      advisor: "",
+      interlocutor: ""
+    }
+  }
+}
+
+async function validateAttendee(name, expectedData, attendeeType) {
+  const cols = await CreateReport.getAttendeeColumns(name)
+  expect(await cols[3].getText()).to.equal(expectedData.positions[attendeeType])
+  expect(await cols[4].getText()).to.equal(expectedData.locations[attendeeType])
+  expect(await cols[5].getText()).to.equal(
+    expectedData.organizations[attendeeType]
+  )
+}
+
+describe("When creating a report", () => {
+  let reportUuid
+  it("Should show attendee positions at engagement date = now", async() => {
+    await CreateReport.open()
+    await browser.pause(500) // wait for the page transition and rendering of custom fields
+    await CreateReport.fillForm(REPORT_FIELDS)
+    await browser.pause(500)
+    // Validate the attendees
+    await validateAttendee(AUTHOR, EXPECTED_DATA.now, "author")
+    await validateAttendee(ADVISOR, EXPECTED_DATA.now, "advisor")
+    await validateAttendee(INTERLOCUTOR, EXPECTED_DATA.now, "interlocutor")
+  })
+  it("Should show report with advisor and interlocutor organizations at engagement date = now", async() => {
+    await CreateReport.submitForm()
+    await browser.pause(500)
+    reportUuid = await ShowReport.getUuid()
+    expect(reportUuid.length).to.equal(36)
+    // Validate the attendees
+    await validateAttendee(AUTHOR, EXPECTED_DATA.now, "author")
+    await validateAttendee(ADVISOR, EXPECTED_DATA.now, "advisor")
+    await validateAttendee(INTERLOCUTOR, EXPECTED_DATA.now, "interlocutor")
+    // Validate the organizations
+    expect(await ShowReport.getAdvisorOrg()).to.equal(
+      EXPECTED_DATA.now.organizations.author
+    )
+    expect(await ShowReport.getInterlocutorOrg()).to.equal(
+      EXPECTED_DATA.now.organizations.interlocutor
+    )
+  })
+
+  it("Should show attendee positions at engagement date in 2020", async() => {
+    // Edit the report
+    await (await ShowReport.getEditReportButton()).click()
+    // Change the engagement date
+    await CreateReport.setEngagementDate(moment("2020-07-01"))
+    await browser.pause(500)
+    // Validate the attendees
+    await validateAttendee(AUTHOR, EXPECTED_DATA.in_2020, "author")
+    await validateAttendee(ADVISOR, EXPECTED_DATA.in_2020, "advisor")
+    await validateAttendee(INTERLOCUTOR, EXPECTED_DATA.in_2020, "interlocutor")
+  })
+
+  it("Should show report with advisor and interlocutor organizations at engagement date in 2020", async() => {
+    await CreateReport.submitForm()
+    await browser.pause(500)
+    // Validate the attendees
+    await validateAttendee(AUTHOR, EXPECTED_DATA.in_2020, "author")
+    await validateAttendee(ADVISOR, EXPECTED_DATA.in_2020, "advisor")
+    await validateAttendee(INTERLOCUTOR, EXPECTED_DATA.in_2020, "interlocutor")
+    // Validate the organizations
+    expect(await ShowReport.getAdvisorOrg()).to.equal(
+      EXPECTED_DATA.in_2020.organizations.author
+    )
+    expect(await ShowReport.getInterlocutorOrg()).to.equal(
+      EXPECTED_DATA.in_2020.organizations.interlocutor
+    )
+  })
+
+  it("Should show attendee positions at engagement date in 2019", async() => {
+    // Edit the report
+    await (await ShowReport.getEditReportButton()).click()
+    // Change the engagement date
+    await CreateReport.setEngagementDate(moment("2019-07-01"))
+    await browser.pause(500)
+    // Validate the attendees
+    await validateAttendee(AUTHOR, EXPECTED_DATA.in_2019, "author")
+    await validateAttendee(ADVISOR, EXPECTED_DATA.in_2019, "advisor")
+    await validateAttendee(INTERLOCUTOR, EXPECTED_DATA.in_2019, "interlocutor")
+  })
+
+  it("Should show report with advisor and interlocutor organizations at engagement date in 2019", async() => {
+    await CreateReport.submitForm()
+    await browser.pause(500)
+    // Validate the attendees
+    await validateAttendee(AUTHOR, EXPECTED_DATA.in_2019, "author")
+    await validateAttendee(ADVISOR, EXPECTED_DATA.in_2019, "advisor")
+    await validateAttendee(INTERLOCUTOR, EXPECTED_DATA.in_2019, "interlocutor")
+    // Validate the organizations
+    expect(await ShowReport.getAdvisorOrg()).to.equal("Unspecified")
+    expect(await ShowReport.getInterlocutorOrg()).to.equal("Unspecified")
+  })
+})

--- a/client/tests/webdriver/baseSpecs/createReportWithPlanningConflict.spec.js
+++ b/client/tests/webdriver/baseSpecs/createReportWithPlanningConflict.spec.js
@@ -216,7 +216,7 @@ describe("When creating a Report with conflicts", () => {
 
   it("Should delete the first report", async() => {
     await EditReport.open(firstReportUUID)
-    await EditReport.deleteReport(firstReportUUID)
+    await EditReport.deleteReport(firstReportUUID, true)
 
     expect(await (await EditReport.getAlertSuccess()).getText()).to.equal(
       "Report deleted"
@@ -225,7 +225,7 @@ describe("When creating a Report with conflicts", () => {
 
   it("Should delete the second report", async() => {
     await EditReport.open(secondReportUUID)
-    await EditReport.deleteReport(secondReportUUID)
+    await EditReport.deleteReport(secondReportUUID, true)
 
     expect(await (await EditReport.getAlertSuccess()).getText()).to.equal(
       "Report deleted"

--- a/client/tests/webdriver/baseSpecs/mergePeople.spec.js
+++ b/client/tests/webdriver/baseSpecs/mergePeople.spec.js
@@ -21,7 +21,7 @@ const EXAMPLE_PEOPLE = {
     previousPositions: [
       {
         name: "Chief of Merge People Test 1",
-        date: `${moment().format("D MMMM YYYY")} -  `
+        date: `${moment("2020-01-01").format("D MMMM YYYY")} -  `
       }
     ],
     biography: "Winner is a test person who will be merged",
@@ -48,7 +48,7 @@ const EXAMPLE_PEOPLE = {
     previousPositions: [
       {
         name: "Chief of Merge People Test 2",
-        date: `${moment().format("D MMMM YYYY")} -  `
+        date: `${moment("2020-01-01").format("D MMMM YYYY")} -  `
       }
     ],
     biography: "Loser is a test person who will be merged",
@@ -75,7 +75,7 @@ const EXAMPLE_PEOPLE = {
     previousPositions: [
       {
         name: "EF 1 Manager",
-        date: `${moment().format("D MMMM YYYY")} -  `
+        date: `${moment("2020-01-01").format("D MMMM YYYY")} -  `
       }
     ],
     biography: "Andrew is the EF 1 Manager",

--- a/client/tests/webdriver/baseSpecs/mergePositions.spec.js
+++ b/client/tests/webdriver/baseSpecs/mergePositions.spec.js
@@ -19,7 +19,7 @@ const EXAMPLE_POSITIONS = {
     previousPeople: [
       {
         name: "CIV BEMERGED, Myposwill",
-        date: `${moment().format("D MMMM YYYY")} -  `
+        date: `${moment("2020-01-01").format("D MMMM YYYY")} -  `
       }
     ],
     location: "Unspecified",

--- a/client/tests/webdriver/pages/createFutureReport.page.js
+++ b/client/tests/webdriver/pages/createFutureReport.page.js
@@ -38,14 +38,6 @@ class CreateFutureReport extends CreateReport {
     return (await this.getAttendeesFieldValue()).$(`tbody tr:nth-child(${n})`)
   }
 
-  async getAttendeesAssessments() {
-    return browser.$("#attendees-engagement-assessments")
-  }
-
-  async getAttendeeAssessment(name) {
-    return (await this.getAttendeesAssessments()).$(`//td//a[text()="${name}"]`)
-  }
-
   async getTasksFieldFormGroup() {
     return browser.$(`div[id="fg-${tskId}"]`)
   }
@@ -72,16 +64,6 @@ class CreateFutureReport extends CreateReport {
 
   async getTasksFieldValueRow(n) {
     return (await this.getTasksFieldValue()).$(`tbody tr:nth-child(${n})`)
-  }
-
-  async getTasksAssessments() {
-    return browser.$("#tasks-engagement-assessments")
-  }
-
-  async getTaskAssessment(shortName) {
-    return (await this.getTasksAssessments()).$(
-      `//td//a[text()="${shortName}"]`
-    )
   }
 
   async getDeleteButton() {

--- a/client/tests/webdriver/pages/createReport.page.js
+++ b/client/tests/webdriver/pages/createReport.page.js
@@ -252,7 +252,7 @@ export class CreateReport extends Page {
   }
 
   async getAttendeeAssessment(name) {
-    return (await this.getAttendeesAssessments()).$(`//td/a[text()="${name}"]`)
+    return (await this.getAttendeesAssessments()).$(`//td//a[text()="${name}"]`)
   }
 
   async getTasksAssessments() {
@@ -264,7 +264,9 @@ export class CreateReport extends Page {
   }
 
   async getTaskAssessment(shortName) {
-    return (await this.getTasksAssessments()).$(`//td/a[text()="${shortName}"]`)
+    return (await this.getTasksAssessments()).$(
+      `//td//a[text()="${shortName}"]`
+    )
   }
 
   async getSubmitButton() {

--- a/client/tests/webdriver/pages/report/createReport.page.js
+++ b/client/tests/webdriver/pages/report/createReport.page.js
@@ -70,6 +70,12 @@ class CreateReport extends cr.CreateReport {
     return browser.$("#fg-reportText .editable")
   }
 
+  async getAttendeeColumns(name) {
+    return browser.$$(
+      `//div[@id="reportPeopleContainer"]//tr[td[@class="reportPeopleName" and .//a[text()="${name}"]]]/td`
+    )
+  }
+
   async getPersonByName(name) {
     const personRow = await browser.$$(
       `//div[@id="reportPeopleContainer"]//tr[td[@class="reportPeopleName" and .//a[text()="${name}"]]]/td[@class="primary-attendee" or @class="conflictButton" or @class="reportPeopleName"]`
@@ -98,7 +104,8 @@ class CreateReport extends cr.CreateReport {
     if (
       (await searchTerm.startsWith("CIV")) ||
       (await searchTerm.startsWith("OF-4")) ||
-      (await searchTerm.startsWith("OF-3"))
+      (await searchTerm.startsWith("OF-3")) ||
+      (await searchTerm.startsWith("OF-2"))
     ) {
       searchTerm = name.substr(name.indexOf(" ") + 1)
     }
@@ -191,6 +198,14 @@ class CreateReport extends cr.CreateReport {
     }
   }
 
+  async setEngagementDate(engagementDate) {
+    await (await this.getEngagementDate()).waitForClickable()
+    await (await this.getEngagementDate()).click()
+    await (await this.getTodayButton()).waitForDisplayed()
+    await this.deleteInput(this.getEngagementDate())
+    await browser.keys(engagementDate.format("DD-MM-YYYY HH:mm"))
+  }
+
   async fillForm(fields) {
     await (await this.getForm()).waitForClickable()
 
@@ -200,11 +215,7 @@ class CreateReport extends cr.CreateReport {
     }
 
     if (moment.isMoment(fields.engagementDate)) {
-      await (await this.getEngagementDate()).waitForClickable()
-      await (await this.getEngagementDate()).click()
-      await (await this.getTodayButton()).waitForDisplayed()
-      await browser.keys(fields.engagementDate.format("DD-MM-YYYY HH:mm"))
-
+      await this.setEngagementDate(fields.engagementDate)
       await (await this.getTitle()).click()
       await (
         await this.getDatepicker()

--- a/client/tests/webdriver/pages/report/editReport.page.js
+++ b/client/tests/webdriver/pages/report/editReport.page.js
@@ -7,9 +7,9 @@ class EditReport extends Page {
     return browser.$("#formBottomSubmit")
   }
 
-  async getDeleteButton() {
+  async getDeleteButton(planned) {
     return browser.$(
-      "//div[@class='submit-buttons']//button[text()='Delete this planned engagement']"
+      `//div[@class='submit-buttons']//button[text()='Delete this ${planned ? "planned engagement" : "report"}']`
     )
   }
 
@@ -33,8 +33,8 @@ class EditReport extends Page {
     return browser.$('//button[text()="Yes, I am sure"]')
   }
 
-  async deleteReport(uuid) {
-    await (await this.getDeleteButton()).click()
+  async deleteReport(uuid, planned) {
+    await (await this.getDeleteButton(planned)).click()
     await browser.pause(300) // wait for modal animation to finish
     await (await this.confirmDeleteButton(uuid)).waitForExist()
     await (await this.confirmDeleteButton(uuid)).waitForDisplayed()

--- a/client/tests/webdriver/pages/report/showReport.page.js
+++ b/client/tests/webdriver/pages/report/showReport.page.js
@@ -119,6 +119,14 @@ class ShowReport extends Page {
     return (await browser.$("div[name='authors']")).getText()
   }
 
+  async getAdvisorOrg() {
+    return (await browser.$("div[name='advisorOrg']")).getText()
+  }
+
+  async getInterlocutorOrg() {
+    return (await browser.$("div[name='interlocutorOrg']")).getText()
+  }
+
   async getSubmitButton() {
     return browser.$('//button[text()="Submit report"]')
   }

--- a/insertBaseData-psql.sql
+++ b/insertBaseData-psql.sql
@@ -300,127 +300,127 @@ INSERT INTO "emailAddresses" (network, address, "relatedObjectType", "relatedObj
 
 -- Put Andrew in the EF 1 Manager Billet
 INSERT INTO "peoplePositions" ("positionUuid", "personUuid", "createdAt") VALUES
-  ((SELECT uuid from positions where name = 'EF 1 Manager'), (SELECT uuid from people where "domainUsername" = 'andrew'), CURRENT_TIMESTAMP);
+  ((SELECT uuid from positions where name = 'EF 1 Manager'), (SELECT uuid from people where "domainUsername" = 'andrew'), '2020-01-01');
 UPDATE positions SET "currentPersonUuid" = (SELECT uuid from people where "domainUsername" = 'andrew') WHERE name = 'EF 1 Manager';
 
 -- Put Bob into the Superuser Billet in EF 1.1
 INSERT INTO "peoplePositions" ("positionUuid", "personUuid", "createdAt") VALUES
-  ((SELECT uuid from positions where name = 'EF 1.1 Superuser'), (SELECT uuid from people where "domainUsername" = 'bob'), CURRENT_TIMESTAMP);
+  ((SELECT uuid from positions where name = 'EF 1.1 Superuser'), (SELECT uuid from people where "domainUsername" = 'bob'), '2020-01-01');
 UPDATE positions SET "currentPersonUuid" = (SELECT uuid from people where "domainUsername" = 'bob') WHERE name = 'EF 1.1 Superuser';
 
 -- Put Henry into the Superuser Billet in EF 2.1
 INSERT INTO "peoplePositions" ("positionUuid", "personUuid", "createdAt") VALUES
-  ((SELECT uuid from positions where name = 'EF 2.1 Superuser'), (SELECT uuid from people where "domainUsername" = 'henry'), CURRENT_TIMESTAMP);
+  ((SELECT uuid from positions where name = 'EF 2.1 Superuser'), (SELECT uuid from people where "domainUsername" = 'henry'), '2020-01-01');
 UPDATE positions SET "currentPersonUuid" = (SELECT uuid from people where "domainUsername" = 'henry') WHERE name = 'EF 2.1 Superuser';
 
 -- Rotate an advisor through a billet ending up with Jack in the EF 2.1 Advisor B Billet
 INSERT INTO "peoplePositions" ("positionUuid", "personUuid", "createdAt") VALUES
-  ((SELECT uuid from positions where name = 'EF 2.1 Advisor B'), (SELECT uuid from people where "domainUsername" = 'erin'), CURRENT_TIMESTAMP);
+  ((SELECT uuid from positions where name = 'EF 2.1 Advisor B'), (SELECT uuid from people where "domainUsername" = 'erin'), '2020-01-01');
 UPDATE positions SET "currentPersonUuid" = (SELECT uuid from people where "domainUsername" = 'erin') WHERE name = 'EF 2.1 Advisor B';
-UPDATE "peoplePositions" SET "endedAt" = CURRENT_TIMESTAMP + INTERVAL '1 millisecond' WHERE "positionUuid" = (SELECT uuid from positions where name = 'EF 2.1 Advisor B');
+UPDATE "peoplePositions" SET "endedAt" = '2021-01-01' WHERE "positionUuid" = (SELECT uuid from positions where name = 'EF 2.1 Advisor B');
 INSERT INTO "peoplePositions" ("positionUuid", "personUuid", "createdAt") VALUES
-  ((SELECT uuid from positions where name = 'EF 2.1 Advisor B'), (SELECT uuid from people where "domainUsername" = 'jack'), CURRENT_TIMESTAMP + INTERVAL '1 millisecond');
+  ((SELECT uuid from positions where name = 'EF 2.1 Advisor B'), (SELECT uuid from people where "domainUsername" = 'jack'), '2021-01-01');
 UPDATE positions SET "currentPersonUuid" = (SELECT uuid from people where "domainUsername" = 'jack') WHERE name = 'EF 2.1 Advisor B';
 
 -- Rotate advisors through billets ending up with Dvisor in the EF 2.2 Advisor Sewing Facilities Billet and Selena in the EF 1.2 Advisor Billet
 INSERT INTO "peoplePositions" ("positionUuid", "personUuid", "createdAt") VALUES
-  ((SELECT uuid from positions where name = 'EF 1.2 Advisor'), (SELECT uuid from people where "domainUsername" = 'advisor'), CURRENT_TIMESTAMP);
+  ((SELECT uuid from positions where name = 'EF 1.2 Advisor'), (SELECT uuid from people where "domainUsername" = 'advisor'), '2020-01-01');
 INSERT INTO "peoplePositions" ("positionUuid", "personUuid", "createdAt") VALUES
-  ((SELECT uuid from positions where name = 'EF 2.2 Advisor Sewing Facilities'), (SELECT uuid from people where "domainUsername" = 'selena'), CURRENT_TIMESTAMP);
+  ((SELECT uuid from positions where name = 'EF 2.2 Advisor Sewing Facilities'), (SELECT uuid from people where "domainUsername" = 'selena'), '2020-01-01');
 
-UPDATE "peoplePositions" SET "endedAt" = CURRENT_TIMESTAMP + INTERVAL '1 millisecond' WHERE "positionUuid" = (SELECT uuid from positions where name = 'EF 1.2 Advisor');
-UPDATE "peoplePositions" SET "endedAt" = CURRENT_TIMESTAMP + INTERVAL '1 millisecond' WHERE "positionUuid" = (SELECT uuid from positions where name = 'EF 2.2 Advisor Sewing Facilities');
+UPDATE "peoplePositions" SET "endedAt" = '2021-01-01' WHERE "positionUuid" = (SELECT uuid from positions where name = 'EF 1.2 Advisor');
+UPDATE "peoplePositions" SET "endedAt" = '2021-01-01' WHERE "positionUuid" = (SELECT uuid from positions where name = 'EF 2.2 Advisor Sewing Facilities');
 
 INSERT INTO "peoplePositions" ("positionUuid", "personUuid", "createdAt") VALUES
-  ((SELECT uuid from positions where name = 'EF 2.2 Advisor Sewing Facilities'), (SELECT uuid from people where "domainUsername" = 'advisor'), CURRENT_TIMESTAMP + INTERVAL '1 millisecond');
+  ((SELECT uuid from positions where name = 'EF 2.2 Advisor Sewing Facilities'), (SELECT uuid from people where "domainUsername" = 'advisor'), '2021-01-01');
 UPDATE positions SET "currentPersonUuid" = (SELECT uuid from people where "domainUsername" = 'advisor') WHERE name = 'EF 2.2 Advisor Sewing Facilities';
 INSERT INTO "peoplePositions" ("positionUuid", "personUuid", "createdAt") VALUES
-  ((SELECT uuid from positions where name = 'EF 1.2 Advisor'), (SELECT uuid from people where "domainUsername" = 'selena'), CURRENT_TIMESTAMP + INTERVAL '1 millisecond');
+  ((SELECT uuid from positions where name = 'EF 1.2 Advisor'), (SELECT uuid from people where "domainUsername" = 'selena'), '2021-01-01');
 UPDATE positions SET "currentPersonUuid" = (SELECT uuid from people where "domainUsername" = 'selena') WHERE name = 'EF 1.2 Advisor';
 
 -- Put Elizabeth into the EF 1.1 Advisor A Billet
 INSERT INTO "peoplePositions" ("positionUuid", "personUuid", "createdAt") VALUES
-  ((SELECT uuid from positions where name = 'EF 1.1 Advisor A'), (SELECT uuid from people where "domainUsername" = 'elizabeth'), CURRENT_TIMESTAMP);
+  ((SELECT uuid from positions where name = 'EF 1.1 Advisor A'), (SELECT uuid from people where "domainUsername" = 'elizabeth'), '2020-01-01');
 UPDATE positions SET "currentPersonUuid" = (SELECT uuid from people where "domainUsername" = 'elizabeth') WHERE name = 'EF 1.1 Advisor A';
 
 -- Put Reina into the EF 2.2 Advisor C Billet
 INSERT INTO "peoplePositions" ("positionUuid", "personUuid", "createdAt") VALUES
-  ((SELECT uuid from positions where name = 'EF 2.2 Advisor C'), (SELECT uuid from people where "domainUsername" = 'reina'), CURRENT_TIMESTAMP);
+  ((SELECT uuid from positions where name = 'EF 2.2 Advisor C'), (SELECT uuid from people where "domainUsername" = 'reina'), '2020-01-01');
 UPDATE positions SET "currentPersonUuid" = (SELECT uuid from people where "domainUsername" = 'reina') WHERE name = 'EF 2.2 Advisor C';
 
 -- Put Erin into the EF 2.2 Advisor D Billet
 INSERT INTO "peoplePositions" ("positionUuid", "personUuid", "createdAt") VALUES
-  ((SELECT uuid from positions where name = 'EF 2.2 Advisor D'), (SELECT uuid from people where "domainUsername" = 'erin'), CURRENT_TIMESTAMP);
+  ((SELECT uuid from positions where name = 'EF 2.2 Advisor D'), (SELECT uuid from people where "domainUsername" = 'erin'), '2020-01-01');
 UPDATE positions SET "currentPersonUuid" = (SELECT uuid from people where "domainUsername" = 'erin') WHERE name = 'EF 2.2 Advisor D';
 
 -- Put Jacob in the EF 2.2 Superuser Billet
 INSERT INTO "peoplePositions" ("positionUuid", "personUuid", "createdAt") VALUES
-  ((SELECT uuid from positions where name = 'EF 2.2 Superuser'), (SELECT uuid from people where "domainUsername" = 'jacob'), CURRENT_TIMESTAMP);
+  ((SELECT uuid from positions where name = 'EF 2.2 Superuser'), (SELECT uuid from people where "domainUsername" = 'jacob'), '2020-01-01');
 UPDATE positions SET "currentPersonUuid" = (SELECT uuid from people where "domainUsername" = 'jacob') WHERE name = 'EF 2.2 Superuser';
 
 -- Put Rebecca in the EF 2.2 Final Reviewer Position
 INSERT INTO "peoplePositions" ("positionUuid", "personUuid", "createdAt") VALUES
-  ((SELECT uuid from positions where name = 'EF 2.2 Final Reviewer'), (SELECT uuid from people where "domainUsername" = 'rebecca'), CURRENT_TIMESTAMP);
+  ((SELECT uuid from positions where name = 'EF 2.2 Final Reviewer'), (SELECT uuid from people where "domainUsername" = 'rebecca'), '2020-01-01');
 UPDATE positions SET "currentPersonUuid" = (SELECT uuid from people where "domainUsername" = 'rebecca') WHERE name = 'EF 2.2 Final Reviewer';
 
 -- Put Arthur into the Admin Billet
 INSERT INTO "peoplePositions" ("positionUuid", "personUuid", "createdAt") VALUES
-  ((SELECT uuid from positions where name = 'ANET Administrator'), (SELECT uuid from people where "domainUsername" = 'arthur'), CURRENT_TIMESTAMP);
+  ((SELECT uuid from positions where name = 'ANET Administrator'), (SELECT uuid from people where "domainUsername" = 'arthur'), '2020-01-01');
 UPDATE positions SET "currentPersonUuid" = (SELECT uuid from people where "domainUsername" = 'arthur') WHERE name = 'ANET Administrator';
 
 -- Put Creed into the EF 5.1 Quality Ensurance
 INSERT INTO "peoplePositions" ("positionUuid", "personUuid", "createdAt") VALUES
-  ((SELECT uuid from positions where name = 'EF 5.1 Advisor Quality Assurance'), (SELECT uuid from people where "domainUsername" = 'creed'), CURRENT_TIMESTAMP);
+  ((SELECT uuid from positions where name = 'EF 5.1 Advisor Quality Assurance'), (SELECT uuid from people where "domainUsername" = 'creed'), '2020-01-01');
 UPDATE positions SET "currentPersonUuid" = (SELECT uuid from people where "domainUsername" = 'creed') WHERE name = 'EF 5.1 Advisor Quality Assurance';
 
 -- Put Kevin into the EF 5.1 Accounting
 INSERT INTO "peoplePositions" ("positionUuid", "personUuid", "createdAt") VALUES
-  ((SELECT uuid from positions where name = 'EF 5.1 Advisor Accounting'), (SELECT uuid from people where "domainUsername" = 'kevin'), CURRENT_TIMESTAMP);
+  ((SELECT uuid from positions where name = 'EF 5.1 Advisor Accounting'), (SELECT uuid from people where "domainUsername" = 'kevin'), '2020-01-01');
 UPDATE positions SET "currentPersonUuid" = (SELECT uuid from people where "domainUsername" = 'kevin') WHERE name = 'EF 5.1 Advisor Accounting';
 
 -- Put Jim into the EF 5.1 Sales 1
 INSERT INTO "peoplePositions" ("positionUuid", "personUuid", "createdAt") VALUES
-  ((SELECT uuid from positions where name = 'EF 5.1 Superuser Sales 1'), (SELECT uuid from people where "domainUsername" = 'jim'), CURRENT_TIMESTAMP);
+  ((SELECT uuid from positions where name = 'EF 5.1 Superuser Sales 1'), (SELECT uuid from people where "domainUsername" = 'jim'), '2020-01-01');
 UPDATE positions SET "currentPersonUuid" = (SELECT uuid from people where "domainUsername" = 'jim') WHERE name = 'EF 5.1 Superuser Sales 1';
 
 -- Put Dwight into the EF 5.1 Sales 2
 INSERT INTO "peoplePositions" ("positionUuid", "personUuid", "createdAt") VALUES
-  ((SELECT uuid from positions where name = 'EF 5.1 Superuser Sales 2'), (SELECT uuid from people where "domainUsername" = 'dwight'), CURRENT_TIMESTAMP);
+  ((SELECT uuid from positions where name = 'EF 5.1 Superuser Sales 2'), (SELECT uuid from people where "domainUsername" = 'dwight'), '2020-01-01');
 UPDATE positions SET "currentPersonUuid" = (SELECT uuid from people where "domainUsername" = 'dwight') WHERE name = 'EF 5.1 Superuser Sales 2';
 
 -- Put Michael into the EF 5 Admin
 INSERT INTO "peoplePositions" ("positionUuid", "personUuid", "createdAt") VALUES
-  ((SELECT uuid from positions where name = 'EF 5 Admin'), (SELECT uuid from people where "domainUsername" = 'michael'), CURRENT_TIMESTAMP);
+  ((SELECT uuid from positions where name = 'EF 5 Admin'), (SELECT uuid from people where "domainUsername" = 'michael'), '2020-01-01');
 UPDATE positions SET "currentPersonUuid" = (SELECT uuid from people where "domainUsername" = 'michael') WHERE name = 'EF 5 Admin';
 
 -- Put Kevin Rivers into the EF 6 Approver
 INSERT INTO "peoplePositions" ("positionUuid", "personUuid", "createdAt")
-VALUES ((SELECT uuid from positions where name = 'EF 6 Approver'), (SELECT uuid from people where name = 'RIVERS, Kevin'), CURRENT_TIMESTAMP);
+VALUES ((SELECT uuid from positions where name = 'EF 6 Approver'), (SELECT uuid from people where name = 'RIVERS, Kevin'), '2020-01-01');
 UPDATE positions SET "currentPersonUuid" = (SELECT uuid from people where name = 'RIVERS, Kevin') WHERE name = 'EF 6 Approver';
 
 -- Put Ben Rogers into the EF 6.1 Advisor
 INSERT INTO "peoplePositions" ("positionUuid", "personUuid", "createdAt")
-VALUES ((SELECT uuid from positions where name = 'EF 6.1 Advisor'), (SELECT uuid from people where name = 'ROGERS, Ben'), CURRENT_TIMESTAMP);
+VALUES ((SELECT uuid from positions where name = 'EF 6.1 Advisor'), (SELECT uuid from people where name = 'ROGERS, Ben'), '2020-01-01');
 UPDATE positions SET "currentPersonUuid" = (SELECT uuid from people where name = 'ROGERS, Ben') WHERE name = 'EF 6.1 Advisor';
 
 -- Put Nick into the EF 9 Advisor
 INSERT INTO "peoplePositions" ("positionUuid", "personUuid", "createdAt") VALUES
-  ((SELECT uuid from positions where name = 'EF 9 Advisor'), (SELECT uuid from people where "domainUsername" = 'nick'), CURRENT_TIMESTAMP);
+  ((SELECT uuid from positions where name = 'EF 9 Advisor'), (SELECT uuid from people where "domainUsername" = 'nick'), '2020-01-01');
 UPDATE positions SET "currentPersonUuid" = (SELECT uuid from people where "domainUsername" = 'nick') WHERE name = 'EF 9 Advisor';
 
 -- Put Yoshie Beau into the EF 9 Approver
 INSERT INTO "peoplePositions" ("positionUuid", "personUuid", "createdAt") VALUES
-  ((SELECT uuid from positions where name = 'EF 9 Approver'), (SELECT uuid from people where "domainUsername" = 'yoshie'), CURRENT_TIMESTAMP);
+  ((SELECT uuid from positions where name = 'EF 9 Approver'), (SELECT uuid from people where "domainUsername" = 'yoshie'), '2020-01-01');
 UPDATE positions SET "currentPersonUuid" = (SELECT uuid from people where "domainUsername" = 'yoshie') WHERE name = 'EF 9 Approver';
 
 -- Put Lin into the LNG Advisor A
 INSERT INTO "peoplePositions" ("positionUuid", "personUuid", "createdAt") VALUES
-  ((SELECT uuid from positions where name = 'LNG Advisor A'), (SELECT uuid from people where "domainUsername" = 'lin'), CURRENT_TIMESTAMP);
+  ((SELECT uuid from positions where name = 'LNG Advisor A'), (SELECT uuid from people where "domainUsername" = 'lin'), '2020-01-01');
 UPDATE positions SET "currentPersonUuid" = (SELECT uuid from people where "domainUsername" = 'lin') WHERE name = 'LNG Advisor A';
 
 -- Put Inter into the LNG Advisor B
 INSERT INTO "peoplePositions" ("positionUuid", "personUuid", "createdAt") VALUES
-  ((SELECT uuid from positions where name = 'LNG Advisor B'), (SELECT uuid from people where "domainUsername" = 'inter'), CURRENT_TIMESTAMP);
+  ((SELECT uuid from positions where name = 'LNG Advisor B'), (SELECT uuid from people where "domainUsername" = 'inter'), '2020-01-01');
 UPDATE positions SET "currentPersonUuid" = (SELECT uuid from people where "domainUsername" = 'inter') WHERE name = 'LNG Advisor B';
 
 -- Top-level organizations
@@ -739,7 +739,7 @@ INSERT INTO "emailAddresses" (network, address, "relatedObjectType", "relatedObj
 
 -- Put Steve into a Tashkil and associate with the EF 1.1 Advisor A Billet
 INSERT INTO "peoplePositions" ("positionUuid", "personUuid", "createdAt") VALUES
-  ((SELECT uuid from positions where name = 'Cost Adder - MoD'), (SELECT uuid from people where name = 'STEVESON, Steve'), CURRENT_TIMESTAMP);
+  ((SELECT uuid from positions where name = 'Cost Adder - MoD'), (SELECT uuid from people where name = 'STEVESON, Steve'), '2020-01-01');
 UPDATE positions SET "currentPersonUuid" = (SELECT uuid from people where name = 'STEVESON, Steve') WHERE name = 'Cost Adder - MoD';
 INSERT INTO "positionRelationships" ("positionUuid_a", "positionUuid_b", "createdAt", "updatedAt", deleted) VALUES
   ((SELECT uuid from positions WHERE name ='EF 1.1 Advisor A'),
@@ -748,7 +748,7 @@ INSERT INTO "positionRelationships" ("positionUuid_a", "positionUuid_b", "create
 
 -- Put Roger in a Tashkil and associate with the EF 2.1 Advisor B Billet
 INSERT INTO "peoplePositions" ("positionUuid", "personUuid", "createdAt") VALUES
-  ((SELECT uuid from positions where name = 'Chief of Police'), (SELECT uuid from people where name = 'ROGWELL, Roger'), CURRENT_TIMESTAMP);
+  ((SELECT uuid from positions where name = 'Chief of Police'), (SELECT uuid from people where name = 'ROGWELL, Roger'), '2020-01-01');
 UPDATE positions SET "currentPersonUuid" = (SELECT uuid from people where name = 'ROGWELL, Roger') WHERE name = 'Chief of Police';
 INSERT INTO "positionRelationships" ("positionUuid_a", "positionUuid_b", "createdAt", "updatedAt", deleted) VALUES
   ((SELECT uuid FROM positions WHERE name='EF 2.1 Advisor B'),
@@ -757,7 +757,7 @@ INSERT INTO "positionRelationships" ("positionUuid_a", "positionUuid_b", "create
 
 -- Put Christopf in a Tashkil and associate with the EF 2.2 Advisor D Billet
 INSERT INTO "peoplePositions" ("positionUuid", "personUuid", "createdAt") VALUES
-  ((SELECT uuid from positions where name = 'Planning Captain'), (SELECT uuid from people where name = 'TOPFERNESS, Christopf'), CURRENT_TIMESTAMP);
+  ((SELECT uuid from positions where name = 'Planning Captain'), (SELECT uuid from people where name = 'TOPFERNESS, Christopf'), '2020-01-01');
 UPDATE positions SET "currentPersonUuid" = (SELECT uuid from people where name = 'TOPFERNESS, Christopf') WHERE name = 'Planning Captain';
 INSERT INTO "positionRelationships" ("positionUuid_a", "positionUuid_b", "createdAt", "updatedAt", deleted) VALUES
   ((SELECT uuid FROM positions WHERE name='EF 2.2 Advisor D'),
@@ -766,7 +766,7 @@ INSERT INTO "positionRelationships" ("positionUuid_a", "positionUuid_b", "create
 
 -- Put Chris in a Tashkil and associate with the EF 5.1 Advisor Accounting
 INSERT INTO "peoplePositions" ("positionUuid", "personUuid", "createdAt") VALUES
-  ((SELECT uuid from positions where name = 'Chief of Tests'), (SELECT uuid from people where name = 'CHRISVILLE, Chris'), CURRENT_TIMESTAMP);
+  ((SELECT uuid from positions where name = 'Chief of Tests'), (SELECT uuid from people where name = 'CHRISVILLE, Chris'), '2020-01-01');
 UPDATE positions SET "currentPersonUuid" = (SELECT uuid from people where name = 'CHRISVILLE, Chris') WHERE name = 'Chief of Tests';
 INSERT INTO "positionRelationships" ("positionUuid_a", "positionUuid_b", "createdAt", "updatedAt", deleted) VALUES
   ((SELECT uuid FROM positions WHERE name='EF 5.1 Advisor Accounting'),
@@ -775,7 +775,7 @@ INSERT INTO "positionRelationships" ("positionUuid_a", "positionUuid_b", "create
 
 -- Put Kyle in a Tashkil and associate with the EF 5.1 Advisor Quality Assurance
 INSERT INTO "peoplePositions" ("positionUuid", "personUuid", "createdAt") VALUES
-  ((SELECT uuid from positions where name = 'Director of Tests'), (SELECT uuid from people where name = 'KYLESON, Kyle'), CURRENT_TIMESTAMP);
+  ((SELECT uuid from positions where name = 'Director of Tests'), (SELECT uuid from people where name = 'KYLESON, Kyle'), '2020-01-01');
 UPDATE positions SET "currentPersonUuid" = (SELECT uuid from people where name = 'KYLESON, Kyle') WHERE name = 'Director of Tests';
 INSERT INTO "positionRelationships" ("positionUuid_a", "positionUuid_b", "createdAt", "updatedAt", deleted) VALUES
   ((SELECT uuid FROM positions WHERE name='EF 5.1 Advisor Quality Assurance'),
@@ -784,7 +784,7 @@ INSERT INTO "positionRelationships" ("positionUuid_a", "positionUuid_b", "create
 
 -- Put Myposwill in a Tashkil
 INSERT INTO "peoplePositions" ("positionUuid", "personUuid", "createdAt") VALUES
-  ((SELECT uuid from positions where name = 'Merge One'), (SELECT uuid from people where name = 'BEMERGED, Myposwill'), CURRENT_TIMESTAMP);
+  ((SELECT uuid from positions where name = 'Merge One'), (SELECT uuid from people where name = 'BEMERGED, Myposwill'), '2020-01-01');
 UPDATE positions SET "currentPersonUuid" = (SELECT uuid from people where name = 'BEMERGED, Myposwill') WHERE name = 'Merge One';
 -- Associate Merge One and Merge Two positions with some advisor positions to test merging
 INSERT INTO "positionRelationships" ("positionUuid_a", "positionUuid_b", "createdAt", "updatedAt", deleted) VALUES
@@ -795,11 +795,11 @@ INSERT INTO "positionRelationships" ("positionUuid_a", "positionUuid_b", "create
 
 -- Put Winner Duplicate in a Tashkil
 INSERT INTO "peoplePositions" ("positionUuid", "personUuid", "createdAt") VALUES
-  ((SELECT uuid from positions where name = 'Chief of Merge People Test 1'), (SELECT uuid from people where name = 'MERGED, Duplicate Winner'), CURRENT_TIMESTAMP);
+  ((SELECT uuid from positions where name = 'Chief of Merge People Test 1'), (SELECT uuid from people where name = 'MERGED, Duplicate Winner'), '2020-01-01');
 UPDATE positions SET "currentPersonUuid" = (SELECT uuid from people where name = 'MERGED, Duplicate Winner') WHERE name = 'Chief of Merge People Test 1';
 -- Put Loser Duplicate in a Tashkil
 INSERT INTO "peoplePositions" ("positionUuid", "personUuid", "createdAt") VALUES
-  ((SELECT uuid from positions where name = 'Chief of Merge People Test 2'), (SELECT uuid from people where name = 'MERGED, Duplicate Loser'), CURRENT_TIMESTAMP);
+  ((SELECT uuid from positions where name = 'Chief of Merge People Test 2'), (SELECT uuid from people where name = 'MERGED, Duplicate Loser'), '2020-01-01');
 UPDATE positions SET "currentPersonUuid" = (SELECT uuid from people where name = 'MERGED, Duplicate Loser') WHERE name = 'Chief of Merge People Test 2';
 
 UPDATE positions SET "locationUuid" = (SELECT uuid from LOCATIONS where name = 'Kabul Police Academy') WHERE name = 'Chief of Police';
@@ -810,7 +810,7 @@ UPDATE positions SET "locationUuid" = (SELECT uuid from LOCATIONS where name = '
 INSERT INTO reports (uuid, "createdAt", "updatedAt", "locationUuid", intent, text, "nextSteps", state, "engagementDate", atmosphere, "advisorOrganizationUuid", "interlocutorOrganizationUuid") VALUES
   ('9bb1861c-1f55-4a1b-bd3d-3c1f56d739b5', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, (SELECT uuid from locations where name='General Hospital'), 'Discuss improvements in Annual Budgeting process',
   'Today I met with this dude to tell him all the great things that he can do to improve his budgeting process. I hope he listened to me',
-  'Meet with the dude again next week', 2, '2016-05-25', 0,
+  'Meet with the dude again next week', 2, '2020-05-25', 0,
   (SELECT uuid FROM organizations where "shortName" = 'EF 2.1'), (SELECT uuid FROM organizations WHERE "longName" LIKE 'Ministry of Defense'));
 INSERT INTO "reportPeople" ("personUuid", "reportUuid", "isPrimary", "isAuthor", "isInterlocutor") VALUES
   ((SELECT uuid FROM people where name = 'STEVESON, Steve'), '9bb1861c-1f55-4a1b-bd3d-3c1f56d739b5', TRUE, FALSE, TRUE),
@@ -820,7 +820,7 @@ INSERT INTO reports (uuid, "createdAt", "updatedAt", "locationUuid", intent, tex
   ('86e4cf7e-c0ae-4bd9-b1ad-f2c65ca0f600', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, (select uuid from locations where name='General Hospital'), 'Run through FY2016 Numbers on tool usage',
   'Today we discussed the fiscal details of how spreadsheets break down numbers into rows and columns and then text is used to fill up space on a web page, it was very interesting and other adjectives',
   'we read over the spreadsheets for the FY17 Budget',
-  'meet with him again :(', 2, '2016-06-01', 0,
+  'meet with him again :(', 2, '2020-06-01', 0,
   (SELECT uuid FROM organizations where "shortName" = 'EF 2.1'), (SELECT uuid FROM organizations WHERE "longName" LIKE 'Ministry of Defense'));
 INSERT INTO "reportPeople" ("personUuid", "reportUuid", "isPrimary", "isAuthor", "isInterlocutor") VALUES
   ((SELECT uuid FROM people where name = 'STEVESON, Steve'), '86e4cf7e-c0ae-4bd9-b1ad-f2c65ca0f600', TRUE, FALSE, TRUE),
@@ -834,7 +834,7 @@ INSERT INTO reports (uuid, "createdAt", "updatedAt", "locationUuid", intent, tex
   ('3e717721-d675-4ff3-b687-533b50978f9e', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, (select uuid from locations where name='Kabul Hospital'), 'Looked at Hospital usage of Drugs',
   'This report needs to fill up more space',
   'putting something in the database to take up space',
-  'to be more creative next time', 2, '2016-06-03', 0,
+  'to be more creative next time', 2, '2020-06-03', 0,
   (SELECT uuid FROM organizations where "shortName" = 'EF 2.1'), (SELECT uuid FROM organizations WHERE "longName" LIKE 'Ministry of Defense'));
 INSERT INTO "reportPeople" ("personUuid", "reportUuid", "isPrimary", "isAuthor", "isInterlocutor") VALUES
   ((SELECT uuid FROM people where name = 'STEVESON, Steve'), '3e717721-d675-4ff3-b687-533b50978f9e', TRUE, FALSE, TRUE),
@@ -846,7 +846,7 @@ INSERT INTO reports (uuid, "createdAt", "updatedAt", "locationUuid", intent, tex
   ('5d11abd0-242b-41ef-8420-a931d19ee513', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, (select uuid from locations where name='Kabul Hospital'), 'discuss enagement of Doctors with Patients',
   'Met with Nobody in this engagement and discussed no tasks, what a waste of time',
   'None',
-  'Head over to the MoD Headquarters buildling for the next engagement', 2, '2016-06-10', 0,
+  'Head over to the MoD Headquarters buildling for the next engagement', 2, '2020-06-10', 0,
   (SELECT uuid FROM organizations where "shortName" = 'EF 2.1'), (SELECT uuid FROM organizations WHERE "longName" LIKE 'Ministry of Defense'));
 INSERT INTO "reportPeople" ("personUuid", "reportUuid", "isPrimary", "isAuthor", "isInterlocutor") VALUES
   ((SELECT uuid FROM people where name = 'STEVESON, Steve'), '5d11abd0-242b-41ef-8420-a931d19ee513', TRUE, FALSE, TRUE),
@@ -881,7 +881,7 @@ INSERT INTO "reportTasks" ("taskUuid", "reportUuid") VALUES
 INSERT INTO reports (uuid, "createdAt", "updatedAt", "locationUuid", intent, text, "nextSteps", state, "engagementDate", atmosphere, "advisorOrganizationUuid", "interlocutorOrganizationUuid") VALUES
   ('5f681376-6eac-464d-8d46-02ff89d45071', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, (select uuid from locations where name='Cabot Tower'), 'Inspect Cabot Tower Budgeting Facility',
   'Looked over the places around Cabot Tower for all of the things that people do when they need to do math.  There were calculators, and slide rules, and paper, and computers',
-  'keep writing fake reports to fill the database!!!', 1, '2016-06-20', 1,
+  'keep writing fake reports to fill the database!!!', 1, '2020-06-20', 1,
   (SELECT uuid FROM organizations where "shortName" = 'EF 2.1'), (SELECT uuid FROM organizations WHERE "longName" LIKE 'Ministry of Defense'));
 INSERT INTO "reportPeople" ("personUuid", "reportUuid", "isPrimary", "isAuthor", "isInterlocutor") VALUES
   ((SELECT uuid FROM people where name = 'STEVESON, Steve'), '5f681376-6eac-464d-8d46-02ff89d45071', TRUE, FALSE, TRUE),
@@ -892,7 +892,7 @@ INSERT INTO "reportTasks" ("taskUuid", "reportUuid") VALUES
 INSERT INTO reports (uuid, "createdAt", "updatedAt", "locationUuid", intent, text, "nextSteps", state, "engagementDate", atmosphere, "advisorOrganizationUuid", "interlocutorOrganizationUuid") VALUES
   ('5367a91a-9f70-469d-b0a4-69990ea8ac82', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, (SELECT uuid from locations where name='General Hospital'), 'Discuss discrepancies in monthly budgets',
   'Back to the hospital this week to test the recent locations feature of ANET, and also to look at math and numbers and budgets and things',
-  'Meet with the dude again next week', 1, '2016-06-25', 0,
+  'Meet with the dude again next week', 1, '2020-06-25', 0,
   (SELECT uuid FROM organizations where "shortName" = 'EF 2.1'), (SELECT uuid FROM organizations WHERE "longName" LIKE 'Ministry of Defense'));
 INSERT INTO "reportPeople" ("personUuid", "reportUuid", "isPrimary", "isAuthor", "isInterlocutor") VALUES
   ((SELECT uuid FROM people where name = 'STEVESON, Steve'), '5367a91a-9f70-469d-b0a4-69990ea8ac82', TRUE, FALSE, TRUE),
@@ -903,7 +903,7 @@ INSERT INTO "reportTasks" ("taskUuid", "reportUuid") VALUES
 INSERT INTO reports (uuid, "createdAt", "updatedAt", "locationUuid", intent, text, "nextSteps", state, "engagementDate", atmosphere, "advisorOrganizationUuid", "interlocutorOrganizationUuid") VALUES
   ('3e0ef6c9-68ed-43cf-8beb-d24c1c59c7a5', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, (SELECT uuid from locations where name='St Johns Airport'), 'Inspect Air Operations Capabilities',
   'We went to the Aiport and looked at the planes, and the hangers, and the other things that airports have. ',
-  'Go over to the Airport next week to look at the helicopters', 2, '2016-05-20', 0,
+  'Go over to the Airport next week to look at the helicopters', 2, '2020-05-20', 0,
   (SELECT uuid FROM organizations where "shortName" = 'EF 1.1'), (SELECT uuid FROM organizations WHERE "longName" LIKE 'Ministry of Defense'));
 INSERT INTO "reportPeople" ("personUuid", "reportUuid", "isPrimary", "isAuthor", "isInterlocutor") VALUES
   ((SELECT uuid FROM people where name = 'ROGWELL, Roger'), '3e0ef6c9-68ed-43cf-8beb-d24c1c59c7a5', TRUE, FALSE, TRUE),
@@ -914,7 +914,7 @@ INSERT INTO "reportTasks" ("taskUuid", "reportUuid") VALUES
 INSERT INTO reports (uuid, "createdAt", "updatedAt", "locationUuid", intent, text, "nextSteps", state, "engagementDate", atmosphere, "advisorOrganizationUuid", "interlocutorOrganizationUuid") VALUES
   ('e5319bc4-91f2-473b-92c7-e796bc84b169', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, (SELECT uuid from locations where name='St Johns Airport'), 'Inspect Helicopter Capabilities',
   'Today we looked at the helicopters at the aiport and talked in depth about how they were not in good condition and the AAF needed new equipment.  I expressed my concerns to the pilots and promised to see what we can do.',
-  'Figure out what can be done about the helicopters', 2, '2016-05-22', 0,
+  'Figure out what can be done about the helicopters', 2, '2020-05-22', 0,
   (SELECT uuid FROM organizations where "shortName" = 'EF 1.1'), (SELECT uuid FROM organizations WHERE "longName" LIKE 'Ministry of Defense'));
 INSERT INTO "reportPeople" ("personUuid", "reportUuid", "isPrimary", "isAuthor", "isInterlocutor") VALUES
   ((SELECT uuid FROM people where name = 'ROGWELL, Roger'), 'e5319bc4-91f2-473b-92c7-e796bc84b169', TRUE, FALSE, TRUE),
@@ -925,7 +925,7 @@ INSERT INTO "reportTasks" ("taskUuid", "reportUuid") VALUES
 INSERT INTO reports (uuid, "createdAt", "updatedAt", "locationUuid", intent, text, "nextSteps", "keyOutcomes", state, "engagementDate", atmosphere, "advisorOrganizationUuid", "interlocutorOrganizationUuid") VALUES
   ('a766b3f1-4705-43c1-b62a-ca4e3bb4dce3', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, (SELECT uuid from locations where name='General Hospital'), 'Look for Budget Controls',
   'Goal of the meeting was to look for the word spreadsheet in a report and then return that in a search result about budget. Lets see what happens!!',
-  'Searching for text', 'Test Cases are good', 2, '2017-01-14', 0,
+  'Searching for text', 'Test Cases are good', 2, '2021-01-14', 0,
   (SELECT uuid FROM organizations where "shortName" = 'EF 2.2'), (SELECT uuid FROM organizations WHERE "longName" LIKE 'Ministry of Defense'));
 INSERT INTO "reportPeople" ("personUuid", "reportUuid", "isPrimary", "isAuthor", "isInterlocutor") VALUES
   ((SELECT uuid FROM people where name = 'TOPFERNESS, Christopf'), 'a766b3f1-4705-43c1-b62a-ca4e3bb4dce3', TRUE, FALSE, TRUE),
@@ -939,7 +939,7 @@ INSERT INTO "reportsSensitiveInformation" (uuid, "createdAt", "updatedAt", text,
 INSERT INTO reports (uuid, "createdAt", "updatedAt", "locationUuid", intent, text, "nextSteps", "keyOutcomes", state, "engagementDate", atmosphere, "advisorOrganizationUuid", "interlocutorOrganizationUuid") VALUES
   ('91cac8ff-dca5-4cf5-bf2c-dd72aa3685f8', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, (SELECT uuid from locations where name='General Hospital'), 'Look for Budget Controls Again',
   'The search for the spreadsheet was doomed to be successful, so we needed to generate more data in order to get a more full test of the system that really is going to have much much larger reports in it one day.',
-  'Mocking up test cases','Better test data is always better', 2, '2017-01-04', 0,
+  'Mocking up test cases','Better test data is always better', 2, '2021-01-04', 0,
   (SELECT uuid FROM organizations where "shortName" = 'EF 2.2'), (SELECT uuid FROM organizations WHERE "longName" LIKE 'Ministry of Defense'));
 INSERT INTO "reportPeople" ("personUuid", "reportUuid", "isPrimary", "isAuthor", "isInterlocutor") VALUES
   ((SELECT uuid FROM people where name = 'TOPFERNESS, Christopf'), '91cac8ff-dca5-4cf5-bf2c-dd72aa3685f8', TRUE, FALSE, TRUE),
@@ -950,7 +950,7 @@ INSERT INTO "reportTasks" ("taskUuid", "reportUuid") VALUES
 INSERT INTO reports (uuid, "createdAt", "updatedAt", "locationUuid", intent, text, "nextSteps", "keyOutcomes", state, "engagementDate", atmosphere, "advisorOrganizationUuid", "interlocutorOrganizationUuid") VALUES
   ('3fa48376-0519-48ba-8d91-2fa18c7a040f', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, (SELECT uuid from locations where name='General Hospital'), 'Talk to the Interior about things',
   'We know that we want to go to the house with the food and eat the food, but the words in the database need to be long enough to do something. What that is were not sure, but we know we cant use apostrophies or spell.  Wow, we really cant do much, right? It was decided that we would do more tomorrow.',
-  'Mocking up test cases','Looking at the telescope with our eyes', 2, '2017-01-04', 0,
+  'Mocking up test cases','Looking at the telescope with our eyes', 2, '2021-01-04', 0,
   (SELECT uuid FROM organizations where "shortName" = 'EF 2.2'), (SELECT uuid FROM organizations WHERE "longName" LIKE 'Ministry of Interior'));
 INSERT INTO "reportPeople" ("personUuid", "reportUuid", "isPrimary", "isAuthor", "isInterlocutor") VALUES
   ((SELECT uuid FROM people where name = 'TOPFERNESS, Christopf'), '3fa48376-0519-48ba-8d91-2fa18c7a040f', TRUE, FALSE, TRUE),
@@ -1110,7 +1110,7 @@ INSERT INTO "noteRelatedObjects" ("noteUuid", "relatedObjectType", "relatedObjec
 INSERT INTO reports (uuid, "createdAt", "updatedAt", "locationUuid", intent, text, "nextSteps", state, "engagementDate", atmosphere, "advisorOrganizationUuid", "interlocutorOrganizationUuid") VALUES
   ('8655bf58-4452-4ac0-9221-70b035d8eb7e', CURRENT_TIMESTAMP + INTERVAL '-2 day', CURRENT_TIMESTAMP + INTERVAL '-2 day', (SELECT uuid from locations where name='General Hospital'), 'Discuss further improvements in Annual Budgeting process',
   'Today I met with Edwin the dude to tell him all the great things that he can do to improve his budgeting process. I hope he listened to me',
-  'Meet with the dude again next week', 2, '2016-05-25', 0,
+  'Meet with the dude again next week', 2, '2020-05-25', 0,
   (SELECT uuid FROM organizations where "shortName" = 'EF 2.1'), (SELECT uuid FROM organizations WHERE "longName" LIKE 'Ministry of Defense'));
 INSERT INTO "reportPeople" ("personUuid", "reportUuid", "isPrimary", "isAuthor", "isInterlocutor") VALUES
   ((SELECT uuid FROM people where name = 'STEVESON, Steve'), '8655bf58-4452-4ac0-9221-70b035d8eb7e', TRUE, FALSE, TRUE),

--- a/src/main/java/mil/dds/anet/database/ForeignKeyByDateBatcher.java
+++ b/src/main/java/mil/dds/anet/database/ForeignKeyByDateBatcher.java
@@ -1,0 +1,92 @@
+package mil.dds.anet.database;
+
+import static org.jdbi.v3.core.statement.EmptyHandling.NULL_KEYWORD;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import mil.dds.anet.database.mappers.ForeignKeyMapper;
+import mil.dds.anet.utils.DaoUtils;
+import mil.dds.anet.views.AbstractAnetBean;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.core.mapper.RowMapper;
+import org.jdbi.v3.core.statement.Query;
+import org.springframework.transaction.annotation.Transactional;
+
+public class ForeignKeyByDateBatcher<T extends AbstractAnetBean> {
+
+  private static final List<String> defaultIfEmpty = Arrays.asList("-1");
+
+  private final DatabaseHandler databaseHandler;
+  private final String sql;
+  private final String paramName;
+  private final RowMapper<T> objectMapper;
+  private final String foreignKeyName;
+  private final Map<String, Object> additionalParams;
+
+  public ForeignKeyByDateBatcher(DatabaseHandler databaseHandler, String sql, String paramName,
+      RowMapper<T> objectMapper, String foreignKeyName, Map<String, Object> additionalParams) {
+    this.databaseHandler = databaseHandler;
+    this.sql = sql;
+    this.paramName = paramName;
+    this.objectMapper = objectMapper;
+    this.foreignKeyName = foreignKeyName;
+    this.additionalParams = additionalParams;
+  }
+
+  public ForeignKeyByDateBatcher(DatabaseHandler databaseHandler, String sql, String paramName,
+      RowMapper<T> objectMapper, String foreignKeyName) {
+    this(databaseHandler, sql, paramName, objectMapper, foreignKeyName, null);
+  }
+
+  protected Handle getDbHandle() {
+    return databaseHandler.getHandle();
+  }
+
+  protected void closeDbHandle(Handle handle) {
+    databaseHandler.closeHandle(handle);
+  }
+
+  @Transactional
+  public List<List<T>> getByForeignKeys(List<ImmutablePair<String, Instant>> foreignKeys) {
+    final Handle handle = getDbHandle();
+    try {
+      final Map<ImmutablePair<String, Instant>, List<T>> resultsMap = new HashMap<>();
+
+      // group in smaller batches by query
+      final Map<Instant, List<String>> dateToForeignKeyListMap =
+          foreignKeys.stream().collect(Collectors.groupingBy(ImmutablePair::getRight,
+              Collectors.mapping(ImmutablePair::getLeft, Collectors.toList())));
+      for (Map.Entry<Instant, List<String>> gqlQuery : dateToForeignKeyListMap.entrySet()) {
+        final Instant when = gqlQuery.getKey();
+        final List<String> args = foreignKeys.isEmpty() ? defaultIfEmpty : gqlQuery.getValue();
+        final Query query = handle.createQuery(sql).bindList(NULL_KEYWORD, paramName, args);
+        query.bind("when", DaoUtils.asLocalDateTime(when));
+        if (additionalParams != null && !additionalParams.isEmpty()) {
+          query.bindMap(additionalParams);
+        }
+        final ForeignKeyMapper<T> mapper = new ForeignKeyMapper<>(foreignKeyName, objectMapper);
+        final Map<ImmutablePair<String, Instant>, List<T>> map = query.map(mapper)
+            .withStream(result -> result
+                .collect(Collectors.toMap(obj -> new ImmutablePair<>(obj.getForeignKey(), when), // key
+                    obj -> new ArrayList<>(List.of(obj.getObject())), // value
+                    (obj1, obj2) -> {
+                      obj1.addAll(obj2);
+                      return obj1;
+                    })));
+        resultsMap.putAll(map);
+      }
+
+      // when null, use an empty list
+      return foreignKeys.stream().map(resultsMap::get)
+          .map(l -> (l == null) ? new ArrayList<T>() : l).collect(Collectors.toList());
+    } finally {
+      closeDbHandle(handle);
+    }
+  }
+}

--- a/src/main/java/mil/dds/anet/database/PositionDao.java
+++ b/src/main/java/mil/dds/anet/database/PositionDao.java
@@ -524,15 +524,13 @@ public class PositionDao extends AnetSubscribableObjectDao<Position, PositionSea
     }
   }
 
-  public static String generateCurrentPositionFilter(String personJoinColumn,
+  public static String generatePositionFilterAtDate(String personJoinColumn,
       String dateFilterColumn, String placeholderName) {
-    // it is possible this would be better implemented using WHERE NOT EXISTS instead of the left
-    // join
     return String.format(
-        "JOIN \"peoplePositions\" pp ON pp.\"personUuid\" = %1$s  AND pp.\"createdAt\" <= %2$s "
-            + " LEFT JOIN \"peoplePositions\" maxPp ON"
-            + "   maxPp.\"positionUuid\" = pp.\"positionUuid\" AND maxPp.\"createdAt\" > pp.\"createdAt\" AND maxPp.\"createdAt\" <= %2$s "
-            + " WHERE pp.\"positionUuid\" = :%3$s AND maxPp.\"createdAt\" IS NULL ",
+        "JOIN \"peoplePositions\" pp ON pp.\"personUuid\" = %1$s"
+            + " WHERE pp.\"createdAt\" <= %2$s"
+            + " AND (pp.\"endedAt\" IS NULL OR pp.\"endedAt\" > %2$s)"
+            + " AND pp.\"positionUuid\" = :%3$s",
         personJoinColumn, dateFilterColumn, placeholderName);
   }
 

--- a/src/main/java/mil/dds/anet/search/AbstractReportSearcher.java
+++ b/src/main/java/mil/dds/anet/search/AbstractReportSearcher.java
@@ -254,7 +254,7 @@ public abstract class AbstractReportSearcher extends AbstractSearcher<Report, Re
       // date
       qb.addWhereClause("reports.uuid IN (SELECT r.uuid FROM reports r"
           + " JOIN \"reportPeople\" rp ON rp.\"reportUuid\" = r.uuid "
-          + PositionDao.generateCurrentPositionFilter("rp.\"personUuid\"", "r.\"createdAt\"",
+          + PositionDao.generatePositionFilterAtDate("rp.\"personUuid\"", "r.\"createdAt\"",
               "authorPositionUuid")
           + " AND rp.\"isAuthor\" = :isAuthor)");
       qb.addSqlArg("isAuthor", true);
@@ -277,7 +277,7 @@ public abstract class AbstractReportSearcher extends AbstractSearcher<Report, Re
       qb.addWhereClause(
           "reports.uuid IN (SELECT r.uuid FROM reports r"
               + " JOIN \"reportPeople\" rp ON rp.\"reportUuid\" = r.uuid "
-              + PositionDao.generateCurrentPositionFilter("rp.\"personUuid\"",
+              + PositionDao.generatePositionFilterAtDate("rp.\"personUuid\"",
                   "r.\"engagementDate\"", "attendeePositionUuid")
               + " AND rp.\"isAttendee\" = :isAttendee)");
       qb.addSqlArg("isAttendee", true);

--- a/src/main/java/mil/dds/anet/utils/BatchingUtils.java
+++ b/src/main/java/mil/dds/anet/utils/BatchingUtils.java
@@ -1,5 +1,6 @@
 package mil.dds.anet.utils;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
@@ -187,6 +188,12 @@ public final class BatchingUtils {
         DataLoaderFactory.newDataLoader(
             (BatchLoader<String, List<Organization>>) foreignKeys -> CompletableFuture.supplyAsync(
                 () -> engine.getOrganizationDao().getOrganizations(foreignKeys), dispatcherService),
+            dataLoaderOptions));
+    dataLoaderRegistry.register(FkDataLoaderKey.PERSON_ORGANIZATIONS_WHEN.toString(),
+        DataLoaderFactory.newDataLoader(
+            (BatchLoader<ImmutablePair<String, Instant>, List<Organization>>) foreignKeys -> CompletableFuture
+                .supplyAsync(() -> engine.getOrganizationDao().getOrganizationsByDate(foreignKeys),
+                    dispatcherService),
             dataLoaderOptions));
     dataLoaderRegistry.register(FkDataLoaderKey.PERSON_PERSON_POSITION_HISTORY.toString(),
         DataLoaderFactory.newDataLoader(

--- a/src/main/java/mil/dds/anet/utils/FkDataLoaderKey.java
+++ b/src/main/java/mil/dds/anet/utils/FkDataLoaderKey.java
@@ -14,6 +14,7 @@ public enum FkDataLoaderKey {
   NOTE_RELATED_OBJECT_NOTES, // noteRelatedObject.notes
   ORGANIZATION_ADMINISTRATIVE_POSITIONS, // organization.responsiblePositions
   PERSON_ORGANIZATIONS, // person.organizations
+  PERSON_ORGANIZATIONS_WHEN, // person.organizations at a given date
   PERSON_PERSON_POSITION_HISTORY, // person.personPositionHistory
   POSITION_ASSOCIATED_POSITIONS, // position.associatedPositions
   POSITION_CURRENT_POSITION_FOR_PERSON, // position.currentPositionForPerson

--- a/src/main/java/mil/dds/anet/views/ForeignKeyByDateFetcher.java
+++ b/src/main/java/mil/dds/anet/views/ForeignKeyByDateFetcher.java
@@ -1,0 +1,22 @@
+package mil.dds.anet.views;
+
+import graphql.GraphQLContext;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import mil.dds.anet.utils.FkDataLoaderKey;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.dataloader.DataLoader;
+import org.dataloader.DataLoaderRegistry;
+
+public class ForeignKeyByDateFetcher<T extends AbstractAnetBean> {
+  public CompletableFuture<List<T>> load(GraphQLContext context, FkDataLoaderKey dataLoaderKey,
+      ImmutablePair<String, Instant> foreignKey) {
+    final DataLoaderRegistry dlr = context.get("dataLoaderRegistry");
+    final DataLoader<ImmutablePair<String, Instant>, List<T>> dl =
+        dlr.getDataLoader(dataLoaderKey.toString());
+    return (foreignKey == null) ? CompletableFuture.completedFuture(new ArrayList<T>())
+        : dl.load(foreignKey);
+  }
+}

--- a/src/test/java/mil/dds/anet/test/resources/SubscriptionUpdateResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/SubscriptionUpdateResourceTest.java
@@ -211,13 +211,10 @@ class SubscriptionUpdateResourceTest extends SubscriptionTestHelper {
         .withLocation(
             getLocationInput(getLocation(getSubscribedObjectUuid(LocationDao.TABLE_NAME))))
         .withCancelledReason(ReportCancelledReason.CANCELLED_BY_ADVISOR)
-        .withReportPeople(
-            getReportPeopleInput(List.of(personToPrimaryReportAuthor(getJackJackson()),
-                personToReportPerson(getPerson(getSubscribedObjectUuid(PersonDao.TABLE_NAME)),
-                    false),
-                personToPrimaryReportPerson(getChristopfTopferness(), true))))
-        .withAdvisorOrg(getOrganizationInput(
-            getOrganization(getSubscribedObjectUuid(OrganizationDao.TABLE_NAME))))
+        .withReportPeople(getReportPeopleInput(List.of(personToReportAuthor(getJackJackson()),
+            personToPrimaryReportPerson(getPerson(getSubscribedObjectUuid(PersonDao.TABLE_NAME)),
+                false),
+            personToReportPerson(getChristopfTopferness(), true))))
         .withTasks(List.of(getTaskInput(getTask(getSubscribedObjectUuid(TaskDao.TABLE_NAME)))))
         .withAuthorizationGroups(List.of(getAuthorizationGroupInput(
             getAuthorizationGroup(getSubscribedObjectUuid(AuthorizationGroupDao.TABLE_NAME)))))


### PR DESCRIPTION
Show the position that report attendees held at the engagement date (instead of at the current date), making the report as shown more historically accurate.

Closes [AB#1188](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1188)

#### User changes
- Report attendees are now shown with the position they held at the engagement date of the report.

#### Superuser changes
- None.

#### Admin changes
- None.

#### System admin changes
- [ ] anet.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
  - [x] Described the user behavior in PR body
  - [x] Referenced/updated all related issues
  - [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
  - [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
  - [x] Added and/or updated unit tests
  - [x] Added and/or updated e2e tests
  - [ ] Added and/or updated data migrations
  - [ ] Updated documentation
  - [x] Resolved all build errors and warnings
  - [ ] Opened debt issues for anything not resolved here
