### PR TITLE
Pin chromedriver at v131

### DIFF
--- a/client/config/wdio.config.js
+++ b/client/config/wdio.config.js
@@ -64,7 +64,7 @@ const config = {
       // 5 instances get started at a time.
       maxInstances: 5,
       browserName: "chrome",
-      // browserVersion: "stable",
+      browserVersion: "131", // or "stable"
       acceptInsecureCerts: true,
       "goog:chromeOptions": {
         // run in incognito mode
@@ -73,9 +73,12 @@ const config = {
         // while scrolling some form fields might go under the header and
         // therefore we would get failing tests related to these fields.
         args: [
-          "--headless",
+          "--headless=old",
           "--disable-gpu",
           "--disable-search-engine-choice-screen",
+          "--disable-dev-shm-usage",
+          "--disable-browser-side-navigation",
+          "--no-sandbox",
           "--window-size=1600,1200"
         ],
         prefs: {

--- a/client/tests/util/test.js
+++ b/client/tests/util/test.js
@@ -90,12 +90,17 @@ test.beforeEach(t => {
   let builder = new webdriver.Builder()
   if (testEnv === "local") {
     const chrome = require("selenium-webdriver/chrome")
-    const options = new chrome.Options(capabilities).addArguments([
-      "--headless",
-      "--disable-gpu",
-      "--disable-search-engine-choice-screen",
-      "--window-size=1600,1200"
-    ])
+    const options = new chrome.Options(capabilities)
+      .setBrowserVersion("131") // or "stable"
+      .addArguments([
+        "--headless=old",
+        "--disable-gpu",
+        "--disable-search-engine-choice-screen",
+        "--disable-dev-shm-usage",
+        "--disable-browser-side-navigation",
+        "--no-sandbox",
+        "--window-size=1600,1200"
+      ])
     builder = builder
       .forBrowser(webdriver.Browser.CHROME)
       .setChromeOptions(options)


### PR DESCRIPTION
And use old headless mode; it should reduce the number of intermittent test failures. Also set some extra Chrome options.