### PR TITLE
Display objective tree on search filter

### DIFF
--- a/client/src/components/Checkbox.tsx
+++ b/client/src/components/Checkbox.tsx
@@ -2,11 +2,17 @@ import React, { useEffect, useRef } from "react"
 
 interface CheckboxProps {
   checked?: boolean
+  disabled?: boolean
   onChange?: (...args: unknown[]) => unknown
   label?: string
 }
 
-const Checkbox = ({ checked = false, onChange, label = "" }: CheckboxProps) => {
+const Checkbox = ({
+  checked = false,
+  disabled,
+  onChange,
+  label = ""
+}: CheckboxProps) => {
   const inputRef = useRef(null)
   useEffect(() => {
     const input = inputRef.current
@@ -23,6 +29,7 @@ const Checkbox = ({ checked = false, onChange, label = "" }: CheckboxProps) => {
           className="checkbox"
           type="checkbox"
           ref={inputRef}
+          disabled={disabled}
           onChange={onChange}
         />
         {label}

--- a/client/src/components/SearchFilters.tsx
+++ b/client/src/components/SearchFilters.tsx
@@ -30,9 +30,8 @@ import ReportStateFilter, {
 import SelectFilter, {
   deserialize as deserializeSelectFilter
 } from "components/advancedSearch/SelectFilter"
-import {
-  deserializeMulti as deserializeTaskMultiFilter,
-  TaskMultiFilter
+import TaskFilter, {
+  deserialize as deserializeTaskFilter
 } from "components/advancedSearch/TaskFilter"
 import {
   CountryOverlayRow,
@@ -377,8 +376,8 @@ export const searchFilters = function(includeAdminFilters) {
       }
     },
     [`Within ${Settings.fields.task.shortLabel}`]: {
-      component: TaskMultiFilter,
-      deserializer: deserializeTaskMultiFilter,
+      component: TaskFilter,
+      deserializer: deserializeTaskFilter,
       props: {
         queryKey: "taskUuid"
       }
@@ -640,8 +639,8 @@ export const searchFilters = function(includeAdminFilters) {
         }
       },
       [`Within ${Settings.fields.task.shortLabel}`]: {
-        component: TaskMultiFilter,
-        deserializer: deserializeTaskMultiFilter,
+        component: TaskFilter,
+        deserializer: deserializeTaskFilter,
         props: {
           queryKey: "parentTaskUuid",
           queryRecurseStrategyKey: "parentTaskRecurseStrategy",
@@ -771,8 +770,8 @@ export const searchFilters = function(includeAdminFilters) {
         }
       },
       [`Within ${Settings.fields.task.shortLabel}`]: {
-        component: TaskMultiFilter,
-        deserializer: deserializeTaskMultiFilter,
+        component: TaskFilter,
+        deserializer: deserializeTaskFilter,
         props: {
           queryKey: "taskUuid"
         }

--- a/client/src/components/advancedSearch/TaskFilter.tsx
+++ b/client/src/components/advancedSearch/TaskFilter.tsx
@@ -97,15 +97,13 @@ const HierarchicalOverlayTable = ({
         newSet.delete(task.uuid)
         return newSet
       })
-    } else {
-      if (!childrenMap.has(task.uuid)) {
-        fetchChildren(task).then(children => {
-          setChildrenMap(prev => new Map(prev).set(task.uuid, children))
-          setExpandedItems(prev => new Set([...prev, task.uuid]))
-        })
-      } else {
+    } else if (!childrenMap.has(task.uuid)) {
+      fetchChildren(task).then(children => {
+        setChildrenMap(prev => new Map(prev).set(task.uuid, children))
         setExpandedItems(prev => new Set([...prev, task.uuid]))
-      }
+      })
+    } else {
+      setExpandedItems(prev => new Set([...prev, task.uuid]))
     }
   }
 
@@ -330,30 +328,7 @@ const TaskFilter = ({
   }
 }
 
-export const TaskMultiFilter = ({ ...props }) => <TaskFilter {...props} />
-
 export const deserialize = ({ queryKey }, query, key) => {
-  if (query[queryKey]) {
-    return API.query(GQL_GET_TASK, {
-      uuid: query[queryKey]
-    }).then(data => {
-      if (data.task) {
-        return {
-          key,
-          value: {
-            value: data.task,
-            toQuery: { ...query }
-          }
-        }
-      } else {
-        return null
-      }
-    })
-  }
-  return null
-}
-
-export const deserializeMulti = ({ queryKey }, query, key) => {
   if (query[queryKey]) {
     return API.query(GQL_GET_TASKS, {
       uuids: query[queryKey]

--- a/client/src/components/advancedSearch/TaskFilter.tsx
+++ b/client/src/components/advancedSearch/TaskFilter.tsx
@@ -302,7 +302,7 @@ const TaskFilter = ({
       onChange={handleChangeTask}
       pageSize={0}
       value={value.value}
-      autoComplete={"off"}
+      autoComplete="off"
       renderSelected={
         <TaskTable
           tasks={value.value}

--- a/client/src/components/advancedSearch/TaskFilter.tsx
+++ b/client/src/components/advancedSearch/TaskFilter.tsx
@@ -119,13 +119,9 @@ const TaskFilter = ({
   `
 
   const HierarchicalOverlayTable = props => {
-    const {
-      items,
-      valueKey: propsValueKey,
-      selectedItems,
-      handleAddItem,
-      handleRemoveItem
-    } = { ...props }
+    const { items, selectedItems, handleAddItem, handleRemoveItem } = {
+      ...props
+    }
     const fetchChildren = async task => {
       const query = gql`
         query ($query: TaskSearchQueryInput) {
@@ -134,13 +130,6 @@ const TaskFilter = ({
               uuid
               shortName
               longName
-              parentTask {
-                uuid
-                shortName
-                parentTask {
-                  uuid
-                }
-              }
               ascendantTasks {
                 uuid
                 shortName
@@ -150,7 +139,6 @@ const TaskFilter = ({
               }
               childrenTasks {
                 uuid
-                shortName
               }
               descendantTasks {
                 uuid
@@ -186,7 +174,7 @@ const TaskFilter = ({
     const buildFlattenedList = (tasks, level = 0) => {
       return tasks.flatMap(task => {
         const isTaskSelected = selectedItems?.some(
-          item => item[propsValueKey] === task[propsValueKey]
+          item => item.uuid === task.uuid
         )
         const isChildrenTaskSelected = selectedItems?.some(item =>
           task.descendantTasks?.some(child => child.uuid === item.uuid)
@@ -211,9 +199,7 @@ const TaskFilter = ({
     const enhancedRenderRow = task => {
       const hasChildren = task.childrenTasks?.length > 0
       const isExpanded = expandedItems.has(task.uuid)
-      const isSelected = selectedItems?.some(
-        item => item[propsValueKey] === task[propsValueKey]
-      )
+      const isSelected = selectedItems?.some(item => item.uuid === task.uuid)
 
       const handleToggleSelection = e => {
         e.stopPropagation()
@@ -341,7 +327,7 @@ const TaskFilter = ({
       onChange={handleChangeTask}
       pageSize={0}
       value={value.value}
-      autoComplete={"off"}
+      autoComplete="off"
       renderSelected={
         <TaskTable
           tasks={value.value}

--- a/client/src/components/advancedSearch/TaskFilter.tsx
+++ b/client/src/components/advancedSearch/TaskFilter.tsx
@@ -4,6 +4,7 @@ import { IconNames } from "@blueprintjs/icons"
 import API from "api"
 import useSearchFilter from "components/advancedSearch/hooks"
 import AdvancedMultiSelect from "components/advancedSelectWidget/AdvancedMultiSelect"
+import { TaskOverlayRow } from "components/advancedSelectWidget/AdvancedSelectOverlayRow"
 import { AdvancedMultiSelectOverlayTable } from "components/advancedSelectWidget/AdvancedSelectOverlayTable"
 import AdvancedSingleSelect from "components/advancedSelectWidget/AdvancedSingleSelect"
 import { getBreadcrumbTrailAsText } from "components/BreadcrumbTrail"
@@ -292,6 +293,7 @@ const TaskFilter = ({
       showRemoveButton={false}
       filterDefs={advancedSelectFilters}
       overlayColumns={["Name"]}
+      overlayRenderRow={TaskOverlayRow}
       overlayTable={HierarchicalOverlayTable}
       objectType={Task}
       valueKey={valueKey}

--- a/client/src/components/advancedSearch/TaskFilter.tsx
+++ b/client/src/components/advancedSearch/TaskFilter.tsx
@@ -4,7 +4,6 @@ import { IconNames } from "@blueprintjs/icons"
 import API from "api"
 import useSearchFilter from "components/advancedSearch/hooks"
 import AdvancedMultiSelect from "components/advancedSelectWidget/AdvancedMultiSelect"
-import { TaskOverlayRow } from "components/advancedSelectWidget/AdvancedSelectOverlayRow"
 import { AdvancedMultiSelectOverlayTable } from "components/advancedSelectWidget/AdvancedSelectOverlayTable"
 import AdvancedSingleSelect from "components/advancedSelectWidget/AdvancedSingleSelect"
 import { getBreadcrumbTrailAsText } from "components/BreadcrumbTrail"
@@ -13,23 +12,26 @@ import { Task } from "models"
 import pluralize from "pluralize"
 import React, { useState } from "react"
 import TASKS_ICON from "resources/tasks.png"
+import { RECURSE_STRATEGY } from "searchUtils"
 import Settings from "settings"
+
+const taskFields = `
+    ${Task.autocompleteQuery}
+    childrenTasks(query: { pageSize: 1 }) {
+      uuid
+    }
+    parentTask {
+      uuid
+    }
+    descendantTasks {
+      uuid
+    }
+  `
 
 const GQL_GET_TASK = gql`
   query ($uuid: String!) {
     task(uuid: $uuid) {
-      uuid
-      shortName
-      parentTask {
-        uuid
-      }
-      ascendantTasks {
-        uuid
-        shortName
-        parentTask {
-          uuid
-        }
-      }
+      ${taskFields}
     }
   }
 `
@@ -37,28 +39,199 @@ const GQL_GET_TASK = gql`
 const GQL_GET_TASKS = gql`
   query ($uuids: [String]) {
     tasks(uuids: $uuids) {
-      uuid
-      shortName
-      parentTask {
-        uuid
-      }
-      ascendantTasks {
-        uuid
-        shortName
-        parentTask {
-          uuid
-        }
-      }
+      ${taskFields}
     }
   }
 `
+
+interface HierarchicalOverlayTableProps {
+  items: any[]
+  selectedItems: any[]
+  handleAddItem?: (...args: unknown[]) => unknown
+  handleRemoveItem?: (...args: unknown[]) => unknown
+}
+
+const HierarchicalOverlayTable = ({
+  items,
+  selectedItems,
+  handleAddItem,
+  handleRemoveItem,
+  ...otherProps
+}: HierarchicalOverlayTableProps) => {
+  const [expandedItems, setExpandedItems] = useState(new Set<string>())
+  const [childrenMap, setChildrenMap] = useState(new Map<string, any[]>())
+
+  const fetchChildren = async task => {
+    const query = gql`
+      query ($query: TaskSearchQueryInput) {
+        taskList(query: $query) {
+          list {
+            uuid
+            shortName
+            longName
+            ascendantTasks {
+              uuid
+              shortName
+              parentTask {
+                uuid
+              }
+            }
+            childrenTasks {
+              uuid
+            }
+            descendantTasks {
+              uuid
+            }
+          }
+        }
+      }
+    `
+    const queryVars = {
+      parentTaskUuid: task.uuid,
+      parentTaskRecurseStrategy: RECURSE_STRATEGY.NONE
+    }
+    const data = await API.query(query, { query: queryVars })
+    return data.taskList.list
+  }
+
+  const handleExpand = task => {
+    if (expandedItems.has(task.uuid)) {
+      setExpandedItems(prev => {
+        const newSet = new Set(prev)
+        newSet.delete(task.uuid)
+        return newSet
+      })
+    } else {
+      if (!childrenMap.has(task.uuid)) {
+        fetchChildren(task).then(children => {
+          setChildrenMap(prev => new Map(prev).set(task.uuid, children))
+          setExpandedItems(prev => new Set([...prev, task.uuid]))
+        })
+      } else {
+        setExpandedItems(prev => new Set([...prev, task.uuid]))
+      }
+    }
+  }
+
+  const buildFlattenedList = (tasks, level = 0) => {
+    return tasks.flatMap(task => {
+      const isTaskSelected = selectedItems?.some(
+        item => item.uuid === task.uuid
+      )
+      const hasDescendantTasksSelected = selectedItems?.some(item =>
+        task.descendantTasks?.some(child => child.uuid === item.uuid)
+      )
+      const isCollapsed = !expandedItems.has(task.uuid)
+      const isSelected = isTaskSelected
+        ? true
+        : hasDescendantTasksSelected && isCollapsed
+          ? null
+          : false
+      const taskWithLevel = { ...task, level, isSelected }
+      const children = expandedItems.has(task.uuid)
+        ? childrenMap.get(task.uuid) || []
+        : []
+      return [taskWithLevel, ...buildFlattenedList(children, level + 1)]
+    })
+  }
+
+  const topLevelItems = items.filter(task => !task.parentTask)
+  const flattenedItems = buildFlattenedList(topLevelItems)
+
+  const enhancedRenderRow = task => {
+    const hasChildren = task.childrenTasks?.length > 0
+    const isExpanded = expandedItems.has(task.uuid)
+    const isSelected = selectedItems?.some(item => item.uuid === task.uuid)
+
+    const handleToggleSelection = e => {
+      e.stopPropagation()
+      if (isSelected) {
+        handleRemoveItem(task)
+      } else {
+        handleAddItem(task)
+      }
+    }
+
+    const displayLabel = task.longName
+      ? `${task.shortName}: ${task.longName}`
+      : task.shortName
+    const padding = Math.min(task.level, 3) * 20 + (hasChildren ? 0 : 26)
+    const indentedLabel = (
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "row",
+          alignItems: "center",
+          paddingLeft: padding,
+          gap: 10,
+          cursor: "auto"
+        }}
+      >
+        {(hasChildren && (
+          <>
+            <span
+              onClick={e => {
+                e.stopPropagation()
+                handleExpand(task)
+              }}
+              style={{ cursor: "pointer" }}
+            >
+              <Icon
+                icon={
+                  isExpanded ? IconNames.CHEVRON_DOWN : IconNames.CHEVRON_RIGHT
+                }
+                size={IconSize.STANDARD}
+              />
+            </span>
+            <Icon
+              icon={isExpanded ? IconNames.FOLDER_OPEN : IconNames.FOLDER_CLOSE}
+              size={IconSize.STANDARD}
+            />
+          </>
+        )) || <Icon icon={IconNames.DOCUMENT} size={IconSize.STANDARD} />}
+        <img
+          src={TASKS_ICON}
+          alt=""
+          style={{ marginLeft: 5, marginRight: 5, height: "1em" }}
+        />
+        <span
+          onClick={handleToggleSelection}
+          style={{
+            cursor: "pointer",
+            flexGrow: "1"
+          }}
+        >
+          {displayLabel}
+        </span>
+      </div>
+    )
+
+    return (
+      <React.Fragment key={task.uuid}>
+        <td className="taskName" onClick={e => e.stopPropagation()}>
+          {indentedLabel}
+        </td>
+      </React.Fragment>
+    )
+  }
+
+  return (
+    <AdvancedMultiSelectOverlayTable
+      {...otherProps}
+      items={flattenedItems}
+      selectedItems={selectedItems}
+      handleAddItem={handleAddItem}
+      handleRemoveItem={handleRemoveItem}
+      renderRow={enhancedRenderRow}
+    />
+  )
+}
 
 interface TaskFilterProps {
   queryKey: string
   queryRecurseStrategyKey: string
   fixedRecurseStrategy: string
   value?: any
-  multi?: boolean
   onChange?: (...args: unknown[]) => unknown
   taskFilterQueryParams?: any
   asFormField?: boolean
@@ -70,17 +243,16 @@ const TaskFilter = ({
   queryRecurseStrategyKey,
   fixedRecurseStrategy,
   value: inputValue,
-  multi,
   onChange,
   taskFilterQueryParams,
   ...advancedSelectProps
 }: TaskFilterProps) => {
   const defaultValue = {
-    value: inputValue.value || (multi ? [] : {})
+    value: inputValue.value || []
   }
   const toQuery = val => {
     return {
-      [queryKey]: multi ? val.value?.map(v => v.uuid) : val.value?.uuid,
+      [queryKey]: val.value?.map(v => v.uuid),
       [queryRecurseStrategyKey]: fixedRecurseStrategy
     }
   }
@@ -103,220 +275,23 @@ const TaskFilter = ({
   }
 
   const parentKey = "parentTask"
-  const valueKey = multi ? "uuid" : "shortName"
+  const valueKey = "uuid"
 
-  const taskFields = `
-    ${Task.autocompleteQuery}
-    childrenTasks(query: { pageSize: 1 }) {
-      uuid
-    }
-    parentTask {
-      uuid
-    }
-    descendantTasks {
-      uuid
-    }
-  `
-
-  const HierarchicalOverlayTable = props => {
-    const { items, selectedItems, handleAddItem, handleRemoveItem } = {
-      ...props
-    }
-    const fetchChildren = async task => {
-      const query = gql`
-        query ($query: TaskSearchQueryInput) {
-          taskList(query: $query) {
-            list {
-              uuid
-              shortName
-              longName
-              ascendantTasks {
-                uuid
-                shortName
-                parentTask {
-                  uuid
-                }
-              }
-              childrenTasks {
-                uuid
-              }
-              descendantTasks {
-                uuid
-              }
-            }
-          }
-        }
-      `
-      const queryVars = { parentTaskUuid: task.uuid }
-      const data = await API.query(query, { query: queryVars })
-      return data.taskList.list
-    }
-
-    const handleExpand = task => {
-      if (expandedItems.has(task.uuid)) {
-        setExpandedItems(prev => {
-          const newSet = new Set(prev)
-          newSet.delete(task.uuid)
-          return newSet
-        })
-      } else {
-        if (!childrenMap.has(task.uuid)) {
-          fetchChildren(task).then(children => {
-            setChildrenMap(prev => new Map(prev).set(task.uuid, children))
-            setExpandedItems(prev => new Set([...prev, task.uuid]))
-          })
-        } else {
-          setExpandedItems(prev => new Set([...prev, task.uuid]))
-        }
-      }
-    }
-
-    const buildFlattenedList = (tasks, level = 0) => {
-      return tasks.flatMap(task => {
-        const isTaskSelected = selectedItems?.some(
-          item => item.uuid === task.uuid
-        )
-        const isChildrenTaskSelected = selectedItems?.some(item =>
-          task.descendantTasks?.some(child => child.uuid === item.uuid)
-        )
-        const isCollapsed = !expandedItems.has(task.uuid)
-        const isSelected = isTaskSelected
-          ? true
-          : isChildrenTaskSelected && isCollapsed
-            ? null
-            : false
-        const taskWithLevel = { ...task, level, isSelected }
-        const children = expandedItems.has(task.uuid)
-          ? childrenMap.get(task.uuid) || []
-          : []
-        return [taskWithLevel, ...buildFlattenedList(children, level + 1)]
-      })
-    }
-
-    const topLevelItems = items.filter(task => !task.parentTask)
-    const flattenedItems = buildFlattenedList(topLevelItems)
-
-    const enhancedRenderRow = task => {
-      const hasChildren = task.childrenTasks?.length > 0
-      const isExpanded = expandedItems.has(task.uuid)
-      const isSelected = selectedItems?.some(item => item.uuid === task.uuid)
-
-      const handleToggleSelection = e => {
-        e.stopPropagation()
-        if (isSelected) {
-          handleRemoveItem(task)
-        } else {
-          handleAddItem(task)
-        }
-      }
-
-      const displayLabel = task.longName
-        ? `${task.shortName}: ${task.longName}`
-        : task.shortName
-      const padding = Math.min(task.level, 3) * 20 + (hasChildren ? 0 : 26)
-      const indentedLabel = (
-        <div
-          style={{
-            display: "flex",
-            flexDirection: "row",
-            alignItems: "center",
-            paddingLeft: padding,
-            gap: 10,
-            cursor: "auto"
-          }}
-        >
-          {hasChildren && (
-            <span
-              onClick={e => {
-                e.stopPropagation()
-                handleExpand(task)
-              }}
-              style={{ cursor: "pointer" }}
-            >
-              <Icon
-                icon={
-                  isExpanded ? IconNames.CHEVRON_DOWN : IconNames.CHEVRON_RIGHT
-                }
-                size={IconSize.STANDARD}
-                color="#5f6b7c"
-              />
-            </span>
-          )}
-          {hasChildren ? (
-            <Icon
-              icon={isExpanded ? IconNames.FOLDER_OPEN : IconNames.FOLDER_CLOSE}
-              size={IconSize.STANDARD}
-              color="#5f6b7c"
-            />
-          ) : (
-            <Icon
-              icon={IconNames.DOCUMENT}
-              size={IconSize.STANDARD}
-              color="#5f6b7c"
-            />
-          )}
-          <Icon icon={IconNames.STAR} size={12} />
-          <span
-            onClick={handleToggleSelection}
-            style={{
-              cursor: "pointer",
-              flexGrow: "1"
-            }}
-          >
-            {displayLabel}
-          </span>
-        </div>
-      )
-
-      return (
-        <React.Fragment key={task.uuid}>
-          <td className="taskName" onClick={e => e.stopPropagation()}>
-            {indentedLabel}
-          </td>
-        </React.Fragment>
-      )
-    }
-
-    return (
-      <AdvancedMultiSelectOverlayTable
-        {...props}
-        items={flattenedItems}
-        renderRow={enhancedRenderRow}
-      />
-    )
-  }
-
-  const AdvancedSelectComponent = multi
-    ? AdvancedMultiSelect
-    : AdvancedSingleSelect
   return !asFormField ? (
     <>
-      {multi
-        ? value.value
-          ?.map(v =>
-            getBreadcrumbTrailAsText(
-              v,
-              v?.ascendantTasks,
-              parentKey,
-              "shortName"
-            )
-          )
-          .join(" or ")
-        : getBreadcrumbTrailAsText(
-          value.value,
-          value.value?.ascendantTasks,
-          parentKey,
-          valueKey
-        )}
+      {value.value
+        ?.map(v =>
+          getBreadcrumbTrailAsText(v, v?.ascendantTasks, parentKey, "shortName")
+        )
+        .join(" or ")}
     </>
   ) : (
-    <AdvancedSelectComponent
+    <AdvancedMultiSelect
       {...advancedSelectProps}
       fieldName={queryKey}
       showRemoveButton={false}
       filterDefs={advancedSelectFilters}
       overlayColumns={["Name"]}
-      overlayRenderRow={TaskOverlayRow}
       overlayTable={HierarchicalOverlayTable}
       objectType={Task}
       valueKey={valueKey}
@@ -348,7 +323,7 @@ const TaskFilter = ({
   }
 }
 
-export const TaskMultiFilter = ({ ...props }) => <TaskFilter {...props} multi />
+export const TaskMultiFilter = ({ ...props }) => <TaskFilter {...props} />
 
 export const deserialize = ({ queryKey }, query, key) => {
   if (query[queryKey]) {

--- a/client/src/components/advancedSearch/TaskFilter.tsx
+++ b/client/src/components/advancedSearch/TaskFilter.tsx
@@ -113,6 +113,9 @@ const TaskFilter = ({
     parentTask {
       uuid
     }
+    descendantTasks {
+      uuid
+    }
   `
 
   const HierarchicalOverlayTable = props => {
@@ -149,6 +152,9 @@ const TaskFilter = ({
                 uuid
                 shortName
               }
+              descendantTasks {
+                uuid
+              }
             }
           }
         }
@@ -179,7 +185,19 @@ const TaskFilter = ({
 
     const buildFlattenedList = (tasks, level = 0) => {
       return tasks.flatMap(task => {
-        const taskWithLevel = { ...task, level }
+        const isTaskSelected = selectedItems?.some(
+          item => item[propsValueKey] === task[propsValueKey]
+        )
+        const isChildrenTaskSelected = selectedItems?.some(item =>
+          task.descendantTasks?.some(child => child.uuid === item.uuid)
+        )
+        const isCollapsed = !expandedItems.has(task.uuid)
+        const isSelected = isTaskSelected
+          ? true
+          : isChildrenTaskSelected && isCollapsed
+            ? null
+            : false
+        const taskWithLevel = { ...task, level, isSelected }
         const children = expandedItems.has(task.uuid)
           ? childrenMap.get(task.uuid) || []
           : []
@@ -215,7 +233,8 @@ const TaskFilter = ({
             flexDirection: "row",
             alignItems: "center",
             paddingLeft: padding,
-            gap: 10
+            gap: 10,
+            cursor: "auto"
           }}
         >
           {hasChildren && (

--- a/client/src/components/advancedSearch/TaskFilter.tsx
+++ b/client/src/components/advancedSearch/TaskFilter.tsx
@@ -5,7 +5,6 @@ import API from "api"
 import useSearchFilter from "components/advancedSearch/hooks"
 import AdvancedMultiSelect from "components/advancedSelectWidget/AdvancedMultiSelect"
 import { AdvancedMultiSelectOverlayTable } from "components/advancedSelectWidget/AdvancedSelectOverlayTable"
-import AdvancedSingleSelect from "components/advancedSelectWidget/AdvancedSingleSelect"
 import { getBreadcrumbTrailAsText } from "components/BreadcrumbTrail"
 import TaskTable from "components/TaskTable"
 import { Task } from "models"
@@ -16,17 +15,17 @@ import { RECURSE_STRATEGY } from "searchUtils"
 import Settings from "settings"
 
 const taskFields = `
-    ${Task.autocompleteQuery}
-    childrenTasks(query: { pageSize: 1 }) {
-      uuid
-    }
-    parentTask {
-      uuid
-    }
-    descendantTasks {
-      uuid
-    }
-  `
+  ${Task.autocompleteQuery}
+  childrenTasks(query: { pageSize: 1 }) {
+    uuid
+  }
+  parentTask {
+    uuid
+  }
+  descendantTasks {
+    uuid
+  }
+`
 
 const GQL_GET_TASK = gql`
   query ($uuid: String!) {
@@ -86,10 +85,7 @@ const HierarchicalOverlayTable = ({
         }
       }
     `
-    const queryVars = {
-      parentTaskUuid: task.uuid,
-      parentTaskRecurseStrategy: RECURSE_STRATEGY.NONE
-    }
+    const queryVars = { parentTaskUuid: task.uuid }
     const data = await API.query(query, { query: queryVars })
     return data.taskList.list
   }
@@ -118,13 +114,13 @@ const HierarchicalOverlayTable = ({
       const isTaskSelected = selectedItems?.some(
         item => item.uuid === task.uuid
       )
-      const hasDescendantTasksSelected = selectedItems?.some(item =>
+      const isChildrenTaskSelected = selectedItems?.some(item =>
         task.descendantTasks?.some(child => child.uuid === item.uuid)
       )
       const isCollapsed = !expandedItems.has(task.uuid)
       const isSelected = isTaskSelected
         ? true
-        : hasDescendantTasksSelected && isCollapsed
+        : isChildrenTaskSelected && isCollapsed
           ? null
           : false
       const taskWithLevel = { ...task, level, isSelected }
@@ -167,33 +163,37 @@ const HierarchicalOverlayTable = ({
           cursor: "auto"
         }}
       >
-        {(hasChildren && (
-          <>
-            <span
-              onClick={e => {
-                e.stopPropagation()
-                handleExpand(task)
-              }}
-              style={{ cursor: "pointer" }}
-            >
-              <Icon
-                icon={
-                  isExpanded ? IconNames.CHEVRON_DOWN : IconNames.CHEVRON_RIGHT
-                }
-                size={IconSize.STANDARD}
-              />
-            </span>
+        {hasChildren && (
+          <span
+            onClick={e => {
+              e.stopPropagation()
+              handleExpand(task)
+            }}
+            style={{ cursor: "pointer" }}
+          >
             <Icon
-              icon={isExpanded ? IconNames.FOLDER_OPEN : IconNames.FOLDER_CLOSE}
+              icon={
+                isExpanded ? IconNames.CHEVRON_DOWN : IconNames.CHEVRON_RIGHT
+              }
               size={IconSize.STANDARD}
+              color="#5f6b7c"
             />
-          </>
-        )) || <Icon icon={IconNames.DOCUMENT} size={IconSize.STANDARD} />}
-        <img
-          src={TASKS_ICON}
-          alt=""
-          style={{ marginLeft: 5, marginRight: 5, height: "1em" }}
-        />
+          </span>
+        )}
+        {hasChildren ? (
+          <Icon
+            icon={isExpanded ? IconNames.FOLDER_OPEN : IconNames.FOLDER_CLOSE}
+            size={IconSize.STANDARD}
+            color="#5f6b7c"
+          />
+        ) : (
+          <Icon
+            icon={IconNames.DOCUMENT}
+            size={IconSize.STANDARD}
+            color="#5f6b7c"
+          />
+        )}
+        <Icon icon={IconNames.STAR} size={12} />
         <span
           onClick={handleToggleSelection}
           style={{

--- a/client/src/components/advancedSearch/TaskFilter.tsx
+++ b/client/src/components/advancedSearch/TaskFilter.tsx
@@ -26,14 +26,6 @@ const taskFields = `
   }
 `
 
-const GQL_GET_TASK = gql`
-  query ($uuid: String!) {
-    task(uuid: $uuid) {
-      ${taskFields}
-    }
-  }
-`
-
 const GQL_GET_TASKS = gql`
   query ($uuids: [String]) {
     tasks(uuids: $uuids) {
@@ -76,11 +68,6 @@ const HierarchicalOverlayTable = ({
             descendantTasks {
               uuid
             }
-            parentTask {
-              childrenTasks {
-                ${taskFields}
-              }
-            }
           }
         }
       }
@@ -121,12 +108,12 @@ const HierarchicalOverlayTable = ({
           task.ascendantTasks?.some(child => child.uuid === item.uuid)
         )
       const isCollapsed = !expandedItems.has(task.uuid)
+      const isDescendantTaskSelectedAndCollapsed =
+        isDescendantTaskSelected && isCollapsed ? null : false
       const isSelected =
         isTaskSelected || isAscendantTaskSelected
           ? true
-          : isDescendantTaskSelected && isCollapsed
-            ? null
-            : false
+          : isDescendantTaskSelectedAndCollapsed
       const disabled = isAscendantTaskSelected
       const taskWithLevel = { ...task, level, isSelected, disabled }
       const children = expandedItems.has(task.uuid)
@@ -181,7 +168,6 @@ const HierarchicalOverlayTable = ({
                 isExpanded ? IconNames.CHEVRON_DOWN : IconNames.CHEVRON_RIGHT
               }
               size={IconSize.STANDARD}
-              color="#5f6b7c"
             />
           </span>
         )}
@@ -189,14 +175,9 @@ const HierarchicalOverlayTable = ({
           <Icon
             icon={isExpanded ? IconNames.FOLDER_OPEN : IconNames.FOLDER_CLOSE}
             size={IconSize.STANDARD}
-            color="#5f6b7c"
           />
         ) : (
-          <Icon
-            icon={IconNames.DOCUMENT}
-            size={IconSize.STANDARD}
-            color="#5f6b7c"
-          />
+          <Icon icon={IconNames.DOCUMENT} size={IconSize.STANDARD} />
         )}
         <Icon icon={IconNames.STAR} size={12} />
         <span
@@ -268,9 +249,6 @@ const TaskFilter = ({
     defaultValue,
     toQuery
   )
-
-  const [expandedItems, setExpandedItems] = useState(new Set<string>())
-  const [childrenMap, setChildrenMap] = useState(new Map<string, any[]>())
 
   const advancedSelectFilters = {
     all: {

--- a/client/src/components/advancedSearch/TaskFilter.tsx
+++ b/client/src/components/advancedSearch/TaskFilter.tsx
@@ -302,7 +302,7 @@ const TaskFilter = ({
       onChange={handleChangeTask}
       pageSize={0}
       value={value.value}
-      autoComplete="off"
+      autoComplete={"off"}
       renderSelected={
         <TaskTable
           tasks={value.value}

--- a/client/src/components/advancedSearch/TaskFilter.tsx
+++ b/client/src/components/advancedSearch/TaskFilter.tsx
@@ -278,6 +278,204 @@ const TaskFilter = ({
   const parentKey = "parentTask"
   const valueKey = "uuid"
 
+  const taskFields = `
+    ${Task.autocompleteQuery}
+    childrenTasks(query: { pageSize: 1 }) {
+      uuid
+    }
+    parentTask {
+      uuid
+    }
+    descendantTasks {
+      uuid
+    }
+  `
+
+  const HierarchicalOverlayTable = props => {
+    const {
+      items,
+      valueKey: propsValueKey,
+      selectedItems,
+      handleAddItem,
+      handleRemoveItem
+    } = { ...props }
+    const fetchChildren = async task => {
+      const query = gql`
+        query ($query: TaskSearchQueryInput) {
+          taskList(query: $query) {
+            list {
+              uuid
+              shortName
+              longName
+              parentTask {
+                uuid
+                shortName
+                parentTask {
+                  uuid
+                }
+              }
+              ascendantTasks {
+                uuid
+                shortName
+                parentTask {
+                  uuid
+                }
+              }
+              childrenTasks {
+                uuid
+                shortName
+              }
+              descendantTasks {
+                uuid
+              }
+            }
+          }
+        }
+      `
+      const queryVars = { parentTaskUuid: task.uuid }
+      const data = await API.query(query, { query: queryVars })
+      return data.taskList.list
+    }
+
+    const handleExpand = task => {
+      if (expandedItems.has(task.uuid)) {
+        setExpandedItems(prev => {
+          const newSet = new Set(prev)
+          newSet.delete(task.uuid)
+          return newSet
+        })
+      } else {
+        if (!childrenMap.has(task.uuid)) {
+          fetchChildren(task).then(children => {
+            setChildrenMap(prev => new Map(prev).set(task.uuid, children))
+            setExpandedItems(prev => new Set([...prev, task.uuid]))
+          })
+        } else {
+          setExpandedItems(prev => new Set([...prev, task.uuid]))
+        }
+      }
+    }
+
+    const buildFlattenedList = (tasks, level = 0) => {
+      return tasks.flatMap(task => {
+        const isTaskSelected = selectedItems?.some(
+          item => item[propsValueKey] === task[propsValueKey]
+        )
+        const isChildrenTaskSelected = selectedItems?.some(item =>
+          task.descendantTasks?.some(child => child.uuid === item.uuid)
+        )
+        const isCollapsed = !expandedItems.has(task.uuid)
+        const isSelected = isTaskSelected
+          ? true
+          : isChildrenTaskSelected && isCollapsed
+            ? null
+            : false
+        const taskWithLevel = { ...task, level, isSelected }
+        const children = expandedItems.has(task.uuid)
+          ? childrenMap.get(task.uuid) || []
+          : []
+        return [taskWithLevel, ...buildFlattenedList(children, level + 1)]
+      })
+    }
+
+    const topLevelItems = items.filter(task => !task.parentTask)
+    const flattenedItems = buildFlattenedList(topLevelItems)
+
+    const enhancedRenderRow = task => {
+      const hasChildren = task.childrenTasks?.length > 0
+      const isExpanded = expandedItems.has(task.uuid)
+      const isSelected = selectedItems?.some(
+        item => item[propsValueKey] === task[propsValueKey]
+      )
+
+      const handleToggleSelection = e => {
+        e.stopPropagation()
+        if (isSelected) {
+          handleRemoveItem(task)
+        } else {
+          handleAddItem(task)
+        }
+      }
+
+      const displayLabel = task.longName
+        ? `${task.shortName}: ${task.longName}`
+        : task.shortName
+      const padding = Math.min(task.level, 3) * 20 + (hasChildren ? 0 : 26)
+      const indentedLabel = (
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "row",
+            alignItems: "center",
+            paddingLeft: padding,
+            gap: 10,
+            cursor: "auto"
+          }}
+        >
+          {hasChildren && (
+            <span
+              onClick={e => {
+                e.stopPropagation()
+                handleExpand(task)
+              }}
+              style={{ cursor: "pointer" }}
+            >
+              <Icon
+                icon={
+                  isExpanded ? IconNames.CHEVRON_DOWN : IconNames.CHEVRON_RIGHT
+                }
+                size={IconSize.STANDARD}
+                color="#5f6b7c"
+              />
+            </span>
+          )}
+          {hasChildren ? (
+            <Icon
+              icon={isExpanded ? IconNames.FOLDER_OPEN : IconNames.FOLDER_CLOSE}
+              size={IconSize.STANDARD}
+              color="#5f6b7c"
+            />
+          ) : (
+            <Icon
+              icon={IconNames.DOCUMENT}
+              size={IconSize.STANDARD}
+              color="#5f6b7c"
+            />
+          )}
+          <Icon icon={IconNames.STAR} size={12} />
+          <span
+            onClick={handleToggleSelection}
+            style={{
+              cursor: "pointer",
+              flexGrow: "1"
+            }}
+          >
+            {displayLabel}
+          </span>
+        </div>
+      )
+
+      return (
+        <React.Fragment key={task.uuid}>
+          <td className="taskName" onClick={e => e.stopPropagation()}>
+            {indentedLabel}
+          </td>
+        </React.Fragment>
+      )
+    }
+
+    return (
+      <AdvancedMultiSelectOverlayTable
+        {...props}
+        items={flattenedItems}
+        renderRow={enhancedRenderRow}
+      />
+    )
+  }
+
+  const AdvancedSelectComponent = multi
+    ? AdvancedMultiSelect
+    : AdvancedSingleSelect
   return !asFormField ? (
     <>
       {value.value

--- a/client/src/components/advancedSearch/TaskFilter.tsx
+++ b/client/src/components/advancedSearch/TaskFilter.tsx
@@ -111,16 +111,16 @@ const HierarchicalOverlayTable = ({
 
   const buildFlattenedList = (tasks, level = 0) => {
     return tasks.flatMap(task => {
-      const isTaskSelected = selectedItems?.some(
-        item => item.uuid === task.uuid
-      )
-      const isChildrenTaskSelected = selectedItems?.some(item =>
+      const isDescendantTaskSelected = selectedItems?.some(item =>
         task.descendantTasks?.some(child => child.uuid === item.uuid)
       )
+      const isAscendantTaskSelected = selectedItems?.some(item =>
+        task.ascendantTasks?.some(child => child.uuid === item.uuid)
+      )
       const isCollapsed = !expandedItems.has(task.uuid)
-      const isSelected = isTaskSelected
+      const isSelected = isAscendantTaskSelected
         ? true
-        : isChildrenTaskSelected && isCollapsed
+        : isDescendantTaskSelected && isCollapsed
           ? null
           : false
       const taskWithLevel = { ...task, level, isSelected }

--- a/client/src/components/advancedSearch/TaskFilter.tsx
+++ b/client/src/components/advancedSearch/TaskFilter.tsx
@@ -231,10 +231,33 @@ const TaskFilter = ({
                   isExpanded ? IconNames.CHEVRON_DOWN : IconNames.CHEVRON_RIGHT
                 }
                 size={IconSize.STANDARD}
+                color="#5f6b7c"
               />
             </span>
           )}
-          <span onClick={handleToggleSelection}>{displayLabel}</span>
+          {hasChildren ? (
+            <Icon
+              icon={isExpanded ? IconNames.FOLDER_OPEN : IconNames.FOLDER_CLOSE}
+              size={IconSize.STANDARD}
+              color="#5f6b7c"
+            />
+          ) : (
+            <Icon
+              icon={IconNames.DOCUMENT}
+              size={IconSize.STANDARD}
+              color="#5f6b7c"
+            />
+          )}
+          <Icon icon={IconNames.STAR} size={12} />
+          <span
+            onClick={handleToggleSelection}
+            style={{
+              cursor: "pointer",
+              flexGrow: "1"
+            }}
+          >
+            {displayLabel}
+          </span>
         </div>
       )
 

--- a/client/src/components/advancedSearch/TaskFilter.tsx
+++ b/client/src/components/advancedSearch/TaskFilter.tsx
@@ -292,13 +292,9 @@ const TaskFilter = ({
   `
 
   const HierarchicalOverlayTable = props => {
-    const {
-      items,
-      valueKey: propsValueKey,
-      selectedItems,
-      handleAddItem,
-      handleRemoveItem
-    } = { ...props }
+    const { items, selectedItems, handleAddItem, handleRemoveItem } = {
+      ...props
+    }
     const fetchChildren = async task => {
       const query = gql`
         query ($query: TaskSearchQueryInput) {
@@ -307,13 +303,6 @@ const TaskFilter = ({
               uuid
               shortName
               longName
-              parentTask {
-                uuid
-                shortName
-                parentTask {
-                  uuid
-                }
-              }
               ascendantTasks {
                 uuid
                 shortName
@@ -323,7 +312,6 @@ const TaskFilter = ({
               }
               childrenTasks {
                 uuid
-                shortName
               }
               descendantTasks {
                 uuid
@@ -359,7 +347,7 @@ const TaskFilter = ({
     const buildFlattenedList = (tasks, level = 0) => {
       return tasks.flatMap(task => {
         const isTaskSelected = selectedItems?.some(
-          item => item[propsValueKey] === task[propsValueKey]
+          item => item.uuid === task.uuid
         )
         const isChildrenTaskSelected = selectedItems?.some(item =>
           task.descendantTasks?.some(child => child.uuid === item.uuid)
@@ -384,9 +372,7 @@ const TaskFilter = ({
     const enhancedRenderRow = task => {
       const hasChildren = task.childrenTasks?.length > 0
       const isExpanded = expandedItems.has(task.uuid)
-      const isSelected = selectedItems?.some(
-        item => item[propsValueKey] === task[propsValueKey]
-      )
+      const isSelected = selectedItems?.some(item => item.uuid === task.uuid)
 
       const handleToggleSelection = e => {
         e.stopPropagation()
@@ -502,7 +488,7 @@ const TaskFilter = ({
       onChange={handleChangeTask}
       pageSize={0}
       value={value.value}
-      autoComplete={"off"}
+      autoComplete="off"
       renderSelected={
         <TaskTable
           tasks={value.value}

--- a/client/src/components/advancedSearch/TaskFilter.tsx
+++ b/client/src/components/advancedSearch/TaskFilter.tsx
@@ -224,7 +224,9 @@ const TaskFilter = ({
         }
       }
 
-      const displayLabel = task.shortName || `Task ${task.uuid}`
+      const displayLabel = task.longName
+        ? `${task.shortName}: ${task.longName}`
+        : task.shortName
       const padding = Math.min(task.level, 3) * 20 + (hasChildren ? 0 : 26)
       const indentedLabel = (
         <div

--- a/client/src/components/advancedSearch/TaskFilter.tsx
+++ b/client/src/components/advancedSearch/TaskFilter.tsx
@@ -341,6 +341,7 @@ const TaskFilter = ({
       onChange={handleChangeTask}
       pageSize={0}
       value={value.value}
+      autoComplete={"off"}
       renderSelected={
         <TaskTable
           tasks={value.value}

--- a/client/src/components/advancedSearch/TaskFilter.tsx
+++ b/client/src/components/advancedSearch/TaskFilter.tsx
@@ -502,7 +502,7 @@ const TaskFilter = ({
       onChange={handleChangeTask}
       pageSize={0}
       value={value.value}
-      autoComplete="off"
+      autoComplete={"off"}
       renderSelected={
         <TaskTable
           tasks={value.value}

--- a/client/src/components/advancedSelectWidget/AdvancedSelect.tsx
+++ b/client/src/components/advancedSelectWidget/AdvancedSelect.tsx
@@ -141,7 +141,7 @@ const AdvancedSelect = ({
   handleAddItem,
   handleRemoveItem,
   createEntityComponent,
-  autoComplete = "on"
+  autoComplete
 }: AdvancedSelectProps) => {
   const firstFilter = Object.keys(filterDefs)[0]
 

--- a/client/src/components/advancedSelectWidget/AdvancedSelect.tsx
+++ b/client/src/components/advancedSelectWidget/AdvancedSelect.tsx
@@ -100,7 +100,7 @@ export interface AdvancedSelectProps {
   renderSelected?: React.ReactElement
   overlayTable?: React.ReactElement // how to render the selected items
   overlayColumns: string[] // search results component for in the overlay
-  overlayRenderRow: (...args: unknown[]) => unknown
+  overlayRenderRow?: (...args: unknown[]) => unknown
   closeOverlayOnAdd?: boolean // set to true if you want the overlay to be closed after an add action
   filterDefs: any
   onChange?: (...args: unknown[]) => unknown // config of the search filters
@@ -141,7 +141,7 @@ const AdvancedSelect = ({
   handleAddItem,
   handleRemoveItem,
   createEntityComponent,
-  autoComplete = "on"
+  autoComplete
 }: AdvancedSelectProps) => {
   const firstFilter = Object.keys(filterDefs)[0]
 

--- a/client/src/components/advancedSelectWidget/AdvancedSelect.tsx
+++ b/client/src/components/advancedSelectWidget/AdvancedSelect.tsx
@@ -113,6 +113,7 @@ export interface AdvancedSelectProps {
   handleAddItem?: (...args: unknown[]) => unknown
   handleRemoveItem?: (...args: unknown[]) => unknown
   createEntityComponent?: (...args: unknown[]) => React.ReactNode
+  autoComplete?: string
 }
 
 const AdvancedSelect = ({
@@ -139,7 +140,8 @@ const AdvancedSelect = ({
   fields,
   handleAddItem,
   handleRemoveItem,
-  createEntityComponent
+  createEntityComponent,
+  autoComplete = "on"
 }: AdvancedSelectProps) => {
   const firstFilter = Object.keys(filterDefs)[0]
 
@@ -398,6 +400,7 @@ const AdvancedSelect = ({
                 <InputGroup>
                   <Form.Control
                     name={fieldName}
+                    autoComplete={autoComplete}
                     value={searchTerms || ""}
                     placeholder={placeholder}
                     onChange={changeSearchTerms}

--- a/client/src/components/advancedSelectWidget/AdvancedSelect.tsx
+++ b/client/src/components/advancedSelectWidget/AdvancedSelect.tsx
@@ -141,7 +141,7 @@ const AdvancedSelect = ({
   handleAddItem,
   handleRemoveItem,
   createEntityComponent,
-  autoComplete
+  autoComplete = "on"
 }: AdvancedSelectProps) => {
   const firstFilter = Object.keys(filterDefs)[0]
 

--- a/client/src/components/advancedSelectWidget/AdvancedSelectOverlayTable.tsx
+++ b/client/src/components/advancedSelectWidget/AdvancedSelectOverlayTable.tsx
@@ -49,17 +49,26 @@ const AdvancedSelectOverlayTable = ({
           const isSelected = Object.hasOwn(item, "isSelected")
             ? item.isSelected
             : selectedItemsUuids.includes(item.uuid)
+          const disabled = item.disabled
           const handleClick = () =>
             isSelected ? handleRemoveItem(item) : handleAddItem(item)
           const renderSelectComponent = React.cloneElement(
             selectItemComponent,
-            { name: fieldName, checked: isSelected, onChange: () => null }
+            {
+              name: fieldName,
+              checked: isSelected,
+              disabled,
+              onChange: () => null
+            }
           )
           return (
             <tr
               key={`${item.uuid}-${pageNum}-${i}`}
               onClick={handleClick}
-              style={{ cursor: "pointer" }}
+              style={{
+                cursor: disabled ? "auto" : "pointer",
+                pointerEvents: disabled ? "none" : "all"
+              }}
             >
               <td style={{ textAlign: "center" }}>{renderSelectComponent}</td>
               {renderRow(item)}

--- a/client/src/components/advancedSelectWidget/AdvancedSelectOverlayTable.tsx
+++ b/client/src/components/advancedSelectWidget/AdvancedSelectOverlayTable.tsx
@@ -46,10 +46,9 @@ const AdvancedSelectOverlayTable = ({
       </thead>
       <tbody>
         {objectType.map(items, (item, i) => {
-          const isSelected =
-            "isSelected" in item
-              ? item.isSelected
-              : selectedItemsUuids.includes(item.uuid)
+          const isSelected = Object.hasOwn(item, "isSelected")
+            ? item.isSelected
+            : selectedItemsUuids.includes(item.uuid)
           const handleClick = () =>
             isSelected ? handleRemoveItem(item) : handleAddItem(item)
           const renderSelectComponent = React.cloneElement(

--- a/client/src/components/advancedSelectWidget/AdvancedSelectOverlayTable.tsx
+++ b/client/src/components/advancedSelectWidget/AdvancedSelectOverlayTable.tsx
@@ -46,7 +46,10 @@ const AdvancedSelectOverlayTable = ({
       </thead>
       <tbody>
         {objectType.map(items, (item, i) => {
-          const isSelected = selectedItemsUuids.includes(item.uuid)
+          const isSelected =
+            "isSelected" in item
+              ? item.isSelected
+              : selectedItemsUuids.includes(item.uuid)
           const handleClick = () =>
             isSelected ? handleRemoveItem(item) : handleAddItem(item)
           const renderSelectComponent = React.cloneElement(

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -965,6 +965,10 @@ header.searchPagination {
   min-width: 50vw;
 }
 
+#taskUuid-popover .bp5-icon, #parentTaskUuid-popover .bp5-icon {
+  color: #5f6b7c;
+}
+
 .advanced-search {
   padding: 15px;
 }

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -963,10 +963,9 @@ header.searchPagination {
 
 #taskUuid-popover, #parentTaskUuid-popover {
   min-width: 50vw;
-}
-
-#taskUuid-popover .bp5-icon, #parentTaskUuid-popover .bp5-icon {
-  color: #5f6b7c;
+  & .bp5-icon {
+    color: #5f6b7c;
+  }
 }
 
 .advanced-search {

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -961,6 +961,10 @@ header.searchPagination {
   overflow-y: scroll;
 }
 
+#taskUuid-popover, #parentTaskUuid-popover {
+  min-width: 50vw;
+}
+
 .advanced-search {
   padding: 15px;
 }


### PR DESCRIPTION
To improve visual indication of task hierarchy, tasks will now be displayed in a tree instead of a flat list with the task breadcrumbs.

Closes [AB#1292](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1292)

#### User changes
- Task filters now displays a tree-like list of the objectives
  -  Multi selection of the task
  -  Expansion/collapse of the trees
  -  Hide autocomplete result for better visual clarity
  -  Wider popover

#### Superuser changes
- None

#### Admin changes
- None

#### System admin changes
- [ ] application.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
- [x] described the user behavior in PR body
- [x] referenced/updated all related issues
- [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
- [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
- [ ] added and/or updated unit tests
- [ ] added and/or updated e2e tests
- [ ] added and/or updated data migrations
- [ ] updated documentation
- [x] resolved all build errors and warnings
- [ ] opened debt issues for anything not resolved here
