### PR TITLE
Use ISO 8601 dates

### DIFF
--- a/anet-dictionary.yml
+++ b/anet-dictionary.yml
@@ -10,6 +10,7 @@ eventsIncludeStartAndEndTime: true
 calendarOptions:
   attendeesType: advisor
 
+useISO8601: true
 dateFormats:
   email:
     date: d MMMM yyyy Z

--- a/client/src/components/AdvisorReports/AdvisorReportsTableHead.tsx
+++ b/client/src/components/AdvisorReports/AdvisorReportsTableHead.tsx
@@ -18,7 +18,7 @@ const AdvisorReportsTableHead = (props: AdvisorReportsTableHeadProps) => {
     const keyAttended = `a-${week}`
     weekHeadings.push(
       <th colSpan={2} key={keyWeek}>
-        Week {week}
+        ISO Week {week}
       </th>
     )
     weekCols.push(<th key={keySubmitted}>Reports submitted</th>)

--- a/client/src/components/Calendar.tsx
+++ b/client/src/components/Calendar.tsx
@@ -6,6 +6,7 @@ import interactionPlugin from "@fullcalendar/interaction"
 import listPlugin from "@fullcalendar/list"
 import timeGridPlugin from "@fullcalendar/timegrid"
 import React from "react"
+import Settings from "settings"
 import "./Calendar.css"
 
 interface CalendarProps {
@@ -58,6 +59,8 @@ const Calendar = ({
     height="auto" // assume a natural height, no scrollbars will be used
     aspectRatio={3} // ratio of width-to-height
     fixedWeekCount={false}
+    firstDay={Settings.useISO8601 ? 1 : 0}
+    weekNumberCalculation={Settings.useISO8601 ? "ISO" : "local"}
     ref={calendarComponentRef}
     // set an absolute max; workaround for https://github.com/fullcalendar/fullcalendar/issues/5595
     dayMaxEvents={2}

--- a/client/src/components/CustomDateInput.tsx
+++ b/client/src/components/CustomDateInput.tsx
@@ -64,6 +64,10 @@ const CustomDateInput = ({
     ? Settings.dateFormats.forms.input.withTime
     : Settings.dateFormats.forms.input.date
   const inputFormat = dateFormats[0]
+  const dayPickerProps = {
+    weekStartsOn: Settings.useISO8601 ? 1 : 0,
+    firstWeekContainsDate: Settings.useISO8601 ? 4 : 1
+  }
   const timePrecision = !withTime ? undefined : TimePrecision.MINUTE
   const timePickerProps = !withTime
     ? undefined
@@ -101,6 +105,7 @@ const CustomDateInput = ({
       canClearSelection={canClearSelection}
       showActionsBar
       closeOnSelection={!withTime}
+      dayPickerProps={dayPickerProps}
       timePrecision={timePrecision}
       timePickerProps={timePickerProps}
       showTimezoneSelect={false}

--- a/client/src/components/ReportsByDayOfWeek.tsx
+++ b/client/src/components/ReportsByDayOfWeek.tsx
@@ -18,9 +18,9 @@ import ReportCollection, {
 import * as d3 from "d3"
 import _escape from "lodash/escape"
 import _isEqual from "lodash/isEqual"
+import moment from "moment"
 import React, { useMemo, useState } from "react"
 import { useResizeDetector } from "react-resize-detector"
-import Settings from "settings"
 
 const GQL_GET_REPORT_LIST = gql`
   query ($reportQuery: ReportSearchQueryInput) {
@@ -65,30 +65,13 @@ const Chart = ({
     if (!data) {
       return []
     }
-    // The server returns values from 1 to 7
-    const daysOfWeekInt = [1, 2, 3, 4, 5, 6, 7]
-    // The day of the week (returned by the server) with value 1 is Sunday
-    const daysOfWeek = [
-      "Sunday",
-      "Monday",
-      "Tuesday",
-      "Wednesday",
-      "Thursday",
-      "Friday",
-      "Saturday"
-    ]
+    // The server returns values from 0 to 6
+    const daysOfWeekInt = [0, 1, 2, 3, 4, 5, 6]
+    // The day of the week (returned by the server) with value 0 is Sunday
+    // See https://momentjs.com/docs/#/i18n/locale-data/
+    const daysOfWeek = moment.localeData().weekdays(false)
     // Set the order in which to display the days of the week
-    const displayOrderDaysOfWeek = Settings.useISO8601
-      ? [
-        "Monday",
-        "Tuesday",
-        "Wednesday",
-        "Thursday",
-        "Friday",
-        "Saturday",
-        "Sunday"
-      ]
-      : daysOfWeek
+    const displayOrderDaysOfWeek = moment.localeData().weekdays(true)
     const reportsList = data.reportList.list || []
     if (!reportsList.length) {
       return []

--- a/client/src/components/ReportsByDayOfWeek.tsx
+++ b/client/src/components/ReportsByDayOfWeek.tsx
@@ -20,6 +20,7 @@ import _escape from "lodash/escape"
 import _isEqual from "lodash/isEqual"
 import React, { useMemo, useState } from "react"
 import { useResizeDetector } from "react-resize-detector"
+import Settings from "settings"
 
 const GQL_GET_REPORT_LIST = gql`
   query ($reportQuery: ReportSearchQueryInput) {
@@ -77,15 +78,17 @@ const Chart = ({
       "Saturday"
     ]
     // Set the order in which to display the days of the week
-    const displayOrderDaysOfWeek = [
-      "Monday",
-      "Tuesday",
-      "Wednesday",
-      "Thursday",
-      "Friday",
-      "Saturday",
-      "Sunday"
-    ]
+    const displayOrderDaysOfWeek = Settings.useISO8601
+      ? [
+        "Monday",
+        "Tuesday",
+        "Wednesday",
+        "Thursday",
+        "Friday",
+        "Saturday",
+        "Sunday"
+      ]
+      : daysOfWeek
     const reportsList = data.reportList.list || []
     if (!reportsList.length) {
       return []

--- a/client/src/pages/admin/useractivities/UserActivitiesOverTime.tsx
+++ b/client/src/pages/admin/useractivities/UserActivitiesOverTime.tsx
@@ -26,6 +26,7 @@ import { Button, FormSelect, Table } from "react-bootstrap"
 import { connect } from "react-redux"
 import { useResizeDetector } from "react-resize-detector"
 import { useNavigate } from "react-router-dom"
+import Settings from "settings"
 import utils from "utils"
 
 const GQL_GET_USER_ACTIVITY_COUNT = gql`
@@ -42,7 +43,7 @@ const GQL_GET_USER_ACTIVITY_COUNT = gql`
 
 const AGGREGATION_DATE_FORMATS = {
   DAY: "D MMMM YYYY",
-  WEEK: "[week] W YYYY",
+  WEEK: Settings.useISO8601 ? "[week] W GGGG" : "[week] w gggg",
   MONTH: "MMMM YYYY"
 }
 const DEFAULT_AGGREGATION_PERIOD = "MONTH"

--- a/client/src/pages/admin/useractivities/UserActivitiesPerPeriod.tsx
+++ b/client/src/pages/admin/useractivities/UserActivitiesPerPeriod.tsx
@@ -29,6 +29,7 @@ import { Button, FormSelect, Table } from "react-bootstrap"
 import { connect } from "react-redux"
 import { useResizeDetector } from "react-resize-detector"
 import { useLocation } from "react-router-dom"
+import Settings from "settings"
 import utils from "utils"
 
 const GQL_GET_USER_ACTIVITY_LIST_BY_ORGANIZATION = gql`
@@ -83,7 +84,7 @@ const DEFAULT_PAGESIZE = 25
 
 const AGGREGATION_DATE_FORMATS = {
   DAY: "D MMMM YYYY",
-  WEEK: "[week] W YYYY",
+  WEEK: Settings.useISO8601 ? "[week] W GGGG" : "[week] w gggg",
   MONTH: "MMMM YYYY"
 }
 const DEFAULT_AGGREGATION_PERIOD = "MONTH"

--- a/client/src/periodUtils.tsx
+++ b/client/src/periodUtils.tsx
@@ -1,6 +1,16 @@
 import moment, { Moment } from "moment"
 import React, { useLayoutEffect } from "react"
 import { useResizeDetector } from "react-resize-detector"
+import Settings from "settings"
+
+// Configure local date formatting;
+// see https://momentjs.com/docs/#/customization/dow-doy/
+moment.updateLocale("en", {
+  week: {
+    dow: Settings.useISO8601 ? 1 : 0,
+    doy: Settings.useISO8601 ? 4 : 6
+  }
+})
 
 const ASSESSMENT_PERIOD_DATE_FORMAT = "YYYY-MM-DD"
 
@@ -37,8 +47,6 @@ const PERIOD_FORMAT = {
   END_LONG: "D MMMM YYYY"
 }
 
-const weekType = "isoWeek"
-
 const refMondayForBiweekly = "2021-01-04" // lets select 1st monday of 2021
 
 export const PERIOD_FACTORIES = {
@@ -52,8 +60,8 @@ export const PERIOD_FACTORIES = {
   }),
   [RECURRENCE_TYPE.BIWEEKLY]: (date, offset) => {
     // every biweekly period's start is even number of weeks apart from reference monday
-    const refMonday = moment(refMondayForBiweekly).startOf(weekType)
-    const curWeekMonday = date.clone().startOf(weekType)
+    const refMonday = moment(refMondayForBiweekly).startOf("week")
+    const curWeekMonday = date.clone().startOf("week")
 
     const diffInWeeks = refMonday.diff(curWeekMonday, "weeks")
     // current biweekly period's start has to be even number of weeks apart from reference monday
@@ -65,7 +73,7 @@ export const PERIOD_FACTORIES = {
     const curBiweeklyEnd = curBiweeklyStart
       .clone()
       .add(1, "weeks")
-      .endOf(weekType)
+      .endOf("week")
 
     return {
       start: curBiweeklyStart.clone().subtract(2 * offset, "weeks"),

--- a/src/main/java/mil/dds/anet/beans/Report.java
+++ b/src/main/java/mil/dds/anet/beans/Report.java
@@ -186,7 +186,7 @@ public class Report extends AbstractCustomizableAnetBean
   }
 
   /**
-   * Returns an Integer value from the set (1,2,3,4,5,6,7) in accordance with week days [Sunday,
+   * Returns an Integer value from the set (0,1,2,3,4,5,6) in accordance with week days [Sunday,
    * Monday, Tuesday, Wednesday, Thursday, Friday, Saturday].
    *
    * @return Integer engagement day of week

--- a/src/main/java/mil/dds/anet/resources/ReportResource.java
+++ b/src/main/java/mil/dds/anet/resources/ReportResource.java
@@ -13,7 +13,6 @@ import java.io.StringWriter;
 import java.lang.invoke.MethodHandles;
 import java.time.DayOfWeek;
 import java.time.Instant;
-import java.time.format.DateTimeFormatter;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -786,7 +785,6 @@ public class ReportResource {
         ConfidentialityRecord.create(siteClassification).toString());
     emailContext.put("SECURITY_BANNER_COLOR", siteClassification.get("color"));
     emailContext.put(DailyRollupEmail.SHOW_REPORT_TEXT_FLAG, showReportText);
-    logger.error("GJ: context={}", emailContext);
     addConfigToContext(emailContext);
 
     try {
@@ -1042,17 +1040,14 @@ public class ReportResource {
   }
 
   private void addConfigToContext(Map<String, Object> context) {
-    context.put("dateFormatter",
-        DateTimeFormatter.ofPattern((String) dict.getDictionaryEntry("dateFormats.email.date"))
-            .withZone(DaoUtils.getServerNativeZoneId()));
-    context.put("engagementsIncludeTimeAndDuration",
-        Boolean.TRUE.equals(dict.getDictionaryEntry("engagementsIncludeTimeAndDuration")));
-    final String edtfPattern = (String) dict.getDictionaryEntry(
-        Boolean.TRUE.equals(dict.getDictionaryEntry("engagementsIncludeTimeAndDuration"))
-            ? "dateFormats.email.withTime"
-            : "dateFormats.email.date");
-    context.put("engagementDateFormatter",
-        DateTimeFormatter.ofPattern(edtfPattern).withZone(DaoUtils.getServerNativeZoneId()));
+    context.put("dateFormatter", Utils.getDateFormatter(dict, "dateFormats.email.date"));
+    context.put("dateTimeFormatter",
+        Utils.getDateTimeFormatter(dict, "dateFormats.email.withTime"));
+    final boolean engagementsIncludeTimeAndDuration =
+        Boolean.TRUE.equals(dict.getDictionaryEntry("engagementsIncludeTimeAndDuration"));
+    context.put("engagementsIncludeTimeAndDuration", engagementsIncludeTimeAndDuration);
+    context.put("engagementDateFormatter", Utils.getEngagementDateFormatter(dict,
+        engagementsIncludeTimeAndDuration, "dateFormats.email.withTime", "dateFormats.email.date"));
     @SuppressWarnings("unchecked")
     final Map<String, Object> fields = (Map<String, Object>) dict.getDictionaryEntry("fields");
     context.put("fields", fields);

--- a/src/main/java/mil/dds/anet/search/pg/PostgresqlReportSearcher.java
+++ b/src/main/java/mil/dds/anet/search/pg/PostgresqlReportSearcher.java
@@ -21,9 +21,8 @@ public class PostgresqlReportSearcher extends AbstractReportSearcher {
   private final String isoDowFormat;
 
   public PostgresqlReportSearcher(DatabaseHandler databaseHandler) {
-    super(databaseHandler,
-        new PostgresqlSearchQueryBuilder<Report, ReportSearchQuery>("PostgresqlReportSearch"));
-    this.isoDowFormat = "EXTRACT(DOW FROM %s)+1"; // We need Sunday=1, Monday=2, etc.
+    super(databaseHandler, new PostgresqlSearchQueryBuilder<>("PostgresqlReportSearch"));
+    this.isoDowFormat = "EXTRACT(DOW FROM %s)"; // Sunday=0, Monday=1, etc.
   }
 
   @Transactional

--- a/src/main/java/mil/dds/anet/threads/AnetEmailWorker.java
+++ b/src/main/java/mil/dds/anet/threads/AnetEmailWorker.java
@@ -11,7 +11,6 @@ import jakarta.mail.internet.InternetAddress;
 import java.io.StringWriter;
 import java.lang.invoke.MethodHandles;
 import java.time.Instant;
-import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -30,7 +29,6 @@ import mil.dds.anet.config.AnetDictionary;
 import mil.dds.anet.database.EmailDao;
 import mil.dds.anet.database.JobHistoryDao;
 import mil.dds.anet.database.mappers.MapperUtils;
-import mil.dds.anet.utils.DaoUtils;
 import mil.dds.anet.utils.Utils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.simplejavamail.api.email.Email;
@@ -140,20 +138,14 @@ public class AnetEmailWorker extends AbstractWorker {
         ConfidentialityRecord.create(siteClassification).toString());
     emailContext.put("SECURITY_BANNER_COLOR", siteClassification.get("color"));
     emailContext.put("SUPPORT_EMAIL_ADDR", dict.getDictionaryEntry("SUPPORT_EMAIL_ADDR"));
-    emailContext.put("dateFormatter",
-        DateTimeFormatter.ofPattern((String) dict.getDictionaryEntry("dateFormats.email.date"))
-            .withZone(DaoUtils.getServerLocalZoneId()));
+    emailContext.put("dateFormatter", Utils.getDateFormatter(dict, "dateFormats.email.date"));
     emailContext.put("dateTimeFormatter",
-        DateTimeFormatter.ofPattern((String) dict.getDictionaryEntry("dateFormats.email.withTime"))
-            .withZone(DaoUtils.getServerLocalZoneId()));
+        Utils.getDateTimeFormatter(dict, "dateFormats.email.withTime"));
     final boolean engagementsIncludeTimeAndDuration =
         Boolean.TRUE.equals(dict.getDictionaryEntry("engagementsIncludeTimeAndDuration"));
     emailContext.put("engagementsIncludeTimeAndDuration", engagementsIncludeTimeAndDuration);
-    final String edtfPattern = (String) dict
-        .getDictionaryEntry(engagementsIncludeTimeAndDuration ? "dateFormats.email.withTime"
-            : "dateFormats.email.date");
-    emailContext.put("engagementDateFormatter",
-        DateTimeFormatter.ofPattern(edtfPattern).withZone(DaoUtils.getServerLocalZoneId()));
+    emailContext.put("engagementDateFormatter", Utils.getEngagementDateFormatter(dict,
+        engagementsIncludeTimeAndDuration, "dateFormats.email.withTime", "dateFormats.email.date"));
     @SuppressWarnings("unchecked")
     final Map<String, Object> fields = (Map<String, Object>) dict.getDictionaryEntry("fields");
     emailContext.put("fields", fields);

--- a/src/main/java/mil/dds/anet/utils/Utils.java
+++ b/src/main/java/mil/dds/anet/utils/Utils.java
@@ -14,12 +14,14 @@ import io.leangen.graphql.execution.ResolutionEnvironment;
 import jakarta.annotation.Nullable;
 import java.lang.invoke.MethodHandles;
 import java.nio.charset.StandardCharsets;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -33,6 +35,7 @@ import mil.dds.anet.beans.ApprovalStep.ApprovalStepType;
 import mil.dds.anet.beans.Location;
 import mil.dds.anet.beans.Organization;
 import mil.dds.anet.beans.Task;
+import mil.dds.anet.config.AnetDictionary;
 import mil.dds.anet.config.ApplicationContextProvider;
 import mil.dds.anet.database.ApprovalStepDao;
 import mil.dds.anet.database.mappers.MapperUtils;
@@ -618,5 +621,30 @@ public class Utils {
   public static String getEmailNetworkForNotifications() {
     return (String) ApplicationContextProvider.getDictionary()
         .getDictionaryEntry("emailNetworkForNotifications");
+  }
+
+  private static Locale getLocaleForDateFormatters(AnetDictionary dict) {
+    // For ISO 8601, Monday is the first day of the week, else it is Sunday
+    final var useISO8601 = Boolean.TRUE.equals(dict.getDictionaryEntry("useISO8601"));
+    // Pretty ugly, as it always assumes English, but at least we can control the first day of the
+    // week (and the first week of the year) this way…
+    return new Locale("en", useISO8601 ? "GB" : "US");
+  }
+
+  public static DateTimeFormatter getDateFormatter(AnetDictionary dict, String key) {
+    return DateTimeFormatter.ofPattern((String) dict.getDictionaryEntry(key))
+        .withLocale(getLocaleForDateFormatters(dict)).withZone(DaoUtils.getServerLocalZoneId());
+  }
+
+  public static DateTimeFormatter getDateTimeFormatter(AnetDictionary dict, String key) {
+    return DateTimeFormatter.ofPattern((String) dict.getDictionaryEntry(key))
+        .withLocale(getLocaleForDateFormatters(dict)).withZone(DaoUtils.getServerLocalZoneId());
+  }
+
+  public static DateTimeFormatter getEngagementDateFormatter(AnetDictionary dict,
+      boolean includeTime, String dateKey, String dateTimeKey) {
+    final String pattern = (String) dict.getDictionaryEntry(includeTime ? dateTimeKey : dateKey);
+    return DateTimeFormatter.ofPattern(pattern).withLocale(getLocaleForDateFormatters(dict))
+        .withZone(DaoUtils.getServerLocalZoneId());
   }
 }

--- a/src/main/resources/anet-schema.yml
+++ b/src/main/resources/anet-schema.yml
@@ -409,6 +409,7 @@ required:
   - CONNECTION_ERROR_MSG
   - VERSION_CHANGED_MSG
   - SUPPORT_EMAIL_ADDR
+  - useISO8601
   - dateFormats
   - calendarOptions
   - reportWorkflow
@@ -459,6 +460,11 @@ properties:
     default: false
     title: Whether events also include a time and a duration
     description: Used for events; if set to `true`, you might also want to supply dateFormats.forms.inputWithTime and dateFormats.forms.longWithTime
+
+  useISO8601:
+    type: boolean
+    title: Use ISO 8601?
+    description: Whether to use ISO 8601 (for weekdays and week numbering) or US format.
 
   dateFormats:
     type: object

--- a/src/test/java/mil/dds/anet/test/integration/db/PendingAssessmentsNotificationWorkerTest.java
+++ b/src/test/java/mil/dds/anet/test/integration/db/PendingAssessmentsNotificationWorkerTest.java
@@ -188,7 +188,7 @@ class PendingAssessmentsNotificationWorkerTest {
     };
     for (final Object[] testItem : testData) {
       final AssessmentDates assessmentDates =
-          new AssessmentDates(toInstant(testItem[0]), (Recurrence) testItem[1]);
+          new AssessmentDates(toInstant(testItem[0]), (Recurrence) testItem[1], true);
       logger.debug("checking {} against {}", testItem, assessmentDates);
       assertThat(assessmentDates.getAssessmentDate()).isEqualTo(toInstant(testItem[2]));
       assertThat(assessmentDates.getNotificationDate()).isEqualTo(toInstant(testItem[3]));

--- a/src/test/java/mil/dds/anet/test/resources/ReportResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/ReportResourceTest.java
@@ -2076,7 +2076,7 @@ public class ReportResourceTest extends AbstractResourceTest {
     final AnetBeanList_Report reportResults = runSearchQuery(query);
     assertThat(reportResults).isNotNull();
 
-    final List<Integer> daysOfWeek = Arrays.asList(1, 2, 3, 4, 5, 6, 7);
+    final List<Integer> daysOfWeek = Arrays.asList(0, 1, 2, 3, 4, 5, 6);
     final List<Report> reports = reportResults.getList();
     for (Report rpt : reports) {
       assertThat(rpt.getEngagementDayOfWeek()).isIn(daysOfWeek);

--- a/testDictionaries/no-custom-fields.yml
+++ b/testDictionaries/no-custom-fields.yml
@@ -9,6 +9,7 @@ eventsIncludeStartAndEndTime: true
 calendarOptions:
   attendeesType: advisor
 
+useISO8601: true
 dateFormats:
   email:
     date: d MMMM yyyy Z


### PR DESCRIPTION
Add a dictionary setting that allows to use ISO 8601 for week numbering and the first day of the week.

Closes [AB#1274](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1274)

#### User changes
- Depending on the dictionary setting, weeks start on Monday (ISO 8601) or Sunday (as before).

#### Superuser changes
- None

#### Admin changes
- None

#### System admin changes
- [x] application.yml or anet-dictionary.yml needs change
  Add this setting to the dictionary:
  ```yaml
  […]
  useISO8601: true
  dateFormats:
    […]
  ```
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
- [x] described the user behavior in PR body
- [x] referenced/updated all related issues
- [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
- [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
- [x] added and/or updated unit tests
- [ ] added and/or updated e2e tests
- [ ] added and/or updated data migrations
- [ ] updated documentation
- [x] resolved all build errors and warnings
- [ ] opened debt issues for anything not resolved here
