### PR TITLE
Fix loop detection in object hierarchies

### DIFF
--- a/client/src/utils.tsx
+++ b/client/src/utils.tsx
@@ -395,7 +395,17 @@ export default {
       : ascendantObjects
     let uuid = leaf?.uuid
     const trail = []
+    const seenUuids = []
     while (uuid) {
+      if (seenUuids.includes(uuid)) {
+        // Loop detected! Break the loop and log an error…
+        parentMap[uuid][parentField] = null
+        const msg = `Loop detected for ${uuid}!`
+        console.error(msg)
+        window.onerror(msg, window.location?.toString(), 0, 0)
+        break
+      }
+      seenUuids.push(uuid)
       const node = parentMap[uuid]
       if (!node) {
         break

--- a/client/tests/webdriver/baseSpecs/mergeLocations.spec.js
+++ b/client/tests/webdriver/baseSpecs/mergeLocations.spec.js
@@ -2,6 +2,16 @@ import { expect } from "chai"
 import MergeLocations from "../pages/mergeLocations.page"
 
 const EXAMPLE_LOCATIONS = {
+  childLeft: {
+    search: "Kabul Hospital",
+    name: "Kabul Hospital",
+    fullName: "Kabul Hospital"
+  },
+  parentRight: {
+    search: "Afghanistan",
+    name: "Afghanistan",
+    fullName: "Afghanistan"
+  },
   left: {
     search: "Location Winner",
     name: "Merge Location Winner",
@@ -42,6 +52,52 @@ const EXAMPLE_LOCATIONS = {
       "Location publication approval for merge loser\nPerson Position\nCIV ERINSON, Erin EF 2.2 Advisor D"
   }
 }
+
+describe("Merge locations error", () => {
+  it("Should show an error when merging locations would create a loop", async() => {
+    await MergeLocations.openPage()
+    await (await MergeLocations.getTitle()).waitForExist()
+    await (await MergeLocations.getTitle()).waitForDisplayed()
+
+    await (await MergeLocations.getLeftLocationField()).click()
+    await (
+      await MergeLocations.getLeftLocationField()
+    ).setValue(EXAMPLE_LOCATIONS.childLeft.search)
+    await MergeLocations.waitForAdvancedSelectLoading(
+      EXAMPLE_LOCATIONS.childLeft.fullName
+    )
+    await (await MergeLocations.getFirstItemFromAdvancedSelect()).click()
+    await browser.pause(500)
+    await MergeLocations.waitForColumnToChange(
+      EXAMPLE_LOCATIONS.childLeft.name,
+      "left",
+      "Name"
+    )
+
+    await (await MergeLocations.getRightLocationField()).click()
+    await (
+      await MergeLocations.getRightLocationField()
+    ).setValue(EXAMPLE_LOCATIONS.parentRight.search)
+    await MergeLocations.waitForAdvancedSelectLoading(
+      EXAMPLE_LOCATIONS.parentRight.fullName
+    )
+    await (await MergeLocations.getFirstItemFromAdvancedSelect()).click()
+    await browser.pause(500)
+    await MergeLocations.waitForColumnToChange(
+      EXAMPLE_LOCATIONS.parentRight.name,
+      "right",
+      "Name"
+    )
+
+    await (await MergeLocations.getUseAllButton("left")).click()
+    await browser.pause(500)
+    await (await MergeLocations.getMergeLocationsButton()).click()
+    await MergeLocations.waitForAlertDangerToLoad()
+    expect(await (await MergeLocations.getAlertDanger()).getText()).to.eq(
+      "Location can not be its own (grand…)parent"
+    )
+  })
+})
 
 describe("Merge locations page", () => {
   it("Should be able to select to incompatible locations to merge", async() => {

--- a/client/tests/webdriver/baseSpecs/mergeOrganizations.spec.js
+++ b/client/tests/webdriver/baseSpecs/mergeOrganizations.spec.js
@@ -3,6 +3,16 @@ import MergeOrganizations from "../pages/mergeOrganizations.page"
 
 const IMG_PATH = "/api/attachment/view"
 const EXAMPLE_ORGANIZATIONS = {
+  childLeft: {
+    search: "EF 1.1",
+    shortName: "EF 1.1",
+    displayedName: "EF 1.1"
+  },
+  parentRight: {
+    search: "EF 1 Planning",
+    shortName: "EF 1",
+    displayedName: "EF 1 | Planning Programming, Budgeting and Execution"
+  },
   validLeft: {
     search: "Merge Org 1",
     shortName: "Merge Org 1",
@@ -22,6 +32,52 @@ const EXAMPLE_ORGANIZATIONS = {
     parentOrg: "EF 1 | Planning Programming, Budgeting and Execution"
   }
 }
+
+describe("Merge organizations error", () => {
+  it("Should show an error when merging organizations would create a loop", async() => {
+    await MergeOrganizations.openPage()
+    await (await MergeOrganizations.getTitle()).waitForExist()
+    await (await MergeOrganizations.getTitle()).waitForDisplayed()
+
+    await (await MergeOrganizations.getLeftOrganizationField()).click()
+    await (
+      await MergeOrganizations.getLeftOrganizationField()
+    ).setValue(EXAMPLE_ORGANIZATIONS.childLeft.search)
+    await MergeOrganizations.waitForAdvancedSelectLoading(
+      EXAMPLE_ORGANIZATIONS.childLeft.displayedName
+    )
+    await (await MergeOrganizations.getFirstItemFromAdvancedSelect()).click()
+    await browser.pause(500)
+    await MergeOrganizations.waitForColumnToChange(
+      EXAMPLE_ORGANIZATIONS.childLeft.shortName,
+      "left",
+      "Name"
+    )
+
+    await (await MergeOrganizations.getRightOrganizationField()).click()
+    await (
+      await MergeOrganizations.getRightOrganizationField()
+    ).setValue(EXAMPLE_ORGANIZATIONS.parentRight.search)
+    await MergeOrganizations.waitForAdvancedSelectLoading(
+      EXAMPLE_ORGANIZATIONS.parentRight.displayedName
+    )
+    await (await MergeOrganizations.getFirstItemFromAdvancedSelect()).click()
+    await browser.pause(500)
+    await MergeOrganizations.waitForColumnToChange(
+      EXAMPLE_ORGANIZATIONS.parentRight.shortName,
+      "right",
+      "Name"
+    )
+
+    await (await MergeOrganizations.getUseAllButton("left")).click()
+    await browser.pause(500)
+    await (await MergeOrganizations.getMergeOrganizationsButton()).click()
+    await MergeOrganizations.waitForAlertDangerToLoad()
+    expect(await (await MergeOrganizations.getAlertDanger()).getText()).to.eq(
+      "Organization can not be its own (grand…)parent"
+    )
+  })
+})
 
 describe("Merge organizations page", () => {
   it("Should display field values of the left organization", async() => {

--- a/client/tests/webdriver/pages/page.js
+++ b/client/tests/webdriver/pages/page.js
@@ -151,6 +151,13 @@ class Page {
     return browser.$(".alert-danger")
   }
 
+  async waitForAlertDangerToLoad() {
+    if (!(await (await this.getAlertDanger()).isDisplayed())) {
+      await (await this.getAlertDanger()).waitForExist()
+      await (await this.getAlertDanger()).waitForDisplayed()
+    }
+  }
+
   async getRandomOption(select) {
     const options = await select.$$("option")
     // Ignore the first option, it is always the empty one

--- a/src/main/java/mil/dds/anet/database/AuthorizationGroupDao.java
+++ b/src/main/java/mil/dds/anet/database/AuthorizationGroupDao.java
@@ -245,7 +245,7 @@ public class AuthorizationGroupDao
           new StringBuilder("/* getAuthorizationGroupUuidsForRelatedObject */");
       sql.append(" WITH RECURSIVE parent_orgs(uuid, parent_uuid) AS"
           + " (SELECT uuid, uuid as parent_uuid FROM organizations"
-          + " UNION ALL SELECT pt.uuid, bt.\"parentOrgUuid\" FROM organizations bt"
+          + " UNION SELECT pt.uuid, bt.\"parentOrgUuid\" FROM organizations bt"
           + " INNER JOIN parent_orgs pt ON bt.uuid = pt.parent_uuid) ");
 
       if (isForPerson(relatedObjectType)) {

--- a/src/main/java/mil/dds/anet/search/AbstractSearchQueryBuilder.java
+++ b/src/main/java/mil/dds/anet/search/AbstractSearchQueryBuilder.java
@@ -293,7 +293,7 @@ public abstract class AbstractSearchQueryBuilder<B, T extends AbstractSearchQuer
       outerQb = this;
     }
     outerQb.addWithClause(String.format(
-        "%1$s(uuid, parent_uuid) AS (SELECT %3$s AS uuid, %3$s AS parent_uuid FROM %2$s UNION ALL"
+        "%1$s(uuid, parent_uuid) AS (SELECT %3$s AS uuid, %3$s AS parent_uuid FROM %2$s UNION"
             + " SELECT pt.uuid, bt.%4$s FROM %2$s bt INNER JOIN"
             + " %1$s pt ON bt.%3$s = pt.parent_uuid)",
         withTableName, recursiveTableName, baseKey, recursiveForeignKey));

--- a/src/test/java/mil/dds/anet/test/resources/merge/OrganizationMergeTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/merge/OrganizationMergeTest.java
@@ -13,6 +13,17 @@ import org.junit.jupiter.api.Test;
 
 class OrganizationMergeTest extends AbstractResourceTest {
   @Test
+  void testMergeLoop() {
+    // EF 1.1
+    final Organization childOrg = withCredentials(adminUser,
+        t -> queryExecutor.organization(FIELDS, "04614b0f-7e8e-4bf1-8bc5-13abaffeab8a"));
+    // EF 1
+    final Organization parentOrg = childOrg.getParentOrg();
+    assertThatThrownBy(() -> withCredentials(adminUser, t -> mutationExecutor.mergeOrganizations("",
+        parentOrg.getUuid(), getOrganizationInput(childOrg)))).isInstanceOf(Exception.class);
+  }
+
+  @Test
   void shouldMerge() {
     final var loserInput = OrganizationInput.builder().withShortName("LM1")
         .withLongName("Loser for Merge").withStatus(INACTIVE).build();


### PR DESCRIPTION
When merging organizations/locations, it was possible to create loops in the hierarchy. This is now prevented.
Also, in the case of (pre-existing) loops, PostgreSQL and the GUI client no longer go into an infinite recursion.
And if the GUI client detects a loop, an error is logged on the server.

Closes [AB#1233](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1233)

#### User changes
- None

#### Superuser changes
- None

#### Admin changes
- If merging organizations/locations would create a loop, you now get a clear error message preventing you from completing the merge.

#### System admin changes
- [ ] application.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
- [x] described the user behavior in PR body
- [x] referenced/updated all related issues
- [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
- [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
- [x] added and/or updated unit tests
- [x] added and/or updated e2e tests
- [ ] added and/or updated data migrations
- [ ] updated documentation
- [x] resolved all build errors and warnings
- [ ] opened debt issues for anything not resolved here