### PR TITLE
Add Approved state in addition to Published to several report queries

### DIFF
--- a/client/src/components/DailyRollupChart.tsx
+++ b/client/src/components/DailyRollupChart.tsx
@@ -12,7 +12,7 @@ interface DailyRollupChartProps {
   tooltip?: (...args: unknown[]) => unknown
   barColors: {
     cancelled: string
-    published: string
+    past: string
     planned: string
   }
 }
@@ -43,7 +43,7 @@ const DailyRollupChart = ({
     let chart = d3.select(node.current)
     const xLabels = [].concat.apply(
       [],
-      data.map(d => d.published + d.planned + d.cancelled)
+      data.map(d => d.past + d.planned + d.cancelled)
     )
     const yLabels = {}
     const yDomain = data.map(d => {
@@ -144,29 +144,29 @@ const DailyRollupChart = ({
 
     bar
       .append("rect")
-      .attr("width", d => d.published && xScale(d.published))
+      .attr("width", d => d.past && xScale(d.past))
       .attr("height", BAR_HEIGHT)
-      .attr("fill", barColors.published)
+      .attr("fill", barColors.past)
 
     bar
       .append("text")
-      .attr("x", d => xScale(d.published) - 6)
+      .attr("x", d => xScale(d.past) - 6)
       .attr("y", BAR_HEIGHT / 2)
       .attr("dy", ".35em")
       .style("text-anchor", "end")
-      .text(d => d.published || "")
-      .attr("fill", utils.getContrastYIQ(barColors.published))
+      .text(d => d.past || "")
+      .attr("fill", utils.getContrastYIQ(barColors.past))
 
     bar
       .append("rect")
-      .attr("x", d => d.published && xScale(d.published))
+      .attr("x", d => d.past && xScale(d.past))
       .attr("width", d => d.planned && xScale(d.planned))
       .attr("height", BAR_HEIGHT)
       .attr("fill", barColors.planned)
 
     bar
       .append("text")
-      .attr("x", d => xScale(d.published + d.planned) - 6)
+      .attr("x", d => xScale(d.past + d.planned) - 6)
       .attr("y", BAR_HEIGHT / 2)
       .attr("dy", ".35em")
       .style("text-anchor", "end")
@@ -175,17 +175,14 @@ const DailyRollupChart = ({
 
     bar
       .append("rect")
-      .attr(
-        "x",
-        d => (d.published || d.planned) && xScale(d.published + d.planned)
-      )
+      .attr("x", d => (d.past || d.planned) && xScale(d.past + d.planned))
       .attr("width", d => d.cancelled && xScale(d.cancelled))
       .attr("height", BAR_HEIGHT)
       .attr("fill", barColors.cancelled)
 
     bar
       .append("text")
-      .attr("x", d => xScale(d.published + d.planned + d.cancelled) - 6)
+      .attr("x", d => xScale(d.past + d.planned + d.cancelled) - 6)
       .attr("y", BAR_HEIGHT / 2)
       .attr("dy", ".35em")
       .style("text-anchor", "end")

--- a/client/src/components/ReportsByDayOfWeek.tsx
+++ b/client/src/components/ReportsByDayOfWeek.tsx
@@ -177,8 +177,8 @@ interface ReportsByDayOfWeekProps {
 }
 
 /*
- * Component displaying a chart with number of reports published within a certain
- * period. The counting is done grouped by day of the week.
+ * Component displaying a chart with number of reports within a certain period.
+ * The counting is done grouped by day of the week.
  */
 const ReportsByDayOfWeek = ({
   pageDispatchers,
@@ -220,7 +220,7 @@ const ReportsByDayOfWeek = ({
     second: VISUALIZATIONS[2].id
   }
   const DESCRIPTION = `The reports are grouped by day of the week.
-    In order to see the list of published reports for a day of the week,
+    In order to see the list of reports for a day of the week,
     click on the bar corresponding to the day of the week.`
 
   return (

--- a/client/src/components/ReportsByTask.tsx
+++ b/client/src/components/ReportsByTask.tsx
@@ -187,7 +187,7 @@ const ReportsByTask = ({
     second: VISUALIZATIONS[2].id
   }
   const DESCRIPTION = `The reports are grouped by ${taskShortLabel}.
-    In order to see the list of published reports for a ${taskShortLabel},
+    In order to see the list of reports for a ${taskShortLabel},
     click on the bar corresponding to the ${taskShortLabel}.`
 
   return (

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -237,6 +237,7 @@ const HomeTiles = ({
         orgRecurseStrategy: RECURSE_STRATEGY.NONE,
         createdAtStart: LAST_WEEK,
         state: [
+          Report.STATE.APPROVED,
           Report.STATE.PUBLISHED,
           Report.STATE.CANCELLED,
           Report.STATE.PENDING_APPROVAL
@@ -276,7 +277,10 @@ const HomeTiles = ({
   function mySensitiveInfo() {
     return {
       title: "Reports with sensitive information",
-      query: { state: [Report.STATE.PUBLISHED], sensitiveInfo: true }
+      query: {
+        state: [Report.STATE.APPROVED, Report.STATE.PUBLISHED],
+        sensitiveInfo: true
+      }
     }
   }
 }

--- a/client/src/pages/HopscotchTour.ts
+++ b/client/src/pages/HopscotchTour.ts
@@ -26,7 +26,7 @@ const userTour = (currentUser, navigate) => {
       {
         title: "My ANET snapshot",
         content:
-          "This area shows you how many reports you've drafted but haven't submitted, the number of your reports waiting for approval from your organization's approval chain, and your organization's reports published in the last 7 days and planned engagements.",
+          "This area shows you how many reports you've drafted but haven't submitted, the number of your reports waiting for approval from your organization's approval chain, and your organization's reports in the last 7 days and planned engagements.",
         target: ".home-tile-row",
         placement: "bottom"
       },

--- a/client/src/pages/insights/Show.tsx
+++ b/client/src/pages/insights/Show.tsx
@@ -167,13 +167,13 @@ const InsightsShow = ({
         .valueOf()
     },
     [REPORTS_BY_TASK]: {
-      state: [Report.STATE.PUBLISHED],
+      state: [Report.STATE.APPROVED, Report.STATE.PUBLISHED],
       engagementDateStart: defaultPastDates.referenceDate
         .startOf("day")
         .valueOf()
     },
     [REPORTS_BY_DAY_OF_WEEK]: {
-      state: [Report.STATE.PUBLISHED],
+      state: [Report.STATE.APPROVED, Report.STATE.PUBLISHED],
       engagementDateStart: defaultPastDates.startDate.startOf("day").valueOf(),
       engagementDateEnd: defaultPastDates.endDate.endOf("day").valueOf(),
       includeEngagementDayOfWeek: true

--- a/client/src/pages/rollup/Show.tsx
+++ b/client/src/pages/rollup/Show.tsx
@@ -175,7 +175,7 @@ const Chart = ({
   const CHART_ID = "reports_by_organization"
   const barColors = {
     cancelled: "#ec971f",
-    published: "#75eb75",
+    past: "#75eb75",
     planned: "#2965cc"
   }
   const legendCss = {
@@ -183,8 +183,8 @@ const Chart = ({
     height: "14px",
     display: "inline-block"
   }
-  const publishedLabel = "Published engagement reports"
-  const plannedLabel = "Approved planned engagements"
+  const pastLabel = "Past engagements"
+  const plannedLabel = "Planned engagements"
   const cancelledLabel = "Cancelled engagements"
   return (
     <div ref={ref} className="scrollable-y">
@@ -206,7 +206,7 @@ const Chart = ({
         onBarClick={setOrg}
         tooltip={d => `
             <h4>${d.org.shortName}</h4>
-            <p>${publishedLabel}: ${d.published}</p>
+            <p>${pastLabel}: ${d.past}</p>
             <p>${plannedLabel}: ${d.planned}</p>
             <p>${cancelledLabel}: ${d.cancelled}</p>
             <p>Click to view details</p>
@@ -217,11 +217,11 @@ const Chart = ({
       <div className="graph-legend">
         <div
           className="me-1"
-          style={{ ...legendCss, background: barColors.published }}
+          style={{ ...legendCss, background: barColors.past }}
         />
-        {publishedLabel}:
+        {pastLabel}:
         <strong className="ms-1">
-          {displayedGraphData.reduce((acc, org) => acc + org.published, 0)}
+          {displayedGraphData.reduce((acc, org) => acc + org.past, 0)}
         </strong>
       </div>
       <div className="graph-legend">
@@ -257,15 +257,15 @@ const updateOrgReports = (
   // Initialize the organization object if it is the first report belongs to the organization
   const elem = (orgReports[displayedOrg.uuid] ??= {
     org: displayedOrg,
-    published: 0,
+    past: 0,
     planned: 0,
     cancelled: 0
   })
-  if (reportState === Report.STATE.PUBLISHED) {
+  if ([Report.STATE.APPROVED, Report.STATE.PUBLISHED].includes(reportState)) {
     if (Report.isFuture(engagementDate)) {
       elem.planned++
     } else {
-      elem.published++
+      elem.past++
     }
   } else if (reportState === Report.STATE.CANCELLED) {
     elem.cancelled++
@@ -623,7 +623,11 @@ const RollupShow = ({
 
   function setRollupDefaultSearchQuery() {
     const queryParams = {
-      state: [Report.STATE.PUBLISHED, Report.STATE.CANCELLED],
+      state: [
+        Report.STATE.APPROVED,
+        Report.STATE.PUBLISHED,
+        Report.STATE.CANCELLED
+      ],
       engagementDateStart: moment().startOf("day"),
       engagementDateEnd: moment().endOf("day")
     }


### PR DESCRIPTION
The Home tiles, the Daily Rollup, and the Insights for Reports by Objective and Reports by Day of the Week, by default now include Approved reports in addition to Published ones.

Closes [AB#1219](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1219)

#### User changes
- See above

#### Superuser changes
- None

#### Admin changes
- None

#### System admin changes
- [ ] application.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
- [x] described the user behavior in PR body
- [x] referenced/updated all related issues
- [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
- [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
- [ ] added and/or updated unit tests
- [ ] added and/or updated e2e tests
- [ ] added and/or updated data migrations
- [ ] updated documentation
- [x] resolved all build errors and warnings
- [ ] opened debt issues for anything not resolved here
