### PR TITLE
Add date and time to engagement popup on geo-map

### DIFF
--- a/client/src/components/aggregations/ReportsMapWidget.tsx
+++ b/client/src/components/aggregations/ReportsMapWidget.tsx
@@ -3,7 +3,9 @@ import Leaflet, { ICON_TYPES } from "components/Leaflet"
 import _escape from "lodash/escape"
 import _isEmpty from "lodash/isEmpty"
 import { Location, Report } from "models"
+import moment from "moment"
 import React, { useMemo } from "react"
+import Settings from "settings"
 
 const getIcon = report => {
   if (report.state === Report.STATE.CANCELLED) {
@@ -35,8 +37,11 @@ const ReportsMapWidget = ({
     const markerArray = []
     values.forEach(report => {
       if (Location.hasCoordinates(report.location)) {
-        let label = `<a href="${Report.pathFor(report)}" target="_blank">${_escape(report.intent || "<undefined>")}</a>` // escape HTML in intent!
-        label += `<br/>@ <b>${_escape(report.location.name)}</b>` // escape HTML in locationName!
+        let label = `<b>Report:</b> <a href="${Report.pathFor(report)}" target="_blank">${_escape(report.intent || "<undefined>")}</a>` // escape HTML in intent!
+        label += `<br/><b>Location:</b> ${_escape(report.location.name)}` // escape HTML in locationName!
+        if (report.engagementDate) {
+          label += `<br/><b>Date:</b> ${moment(report.engagementDate).format(Report.getEngagementDateFormat())}`
+        }
         markerArray.push({
           id: report.uuid,
           icon: getIcon(report),


### PR DESCRIPTION
Update engagement popup on geo-map to display the date (and time) of the engagement.

Closes [AB#1272](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1272)

#### User changes
- The engagement popups on geo-map should display a date (and time, if so configured in the dictionary)

#### Superuser changes
- None

#### Admin changes
- None

#### System admin changes
- [ ] application.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
- [x] described the user behavior in PR body
- [x] referenced/updated all related issues
- [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
- [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
- [ ] added and/or updated unit tests
- [ ] added and/or updated e2e tests
- [ ] added and/or updated data migrations
- [ ] updated documentation
- [x] resolved all build errors and warnings
- [ ] opened debt issues for anything not resolved here
