### PR TITLE
Define custom relative period in filter

### DIFF
--- a/client/src/dateUtils.ts
+++ b/client/src/dateUtils.ts
@@ -1,9 +1,11 @@
+import { L } from "@fullcalendar/list/internal-common"
 import moment from "moment"
 
 export const BETWEEN = "0"
 export const BEFORE = "1"
 export const AFTER = "2"
 export const ON = "3"
+export const LAST_X_DAYS = "4"
 export const LAST_DAY = -1 * 1000 * 60 * 60 * 24
 export const LAST_WEEK = LAST_DAY * 7
 export const LAST_MONTH = LAST_DAY * 30
@@ -13,6 +15,7 @@ export const RANGE_TYPE_LABELS = {
   [BEFORE]: "Before",
   [AFTER]: "After",
   [ON]: "On",
+  [LAST_X_DAYS]: "Last … days",
   [LAST_DAY]: "Last 24 hours",
   [LAST_WEEK]: "Last 7 days",
   [LAST_MONTH]: "Last 30 days"
@@ -54,6 +57,16 @@ export function dateToQuery(queryKey, value) {
     return {
       [startKey]: startDateStart,
       [endKey]: startDateEnd
+    }
+  } else if (value.relative === LAST_X_DAYS) {
+    const days = value.days
+    if (days && !isNaN(days)) {
+      const milliseconds = days * LAST_DAY
+      return {
+        [startKey]: milliseconds
+      }
+    } else {
+      return {}
     }
   } else {
     // LAST_DAY, LAST_WEEK, LAST_MONTH => Time relative to now, up till now

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1009,6 +1009,22 @@ header.searchPagination {
   padding-bottom: 1px;
 }
 
+.custom-number-input {
+  width: 5rem;
+  padding: 0.375rem 0.75rem;
+  font-size: 1rem;
+  line-height: 1.5;
+  border: 1px solid #dee2e6;
+  border-radius: 0.375rem;
+  transition: border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+}
+
+.custom-number-input:focus {
+  border-color: #86b7fe;
+  outline: none;
+  box-shadow: 0 0 0 0.25rem rgba(13, 110, 253, 0.25);
+}
+
 @keyframes flash {
   50% {
     background: #fff;


### PR DESCRIPTION
The user wanted to be able to use date filter to retrieve results from the last defined days

Closes AB#1313

#### User changes
- Added a new Date Range Filter to select the Last … days, where the user can input a positive integer value

#### Superuser changes
- None

#### Admin changes
- None

#### System admin changes
- [ ] application.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
- [x] described the user behavior in PR body
- [x] referenced/updated all related issues
- [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
- [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
- [ ] added and/or updated unit tests
- [ ] added and/or updated e2e tests
- [ ] added and/or updated data migrations
- [ ] updated documentation
- [x] resolved all build errors and warnings
- [ ] opened debt issues for anything not resolved here
