### PR TITLE
Better way of displaying key outcomes and next steps

### DIFF
--- a/client/src/components/ListItems.tsx
+++ b/client/src/components/ListItems.tsx
@@ -1,12 +1,14 @@
 interface ListItemsProps {
-  value: string
+  value: string,
+  forceList?: boolean
 }
 
 const ListItems = ({
-  value
+  value,
+  forceList
 }: ListItemsProps) => {
   const items = value.split(/\r\n|\r|\n|\v|\f|\u2028|\u2029/)
-  if (items.length > 1) {
+  if (items.length > 1 || forceList) {
     return (
       <ul>
         {items.map((item, index) => (

--- a/client/src/components/ListItems.tsx
+++ b/client/src/components/ListItems.tsx
@@ -1,0 +1,23 @@
+interface ListItemsProps {
+  value: string
+}
+
+const ListItems = ({
+  value
+}: ListItemsProps) => {
+  const items = value.split(/\r\n|\r|\n|\v|\f|\u2028|\u2029/)
+  if (items.length > 1) {
+    return (
+      <ul>
+        {items.map((item, index) => (
+          <li key={index}>{item}</li>
+        ))}
+      </ul>
+    )
+  }
+  return (<>
+    {value} 
+  </>)
+}
+
+export default ListItems

--- a/client/src/components/ListItems.tsx
+++ b/client/src/components/ListItems.tsx
@@ -1,12 +1,11 @@
+import React from "react"
+
 interface ListItemsProps {
-  value: string,
+  value: string
   forceList?: boolean
 }
 
-const ListItems = ({
-  value,
-  forceList
-}: ListItemsProps) => {
+const ListItems = ({ value, forceList }: ListItemsProps) => {
   const items = value.split(/\r\n|\r|\n|\v|\f|\u2028|\u2029/)
   if (items.length > 1 || forceList) {
     return (
@@ -17,9 +16,7 @@ const ListItems = ({
       </ul>
     )
   }
-  return (<>
-    {value} 
-  </>)
+  return <>{value}</>
 }
 
 export default ListItems

--- a/client/src/components/ListItems.tsx
+++ b/client/src/components/ListItems.tsx
@@ -6,7 +6,7 @@ interface ListItemsProps {
 }
 
 const ListItems = ({ value, forceList }: ListItemsProps) => {
-  const items = value.split(/\r\n|\r|\n|\v|\f|\u2028|\u2029/)
+  const items = value.split(/[\r\n\v\f\u2028\u2029]+/)
   if (items.length > 1 || forceList) {
     return (
       <ul>

--- a/client/src/pages/reports/Show.tsx
+++ b/client/src/pages/reports/Show.tsx
@@ -16,6 +16,7 @@ import * as FieldHelper from "components/FieldHelper"
 import Fieldset from "components/Fieldset"
 import FindObjectsButton from "components/FindObjectsButton"
 import LinkTo from "components/LinkTo"
+import ListItems from "components/ListItems"
 import Messages from "components/Messages"
 import {
   DEFAULT_CUSTOM_FIELDS_PARENT,
@@ -623,6 +624,7 @@ const ReportShow = ({ setSearchQuery, pageDispatchers }: ReportShowProps) => {
                         name="keyOutcomes"
                         component={FieldHelper.ReadonlyField}
                         style={{ marginBottom: 0 }}
+                        humanValue={<ListItems value={report.keyOutcomes} />}
                       />
                       <DictionaryField
                         wrappedComponent={Field}
@@ -630,6 +632,7 @@ const ReportShow = ({ setSearchQuery, pageDispatchers }: ReportShowProps) => {
                         name="nextSteps"
                         component={FieldHelper.ReadonlyField}
                         style={{ marginBottom: 0 }}
+                        humanValue={<ListItems value={report.nextSteps} />}
                       />
                     </div>
                   }

--- a/client/tests/webdriver/baseSpecs/showReport.spec.js
+++ b/client/tests/webdriver/baseSpecs/showReport.spec.js
@@ -50,6 +50,26 @@ describe("Show report page", () => {
       )
     })
   })
+  describe("When on the show page of a with many key outcomes and next steps", () => {
+    it("We should see the key outcomes as a list", async() => {
+      const keyOutcomes = await ShowReport.getKeyOutcomesList()
+      expect(keyOutcomes).to.have.length(3)
+      expect(await keyOutcomes.map(async el => el.getText())).to.deep.equal([
+        "have reports in organizations",
+        "and test key outcomes",
+        "and the next steps"
+      ])
+    })
+    it("We should see the next steps as a list", async() => {
+      const nextSteps = await ShowReport.getNextStepsList()
+      expect(nextSteps).to.have.length(3)
+      expect(await nextSteps.map(async el => el.getText())).to.deep.equal([
+        "keep on testing!",
+        "and testing",
+        "and testing"
+      ])
+    })
+  })
 })
 
 const REPORT_CLASSIFICATION = "NATO UNCLASSIFIED"

--- a/client/tests/webdriver/pages/report/showReport.page.js
+++ b/client/tests/webdriver/pages/report/showReport.page.js
@@ -227,6 +227,14 @@ class ShowReport extends Page {
   async getClassificationFooter() {
     return browser.$("#footer-banner")
   }
+
+  async getKeyOutcomesList() {
+    return browser.$$("#keyOutcomes > ul > li")
+  }
+
+  async getNextStepsList() {
+    return browser.$$("#nextSteps > ul > li")
+  }
 }
 
 export default new ShowReport()

--- a/insertBaseData-psql.sql
+++ b/insertBaseData-psql.sql
@@ -969,7 +969,7 @@ INSERT INTO "reportPeople" ("personUuid", "reportUuid", "isPrimary", "isAuthor",
 
 INSERT INTO reports (uuid, "createdAt", "updatedAt", "locationUuid", intent, text, "nextSteps", "keyOutcomes", state, "engagementDate", atmosphere, "advisorOrganizationUuid", "interlocutorOrganizationUuid","customFields") VALUES
   ('59be259b-30b9-4d04-9e21-e8ceb58cbe9c', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, (SELECT uuid from locations where name='General Hospital'), 'A test report from Arthur', '',
-  'keep on testing!','have reports in organizations', 2, CURRENT_TIMESTAMP + INTERVAL '1 minute', 0,
+  E'keep on testing!\nand testing\rand testing',E'have reports in organizations\u2029and test key outcomes\u2028and the next steps', 2, CURRENT_TIMESTAMP + INTERVAL '1 minute', 0,
   (SELECT uuid FROM organizations where "shortName" = 'ANET Administrators'), (SELECT uuid FROM organizations WHERE "longName" LIKE 'Ministry of Interior'),
    '{"invisibleCustomFields":["formCustomFields.trainingEvent","formCustomFields.numberTrained","formCustomFields.levelTrained","formCustomFields.trainingDate","formCustomFields.assetsUsed"],"itemsAgreed":[],"echelons":"Ut enim ad minim veniam","systemProcess":"","multipleButtons":["advise"],"additionalEngagementNeeded":[],"relatedObject":null,"relatedReport":null}');
 INSERT INTO "reportPeople" ("personUuid", "reportUuid", "isPrimary", "isAuthor", "isInterlocutor") VALUES


### PR DESCRIPTION
When viewing fields like key outcomes and next steps, we should be able to see them as a list.
This issue addresses this by displaying items in a list whenever there are new lines in those fields

Mention [AB#1237](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1237)

There are likely changes to be made regarding this issue after the report style is updated


#### User changes
- See key outcomes and next steps in a list whenever there are new lines

#### Superuser changes
- None

#### Admin changes
- None

#### System admin changes
- [ ] application.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
- [x] described the user behavior in PR body
- [x] referenced/updated all related issues
- [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
- [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
- [ ] added and/or updated unit tests
- [x] added and/or updated e2e tests
- [ ] added and/or updated data migrations
- [ ] updated documentation
- [x] resolved all build errors and warnings
- [ ] opened debt issues for anything not resolved here
