### PR TITLE
Allow advanced search for multiple tasks

### DIFF
--- a/client/src/components/SearchFilters.tsx
+++ b/client/src/components/SearchFilters.tsx
@@ -30,36 +30,26 @@ import ReportStateFilter, {
 import SelectFilter, {
   deserialize as deserializeSelectFilter
 } from "components/advancedSearch/SelectFilter"
-import TaskFilter, {
-  deserialize as deserializeTaskFilter
+import {
+  deserializeMulti as deserializeTaskMultiFilter,
+  TaskMultiFilter
 } from "components/advancedSearch/TaskFilter"
 import {
   CountryOverlayRow,
   EventSeriesOverlayRow,
   PersonDetailedOverlayRow,
-  PositionOverlayRow,
-  TaskOverlayRow
+  PositionOverlayRow
 } from "components/advancedSelectWidget/AdvancedSelectOverlayRow"
 import AppContext from "components/AppContext"
-import { getBreadcrumbTrailAsText } from "components/BreadcrumbTrail"
 import DictionaryField from "components/DictionaryField"
 import Model from "components/Model"
 import _isEmpty from "lodash/isEmpty"
 import _pickBy from "lodash/pickBy"
-import {
-  Event,
-  EventSeries,
-  Location,
-  Person,
-  Position,
-  Report,
-  Task
-} from "models"
+import { Event, EventSeries, Location, Person, Position, Report } from "models"
 import React, { useContext } from "react"
 import EVENT_SERIES_ICON from "resources/eventSeries.png"
 import PEOPLE_ICON from "resources/people.png"
 import POSITIONS_ICON from "resources/positions.png"
-import TASKS_ICON from "resources/tasks.png"
 import { RECURSE_STRATEGY } from "searchUtils"
 import Settings from "settings"
 import utils from "utils"
@@ -90,6 +80,7 @@ export const getSearchQuery = searchQuery => {
       }
     })
   }
+  console.log(query)
   return query
 }
 
@@ -154,16 +145,6 @@ const advancedSelectFilterPositionProps = {
   fields: Position.autocompleteQuery,
   addon: POSITIONS_ICON
 }
-const advancedSelectFilterTaskProps = {
-  overlayColumns: ["Name"],
-  overlayRenderRow: TaskOverlayRow,
-  objectType: Task,
-  valueKey: "shortName",
-  valueFunc: (v, k) =>
-    getBreadcrumbTrailAsText(v, v?.ascendantTasks, "parentTask", k),
-  fields: Task.autocompleteQuery,
-  addon: TASKS_ICON
-}
 const advancedSelectFilterEventSeriesProps = {
   overlayColumns: ["Name"],
   overlayRenderRow: EventSeriesOverlayRow,
@@ -176,7 +157,6 @@ const advancedSelectFilterEventSeriesProps = {
 export const searchFilters = function(includeAdminFilters) {
   const filters = {}
 
-  const taskShortLabel = Settings.fields.task.shortLabel
   const authorWidgetFilters = {
     all: {
       label: "All",
@@ -225,13 +205,6 @@ export const searchFilters = function(includeAdminFilters) {
   // Allow explicit search for "no classification"
   classificationOptions.unshift("")
   classificationLabels.unshift("<none>")
-
-  const taskWidgetFilters = {
-    all: {
-      label: "All",
-      queryVars: {}
-    }
-  }
 
   const eventSeriesFilters = {
     all: {
@@ -405,13 +378,11 @@ export const searchFilters = function(includeAdminFilters) {
       }
     },
     [`Within ${Settings.fields.task.shortLabel}`]: {
-      component: AdvancedSelectFilter,
-      deserializer: deserializeAdvancedSelectFilter,
-      props: Object.assign({}, advancedSelectFilterTaskProps, {
-        filterDefs: taskWidgetFilters,
-        placeholder: `Filter reports by ${taskShortLabel}…`,
+      component: TaskMultiFilter,
+      deserializer: deserializeTaskMultiFilter,
+      props: {
         queryKey: "taskUuid"
-      })
+      }
     }
   }
 
@@ -670,8 +641,8 @@ export const searchFilters = function(includeAdminFilters) {
         }
       },
       [`Within ${Settings.fields.task.shortLabel}`]: {
-        component: TaskFilter,
-        deserializer: deserializeTaskFilter,
+        component: TaskMultiFilter,
+        deserializer: deserializeTaskMultiFilter,
         props: {
           queryKey: "parentTaskUuid",
           queryRecurseStrategyKey: "parentTaskRecurseStrategy",
@@ -801,8 +772,8 @@ export const searchFilters = function(includeAdminFilters) {
         }
       },
       [`Within ${Settings.fields.task.shortLabel}`]: {
-        component: TaskFilter,
-        deserializer: deserializeTaskFilter,
+        component: TaskMultiFilter,
+        deserializer: deserializeTaskMultiFilter,
         props: {
           queryKey: "taskUuid"
         }

--- a/client/src/components/SearchFilters.tsx
+++ b/client/src/components/SearchFilters.tsx
@@ -80,7 +80,6 @@ export const getSearchQuery = searchQuery => {
       }
     })
   }
-  console.log(query)
   return query
 }
 

--- a/client/src/components/TaskTable.tsx
+++ b/client/src/components/TaskTable.tsx
@@ -6,6 +6,7 @@ import {
   PageDispatchersPropType,
   useBoilerplate
 } from "components/Page"
+import RemoveButton from "components/RemoveButton"
 import UltimatePaginationTopDown from "components/UltimatePaginationTopDown"
 import _get from "lodash/get"
 import { Task } from "models"
@@ -97,6 +98,7 @@ interface BaseTaskTableProps {
   onDelete?: (...args: unknown[]) => unknown
   // list of tasks:
   tasks: any[]
+  noTasksMessage?: string
   // fill these when pagination wanted:
   totalCount?: number
   pageNum?: number
@@ -109,14 +111,14 @@ const BaseTaskTable = ({
   showDelete,
   onDelete,
   tasks,
+  noTasksMessage = `No ${pluralize(Settings.fields.task.shortLabel)} found`,
   pageSize,
   pageNum,
   totalCount,
   goToPage
 }: BaseTaskTableProps) => {
-  const taskShortLabel = Settings.fields.task.shortLabel
   if (_get(tasks, "length", 0) === 0) {
-    return <em>No {pluralize(taskShortLabel)} found</em>
+    return <em>{noTasksMessage}</em>
   }
 
   return (
@@ -133,6 +135,7 @@ const BaseTaskTable = ({
           <thead>
             <tr>
               <th>Name</th>
+              {showDelete && <th />}
             </tr>
           </thead>
           <tbody>
@@ -146,6 +149,14 @@ const BaseTaskTable = ({
                     parentField="parentTask"
                   />
                 </td>
+                {showDelete && (
+                  <td id={"taskDelete_" + task.uuid}>
+                    <RemoveButton
+                      title={`Remove ${pluralize(Settings.fields.task.shortLabel)}`}
+                      onClick={() => onDelete(task)}
+                    />
+                  </td>
+                )}
               </tr>
             ))}
           </tbody>

--- a/client/src/components/TaskTable.tsx
+++ b/client/src/components/TaskTable.tsx
@@ -152,7 +152,7 @@ const BaseTaskTable = ({
                 {showDelete && (
                   <td id={"taskDelete_" + task.uuid}>
                     <RemoveButton
-                      title={`Remove ${pluralize(Settings.fields.task.shortLabel)}`}
+                      title={`Remove ${Settings.fields.task.shortLabel}`}
                       onClick={() => onDelete(task)}
                     />
                   </td>

--- a/src/main/java/mil/dds/anet/beans/search/EventSearchQuery.java
+++ b/src/main/java/mil/dds/anet/beans/search/EventSearchQuery.java
@@ -16,7 +16,7 @@ public class EventSearchQuery extends EventSeriesSearchQuery {
   private List<String> locationUuid;
   @GraphQLQuery
   @GraphQLInputField
-  String taskUuid;
+  List<String> taskUuid;
   @GraphQLQuery
   @GraphQLInputField
   Instant includeDate;
@@ -50,11 +50,11 @@ public class EventSearchQuery extends EventSeriesSearchQuery {
     this.locationUuid = locationUuid;
   }
 
-  public String getTaskUuid() {
+  public List<String> getTaskUuid() {
     return taskUuid;
   }
 
-  public void setTaskUuid(String taskUuid) {
+  public void setTaskUuid(List<String> taskUuid) {
     this.taskUuid = taskUuid;
   }
 
@@ -115,6 +115,9 @@ public class EventSearchQuery extends EventSeriesSearchQuery {
     final EventSearchQuery clone = (EventSearchQuery) super.clone();
     if (locationUuid != null) {
       clone.setLocationUuid(new ArrayList<>(locationUuid));
+    }
+    if (taskUuid != null) {
+      clone.setTaskUuid(new ArrayList<>(taskUuid));
     }
     return clone;
   }

--- a/src/main/java/mil/dds/anet/beans/search/ReportSearchQuery.java
+++ b/src/main/java/mil/dds/anet/beans/search/ReportSearchQuery.java
@@ -67,7 +67,7 @@ public class ReportSearchQuery extends SubscribableObjectSearchQuery<ReportSearc
   private RecurseStrategy locationRecurseStrategy;
   @GraphQLQuery
   @GraphQLInputField
-  String taskUuid;
+  List<String> taskUuid;
   @GraphQLQuery
   @GraphQLInputField
   String pendingApprovalOf;
@@ -246,11 +246,11 @@ public class ReportSearchQuery extends SubscribableObjectSearchQuery<ReportSearc
     this.locationRecurseStrategy = locationRecurseStrategy;
   }
 
-  public String getTaskUuid() {
+  public List<String> getTaskUuid() {
     return taskUuid;
   }
 
-  public void setTaskUuid(String taskUuid) {
+  public void setTaskUuid(List<String> taskUuid) {
     this.taskUuid = taskUuid;
   }
 
@@ -416,6 +416,9 @@ public class ReportSearchQuery extends SubscribableObjectSearchQuery<ReportSearc
     }
     if (locationUuid != null) {
       clone.setLocationUuid(new ArrayList<>(locationUuid));
+    }
+    if (taskUuid != null) {
+      clone.setTaskUuid(new ArrayList<>(taskUuid));
     }
     return clone;
   }

--- a/src/main/java/mil/dds/anet/search/AbstractEventSearcher.java
+++ b/src/main/java/mil/dds/anet/search/AbstractEventSearcher.java
@@ -126,7 +126,8 @@ public abstract class AbstractEventSearcher extends AbstractSearcher<Event, Even
 
   protected void addTaskQuery(EventSearchQuery query) {
     qb.addFromClause("INNER JOIN \"eventTasks\" et ON et.\"eventUuid\" = events.uuid");
-    if (Task.DUMMY_TASK_UUID.equals(query.getTaskUuid())) {
+    if (query.getTaskUuid().size() == 1
+        && Task.DUMMY_TASK_UUID.equals(query.getTaskUuid().get(0))) {
       qb.addWhereClause("et.\"taskUuid\" IS NULL");
     } else {
       qb.addRecursiveClause(null, "et", "\"taskUuid\"", "parent_tasks", "tasks",

--- a/src/main/java/mil/dds/anet/search/AbstractReportSearcher.java
+++ b/src/main/java/mil/dds/anet/search/AbstractReportSearcher.java
@@ -346,7 +346,8 @@ public abstract class AbstractReportSearcher extends AbstractSearcher<Report, Re
   protected void addTaskUuidQuery(AbstractSearchQueryBuilder<Report, ReportSearchQuery> outerQb,
       ReportSearchQuery query) {
     qb.addFromClause("INNER JOIN \"reportTasks\" rt ON rt.\"reportUuid\" = reports.uuid");
-    if (Task.DUMMY_TASK_UUID.equals(query.getTaskUuid())) {
+    if (query.getTaskUuid().size() == 1
+        && Task.DUMMY_TASK_UUID.equals(query.getTaskUuid().get(0))) {
       qb.addWhereClause("rt.\"taskUuid\" IS NULL");
     } else {
       qb.addRecursiveClause(outerQb, "rt", "\"taskUuid\"", "parent_tasks", "tasks",

--- a/src/test/java/mil/dds/anet/test/resources/ReportResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/ReportResourceTest.java
@@ -1262,7 +1262,7 @@ public class ReportResourceTest extends AbstractResourceTest {
 
     // Search by Task
     query1.setAttendeeUuid(null);
-    query1.setTaskUuid(task.getUuid());
+    query1.setTaskUuid(List.of(task.getUuid()));
     searchResults =
         withCredentials(jackUser, t -> queryExecutor.reportList(getListFields(FIELDS), query1));
     assertThat(searchResults.getList()).isNotEmpty();

--- a/src/test/resources/anet.graphql
+++ b/src/test/resources/anet.graphql
@@ -505,7 +505,7 @@ input EventSearchQueryInput {
   startDate: Instant
   status: Status
   subscribed: Boolean
-  taskUuid: String
+  taskUuid: [String]
   text: String
   type: String
 }
@@ -1337,7 +1337,7 @@ input ReportSearchQueryInput {
   state: [ReportState]
   status: Status
   subscribed: Boolean
-  taskUuid: String
+  taskUuid: [String]
   text: String
   updatedAtEnd: Instant
   updatedAtStart: Instant


### PR DESCRIPTION
The advanced search filters for tasks (a.k.a. objectives) now allow to search for multiple tasks.

Closes [AB#1293](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1293)

#### User changes
- The advanced search filters for tasks (within reports, tasks and events) now allow to search for multiple tasks.

#### Superuser changes
- None

#### Admin changes
- None

#### System admin changes
- [ ] application.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [x] graphql schema has changed

### Checklist
- [x] described the user behavior in PR body
- [x] referenced/updated all related issues
- [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
- [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
- [x] added and/or updated unit tests
- [ ] added and/or updated e2e tests
- [ ] added and/or updated data migrations
- [ ] updated documentation
- [x] resolved all build errors and warnings
- [ ] opened debt issues for anything not resolved here
