### PR TITLE
Make mail timeout configurable

### DIFF
--- a/application.yml
+++ b/application.yml
@@ -52,6 +52,10 @@ anet:
     start-tls: ${ANET_SMTP_STARTTLS:false}
     disabled: ${ANET_SMTP_DISABLE:true}
     nb-of-hours-for-stale-emails: 72
+    # Timeout in milliseconds when sending mail;
+    # defaults to 5000 when not specified;
+    # 0 means no timeout at all!
+    timeout: 5000
 
   # The email address that all automated emails should come from.
   # ex: "ANET <anet@example.com>"

--- a/src/main/java/mil/dds/anet/config/AnetConfig.java
+++ b/src/main/java/mil/dds/anet/config/AnetConfig.java
@@ -3,6 +3,8 @@ package mil.dds.anet.config;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.invoke.MethodHandles;
@@ -175,6 +177,7 @@ public class AnetConfig {
 
   public static class SmtpConfiguration {
     private String hostname;
+    @Positive
     private int port = 587;
     private String username;
     private String password;
@@ -182,6 +185,8 @@ public class AnetConfig {
     private boolean disabled;
     private Integer nbOfHoursForStaleEmails;
     private String sslTrust;
+    @PositiveOrZero
+    private int timeout = 5000;
 
     public String getHostname() {
       return hostname;
@@ -245,6 +250,14 @@ public class AnetConfig {
 
     public void setSslTrust(String sslTrust) {
       this.sslTrust = sslTrust;
+    }
+
+    public int getTimeout() {
+      return timeout;
+    }
+
+    public void setTimeout(int timeout) {
+      this.timeout = timeout;
     }
   }
 

--- a/src/main/java/mil/dds/anet/threads/AnetEmailWorker.java
+++ b/src/main/java/mil/dds/anet/threads/AnetEmailWorker.java
@@ -242,6 +242,9 @@ public class AnetEmailWorker extends AbstractWorker {
     if (hasUsername(smtpConfig)) {
       props.put("mail.smtp.auth", "true");
     }
+    props.put("mail.smtp.connectiontimeout", smtpConfig.getTimeout());
+    props.put("mail.smtp.timeout", smtpConfig.getTimeout());
+    props.put("mail.smtp.writetimeout", smtpConfig.getTimeout());
     return props;
   }
 


### PR DESCRIPTION
Instead of relying on the system default (which is zero, meaning: infinite), make the mail timeout configurable (with a sensible default of 5000 ms).

Closes [AB#1234](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1234)

#### User changes
- None

#### Superuser changes
- None

#### Admin changes
- None

#### System admin changes
- [x] application.yml or anet-dictionary.yml needs change
  Add the following to `application.yml`:
  ```yaml
  anet:
    […]
    smtp:
      […]
      nb-of-hours-for-stale-emails: 72
      # Timeout in milliseconds when sending mail;
      # defaults to 5000 when not specified;
      # 0 means no timeout at all!
      timeout: 5000
  ```
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
- [x] described the user behavior in PR body
- [x] referenced/updated all related issues
- [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
- [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
- [ ] added and/or updated unit tests
- [ ] added and/or updated e2e tests
- [ ] added and/or updated data migrations
- [ ] updated documentation
- [x] resolved all build errors and warnings
- [ ] opened debt issues for anything not resolved here
