### PR TITLE
Preserve case of last name when onboarding a new user

### DIFF
--- a/client/tests/webdriver/baseSpecs/onboardNewUser.spec.js
+++ b/client/tests/webdriver/baseSpecs/onboardNewUser.spec.js
@@ -3,7 +3,7 @@ import moment from "moment"
 import OnboardPage from "../pages/onboard.page"
 
 const ONBOARD_USER = {
-  lastName: "BONNSDOTTIR",
+  lastName: "Bonnsdottir",
   firstName: "Bonny",
   emailAddresses: ["", "bonny@example.com"]
 }

--- a/src/main/java/mil/dds/anet/utils/SecurityUtils.java
+++ b/src/main/java/mil/dds/anet/utils/SecurityUtils.java
@@ -135,7 +135,7 @@ public class SecurityUtils {
 
   private static String getCombinedName(Map<String, Object> claims) {
     final StringBuilder combinedName = new StringBuilder();
-    // Try to combine FAMILYNAME, GivenName MiddleName
+    // Try to combine FamilyName, GivenName MiddleName
     final String fn =
         Utils.trimStringReturnNull((String) claims.get(StandardClaimNames.FAMILY_NAME));
     if (!Utils.isEmptyOrNull(fn)) {

--- a/src/main/java/mil/dds/anet/utils/SecurityUtils.java
+++ b/src/main/java/mil/dds/anet/utils/SecurityUtils.java
@@ -139,7 +139,7 @@ public class SecurityUtils {
     final String fn =
         Utils.trimStringReturnNull((String) claims.get(StandardClaimNames.FAMILY_NAME));
     if (!Utils.isEmptyOrNull(fn)) {
-      combinedName.append(fn.toUpperCase());
+      combinedName.append(fn);
       final String gn =
           Utils.trimStringReturnNull((String) claims.get(StandardClaimNames.GIVEN_NAME));
       if (!Utils.isEmptyOrNull(gn)) {


### PR DESCRIPTION
When onboarding and filling in the form to create a new user, ANET no longer forces uppercase on the last name.

Closes [AB#1193](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1193)

#### User changes
- Users' last names are no longer forced to uppercase when onboarding

#### Superuser changes
- None

#### Admin changes
- None

#### System admin changes
- [ ] application.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
- [x] described the user behavior in PR body
- [x] referenced/updated all related issues
- [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
- [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
- [ ] added and/or updated unit tests
- [x] added and/or updated e2e tests
- [ ] added and/or updated data migrations
- [ ] updated documentation
- [x] resolved all build errors and warnings
- [ ] opened debt issues for anything not resolved here
