### PR TITLE
Edit attachments in view mode

### DIFF
--- a/client/src/components/Attachment/Attachment.css
+++ b/client/src/components/Attachment/Attachment.css
@@ -1,6 +1,6 @@
 /******** FILE UPLOAD AREA ********/
 .file-upload-container {
-  margin: 10px 0;
+  margin: 0 0 10px 0;
   display: flex;
   position: relative;
   padding: 35px 20px;

--- a/client/src/components/Attachment/AttachmentsDetailView.tsx
+++ b/client/src/components/Attachment/AttachmentsDetailView.tsx
@@ -1,5 +1,5 @@
 import UploadAttachment from "components/Attachment/UploadAttachment"
-import { useState } from "react"
+import React, { useState } from "react"
 import { Button } from "react-bootstrap"
 import AttachmentCard from "./AttachmentCard"
 
@@ -12,7 +12,7 @@ const AttachmentsList = ({ attachments }: AttachmentsListProps) => {
     return null
   }
   return (
-    <div className="attachment-card-list">
+    <div className="attachment-card-list" style={{ gap: "10px" }}>
       {attachments.map(attachment => (
         <AttachmentCard key={attachment.uuid} attachment={attachment} />
       ))}

--- a/client/src/components/Attachment/AttachmentsDetailView.tsx
+++ b/client/src/components/Attachment/AttachmentsDetailView.tsx
@@ -11,7 +11,7 @@ interface AttachmentsListProps {
 
 const AttachmentsList = ({ attachments }: AttachmentsListProps) => {
   if (attachments.length === 0) {
-    return null
+    return <em>No attachments found</em>
   }
   return (
     <div className="attachment-card-list">
@@ -35,33 +35,19 @@ const AttachmentsDetailView = ({
   updateAttachments,
   relatedObjectType,
   relatedObjectUuid,
-  allowEdit = false
+  allowEdit
 }: AttachmentsDetailViewProps) => {
-  const [editAttachments, setEditAttachments] = useState(false)
-
   const { currentUser } = useContext(AppContext)
-  const isAdmin = currentUser && currentUser.isAdmin()
-  const attachmentsEnabled = !Settings.fields.attachment.featureDisabled
-  const attachmentEditEnabled =
-    attachmentsEnabled &&
-    (!Settings.fields.attachment.restrictToAdmins || isAdmin)
-  const canEditAttachments = attachmentEditEnabled && allowEdit
+  const [editAttachments, setEditAttachments] = useState(false)
+  const canEditAttachments =
+    !Settings.fields.attachment.featureDisabled &&
+    (!Settings.fields.attachment.restrictToAdmins || currentUser?.isAdmin()) &&
+    allowEdit
 
   if (!canEditAttachments) {
     return <AttachmentsList attachments={attachments} />
   }
 
-  const renderButton = () => {
-    return (
-      <Button
-        variant="primary"
-        onClick={() => setEditAttachments(!editAttachments)}
-        id="edit-attachments"
-      >
-        {editAttachments ? "View" : "Edit"} attachments
-      </Button>
-    )
-  }
   return (
     <>
       {editAttachments ? (
@@ -74,7 +60,15 @@ const AttachmentsDetailView = ({
       ) : (
         <AttachmentsList attachments={attachments} />
       )}
-      {renderButton()}
+      <div className="clearfix">
+        <Button
+          variant="primary"
+          onClick={() => setEditAttachments(!editAttachments)}
+          id="edit-attachments"
+        >
+          {editAttachments ? "View" : "Edit"} attachments
+        </Button>
+      </div>
     </>
   )
 }

--- a/client/src/components/Attachment/AttachmentsDetailView.tsx
+++ b/client/src/components/Attachment/AttachmentsDetailView.tsx
@@ -1,0 +1,27 @@
+import AttachmentCard from "./AttachmentCard"
+
+interface AttachmentsDetailViewProps {
+  attachments?: any
+  allowEdit?: boolean
+}
+
+const AttachmentsDetailView = ({
+  attachments,
+  allowEdit
+}: AttachmentsDetailViewProps) => {
+  if (attachments.length === 0) {
+    return null
+  }
+  return (
+    <div className="attachment-card-list">
+      {attachments.map(attachment => (
+        <AttachmentCard
+          key={attachment.uuid}
+          attachment={attachment}
+        />
+      ))}
+    </div>
+  )
+}
+
+export default AttachmentsDetailView

--- a/client/src/components/Attachment/AttachmentsDetailView.tsx
+++ b/client/src/components/Attachment/AttachmentsDetailView.tsx
@@ -1,26 +1,60 @@
+import UploadAttachment from "components/Attachment/UploadAttachment"
+import { useState } from "react"
+import { Button } from "react-bootstrap"
 import AttachmentCard from "./AttachmentCard"
 
-interface AttachmentsDetailViewProps {
-  attachments?: any
-  allowEdit?: boolean
+interface AttachmentsListProps {
+  attachments: any
 }
 
-const AttachmentsDetailView = ({
-  attachments,
-  allowEdit
-}: AttachmentsDetailViewProps) => {
+const AttachmentsList = ({ attachments }: AttachmentsListProps) => {
   if (attachments.length === 0) {
     return null
   }
   return (
     <div className="attachment-card-list">
       {attachments.map(attachment => (
-        <AttachmentCard
-          key={attachment.uuid}
-          attachment={attachment}
-        />
+        <AttachmentCard key={attachment.uuid} attachment={attachment} />
       ))}
     </div>
+  )
+}
+
+interface AttachmentsDetailViewProps {
+  attachments: any
+  updateAttachments: any
+  relatedObjectType: any
+  relatedObjectUuid: any
+  allowEdit?: boolean
+}
+
+const AttachmentsDetailView = ({
+  attachments,
+  updateAttachments,
+  relatedObjectType,
+  relatedObjectUuid,
+  allowEdit = false
+}: AttachmentsDetailViewProps) => {
+  const [editAttachments, setEditAttachments] = useState(false)
+
+  return allowEdit ? (
+    editAttachments ? (
+      <UploadAttachment
+        attachments={attachments}
+        updateAttachments={updateAttachments}
+        relatedObjectType={relatedObjectType}
+        relatedObjectUuid={relatedObjectUuid}
+      />
+    ) : (
+      <>
+        <AttachmentsList attachments={attachments} />
+        <Button variant="primary" onClick={() => setEditAttachments(true)}>
+          Edit attachments
+        </Button>
+      </>
+    )
+  ) : (
+    <AttachmentsList attachments={attachments} />
   )
 }
 

--- a/client/src/components/Attachment/AttachmentsDetailView.tsx
+++ b/client/src/components/Attachment/AttachmentsDetailView.tsx
@@ -56,6 +56,7 @@ const AttachmentsDetailView = ({
       <Button
         variant="primary"
         onClick={() => setEditAttachments(!editAttachments)}
+        id="edit-attachments"
       >
         {editAttachments ? "View" : "Edit"} attachments
       </Button>

--- a/client/src/pages/locations/Show.tsx
+++ b/client/src/pages/locations/Show.tsx
@@ -3,7 +3,7 @@ import { DEFAULT_PAGE_PROPS, DEFAULT_SEARCH_PROPS } from "actions"
 import API from "api"
 import AppContext from "components/AppContext"
 import Approvals from "components/approvals/Approvals"
-import AttachmentCard from "components/Attachment/AttachmentCard"
+import AttachmentsDetailView from "components/Attachment/AttachmentsDetailView"
 import { ReadonlyCustomFields } from "components/CustomFields"
 import DictionaryField from "components/DictionaryField"
 import EventCollection from "components/EventCollection"
@@ -269,14 +269,7 @@ const LocationShow = ({ pageDispatchers }: LocationShowProps) => {
                     label="Attachments"
                     component={FieldHelper.ReadonlyField}
                     humanValue={
-                      <div className="attachment-card-list">
-                        {location.attachments.map(attachment => (
-                          <AttachmentCard
-                            key={attachment.uuid}
-                            attachment={attachment}
-                          />
-                        ))}
-                      </div>
+                      <AttachmentsDetailView attachments={location.attachments} />
                     }
                   />
                 )}

--- a/client/src/pages/locations/Show.tsx
+++ b/client/src/pages/locations/Show.tsx
@@ -65,12 +65,6 @@ const LocationShow = ({ pageDispatchers }: LocationShowProps) => {
   const { loading, error, data, refetch } = API.useApiQuery(GQL_GET_LOCATION, {
     uuid
   })
-  useEffect(() => {
-    if (data?.location) {
-      const location = new Location(data ? data.location : {})
-      setAttachments(location.attachments || [])
-    }
-  }, [data])
   const { done, result } = useBoilerplate({
     loading,
     error,
@@ -81,6 +75,9 @@ const LocationShow = ({ pageDispatchers }: LocationShowProps) => {
     pageDispatchers
   })
   usePageTitle(data?.location?.name)
+  useEffect(() => {
+    setAttachments(data?.location?.attachments || [])
+  }, [data])
   if (done) {
     return result
   }
@@ -93,9 +90,6 @@ const LocationShow = ({ pageDispatchers }: LocationShowProps) => {
   const isAdmin = currentUser?.isAdmin()
   const canEdit = currentUser?.isSuperuser()
   const attachmentsEnabled = !Settings.fields.attachment.featureDisabled
-  const updateAttachments = newAttachments => {
-    setAttachments(newAttachments)
-  }
 
   return (
     <Formik enableReinitialize initialValues={location}>
@@ -281,7 +275,7 @@ const LocationShow = ({ pageDispatchers }: LocationShowProps) => {
                     humanValue={
                       <AttachmentsDetailView
                         attachments={attachments}
-                        updateAttachments={updateAttachments}
+                        updateAttachments={setAttachments}
                         relatedObjectType={Location.relatedObjectType}
                         relatedObjectUuid={values.uuid}
                         allowEdit={canEdit}

--- a/client/src/pages/organizations/Show.tsx
+++ b/client/src/pages/organizations/Show.tsx
@@ -4,7 +4,7 @@ import API from "api"
 import AppContext from "components/AppContext"
 import Approvals from "components/approvals/Approvals"
 import AssessmentResultsContainer from "components/assessments/AssessmentResultsContainer"
-import AttachmentCard from "components/Attachment/AttachmentCard"
+import AttachmentsDetailView from "components/Attachment/AttachmentsDetailView"
 import AuthorizationGroupTable from "components/AuthorizationGroupTable"
 import EntityAvatarDisplay from "components/avatar/EntityAvatarDisplay"
 import { ReadonlyCustomFields } from "components/CustomFields"
@@ -585,14 +585,7 @@ const OrganizationShow = ({ pageDispatchers }: OrganizationShowProps) => {
                     label="Attachments"
                     component={FieldHelper.ReadonlyField}
                     humanValue={
-                      <div className="attachment-card-list">
-                        {organization.attachments.map(attachment => (
-                          <AttachmentCard
-                            key={attachment.uuid}
-                            attachment={attachment}
-                          />
-                        ))}
-                      </div>
+                      <AttachmentsDetailView attachments={organization.attachments} />
                     }
                   />
                 )}

--- a/client/src/pages/organizations/Show.tsx
+++ b/client/src/pages/organizations/Show.tsx
@@ -221,12 +221,6 @@ const OrganizationShow = ({ pageDispatchers }: OrganizationShowProps) => {
       uuid
     }
   )
-  useEffect(() => {
-    if (data?.organization) {
-      const organization = new Organization(data ? data.organization : {})
-      setAttachments(organization.attachments || [])
-    }
-  }, [data])
   const { done, result } = useBoilerplate({
     loading,
     error,
@@ -237,6 +231,9 @@ const OrganizationShow = ({ pageDispatchers }: OrganizationShowProps) => {
     pageDispatchers
   })
   usePageTitle(data?.organization?.shortName)
+  useEffect(() => {
+    setAttachments(data?.organization?.attachments || [])
+  }, [data])
   if (done) {
     return result
   }
@@ -308,9 +305,6 @@ const OrganizationShow = ({ pageDispatchers }: OrganizationShowProps) => {
   }
   if (includeChildrenOrgs) {
     reportQueryParams.orgRecurseStrategy = RECURSE_STRATEGY.CHILDREN
-  }
-  const updateAttachments = newAttachments => {
-    setAttachments(newAttachments)
   }
 
   return (
@@ -597,7 +591,7 @@ const OrganizationShow = ({ pageDispatchers }: OrganizationShowProps) => {
                     humanValue={
                       <AttachmentsDetailView
                         attachments={attachments}
-                        updateAttachments={updateAttachments}
+                        updateAttachments={setAttachments}
                         relatedObjectType={Organization.relatedObjectType}
                         relatedObjectUuid={values.uuid}
                         allowEdit={canAdministrateOrg}

--- a/client/src/pages/organizations/Show.tsx
+++ b/client/src/pages/organizations/Show.tsx
@@ -43,7 +43,7 @@ import { PositionRole } from "models/Position"
 import { orgTour } from "pages/GuidedTour"
 import pluralize from "pluralize"
 import { getPositionsForRole } from "positionUtil"
-import React, { useContext, useState } from "react"
+import React, { useContext, useEffect, useState } from "react"
 import {
   Badge,
   Button,
@@ -211,6 +211,7 @@ const OrganizationShow = ({ pageDispatchers }: OrganizationShowProps) => {
   const [stateError, setStateError] = useState(
     routerLocation.state && routerLocation.state.error
   )
+  const [attachments, setAttachments] = useState([])
   const [filterPendingApproval, setFilterPendingApproval] = useState(false)
   const [includeChildrenOrgs, setIncludeChildrenOrgs] = useState(true)
   const { uuid } = useParams()
@@ -220,6 +221,12 @@ const OrganizationShow = ({ pageDispatchers }: OrganizationShowProps) => {
       uuid
     }
   )
+  useEffect(() => {
+    if (data?.organization) {
+      const organization = new Organization(data ? data.organization : {})
+      setAttachments(organization.attachments || [])
+    }
+  }, [data])
   const { done, result } = useBoilerplate({
     loading,
     error,
@@ -301,6 +308,9 @@ const OrganizationShow = ({ pageDispatchers }: OrganizationShowProps) => {
   }
   if (includeChildrenOrgs) {
     reportQueryParams.orgRecurseStrategy = RECURSE_STRATEGY.CHILDREN
+  }
+  const updateAttachments = newAttachments => {
+    setAttachments(newAttachments)
   }
 
   return (
@@ -585,7 +595,13 @@ const OrganizationShow = ({ pageDispatchers }: OrganizationShowProps) => {
                     label="Attachments"
                     component={FieldHelper.ReadonlyField}
                     humanValue={
-                      <AttachmentsDetailView attachments={organization.attachments} />
+                      <AttachmentsDetailView
+                        attachments={attachments}
+                        updateAttachments={updateAttachments}
+                        relatedObjectType={Organization.relatedObjectType}
+                        relatedObjectUuid={values.uuid}
+                        allowEdit={canAdministrateOrg}
+                      />
                     }
                   />
                 )}

--- a/client/src/pages/people/Show.tsx
+++ b/client/src/pages/people/Show.tsx
@@ -46,7 +46,7 @@ import _isEmpty from "lodash/isEmpty"
 import { Attachment, Person, Position } from "models"
 import moment from "moment"
 import { personTour } from "pages/GuidedTour"
-import React, { useContext, useState } from "react"
+import React, { useContext, useEffect, useState } from "react"
 import {
   Button,
   Col,
@@ -164,6 +164,7 @@ const PersonShow = ({ pageDispatchers }: PersonShowProps) => {
   const [stateError, setStateError] = useState(
     routerLocation.state && routerLocation.state.error
   )
+  const [attachments, setAttachments] = useState([])
   const [showAssignPositionModal, setShowAssignPositionModal] = useState(false)
   const [showAssociatedPositionsModal, setShowAssociatedPositionsModal] =
     useState(false)
@@ -172,6 +173,12 @@ const PersonShow = ({ pageDispatchers }: PersonShowProps) => {
   const { loading, error, data, refetch } = API.useApiQuery(GQL_GET_PERSON, {
     uuid
   })
+  useEffect(() => {
+    if (data?.person) {
+      const person = new Person(data ? data.person : {})
+      setAttachments(person.attachments || [])
+    }
+  }, [data])
   const { done, result } = useBoilerplate({
     loading,
     error,
@@ -292,6 +299,9 @@ const PersonShow = ({ pageDispatchers }: PersonShowProps) => {
     numberOfFieldsUnderAvatar
   )
   const rightColumn = orderedFields.slice(numberOfFieldsUnderAvatar)
+  const updateAttachments = newAttachments => {
+    setAttachments(newAttachments)
+  }
 
   return (
     <Formik enableReinitialize initialValues={person}>
@@ -357,7 +367,13 @@ const PersonShow = ({ pageDispatchers }: PersonShowProps) => {
                     label="Attachments"
                     component={FieldHelper.ReadonlyField}
                     humanValue={
-                      <AttachmentsDetailView attachments={person.attachments} />
+                      <AttachmentsDetailView
+                        attachments={attachments}
+                        updateAttachments={updateAttachments}
+                        relatedObjectType={Person.relatedObjectType}
+                        relatedObjectUuid={person.uuid}
+                        allowEdit={canEdit}
+                      />
                     }
                   />
                 )}

--- a/client/src/pages/people/Show.tsx
+++ b/client/src/pages/people/Show.tsx
@@ -6,7 +6,7 @@ import API from "api"
 import AppContext from "components/AppContext"
 import AssessmentResultsContainer from "components/assessments/AssessmentResultsContainer"
 import AssignPositionModal from "components/AssignPositionModal"
-import AttachmentCard from "components/Attachment/AttachmentCard"
+import AttachmentsDetailView from "components/Attachment/AttachmentsDetailView"
 import AuthorizationGroupTable from "components/AuthorizationGroupTable"
 import EntityAvatarDisplay from "components/avatar/EntityAvatarDisplay"
 import CountryDisplay from "components/CountryDisplay"
@@ -357,14 +357,7 @@ const PersonShow = ({ pageDispatchers }: PersonShowProps) => {
                     label="Attachments"
                     component={FieldHelper.ReadonlyField}
                     humanValue={
-                      <div className="attachment-card-list">
-                        {person.attachments.map(attachment => (
-                          <AttachmentCard
-                            key={attachment.uuid}
-                            attachment={attachment}
-                          />
-                        ))}
-                      </div>
+                      <AttachmentsDetailView attachments={person.attachments} />
                     }
                   />
                 )}

--- a/client/src/pages/people/Show.tsx
+++ b/client/src/pages/people/Show.tsx
@@ -352,25 +352,26 @@ const PersonShow = ({ pageDispatchers }: PersonShowProps) => {
                   </Row>
                   <Row>
                     <Col md={12}>{fullWidthFields}</Col>
+                    {attachmentsEnabled && (
+                      <Col md={12}>
+                        <Field
+                          name="attachments"
+                          label="Attachments"
+                          component={FieldHelper.ReadonlyField}
+                          humanValue={
+                            <AttachmentsDetailView
+                              attachments={attachments}
+                              updateAttachments={setAttachments}
+                              relatedObjectType={Person.relatedObjectType}
+                              relatedObjectUuid={person.uuid}
+                              allowEdit={canEdit}
+                            />
+                          }
+                        />
+                      </Col>
+                    )}
                   </Row>
                 </Container>
-
-                {attachmentsEnabled && (
-                  <Field
-                    name="attachments"
-                    label="Attachments"
-                    component={FieldHelper.ReadonlyField}
-                    humanValue={
-                      <AttachmentsDetailView
-                        attachments={attachments}
-                        updateAttachments={setAttachments}
-                        relatedObjectType={Person.relatedObjectType}
-                        relatedObjectUuid={person.uuid}
-                        allowEdit={canEdit}
-                      />
-                    }
-                  />
-                )}
               </Fieldset>
 
               {canEdit && (

--- a/client/src/pages/people/Show.tsx
+++ b/client/src/pages/people/Show.tsx
@@ -173,12 +173,6 @@ const PersonShow = ({ pageDispatchers }: PersonShowProps) => {
   const { loading, error, data, refetch } = API.useApiQuery(GQL_GET_PERSON, {
     uuid
   })
-  useEffect(() => {
-    if (data?.person) {
-      const person = new Person(data ? data.person : {})
-      setAttachments(person.attachments || [])
-    }
-  }, [data])
   const { done, result } = useBoilerplate({
     loading,
     error,
@@ -189,6 +183,9 @@ const PersonShow = ({ pageDispatchers }: PersonShowProps) => {
     pageDispatchers
   })
   usePageTitle(data?.person && `${data.person.rank} ${data?.person.name}`)
+  useEffect(() => {
+    setAttachments(data?.person?.attachments || [])
+  }, [data])
   if (done) {
     return result
   }
@@ -299,9 +296,6 @@ const PersonShow = ({ pageDispatchers }: PersonShowProps) => {
     numberOfFieldsUnderAvatar
   )
   const rightColumn = orderedFields.slice(numberOfFieldsUnderAvatar)
-  const updateAttachments = newAttachments => {
-    setAttachments(newAttachments)
-  }
 
   return (
     <Formik enableReinitialize initialValues={person}>
@@ -369,7 +363,7 @@ const PersonShow = ({ pageDispatchers }: PersonShowProps) => {
                     humanValue={
                       <AttachmentsDetailView
                         attachments={attachments}
-                        updateAttachments={updateAttachments}
+                        updateAttachments={setAttachments}
                         relatedObjectType={Person.relatedObjectType}
                         relatedObjectUuid={person.uuid}
                         allowEdit={canEdit}

--- a/client/src/pages/reports/Show.tsx
+++ b/client/src/pages/reports/Show.tsx
@@ -8,7 +8,7 @@ import {
 import API from "api"
 import AppContext from "components/AppContext"
 import InstantAssessmentsContainerField from "components/assessments/instant/InstantAssessmentsContainerField"
-import AttachmentCard from "components/Attachment/AttachmentCard"
+import AttachmentsDetailView from "components/Attachment/AttachmentsDetailView"
 import ConfirmDestructive from "components/ConfirmDestructive"
 import { ReadonlyCustomFields } from "components/CustomFields"
 import DictionaryField from "components/DictionaryField"
@@ -753,14 +753,7 @@ const ReportShow = ({ setSearchQuery, pageDispatchers }: ReportShowProps) => {
                     label="Attachments"
                     component={FieldHelper.ReadonlyField}
                     humanValue={
-                      <div className="attachment-card-list">
-                        {report.attachments.map(attachment => (
-                          <AttachmentCard
-                            key={attachment.uuid}
-                            attachment={attachment}
-                          />
-                        ))}
-                      </div>
+                      <AttachmentsDetailView attachments={report.attachments} />
                     }
                   />
                 )}

--- a/client/src/pages/reports/Show.tsx
+++ b/client/src/pages/reports/Show.tsx
@@ -9,7 +9,6 @@ import API from "api"
 import AppContext from "components/AppContext"
 import InstantAssessmentsContainerField from "components/assessments/instant/InstantAssessmentsContainerField"
 import AttachmentsDetailView from "components/Attachment/AttachmentsDetailView"
-import UploadAttachment from "components/Attachment/UploadAttachment"
 import ConfirmDestructive from "components/ConfirmDestructive"
 import { ReadonlyCustomFields } from "components/CustomFields"
 import DictionaryField from "components/DictionaryField"
@@ -335,13 +334,6 @@ const ReportShow = ({ setSearchQuery, pageDispatchers }: ReportShowProps) => {
   const { loading, error, data, refetch } = API.useApiQuery(GQL_GET_REPORT, {
     uuid
   })
-
-  useEffect(() => {
-    if (data?.report) {
-      const report = new Report(data.report)
-      setAttachments(report.attachments || [])
-    }
-  }, [data])
   const { done, result } = useBoilerplate({
     loading,
     error,
@@ -352,6 +344,9 @@ const ReportShow = ({ setSearchQuery, pageDispatchers }: ReportShowProps) => {
     pageDispatchers
   })
   usePageTitle(data?.report?.intent || data?.report?.uuid)
+  useEffect(() => {
+    setAttachments(data?.report?.attachments || [])
+  }, [data])
   if (done) {
     return result
   }
@@ -441,9 +436,6 @@ const ReportShow = ({ setSearchQuery, pageDispatchers }: ReportShowProps) => {
   const hasAuthorizationGroups =
     report.authorizationGroups && report.authorizationGroups.length > 0
   const attachmentsEnabled = !Settings.fields.attachment.featureDisabled
-  const updateAttachments = newAttachments => {
-    setAttachments(newAttachments)
-  }
 
   return (
     <Formik
@@ -767,7 +759,7 @@ const ReportShow = ({ setSearchQuery, pageDispatchers }: ReportShowProps) => {
                     humanValue={
                       <AttachmentsDetailView
                         attachments={attachments}
-                        updateAttachments={updateAttachments}
+                        updateAttachments={setAttachments}
                         relatedObjectType={Report.relatedObjectType}
                         relatedObjectUuid={values.uuid}
                         allowEdit={canEdit}

--- a/client/tests/webdriver/baseSpecs/showLocation.spec.js
+++ b/client/tests/webdriver/baseSpecs/showLocation.spec.js
@@ -10,7 +10,7 @@ const LOCATION_WITH_REPORTS_UUID = "0855fb0a-995e-4a79-a132-4024ee2983ff" // Gen
 describe("Show location page", () => {
   describe("When on the show page of a location with attachment(s)", () => {
     it("We should see a container for Attachment List", async() => {
-      await ShowLocation.open(LOCATION_WITH_ATTACHMENTS_UUID)
+      await ShowLocation.openAsAdminUser(LOCATION_WITH_ATTACHMENTS_UUID)
       await (await ShowLocation.getAttachments()).waitForExist()
       await (await ShowLocation.getAttachments()).waitForDisplayed()
     })
@@ -18,6 +18,23 @@ describe("Show location page", () => {
       await (await ShowLocation.getCard()).waitForExist()
       await (await ShowLocation.getCard()).waitForDisplayed()
       expect(await ShowLocation.getCaption()).to.be.equal("Antarctica")
+    })
+    it("We should be able to edit the attachments", async() => {
+      const editAttachmentsButton =
+        await ShowLocation.getEditAttachmentsButton()
+      expect(await editAttachmentsButton.getText()).to.be.equal(
+        "Edit attachments"
+      )
+      await editAttachmentsButton.click()
+      expect(await editAttachmentsButton.getText()).to.be.equal(
+        "View attachments"
+      )
+
+      const editButton = await browser.$(".attachment-card .button-line a")
+      await expect(await editButton.getAttribute("href")).to.include(
+        "/attachments/f7cd5b02-ef73-4ee8-814b-c5a7a916685d/edit"
+      )
+      await editAttachmentsButton.click()
     })
     it("We can go to the show page of Attachment", async() => {
       await (await ShowLocation.getImageClick()).click()

--- a/client/tests/webdriver/baseSpecs/showOrganization.spec.js
+++ b/client/tests/webdriver/baseSpecs/showOrganization.spec.js
@@ -136,7 +136,7 @@ describe("Show organization page", () => {
 
   describe("When on the show page of an organization with authorizationGroup(s)", () => {
     it("We should see a table with authorizationGroups", async() => {
-      await ShowOrganization.open(ORGANIZATION_WITH_AG_UUID)
+      await ShowOrganization.openAsAdminUser(ORGANIZATION_WITH_AG_UUID)
       await (
         await ShowOrganization.getAuthorizationGroupsTable()
       ).waitForExist()
@@ -165,6 +165,23 @@ describe("Show organization page", () => {
       await (await ShowOrganization.getCard()).waitForExist()
       await (await ShowOrganization.getCard()).waitForDisplayed()
       expect(await ShowOrganization.getCaption()).to.be.equal("EF 2.2")
+    })
+    it("We should be able to edit the attachments", async() => {
+      const editAttachmentsButton =
+        await ShowOrganization.getEditAttachmentsButton()
+      expect(await editAttachmentsButton.getText()).to.be.equal(
+        "Edit attachments"
+      )
+      await editAttachmentsButton.click()
+      expect(await editAttachmentsButton.getText()).to.be.equal(
+        "View attachments"
+      )
+
+      const editButton = await browser.$(".attachment-card .button-line a")
+      await expect(await editButton.getAttribute("href")).to.include(
+        "/attachments/9ac41246-25ac-457c-b7d6-946c5f625f1f/edit"
+      )
+      await editAttachmentsButton.click()
     })
     it("We can go to the show page of Attachment", async() => {
       await (await ShowOrganization.getImageClick()).click()

--- a/client/tests/webdriver/baseSpecs/showPerson.spec.js
+++ b/client/tests/webdriver/baseSpecs/showPerson.spec.js
@@ -34,6 +34,22 @@ describe("Show person page", () => {
       await (await ShowPerson.getCard()).waitForDisplayed()
       expect(await ShowPerson.getCaption()).to.be.equal("Erin")
     })
+    it("We should be able to edit the attachments", async() => {
+      const editAttachmentsButton = await ShowPerson.getEditAttachmentsButton()
+      expect(await editAttachmentsButton.getText()).to.be.equal(
+        "Edit attachments"
+      )
+      await editAttachmentsButton.click()
+      expect(await editAttachmentsButton.getText()).to.be.equal(
+        "View attachments"
+      )
+
+      const editButton = await browser.$(".attachment-card .button-line a")
+      await expect(await editButton.getAttribute("href")).to.include(
+        "/attachments/13318e42-a0a3-438f-8ed5-dc16b1ef17bc/edit"
+      )
+      await editAttachmentsButton.click()
+    })
     it("We can go to the show page of Attachment", async() => {
       await (await ShowPerson.getImageClick()).click()
       await expect(await browser.getUrl()).to.include(

--- a/client/tests/webdriver/baseSpecs/showReport.spec.js
+++ b/client/tests/webdriver/baseSpecs/showReport.spec.js
@@ -43,6 +43,22 @@ describe("Show report page", () => {
       await (await ShowReport.getCard()).waitForDisplayed()
       expect(await ShowReport.getCaption()).to.be.equal("Arthur's test report")
     })
+    it("We should be able to edit the attachments", async() => {
+      const editAttachmentsButton = await ShowReport.getEditAttachmentsButton()
+      expect(await editAttachmentsButton.getText()).to.be.equal(
+        "Edit attachments"
+      )
+      await editAttachmentsButton.click()
+      expect(await editAttachmentsButton.getText()).to.be.equal(
+        "View attachments"
+      )
+
+      const editButton = await browser.$(".attachment-card .button-line a")
+      await expect(await editButton.getAttribute("href")).to.include(
+        "/attachments/f076406f-1a9b-4fc9-8ab2-cd2a138ec26d/edit"
+      )
+      await editAttachmentsButton.click()
+    })
     it("We can go to the show page of Attachment", async() => {
       await (await ShowReport.getImageClick()).click()
       await expect(await browser.getUrl()).to.include(

--- a/client/tests/webdriver/pages/location/showLocation.page.js
+++ b/client/tests/webdriver/pages/location/showLocation.page.js
@@ -15,6 +15,10 @@ class ShowLocation extends Page {
     return browser.$('//a[text()="Edit"]')
   }
 
+  async getEditAttachmentsButton() {
+    return await browser.$("#edit-attachments")
+  }
+
   async getSuccessMsg() {
     return browser.$('//div[text()="Location saved"]')
   }

--- a/client/tests/webdriver/pages/report/showReport.page.js
+++ b/client/tests/webdriver/pages/report/showReport.page.js
@@ -155,6 +155,10 @@ class ShowReport extends Page {
     return (await this.getReportModal()).$('//button[text()="Approve anyway"]')
   }
 
+  async getEditAttachmentsButton() {
+    return await browser.$("#edit-attachments")
+  }
+
   async getSuccessfullApprovalToast() {
     return browser.$('//div[text()="Successfully approved report."]')
   }

--- a/client/tests/webdriver/pages/showOrganization.page.js
+++ b/client/tests/webdriver/pages/showOrganization.page.js
@@ -87,6 +87,10 @@ class ShowOrganization extends Page {
     return browser.$("//a[text()='Edit']")
   }
 
+  async getEditAttachmentsButton() {
+    return await browser.$("#edit-attachments")
+  }
+
   async getEditableTasks() {
     return browser.$('div[id="fg-tasks"]')
   }

--- a/client/tests/webdriver/pages/showPerson.page.js
+++ b/client/tests/webdriver/pages/showPerson.page.js
@@ -47,6 +47,10 @@ class ShowPerson extends Page {
     return browser.$("#presetsButton")
   }
 
+  async getEditAttachmentsButton() {
+    return await browser.$("#edit-attachments")
+  }
+
   async getDefaultPreset() {
     return browser.$('//a[text()="Default"]')
   }


### PR DESCRIPTION
In order to edit attachments, users had to enter the edit page of any Person/Location/Organization/Report.
This allows the attachments to also be editable directly from the details page.

Closes [AB#1231](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1231)

#### User changes
- Users with the right permissions should be able to edit attachments directly on the Person/Location/Organization/Report details page.

#### Superuser changes
- None

#### Admin changes
- None

#### System admin changes
- [ ] application.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
- [x] described the user behavior in PR body
- [x] referenced/updated all related issues
- [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
- [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
- [ ] added and/or updated unit tests
- [x] added and/or updated e2e tests
- [ ] added and/or updated data migrations
- [ ] updated documentation
- [x] resolved all build errors and warnings
- [ ] opened debt issues for anything not resolved here
