### PR TITLE
Improve saved searches browsing

### DIFF
--- a/client/src/pages/searches/MySavedSearches.tsx
+++ b/client/src/pages/searches/MySavedSearches.tsx
@@ -120,15 +120,16 @@ const MySavedSearches = ({
   )
 
   function onSaveSearchSelect(event) {
-    const uuid = event && event.target ? event.target.value : event
+    const uuid = event?.target?.value ?? event
     const search = savedSearches.find(el => el.uuid === uuid)
     setSelectedSearch(search)
+    showSearch(search)
   }
 
-  function showSearch() {
-    if (selectedSearch) {
-      const objType = SEARCH_OBJECT_TYPES[selectedSearch.objectType]
-      const queryParams = utils.parseJsonSafe(selectedSearch.query)
+  function showSearch(search = selectedSearch) {
+    if (search) {
+      const objType = SEARCH_OBJECT_TYPES[search.objectType]
+      const queryParams = utils.parseJsonSafe(search.query)
       deserializeQueryParams(objType, queryParams, deserializeCallback)
     }
   }

--- a/client/src/pages/searches/MySavedSearches.tsx
+++ b/client/src/pages/searches/MySavedSearches.tsx
@@ -12,9 +12,10 @@ import {
   usePageTitle
 } from "components/Page"
 import { deserializeQueryParams } from "components/SearchFilters"
+import UltimatePaginationTopDown from "components/UltimatePaginationTopDown"
 import _isEmpty from "lodash/isEmpty"
 import React, { useState } from "react"
-import { Button, Col, Row, Table } from "react-bootstrap"
+import { Button, Table } from "react-bootstrap"
 import { connect } from "react-redux"
 import { useNavigate } from "react-router-dom"
 import utils from "utils"
@@ -41,12 +42,15 @@ interface MySavedSearchesProps {
   pageDispatchers?: PageDispatchersPropType
 }
 
+const DEFAULT_PAGESIZE = 10
+
 const MySavedSearches = ({
   setSearchQuery,
   pageDispatchers
 }: MySavedSearchesProps) => {
   const navigate = useNavigate()
   const [stateError, setStateError] = useState(null)
+  const [pageNum, setPageNum] = useState(0)
   const { loading, error, data, refetch } = API.useApiQuery(
     GQL_GET_SAVED_SEARCHES
   )
@@ -61,48 +65,62 @@ const MySavedSearches = ({
   }
 
   const savedSearches = data?.savedSearches || []
+  const totalCount = savedSearches.length
+  const paginatedSearches = savedSearches.slice(
+    pageNum * DEFAULT_PAGESIZE,
+    (pageNum + 1) * DEFAULT_PAGESIZE
+  )
 
   return (
     <Fieldset title="Saved searches">
       <Messages error={stateError} />
 
-      {savedSearches.length > 0 ? (
-        <Table striped responsive>
-          <thead>
-            <tr>
-              <th style={{ width: "80%" }}>Search Name</th>
-              <th style={{ width: "20%" }}>Actions</th>
-            </tr>
-          </thead>
-          <tbody>
-            {savedSearches.map(savedSearch => (
-              <tr key={savedSearch.uuid}>
-                <td>
-                  <Button
-                    className="text-start text-decoration-none"
-                    variant="link"
-                    onClick={() => showSearch(savedSearch)}
-                  >
-                    {savedSearch.name}
-                  </Button>
-                </td>
-                <td>
-                  <ConfirmDestructive
-                    onConfirm={() => onConfirmDelete(savedSearch.uuid)}
-                    objectType="search"
-                    objectDisplay={savedSearch.name}
-                    variant="danger"
-                    operation="delete"
-                    buttonLabel="Delete"
-                  />
-                </td>
+      <UltimatePaginationTopDown
+        componentClassName="searchPagination"
+        className="float-end"
+        pageNum={pageNum}
+        pageSize={DEFAULT_PAGESIZE}
+        totalCount={totalCount}
+        goToPage={setPageNum}
+      >
+        {paginatedSearches.length > 0 ? (
+          <Table striped responsive className="mt-3 mb-3">
+            <thead>
+              <tr>
+                <th style={{ width: "80%" }}>Search Name</th>
+                <th style={{ width: "20%" }}>Actions</th>
               </tr>
-            ))}
-          </tbody>
-        </Table>
-      ) : (
-        <p>No saved searches found.</p>
-      )}
+            </thead>
+            <tbody>
+              {paginatedSearches.map(savedSearch => (
+                <tr key={savedSearch.uuid}>
+                  <td>
+                    <Button
+                      className="text-start text-decoration-none"
+                      variant="link"
+                      onClick={() => showSearch(savedSearch)}
+                    >
+                      {savedSearch.name}
+                    </Button>
+                  </td>
+                  <td>
+                    <ConfirmDestructive
+                      onConfirm={() => onConfirmDelete(savedSearch.uuid)}
+                      objectType="search"
+                      objectDisplay={savedSearch.name}
+                      variant="danger"
+                      operation="delete"
+                      buttonLabel="Delete"
+                    />
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </Table>
+        ) : (
+          <p>No saved searches found.</p>
+        )}
+      </UltimatePaginationTopDown>
     </Fieldset>
   )
 


### PR DESCRIPTION
Whenever any saved search was selected, if it was a report search, it would not be displayed, and the user would have to click "Open Search" to view it

Replaced the previous dropdown with a paginated list that show all the saved searches.
Whenever the user clicks any search he is immediately redirected to the search page of that specific saved search.
The delete action is on each saved search row, and it still requires a confirmation
Closes AB#1179

#### User changes
- Can view a list of off the searches
- Can open or delete any of the saved searches right away

#### Superuser changes
- None

#### Admin changes
- None

#### System admin changes
- [ ] application.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
- [x] described the user behavior in PR body
- [x] referenced/updated all related issues
- [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
- [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
- [ ] added and/or updated unit tests
- [ ] added and/or updated e2e tests
- [ ] added and/or updated data migrations
- [ ] updated documentation
- [x] resolved all build errors and warnings
- [ ] opened debt issues for anything not resolved here
