### PR TITLE
Use new headless mode for client-side browser tests

### DIFF
--- a/client/config/wdio.config.js
+++ b/client/config/wdio.config.js
@@ -73,7 +73,7 @@ const config = {
         // while scrolling some form fields might go under the header and
         // therefore we would get failing tests related to these fields.
         args: [
-          "--headless=old",
+          "--headless",
           "--disable-gpu",
           "--disable-search-engine-choice-screen",
           "--window-size=1600,1200"

--- a/client/tests/util/test.js
+++ b/client/tests/util/test.js
@@ -91,7 +91,7 @@ test.beforeEach(t => {
   if (testEnv === "local") {
     const chrome = require("selenium-webdriver/chrome")
     const options = new chrome.Options(capabilities).addArguments([
-      "--headless=old",
+      "--headless",
       "--disable-gpu",
       "--disable-search-engine-choice-screen",
       "--window-size=1600,1200"


### PR DESCRIPTION
As of Chrome 132, the old headless mode is no longer available.