### PR TITLE
Prevent nationality validation error message from being shown incorrectly

### DIFF
--- a/client/src/pages/people/Form.tsx
+++ b/client/src/pages/people/Form.tsx
@@ -618,7 +618,7 @@ const PersonForm = ({
                     setFieldTouched("country", true, false) // onBlur doesn't work when selecting an option
                     setFieldValue("country", value)
                     if (value) {
-                      setFieldValue("obsoleteCountry", null)
+                      setFieldValue("obsoleteCountry", null, false)
                     }
                   }}
                   widget={

--- a/client/tests/webdriver/baseSpecs/createNewPerson.spec.js
+++ b/client/tests/webdriver/baseSpecs/createNewPerson.spec.js
@@ -74,6 +74,9 @@ describe("Create new Person form page", () => {
         await (await CreatePerson.getCountryAdvancedSelectFirstItem()).getText()
       ).to.include(VALID_PERSON_INTERLOCUTOR.country)
       await (await CreatePerson.getCountryAdvancedSelectFirstItem()).click()
+      await (
+        await CreatePerson.getCountryHelpBlock()
+      ).waitForExist({ reverse: true })
 
       await CreatePerson.submitForm()
       await CreatePerson.waitForAlertSuccessToLoad()
@@ -111,6 +114,9 @@ describe("Create new Person form page", () => {
         await (await CreatePerson.getCountryAdvancedSelectFirstItem()).getText()
       ).to.include(VALID_PERSON_INTERLOCUTOR.country)
       await (await CreatePerson.getCountryAdvancedSelectFirstItem()).click()
+      await (
+        await CreatePerson.getCountryHelpBlock()
+      ).waitForExist({ reverse: true })
 
       await CreatePerson.submitForm()
       await CreatePerson.waitForAlertSuccessToLoad()
@@ -148,6 +154,9 @@ describe("Create new Person form page", () => {
         await (await CreatePerson.getCountryAdvancedSelectFirstItem()).getText()
       ).to.include(VALID_PERSON_INTERLOCUTOR.country)
       await (await CreatePerson.getCountryAdvancedSelectFirstItem()).click()
+      await (
+        await CreatePerson.getCountryHelpBlock()
+      ).waitForExist({ reverse: true })
 
       await (await CreatePerson.getEmailAddress(0)).setValue("notValidEmail@")
       await (await CreatePerson.getLastName()).click()
@@ -252,6 +261,9 @@ describe("Create new Person form page", () => {
         await (await CreatePerson.getCountryAdvancedSelectFirstItem()).getText()
       ).to.include(VALID_PERSON_ADVISOR.country)
       await (await CreatePerson.getCountryAdvancedSelectFirstItem()).click()
+      await (
+        await CreatePerson.getCountryHelpBlock()
+      ).waitForExist({ reverse: true })
 
       await (await CreatePerson.getEndOfTourDate()).setValue("")
       await (await CreatePerson.getLastName()).click()

--- a/client/tests/webdriver/baseSpecs/onboardNewUser.spec.js
+++ b/client/tests/webdriver/baseSpecs/onboardNewUser.spec.js
@@ -90,6 +90,9 @@ describe("Onboard new user login", () => {
       await (await OnboardPage.getCountryAdvancedSelectFirstItem()).getText()
     ).to.include(personDetails.country)
     await (await OnboardPage.getCountryAdvancedSelectFirstItem()).click()
+    await (
+      await OnboardPage.getCountryHelpBlock()
+    ).waitForExist({ reverse: true })
 
     await (
       await OnboardPage.getEndOfTourDate()

--- a/client/tests/webdriver/customFieldsSpecs/customFields.spec.js
+++ b/client/tests/webdriver/customFieldsSpecs/customFields.spec.js
@@ -224,6 +224,9 @@ describe("When working with custom fields for different anet objects", () => {
         await (await CreatePerson.getCountryAdvancedSelectFirstItem()).getText()
       ).to.include(REQUIRED_PERSON_FIELDS.country)
       await (await CreatePerson.getCountryAdvancedSelectFirstItem()).click()
+      await (
+        await CreatePerson.getCountryHelpBlock()
+      ).waitForExist({ reverse: true })
     })
 
     it("Should not show default invisible fields", async() => {

--- a/client/tests/webdriver/customFieldsSpecs/customSensitiveFields.spec.js
+++ b/client/tests/webdriver/customFieldsSpecs/customSensitiveFields.spec.js
@@ -185,6 +185,9 @@ describe("Creating and editing custom sensitive information", () => {
         await (await CreatePerson.getCountryAdvancedSelectFirstItem()).getText()
       ).to.include(NEW_PERSON_FIELDS_1.country)
       await (await CreatePerson.getCountryAdvancedSelectFirstItem()).click()
+      await (
+        await CreatePerson.getCountryHelpBlock()
+      ).waitForExist({ reverse: true })
     })
     it("Should not be able to edit sensitive fields if not authorized", async() => {
       await (
@@ -249,6 +252,9 @@ describe("Creating and editing custom sensitive information", () => {
         await (await CreatePerson.getCountryAdvancedSelectFirstItem()).getText()
       ).to.include(NEW_PERSON_FIELDS_2.country)
       await (await CreatePerson.getCountryAdvancedSelectFirstItem()).click()
+      await (
+        await CreatePerson.getCountryHelpBlock()
+      ).waitForExist({ reverse: true })
     })
     it("Should be able to create a new person with sensitive information", async() => {
       await CreatePerson.deleteInput(CreatePerson.getBirthday())

--- a/client/tests/webdriver/pages/createNewPerson.page.js
+++ b/client/tests/webdriver/pages/createNewPerson.page.js
@@ -104,6 +104,10 @@ export class CreatePerson extends Page {
     )
   }
 
+  async getCountryHelpBlock() {
+    return browser.$("#fg-country div.invalid-feedback")
+  }
+
   async getEndOfTourDate() {
     return browser.$("#endOfTourDate")
   }


### PR DESCRIPTION
When first filling in a person's nationality, the validation error message "You must provide the Nationality" was incorrectly being shown. This is now corrected.

Closes [AB#1347](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1347)

#### User changes
- When onboarding and filling in their nationality, users no longer see a validation error message.

#### Superuser changes
- When creating a new person and filling in their nationality, superusers no longer see a validation error message.

#### Admin changes
- When creating a new person and filling in their nationality, admins no longer see a validation error message.

#### System admin changes
- [ ] application.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
- [x] described the user behavior in PR body
- [x] referenced/updated all related issues
- [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
- [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
- [ ] added and/or updated unit tests
- [x] added and/or updated e2e tests
- [ ] added and/or updated data migrations
- [ ] updated documentation
- [x] resolved all build errors and warnings
- [ ] opened debt issues for anything not resolved here
