### PR TITLE
Add the EventMatrix to the tasks overview page

### DIFF
--- a/client/src/components/EventMatrix.tsx
+++ b/client/src/components/EventMatrix.tsx
@@ -367,7 +367,7 @@ const EventMatrix = ({
       <div>
         <Table className="event-matrix" responsive hover id="events-matrix">
           <tbody>
-            <tr className="table-primary">
+            <tr id="event-series-table-header" className="table-primary">
               <th>Event Series</th>
               {weekDays.map(weekDay => (
                 <th key={weekDay} style={{ width: "12%" }}>
@@ -401,7 +401,7 @@ const EventMatrix = ({
                   </tr>
                 )
               })}
-            <tr className="table-primary">
+            <tr id="tasks-table-header" className="table-primary">
               <th>{Settings.fields.task.shortLabel}</th>
               {weekDays.map(weekDay => (
                 <th key={weekDay} style={{ width: "12%" }}>

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1225,12 +1225,8 @@ table.event-matrix > :not(caption) > * > * {
   padding: 0;
 }
 
-table.event-matrix thead > *, table.event-matrix thead > * > * {
-  border-top-style: none;
-}
-
-table.event-matrix thead > *:not(:last-child), table.event-matrix thead > *:not(:last-child) > * {
-  border-bottom-style: none;
+table.event-matrix tr.table-primary {
+  border-top: 1.25rem solid white;
 }
 
 table.event-matrix-cell {

--- a/client/src/pages/reports/Form.tsx
+++ b/client/src/pages/reports/Form.tsx
@@ -541,6 +541,8 @@ const ReportForm = ({
         const isFutureEngagement = Report.isFuture(values.engagementDate)
         const hasAssessments = values.engagementDate && !isFutureEngagement
         const relatedObject = hasAssessments ? values : {}
+        const locationDisabled =
+          values.event?.uuid && values.event?.location?.uuid
 
         return (
           <div className="report-form">
@@ -705,7 +707,7 @@ const ReportForm = ({
                     setFieldValue("location", value, true)
                     setLocationUuid(value.uuid)
                   }}
-                  disabled={values.event?.uuid != null}
+                  disabled={locationDisabled}
                   widget={
                     <AdvancedSingleSelect
                       fieldName="location"
@@ -718,7 +720,7 @@ const ReportForm = ({
                       fields={Location.autocompleteQuery}
                       valueKey="name"
                       addon={LOCATIONS_ICON}
-                      showRemoveButton={values.event?.uuid == null}
+                      showRemoveButton={!locationDisabled}
                       createEntityComponent={
                         !canCreateLocation
                           ? null

--- a/client/src/pages/tasks/Top.tsx
+++ b/client/src/pages/tasks/Top.tsx
@@ -1,6 +1,7 @@
 import { gql } from "@apollo/client"
 import { DEFAULT_PAGE_PROPS, DEFAULT_SEARCH_PROPS } from "actions"
 import API from "api"
+import EventMatrix from "components/EventMatrix"
 import Fieldset from "components/Fieldset"
 import {
   mapPageDispatchersToProps,
@@ -23,10 +24,13 @@ const GQL_GET_TOP_LEVEL_TASKS = gql`
         uuid
         shortName
         longName
+        selectable
         parentTask {
           uuid
+        }
+        ascendantTasks {
+          uuid
           shortName
-          longName
           parentTask {
             uuid
           }
@@ -35,8 +39,16 @@ const GQL_GET_TOP_LEVEL_TASKS = gql`
           uuid
           shortName
           longName
+          selectable
           parentTask {
             uuid
+          }
+          ascendantTasks {
+            uuid
+            shortName
+            parentTask {
+              uuid
+            }
           }
         }
       }
@@ -64,11 +76,16 @@ const TopTasks = ({ pageDispatchers }: TopTasksProps) => {
   }
 
   return (
-    <Fieldset title={Settings.fields.task.allTasksLabel}>
-      {(!data?.taskList?.list?.length && (
-        <div>No {Settings.fields.task.allTasksLabel}</div>
-      )) || <TaskTree tasks={data.taskList.list} />}
-    </Fieldset>
+    <>
+      <Fieldset title={Settings.fields.task.allTasksLabel}>
+        {(!data?.taskList?.list?.length && (
+          <div>No {Settings.fields.task.allTasksLabel}</div>
+        )) || <TaskTree tasks={data.taskList.list} />}
+      </Fieldset>
+      <Fieldset id="syncMatrix" title="Sync Matrix">
+        <EventMatrix tasks={data.taskList.list} />
+      </Fieldset>
+    </>
   )
 }
 

--- a/client/tests/webdriver/baseSpecs/showAllTasks.spec.js
+++ b/client/tests/webdriver/baseSpecs/showAllTasks.spec.js
@@ -30,6 +30,7 @@ describe("Show All Tasks Page", () => {
     // eslint-disable-next-line no-unused-expressions
     expect(caret).to.exist
     await caret.click()
+    await browser.pause(300) // wait for tree animation to finish
 
     const descendants = await ShowAllTasks.getAllDescendants(firstTask)
     expect(descendants).to.have.lengthOf(3)
@@ -47,6 +48,8 @@ describe("Show All Tasks Page", () => {
     // eslint-disable-next-line no-unused-expressions
     expect(caret).to.exist
     await caret.click()
+    await browser.pause(300) // wait for tree animation to finish
+
     const descendants = await ShowAllTasks.getAllDescendants(firstTask)
     expect(descendants).to.have.lengthOf(3)
     const firstDescendant = descendants[0]
@@ -74,5 +77,19 @@ describe("Show All Tasks Page", () => {
       0,
       "No descendants should be present for EF 5"
     )
+  })
+
+  it("Should show the event matrix for all tasks", async() => {
+    const eventMatrix = await ShowAllTasks.getEventMatrix()
+    await eventMatrix.waitForExist()
+    await eventMatrix.waitForDisplayed()
+    const tasksTableHeader = await ShowAllTasks.getTasksTableHeader()
+    await tasksTableHeader.waitForExist()
+    await tasksTableHeader.waitForDisplayed()
+
+    const topTasks = await ShowAllTasks.getAllTasks()
+    const tasksTableRows = await ShowAllTasks.getTasksTableRows()
+    // Assert that we have at least a sensible number of rows
+    expect(tasksTableRows.length).to.be.at.least(topTasks.length)
   })
 })

--- a/client/tests/webdriver/pages/showAllTasks.page.js
+++ b/client/tests/webdriver/pages/showAllTasks.page.js
@@ -32,6 +32,18 @@ class ShowAllTasks extends Page {
     }
     return visibleDescendants
   }
+
+  async getEventMatrix() {
+    return browser.$("#events-matrix")
+  }
+
+  async getTasksTableHeader() {
+    return browser.$("#tasks-table-header")
+  }
+
+  async getTasksTableRows() {
+    return browser.$$("#tasks-table-header ~ tr")
+  }
 }
 
 export default new ShowAllTasks()


### PR DESCRIPTION
The EventMatrix (a.k.a. Sync Matrix) is now also shown on the top-level tasks (a.k.a. objectives) page, showing _all_ (selectable) tasks.

Closes [AB#1294](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1294)

#### User changes
- On the top-level objectives pages, the synchronization matrix is shown with all (selectable) objectives.

#### Superuser changes
- None.

#### Admin changes
- None.

#### System admin changes
- [ ] application.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
- [x] described the user behavior in PR body
- [x] referenced/updated all related issues
- [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
- [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
- [ ] added and/or updated unit tests
- [x] added and/or updated e2e tests
- [ ] added and/or updated data migrations
- [ ] updated documentation
- [ ] resolved all build errors and warnings
- [ ] opened debt issues for anything not resolved here
