### PR TITLE
Fix saved search for "Within Objective" and "Within Location"

### DIFF
--- a/client/src/components/advancedSearch/TaskFilter.tsx
+++ b/client/src/components/advancedSearch/TaskFilter.tsx
@@ -17,6 +17,16 @@ const GQL_GET_TASK = gql`
     task(uuid: $uuid) {
       uuid
       shortName
+      parentTask {
+        uuid
+      }
+      ascendantTasks {
+        uuid
+        shortName
+        parentTask {
+          uuid
+        }
+      }
     }
   }
 `
@@ -26,6 +36,16 @@ const GQL_GET_TASKS = gql`
     tasks(uuids: $uuids) {
       uuid
       shortName
+      parentTask {
+        uuid
+      }
+      ascendantTasks {
+        uuid
+        shortName
+        parentTask {
+          uuid
+        }
+      }
     }
   }
 `

--- a/src/main/java/mil/dds/anet/resources/LocationResource.java
+++ b/src/main/java/mil/dds/anet/resources/LocationResource.java
@@ -60,6 +60,11 @@ public class LocationResource {
     return loc;
   }
 
+  @GraphQLQuery(name = "locations")
+  public List<Location> getByUuids(@GraphQLArgument(name = "uuids") List<String> uuids) {
+    return dao.getByIds(uuids);
+  }
+
   @GraphQLQuery(name = "locationList")
   @AllowUnverifiedUsers
   public AnetBeanList<Location> search(@GraphQLRootContext GraphQLContext context,

--- a/src/main/java/mil/dds/anet/resources/TaskResource.java
+++ b/src/main/java/mil/dds/anet/resources/TaskResource.java
@@ -53,6 +53,11 @@ public class TaskResource {
     return p;
   }
 
+  @GraphQLQuery(name = "tasks")
+  public List<Task> getByUuids(@GraphQLArgument(name = "uuids") List<String> uuids) {
+    return dao.getByIds(uuids);
+  }
+
   @GraphQLMutation(name = "createTask")
   public Task createTask(@GraphQLRootContext GraphQLContext context,
       @GraphQLArgument(name = "task") Task t) {

--- a/src/test/resources/anet.graphql
+++ b/src/test/resources/anet.graphql
@@ -1127,6 +1127,7 @@ type Query {
   eventSeriesList(query: EventSeriesSearchQueryInput): AnetBeanList_EventSeries
   location(uuid: String): Location
   locationList(query: LocationSearchQueryInput): AnetBeanList_Location
+  locations(uuids: [String]): [Location]
   martImportedReports(pageNum: Int = 0, pageSize: Int = 0): AnetBeanList_MartImportedReport
   me: Person
   mySearches: [SavedSearch]

--- a/src/test/resources/anet.graphql
+++ b/src/test/resources/anet.graphql
@@ -1148,6 +1148,7 @@ type Query {
   showRollupEmail(endDate: Instant, orgType: RollupGraphType, orgUuid: String, showText: Boolean = false, startDate: Instant): String
   task(uuid: String): Task
   taskList(query: TaskSearchQueryInput): AnetBeanList_Task
+  tasks(uuids: [String]): [Task]
   userActivityList(query: UserActivitySearchQueryInput): AnetBeanList_UserActivity
 }
 


### PR DESCRIPTION
Loading a saved search with a filter "Within Objective" or "Within Location" didn't work correctly.

Closes AB#1293, AB#1085

#### User changes
- Loading a saved search with a filter "Within Objective" or "Within Location" works correctly again.

#### Superuser changes
- None

#### Admin changes
- None

#### System admin changes
- [ ] application.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [x] graphql schema has changed

### Checklist
- [x] described the user behavior in PR body
- [x] referenced/updated all related issues
- [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
- [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
- [ ] added and/or updated unit tests
- [ ] added and/or updated e2e tests
- [ ] added and/or updated data migrations
- [ ] updated documentation
- [ ] resolved all build errors and warnings
- [ ] opened debt issues for anything not resolved here
