### PR TITLE
Improve multiselect interaction

### DIFF
--- a/client/src/components/advancedSelectWidget/AdvancedSelect.tsx
+++ b/client/src/components/advancedSelectWidget/AdvancedSelect.tsx
@@ -315,7 +315,7 @@ const AdvancedSelect = ({
                     <BlueprintButton
                       icon="cross"
                       variant="minimal"
-                      onClick={() => setDoReset(true)} 
+                      onClick={() => setDoReset(true)}
                       style={{
                         position: "absolute",
                         top: "5px",
@@ -339,7 +339,7 @@ const AdvancedSelect = ({
                             items={filterDefs}
                             handleOnChange={handleOnChangeSelect}
                           />
-                          <Col md={hasMultipleItems(filterDefs) ? 8 : 11}>
+                          <Col md={hasMultipleItems(filterDefs) ? 8 : 12}>
                             <OverlayTable
                               fieldName={fieldName}
                               items={items}

--- a/client/src/components/advancedSelectWidget/AdvancedSelect.tsx
+++ b/client/src/components/advancedSelectWidget/AdvancedSelect.tsx
@@ -1,5 +1,9 @@
 import { gql } from "@apollo/client"
-import { Popover, PopoverInteractionKind } from "@blueprintjs/core"
+import {
+  Button as BlueprintButton,
+  Popover,
+  PopoverInteractionKind
+} from "@blueprintjs/core"
 import API from "api"
 import classNames from "classnames"
 import Model from "components/Model"
@@ -307,72 +311,83 @@ const AdvancedSelect = ({
               <Popover
                 popoverClassName="advanced-select-popover bp5-popover-content-sizing"
                 content={
-                  <Row id={`${fieldName}-popover`} className="border-between">
-                    {(showCreateEntityComponent && (
-                      <Col md="12">
-                        {createEntityComponent(searchTerms, setDoReset)}
-                      </Col>
-                    )) || (
-                      <>
-                        <FilterAsNav
-                          items={filterDefs}
-                          currentFilter={filterType}
-                          handleOnClick={changeFilterType}
-                        />
-
-                        <FilterAsDropdown
-                          items={filterDefs}
-                          handleOnChange={handleOnChangeSelect}
-                        />
-
-                        <Col md={hasMultipleItems(filterDefs) ? 8 : 11}>
-                          <OverlayTable
-                            fieldName={fieldName}
-                            items={items}
-                            pageNum={pageNum}
-                            selectedItems={value}
-                            valueKey={valueKey}
-                            handleAddItem={item => {
-                              handleAddItem(item)
-                              if (closeOverlayOnAdd) {
-                                setDoReset(true)
-                              }
-                            }}
-                            handleRemoveItem={handleRemoveItem}
-                            objectType={objectType}
-                            columns={[""].concat(overlayColumns)}
-                            renderRow={overlayRenderRow}
-                            isLoading={isLoading}
-                            loaderMessage={
-                              <div style={{ width: "300px" }}>
-                                <div>No results found.</div>
-                                {createEntityComponent && (
-                                  <div>
-                                    <Button
-                                      id="createEntityLink"
-                                      onClick={() =>
-                                        setShowCreateEntityComponent(true)}
-                                    >
-                                      Create a new {fieldName}
-                                    </Button>
-                                  </div>
-                                )}
-                              </div>
-                            }
-                          />
-                          <UltimatePagination
-                            Component="footer"
-                            componentClassName="searchPagination"
-                            className="float-end"
-                            pageNum={pageNum}
-                            pageSize={pageSize}
-                            totalCount={totalCount}
-                            goToPage={goToPage}
-                          />
+                  <div style={{ position: "relative", padding: "10px" }}>
+                    <BlueprintButton
+                      icon="cross"
+                      variant="minimal"
+                      onClick={() => setDoReset(true)} 
+                      style={{
+                        position: "absolute",
+                        top: "5px",
+                        right: "5px",
+                        zIndex: 10
+                      }}
+                    />
+                    <Row id={`${fieldName}-popover`} className="border-between">
+                      {(showCreateEntityComponent && (
+                        <Col md="12">
+                          {createEntityComponent(searchTerms, setDoReset)}
                         </Col>
-                      </>
-                    )}
-                  </Row>
+                      )) || (
+                        <>
+                          <FilterAsNav
+                            items={filterDefs}
+                            currentFilter={filterType}
+                            handleOnClick={changeFilterType}
+                          />
+                          <FilterAsDropdown
+                            items={filterDefs}
+                            handleOnChange={handleOnChangeSelect}
+                          />
+                          <Col md={hasMultipleItems(filterDefs) ? 8 : 11}>
+                            <OverlayTable
+                              fieldName={fieldName}
+                              items={items}
+                              pageNum={pageNum}
+                              selectedItems={value}
+                              valueKey={valueKey}
+                              handleAddItem={item => {
+                                handleAddItem(item)
+                                if (closeOverlayOnAdd) {
+                                  setDoReset(true)
+                                }
+                              }}
+                              handleRemoveItem={handleRemoveItem}
+                              objectType={objectType}
+                              columns={[""].concat(overlayColumns)}
+                              renderRow={overlayRenderRow}
+                              isLoading={isLoading}
+                              loaderMessage={
+                                <div style={{ width: "300px" }}>
+                                  <div>No results found.</div>
+                                  {createEntityComponent && (
+                                    <div>
+                                      <Button
+                                        id="createEntityLink"
+                                        onClick={() =>
+                                          setShowCreateEntityComponent(true)}
+                                      >
+                                        Create a new {fieldName}
+                                      </Button>
+                                    </div>
+                                  )}
+                                </div>
+                              }
+                            />
+                            <UltimatePagination
+                              Component="footer"
+                              componentClassName="searchPagination"
+                              className="float-end"
+                              pageNum={pageNum}
+                              pageSize={pageSize}
+                              totalCount={totalCount}
+                              goToPage={goToPage}
+                            />
+                          </Col>
+                        </>
+                      )}
+                    </Row>
+                  </div>
                 }
                 isOpen={showOverlay}
                 captureDismiss


### PR DESCRIPTION
It was quite cumbersome to close the multiselect window on the search filters.
The was no close button and the user had to click outside the multiselect, but only on the parent div

Closes AB#1333

#### User changes
- Any AdvancedSelect popover will have a close button on the top right corner

#### Superuser changes
- None

#### Admin changes
- None

#### System admin changes
- [ ] application.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
- [x] described the user behavior in PR body
- [x] referenced/updated all related issues
- [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
- [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
- [ ] added and/or updated unit tests
- [ ] added and/or updated e2e tests
- [ ] added and/or updated data migrations
- [ ] updated documentation
- [x] resolved all build errors and warnings
- [ ] opened debt issues for anything not resolved here
