### PR TITLE
Key outcomes and next steps in summary

### DIFF
--- a/client/src/components/ListItems.tsx
+++ b/client/src/components/ListItems.tsx
@@ -3,13 +3,18 @@ import React from "react"
 interface ListItemsProps {
   value: string
   forceList?: boolean
+  compact?: boolean
 }
 
-const ListItems = ({ value, forceList }: ListItemsProps) => {
+const ListItems = ({ value, forceList, compact }: ListItemsProps) => {
   const items = value.split(/[\r\n\v\f\u2028\u2029]+/)
   if (items.length > 1 || forceList) {
     return (
-      <ul style={{ marginLeft: "-18px" }}>
+      <ul
+        style={
+          compact ? { margin: 0 } : { marginLeft: "-18px", marginBottom: 0 }
+        }
+      >
         {items.map((item, index) => (
           <li key={index}>{item}</li>
         ))}

--- a/client/src/components/ListItems.tsx
+++ b/client/src/components/ListItems.tsx
@@ -1,4 +1,10 @@
+import styled from "@emotion/styled"
 import React from "react"
+
+const ListS = styled.ul`
+  margin: 0;
+  margin-left: ${props => props.marginLeft};
+`
 
 interface ListItemsProps {
   value: string
@@ -10,15 +16,11 @@ const ListItems = ({ value, forceList, compact }: ListItemsProps) => {
   const items = value.split(/[\r\n\v\f\u2028\u2029]+/)
   if (items.length > 1 || forceList) {
     return (
-      <ul
-        style={
-          compact ? { margin: 0 } : { marginLeft: "-18px", marginBottom: 0 }
-        }
-      >
+      <ListS marginLeft={compact || "-18px"}>
         {items.map((item, index) => (
           <li key={index}>{item}</li>
         ))}
-      </ul>
+      </ListS>
     )
   }
   return <>{value}</>

--- a/client/src/components/ReportSummary.tsx
+++ b/client/src/components/ReportSummary.tsx
@@ -4,6 +4,7 @@ import { IconNames } from "@blueprintjs/icons"
 import API from "api"
 import { BreadcrumbTrail } from "components/BreadcrumbTrail"
 import LinkTo from "components/LinkTo"
+import ListItems from "components/ListItems"
 import { GRAPHQL_ENTITY_AVATAR_FIELDS } from "components/Model"
 import { PageDispatchersPropType, useBoilerplate } from "components/Page"
 import { ReportCompactWorkflow } from "components/ReportWorkflow"
@@ -328,7 +329,7 @@ const ReportSummaryRow = ({ report }: ReportSummaryRowProps) => {
           {report.keyOutcomes && (
             <span>
               <strong>{Settings.fields.report.keyOutcomes?.label}:</strong>{" "}
-              {report.keyOutcomes}
+              <ListItems value={report.keyOutcomes} compact />
             </span>
           )}
         </Col>
@@ -338,7 +339,7 @@ const ReportSummaryRow = ({ report }: ReportSummaryRowProps) => {
           {report.nextSteps && (
             <span>
               <strong>{Settings.fields.report.nextSteps?.label}:</strong>{" "}
-              {report.nextSteps}
+              <ListItems value={report.nextSteps} compact />
             </span>
           )}
         </Col>


### PR DESCRIPTION
Update design of key outcomes and next steps on the report summary

Closes [AB#1346](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1346)

#### User changes
- Key outcomes and next steps can now have bullet points on the report summary
- Key outcomes and next steps now have a more consistent margin below them on other locations

#### Superuser changes
- None

#### Admin changes
- None

#### System admin changes
- [ ] application.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
- [x] described the user behavior in PR body
- [x] referenced/updated all related issues
- [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
- [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
- [ ] added and/or updated unit tests
- [ ] added and/or updated e2e tests
- [ ] added and/or updated data migrations
- [ ] updated documentation
- [ ] resolved all build errors and warnings
- [ ] opened debt issues for anything not resolved here
