### PR TITLE
Update Referrer Policy for default security config

### DIFF
--- a/src/main/java/mil/dds/anet/config/SecurityConfig.java
+++ b/src/main/java/mil/dds/anet/config/SecurityConfig.java
@@ -4,6 +4,7 @@ import static mil.dds.anet.config.ContentSecurityPolicy.CSP_NONE;
 import static mil.dds.anet.config.ContentSecurityPolicy.CSP_SELF;
 import static mil.dds.anet.config.ContentSecurityPolicy.CspDirective;
 import static org.springframework.security.web.header.writers.ReferrerPolicyHeaderWriter.ReferrerPolicy.NO_REFERRER;
+import static org.springframework.security.web.header.writers.ReferrerPolicyHeaderWriter.ReferrerPolicy.SAME_ORIGIN;
 
 import jakarta.servlet.http.HttpServletMapping;
 import java.util.List;
@@ -126,7 +127,7 @@ public class SecurityConfig {
         .contentSecurityPolicy(csp -> csp.policyDirectives(String.format(defaultCsp.toString(),
             getAuthServerUrl(), getGeoSearcherUrl(), getBaseLayersUrls()))));
     // Configure Referrer Policy
-    http.headers(header -> header.referrerPolicy(rp -> rp.policy(NO_REFERRER)));
+    http.headers(header -> header.referrerPolicy(rp -> rp.policy(SAME_ORIGIN)));
     return http.build();
   }
 


### PR DESCRIPTION
Make the Admin GUI "Recent Activities & Recent Users" view show useful Requests again.

Closes [AB#1280](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1280) 

#### User changes
- None

#### Superuser changes
- None

#### Admin changes
- The "Recent Activities & Recent Users" view in the Admin GUI shows useful Requests again.

#### System admin changes
- [ ] application.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
- [x] described the user behavior in PR body
- [x] referenced/updated all related issues
- [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
- [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
- [ ] added and/or updated unit tests
- [ ] added and/or updated e2e tests
- [ ] added and/or updated data migrations
- [ ] updated documentation
- [x] resolved all build errors and warnings
- [ ] opened debt issues for anything not resolved here
