### PR TITLE
Fix database connection leak

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -209,22 +209,28 @@ project.version = proc.text.trim();
 runtime {
 	options = ['--vm=server', '--strip-debug', '--compress', '2', '--no-header-files', '--no-man-pages']
 	modules = [
-		'java.sql',
+		'java.base',
+		'java.compiler',
 		'java.desktop',
-		'java.xml',
+		'java.instrument',
 		'java.logging',
 		'java.management',
+		'java.naming',
+		'java.net.http',
+		'java.prefs',
+		'java.rmi',
+		'java.scripting',
+		'java.security.jgss',
+		'java.security.sasl',
+		'java.sql',
+		'java.sql.rowset',
+		'java.transaction.xa',
+		'java.xml',
+		'java.xml.crypto',
 		'jdk.crypto.cryptoki',
 		'jdk.crypto.ec',
 		'jdk.jfr',
-		'jdk.unsupported',
-		'java.security.jgss',
-		'java.naming',
-		'java.transaction.xa',
-		'java.security.sasl',
-		'java.instrument',
-		'java.scripting',
-		'java.xml.crypto'
+		'jdk.unsupported'
 	]
 
 	jpackage {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,7 +9,7 @@ spring:
       max-request-size: -1
 
   jpa:
-    open-in-view: true
+    open-in-view: false
     hibernate:
       ddl-auto: none
 


### PR DESCRIPTION
Spring's `jpa.open-in-view` was opening database connections that weren't closed anymore (when directly streaming data to/from the database), but since we're using JDBI everywhere, disable it.
Also update the list of modules we're jpackage'ing with some extra ones suggested by jdeps.