### PR TITLE
Display rollup reports and insights based on their engagement date rather than their publication date

### DIFF
--- a/client/src/pages/insights/Show.tsx
+++ b/client/src/pages/insights/Show.tsx
@@ -162,16 +162,20 @@ const InsightsShow = ({
     [CANCELLED_REPORTS]: {
       state: [Report.STATE.CANCELLED],
       cancelledReason: null,
-      releasedAtStart: defaultPastDates.referenceDate.startOf("day").valueOf()
+      engagementDateStart: defaultPastDates.referenceDate
+        .startOf("day")
+        .valueOf()
     },
     [REPORTS_BY_TASK]: {
       state: [Report.STATE.PUBLISHED],
-      releasedAtStart: defaultPastDates.referenceDate.startOf("day").valueOf()
+      engagementDateStart: defaultPastDates.referenceDate
+        .startOf("day")
+        .valueOf()
     },
     [REPORTS_BY_DAY_OF_WEEK]: {
       state: [Report.STATE.PUBLISHED],
-      releasedAtStart: defaultPastDates.startDate.startOf("day").valueOf(),
-      releasedAtEnd: defaultPastDates.endDate.endOf("day").valueOf(),
+      engagementDateStart: defaultPastDates.startDate.startOf("day").valueOf(),
+      engagementDateEnd: defaultPastDates.endDate.endOf("day").valueOf(),
       includeEngagementDayOfWeek: true
     },
     [FUTURE_ENGAGEMENTS_BY_LOCATION]: {

--- a/client/src/pages/rollup/Show.tsx
+++ b/client/src/pages/rollup/Show.tsx
@@ -380,8 +380,8 @@ const RollupShow = ({
   } else {
     queryParams = getSearchQuery(searchQuery)
   }
-  const startDate = moment(queryParams.releasedAtStart)
-  const endDate = moment(queryParams.releasedAtEnd)
+  const startDate = moment(queryParams.engagementDateStart)
+  const endDate = moment(queryParams.engagementDateEnd)
   const { orgUuid } = queryParams
   useBoilerplate({
     pageProps: DEFAULT_PAGE_PROPS,
@@ -542,13 +542,13 @@ const RollupShow = ({
     let periodEnd
     if (nextPeriod === HALF_YEAR) {
       // No built-in logic in Moment.js
-      periodStart = moment(queryParams.releasedAtStart)
-        .add((queryParams.releasedAtStart.quarter() % 2) - 1, QUARTER)
+      periodStart = moment(queryParams.engagementDateStart)
+        .add((queryParams.engagementDateStart.quarter() % 2) - 1, QUARTER)
         .add(delta * 2, QUARTER)
         .startOf(QUARTER)
       periodEnd = moment(periodStart).add(1, QUARTER).endOf(QUARTER)
     } else {
-      periodStart = moment(queryParams.releasedAtStart)
+      periodStart = moment(queryParams.engagementDateStart)
         .add(delta, nextPeriod)
         .startOf(nextPeriod)
       periodEnd = moment(periodStart).endOf(nextPeriod)
@@ -560,8 +560,8 @@ const RollupShow = ({
     const { periodStart, periodEnd } = calculatePeriodBounds(1, nextPeriod)
     const newQueryParams = {
       ...queryParams,
-      releasedAtStart: periodStart,
-      releasedAtEnd: periodEnd
+      engagementDateStart: periodStart,
+      engagementDateEnd: periodEnd
     }
     deserializeQueryParams(
       REPORT_SEARCH_PROPS.searchObjectTypes[0],
@@ -574,8 +574,8 @@ const RollupShow = ({
     const { periodStart, periodEnd } = calculatePeriodBounds(-1, nextPeriod)
     const newQueryParams = {
       ...queryParams,
-      releasedAtStart: periodStart,
-      releasedAtEnd: periodEnd
+      engagementDateStart: periodStart,
+      engagementDateEnd: periodEnd
     }
     deserializeQueryParams(
       REPORT_SEARCH_PROPS.searchObjectTypes[0],
@@ -588,8 +588,8 @@ const RollupShow = ({
     const { periodStart, periodEnd } = calculatePeriodBounds(0, nextPeriod)
     const newQueryParams = {
       ...queryParams,
-      releasedAtStart: periodStart,
-      releasedAtEnd: periodEnd
+      engagementDateStart: periodStart,
+      engagementDateEnd: periodEnd
     }
     deserializeQueryParams(
       REPORT_SEARCH_PROPS.searchObjectTypes[0],
@@ -624,8 +624,8 @@ const RollupShow = ({
   function setRollupDefaultSearchQuery() {
     const queryParams = {
       state: [Report.STATE.PUBLISHED, Report.STATE.CANCELLED],
-      releasedAtStart: moment().startOf("day"),
-      releasedAtEnd: moment().endOf("day")
+      engagementDateStart: moment().startOf("day"),
+      engagementDateEnd: moment().endOf("day")
     }
     deserializeQueryParams(
       REPORT_SEARCH_PROPS.searchObjectTypes[0],


### PR DESCRIPTION
When a user opens the Daily Rollup page, reports will be filtered by engagement date instead of publication date. Also, the Insights for Cancelled Reports, Reports by Objective and Reports by Day of the Week are now based on engagement date instead of publication date.

Closes [AB#1199](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1199)

#### User changes
- The Daily Rollup will be filtered by engagement date, rather than publication date
- The Insights for Cancelled Reports, Reports by Objective and Reports by Day of the Week will be filtered by engagement date, rather than publication date

#### Superuser changes
- None

#### Admin changes
- None

#### System admin changes
- [ ] application.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
- [x] described the user behavior in PR body
- [x] referenced/updated all related issues
- [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
- [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
- [ ] added and/or updated unit tests
- [ ] added and/or updated e2e tests
- [ ] added and/or updated data migrations
- [ ] updated documentation
- [x] resolved all build errors and warnings
- [ ] opened debt issues for anything not resolved here
