### PR TITLE
Make engagements shown on the map clickable

### DIFF
--- a/client/src/components/aggregations/ReportsMapWidget.tsx
+++ b/client/src/components/aggregations/ReportsMapWidget.tsx
@@ -35,10 +35,8 @@ const ReportsMapWidget = ({
     const markerArray = []
     values.forEach(report => {
       if (Location.hasCoordinates(report.location)) {
-        let label = report?.intent 
-            ? `<a href="/reports/${report.uuid}">${_escape(report.intent)}</a>` 
-            : "<undefined>";
-        label += `<br/>@ <b>${_escape(report.location.name)}</b>`;
+        let label = `<a href="${Report.pathFor(report)}" target="_blank">${_escape(report.intent || "<undefined>")}</a>` // escape HTML in intent!
+        label += `<br/>@ <b>${_escape(report.location.name)}</b>` // escape HTML in locationName!
         markerArray.push({
           id: report.uuid,
           icon: getIcon(report),

--- a/client/src/components/aggregations/ReportsMapWidget.tsx
+++ b/client/src/components/aggregations/ReportsMapWidget.tsx
@@ -35,8 +35,10 @@ const ReportsMapWidget = ({
     const markerArray = []
     values.forEach(report => {
       if (Location.hasCoordinates(report.location)) {
-        let label = _escape(report.intent || "<undefined>") // escape HTML in intent!
-        label += `<br/>@ <b>${_escape(report.location.name)}</b>` // escape HTML in locationName!
+        let label = report?.intent 
+            ? `<a href="/reports/${report.uuid}">${_escape(report.intent)}</a>` 
+            : "<undefined>";
+        label += `<br/>@ <b>${_escape(report.location.name)}</b>`;
         markerArray.push({
           id: report.uuid,
           icon: getIcon(report),


### PR DESCRIPTION
When navigating through the map and finding an engagement, the user wasn't able to access the respective report.
This provides a direct way of opening the associated report

Closes [AB#1265](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1265)

#### User changes
- Ability to open a report when checking an engagement on the map

#### Superuser changes
- None

#### Admin changes
- None

#### System admin changes
- [ ] application.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
- [x] described the user behavior in PR body
- [x] referenced/updated all related issues
- [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
- [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
- [ ] added and/or updated unit tests
- [ ] added and/or updated e2e tests
- [ ] added and/or updated data migrations
- [ ] updated documentation
- [x] resolved all build errors and warnings
- [ ] opened debt issues for anything not resolved here
