### PR TITLE
Add context to event and event series calendar

### DIFF
--- a/client/src/components/EventCalendar.tsx
+++ b/client/src/components/EventCalendar.tsx
@@ -31,6 +31,39 @@ const GQL_GET_EVENT_LIST = gql`
           lat
           lng
         }
+        reports {
+          uuid
+          intent
+          primaryAdvisor {
+            uuid
+            name
+          }
+          primaryInterlocutor {
+            uuid
+            name
+          }
+          advisorOrg {
+            uuid
+            shortName
+            longName
+            identificationCode
+          }
+          interlocutorOrg {
+            uuid
+            shortName
+            longName
+            identificationCode
+          }
+          engagementDate
+          duration
+          state
+          location {
+            uuid
+            name
+            lat
+            lng
+          }
+        }
       }
     }
   }

--- a/client/src/components/EventCalendar.tsx
+++ b/client/src/components/EventCalendar.tsx
@@ -1,7 +1,6 @@
 import { gql } from "@apollo/client"
 import API from "api"
 import {
-  createCalendarEventFromEvent,
   createCalendarEventFromReport,
   eventsToCalendarEvents
 } from "components/aggregations/utils"
@@ -117,20 +116,14 @@ const EventCalendar = ({
         showLoading()
         apiPromise.current = apiPromise.current.then(data => {
           // Extended props contains both events and reports
-          const results = data
-            .map(d => d.extendedProps)
-            .map(calendarEvent => {
-              if (calendarEvent.engagementDate) {
-                // This is a report, recompute
-                return createCalendarEventFromReport(
-                  calendarEvent,
-                  attendeeType === ATTENDEE_TYPE_INTERLOCUTOR
-                )
-              } else {
-                // This is an event, stays as is
-                return createCalendarEventFromEvent(calendarEvent)
-              }
-            })
+          const results = data.map(d =>
+            d.extendedProps.engagementDate
+              ? createCalendarEventFromReport(
+                d.extendedProps,
+                attendeeType === ATTENDEE_TYPE_INTERLOCUTOR
+              )
+              : d
+          )
           hideLoading()
           return results
         })

--- a/client/src/components/EventCollection.tsx
+++ b/client/src/components/EventCollection.tsx
@@ -3,8 +3,14 @@ import EventCalendar from "components/EventCalendar"
 import EventMap from "components/EventMap"
 import EventSummary from "components/EventSummary"
 import EventTable from "components/EventTable"
+import {
+  ATTENDEE_TYPE_ADVISOR,
+  ATTENDEE_TYPE_INTERLOCUTOR
+} from "components/ReportCalendar"
+import pluralize from "pluralize"
 import React, { useState } from "react"
 import { Button } from "react-bootstrap"
+import Settings from "settings"
 
 export const FORMAT_CALENDAR = "calendar"
 export const FORMAT_MAP = "map"
@@ -32,6 +38,9 @@ const EventCollection = ({
 }: EventCollectionProps) => {
   const [viewFormat, setViewFormat] = useState(viewFormats[0])
   const showHeader = viewFormats.length > 1
+  const [calendarAttendeeType, setCalendarAttendeeType] = useState(
+    Settings.calendarOptions.attendeesType
+  )
   return (
     <div className="event-collection">
       <div>
@@ -65,6 +74,26 @@ const EventCollection = ({
                     </Button>
                   )}
                 </ButtonToggleGroup>
+                {viewFormat === FORMAT_CALENDAR && (
+                  <ButtonToggleGroup
+                    value={calendarAttendeeType}
+                    onChange={setCalendarAttendeeType}
+                    className="float-end"
+                  >
+                    <Button
+                      value={ATTENDEE_TYPE_ADVISOR}
+                      variant="outline-secondary"
+                    >
+                      {pluralize(Settings.fields.advisor.person.name)}
+                    </Button>
+                    <Button
+                      value={ATTENDEE_TYPE_INTERLOCUTOR}
+                      variant="outline-secondary"
+                    >
+                      {pluralize(Settings.fields.interlocutor.person.name)}
+                    </Button>
+                  </ButtonToggleGroup>
+                )}
               </>
             )}
           </header>
@@ -84,7 +113,10 @@ const EventCollection = ({
             />
           )}
           {viewFormat === FORMAT_CALENDAR && (
-            <EventCalendar queryParams={queryParams} />
+            <EventCalendar
+              queryParams={queryParams}
+              attendeeType={calendarAttendeeType}
+            />
           )}
           {viewFormat === FORMAT_MAP && (
             <EventMap

--- a/client/src/components/ReportCalendar.tsx
+++ b/client/src/components/ReportCalendar.tsx
@@ -1,6 +1,9 @@
 import { gql } from "@apollo/client"
 import API from "api"
-import { reportsToEvents } from "components/aggregations/utils"
+import {
+  createCalendarEventFromReport,
+  reportsToEvents
+} from "components/aggregations/utils"
 import Calendar from "components/Calendar"
 import { GRAPHQL_ENTITY_AVATAR_FIELDS } from "components/Model"
 import { PageDispatchersPropType } from "components/Page"
@@ -101,12 +104,14 @@ const ReportCalendar = ({
         prevAttendeeType.current = attendeeType
         showLoading()
         apiPromise.current = apiPromise.current.then(data => {
-          // Each report is stored in the extendedProps
-          const reports = data.map(d => d.extendedProps)
-          const results = reportsToEvents(
-            reports,
-            attendeeType === ATTENDEE_TYPE_INTERLOCUTOR,
-            event
+          // Extended props contains both events and reports
+          const results = data.map(d =>
+            d.extendedProps.engagementDate
+              ? createCalendarEventFromReport(
+                d.extendedProps,
+                attendeeType === ATTENDEE_TYPE_INTERLOCUTOR
+              )
+              : d
           )
           hideLoading()
           return results

--- a/client/src/components/ReportCalendar.tsx
+++ b/client/src/components/ReportCalendar.tsx
@@ -62,13 +62,15 @@ interface ReportCalendarProps {
   queryParams?: any
   setTotalCount?: (...args: unknown[]) => unknown
   attendeeType: string
+  event?: Event
 }
 
 const ReportCalendar = ({
   pageDispatchers: { showLoading, hideLoading },
   queryParams,
   setTotalCount,
-  attendeeType
+  attendeeType,
+  event
 }: ReportCalendarProps) => {
   const navigate = useNavigate()
   const prevReportQuery = useRef(null)
@@ -103,7 +105,8 @@ const ReportCalendar = ({
           const reports = data.map(d => d.extendedProps)
           const results = reportsToEvents(
             reports,
-            attendeeType === ATTENDEE_TYPE_INTERLOCUTOR
+            attendeeType === ATTENDEE_TYPE_INTERLOCUTOR,
+            event
           )
           hideLoading()
           return results
@@ -130,7 +133,8 @@ const ReportCalendar = ({
       }
       const results = reportsToEvents(
         reports,
-        attendeeType === ATTENDEE_TYPE_INTERLOCUTOR
+        attendeeType === ATTENDEE_TYPE_INTERLOCUTOR,
+        event
       )
       hideLoading()
       return results

--- a/client/src/components/ReportCollection.tsx
+++ b/client/src/components/ReportCollection.tsx
@@ -38,6 +38,7 @@ interface ReportCollectionProps {
   width?: number | string
   height?: number | string
   marginBottom?: number | string
+  event?: Event
 }
 
 const ReportCollection = ({
@@ -58,7 +59,8 @@ const ReportCollection = ({
   mapId,
   width,
   height,
-  marginBottom
+  marginBottom,
+  event
 }: ReportCollectionProps) => {
   const [numberOfPeriods, setNumberOfPeriods] = useState(3)
   const contRef = useResponsiveNumberOfPeriods(setNumberOfPeriods)
@@ -145,6 +147,7 @@ const ReportCollection = ({
               queryParams={queryParams}
               setTotalCount={setTotalCount}
               attendeeType={calendarAttendeeType}
+              event={event}
             />
           )}
           {viewFormat === FORMAT_TABLE && (

--- a/client/src/components/aggregations/utils.tsx
+++ b/client/src/components/aggregations/utils.tsx
@@ -200,31 +200,28 @@ export const GET_CALENDAR_EVENTS_FROM = {
 }
 
 export function reportsToEvents(reports, showInterlocutors, event) {
-  // Get reports first
-  const result = reports
-    .map(r => {
-      return createCalendarEventFromReport(r, showInterlocutors)
-    })
-    .sort(
-      (r1, r2) =>
-        // first the all-day events
-        r2.allDay - r1.allDay ||
-        // then (for events that are not all-day)
-        (!r1.allDay &&
-          // ascending by start date
-          (r1.start - r2.start ||
-            // ascending by end date
-            r1.end - r2.end)) ||
-        // and finally ascending by title
-        r1.title.localeCompare(r2.title)
-    )
-
-  // Do we have an event to show as well?
-  if (event) {
-    result.push(createCalendarEventFromEvent(event))
-  }
-
-  return result
+  // Do we have an event to show?
+  const result = event ? [createCalendarEventFromEvent(event)] : []
+  // Get reports
+  return result.concat(
+    reports
+      .map(r => {
+        return createCalendarEventFromReport(r, showInterlocutors)
+      })
+      .sort(
+        (r1, r2) =>
+          // first the all-day events
+          r2.allDay - r1.allDay ||
+          // then (for events that are not all-day)
+          (!r1.allDay &&
+            // ascending by start date
+            (r1.start - r2.start ||
+              // ascending by end date
+              r1.end - r2.end)) ||
+          // and finally ascending by title
+          r1.title.localeCompare(r2.title)
+      )
+  )
 }
 
 export function eventsToCalendarEvents(events, showInterlocutors) {

--- a/client/src/components/aggregations/utils.tsx
+++ b/client/src/components/aggregations/utils.tsx
@@ -227,11 +227,7 @@ export function reportsToEvents(reports, showInterlocutors, event) {
 export function eventsToCalendarEvents(events, showInterlocutors) {
   // Show in the calendar all events and all its reports
   return events
-    .flatMap(event => {
-      return [createCalendarEventFromEvent(event)].concat(
-        reportsToEvents(event.reports, showInterlocutors, null)
-      )
-    })
+    .flatMap(event => createCalendarEventFromEvent(event))
     .sort(
       (e1, e2) =>
         // ascending by start date
@@ -240,6 +236,11 @@ export function eventsToCalendarEvents(events, showInterlocutors) {
         e1.end - e1.end ||
         // and finally ascending by title
         e1.title.localeCompare(e2.title)
+    )
+    .concat(
+      events.flatMap(event =>
+        reportsToEvents(event.reports, showInterlocutors, null)
+      )
     )
 }
 

--- a/client/src/components/aggregations/utils.tsx
+++ b/client/src/components/aggregations/utils.tsx
@@ -233,7 +233,7 @@ export function eventsToCalendarEvents(events, showInterlocutors) {
         // ascending by start date
         e1.start - e2.start ||
         // ascending by end date
-        e1.end - e1.end ||
+        e1.end - e2.end ||
         // and finally ascending by title
         e1.title.localeCompare(e2.title)
     )

--- a/client/src/pages/events/Show.tsx
+++ b/client/src/pages/events/Show.tsx
@@ -349,6 +349,7 @@ const EventShow = ({ pageDispatchers }: EventShowProps) => {
                   paginationKey={`r_${uuid}`}
                   queryParams={reportQueryParams}
                   mapId="reports"
+                  event={event}
                 />
               </Fieldset>
             </Form>

--- a/insertBaseData-psql.sql
+++ b/insertBaseData-psql.sql
@@ -826,11 +826,11 @@ INSERT INTO "reportPeople" ("personUuid", "reportUuid", "isPrimary", "isAuthor",
   ((SELECT uuid FROM people where name = 'Steveson, Steve'), '9bb1861c-1f55-4a1b-bd3d-3c1f56d739b5', TRUE, FALSE, TRUE),
   ((SELECT uuid FROM people where "domainUsername" = 'jack'), '9bb1861c-1f55-4a1b-bd3d-3c1f56d739b5', TRUE, TRUE, FALSE);
 
-INSERT INTO reports (uuid, "createdAt", "updatedAt", "locationUuid", intent, text, "keyOutcomes", "nextSteps", state, "engagementDate", atmosphere, "advisorOrganizationUuid", "interlocutorOrganizationUuid") VALUES
+INSERT INTO reports (uuid, "createdAt", "updatedAt", "locationUuid", intent, text, "keyOutcomes", "nextSteps", state, "engagementDate", duration, atmosphere, "advisorOrganizationUuid", "interlocutorOrganizationUuid") VALUES
   ('86e4cf7e-c0ae-4bd9-b1ad-f2c65ca0f600', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, (select uuid from locations where name='General Hospital'), 'Run through FY2016 Numbers on tool usage',
   'Today we discussed the fiscal details of how spreadsheets break down numbers into rows and columns and then text is used to fill up space on a web page, it was very interesting and other adjectives',
   'we read over the spreadsheets for the FY17 Budget',
-  'meet with him again :(', 2, '2020-06-01', 0,
+  'meet with him again :(', 2, '2024-01-10 12:30', 180, 0,
   (SELECT uuid FROM organizations where "shortName" = 'EF 2.1'), (SELECT uuid FROM organizations WHERE "longName" LIKE 'Ministry of Defense'));
 INSERT INTO "reportPeople" ("personUuid", "reportUuid", "isPrimary", "isAuthor", "isInterlocutor") VALUES
   ((SELECT uuid FROM people where name = 'Steveson, Steve'), '86e4cf7e-c0ae-4bd9-b1ad-f2c65ca0f600', TRUE, FALSE, TRUE),


### PR DESCRIPTION
When in the events show page, the reports calendar will now show the event as well as the reports.
When in the event series show page, the events calendar will also show all the events reports.

Closes [AB#1269](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1269)

#### User changes
- When in the events show page, the reports calendar will now show the event as well as the reports.
- When in the event series show page, the events calendar will also show all the events reports.

#### Superuser changes
- None

#### Admin changes
- None

#### System admin changes
- [ ] application.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
- [x] described the user behavior in PR body
- [x] referenced/updated all related issues
- [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
- [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
- [ ] added and/or updated unit tests
- [ ] added and/or updated e2e tests
- [ ] added and/or updated data migrations
- [ ] updated documentation
- [x] resolved all build errors and warnings
- [ ] opened debt issues for anything not resolved here
