### PR TITLE
Export all sub-tasks to the MART dictionary

### DIFF
--- a/src/main/java/mil/dds/anet/resources/AdminResource.java
+++ b/src/main/java/mil/dds/anet/resources/AdminResource.java
@@ -119,6 +119,8 @@ public class AdminResource {
         final DumperOptions options = new DumperOptions();
         options.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
         options.setIndent(2);
+        options.setIndicatorIndent(2);
+        options.setIndentWithIndicator(true);
 
         // Create YAML instance
         final Yaml yaml = new Yaml(options);

--- a/src/main/java/mil/dds/anet/services/MartDictionaryService.java
+++ b/src/main/java/mil/dds/anet/services/MartDictionaryService.java
@@ -13,7 +13,6 @@ import mil.dds.anet.beans.Location;
 import mil.dds.anet.beans.Organization;
 import mil.dds.anet.beans.Task;
 import mil.dds.anet.beans.WithStatus;
-import mil.dds.anet.beans.search.OrganizationSearchQuery;
 import mil.dds.anet.beans.search.TaskSearchQuery;
 import mil.dds.anet.config.AnetDictionary;
 import mil.dds.anet.database.LocationDao;
@@ -157,6 +156,7 @@ public class MartDictionaryService implements IMartDictionaryService {
     final List<Map<String, String>> tasks = new ArrayList<>();
     final TaskSearchQuery taskSearchQuery = new TaskSearchQuery();
     taskSearchQuery.setStatus(WithStatus.Status.ACTIVE);
+    taskSearchQuery.setPageSize(0); // export all!
     final List<Task> childrenTasks =
         rootTask.loadChildrenTasks(engine.getContext(), taskSearchQuery).join();
     childrenTasks.sort(Comparator.comparing(Task::getShortName));
@@ -178,8 +178,6 @@ public class MartDictionaryService implements IMartDictionaryService {
       final List<Map<String, String>> reportingTeams = new ArrayList<>();
       command.put("guid", org.getUuid());
       command.put("name", org.getShortName());
-      final OrganizationSearchQuery organizationSearchQuery = new OrganizationSearchQuery();
-      organizationSearchQuery.setStatus(WithStatus.Status.ACTIVE);
       final List<Organization> rts = org.loadChildrenOrgs(engine.getContext(), null).join();
       rts.sort(Comparator.comparing(Organization::getShortName));
       for (final Organization rt : rts) {


### PR DESCRIPTION
It was exporting only the first 10.

Closes [AB#1350](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1350)

#### User changes
- None

#### Superuser changes
- None

#### Admin changes
- None

#### System admin changes
- [ ] application.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
- [x] described the user behavior in PR body
- [x] referenced/updated all related issues
- [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
- [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
- [ ] added and/or updated unit tests
- [ ] added and/or updated e2e tests
- [ ] added and/or updated data migrations
- [ ] updated documentation
- [x] resolved all build errors and warnings
- [ ] opened debt issues for anything not resolved here
