### PR TITLE
Avoid duplicate sequence numbers in transmission log

### DIFF
--- a/insertBaseData-psql.sql
+++ b/insertBaseData-psql.sql
@@ -1736,9 +1736,9 @@ INSERT INTO public."assessmentRelatedObjects" ("assessmentUuid", "relatedObjectT
 
 -- End of test data for assessments
 
--- Add mart imported reports for testing
+-- Add mart imported report
 INSERT INTO "martImportedReports" ("sequence", "personUuid", "reportUuid", "success", "submittedAt", "receivedAt", "errors") VALUES
-  (0, '87fdbc6a-3109-4e11-9702-a894d6ca31ef', '59be259b-30b9-4d04-9e21-e8ceb58cbe9c', TRUE, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, NULL);
+  (1, '87fdbc6a-3109-4e11-9702-a894d6ca31ef', '59be259b-30b9-4d04-9e21-e8ceb58cbe9c', TRUE, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, NULL);
 
 -- Update the link-text indexes
 REFRESH MATERIALIZED VIEW CONCURRENTLY "mv_lts_attachments";

--- a/src/test/java/mil/dds/anet/test/TestData.java
+++ b/src/test/java/mil/dds/anet/test/TestData.java
@@ -202,17 +202,18 @@ public class TestData {
     return reportDto;
   }
 
-  public static ReportDto createRetryOfMissingReport(long sequence) {
+  public static ReportDto createRetryOfMissingReport(long sequence, String uuid) {
     final ReportDto reportDto = createGoodMartReport(sequence);
-    reportDto.setUuid("missingReportUuid2");
+    reportDto.setUuid(uuid);
     return reportDto;
   }
 
-  public static List<LogDto> createTransmissionLog() {
+  public static List<LogDto> createTransmissionLog(long maxSequence, String missingReportUuid1,
+      String missingReportUuid2) {
     final List<LogDto> transmissionLog = new ArrayList<>();
 
     // Put all properly transmitted ones
-    for (long i = 0; i < 8; i++) {
+    for (long i = 1; i < maxSequence; i++) {
       final LogDto logDto = new LogDto();
       logDto.setState(LogDto.LogState.SENT.getCode());
       logDto.setSequence(i);
@@ -221,18 +222,18 @@ public class TestData {
 
     // Now Put two missing logs
     final LogDto missing1 = new LogDto();
-    missing1.setReportUuid("missingReportUuid");
+    missing1.setReportUuid(missingReportUuid1);
     missing1.setState(LogDto.LogState.FAILED_TO_SEND_EMAIL.getCode());
     missing1.setErrors("SMTP error sending email in MART");
     missing1.setSubmittedAt(Instant.now());
-    missing1.setSequence(8L);
+    missing1.setSequence(maxSequence + 1);
     transmissionLog.add(missing1);
 
     final LogDto missing2 = new LogDto();
-    missing2.setReportUuid("missingReportUuid2");
+    missing2.setReportUuid(missingReportUuid2);
     missing2.setState(LogDto.LogState.SENT.getCode());
     missing2.setSubmittedAt(Instant.now());
-    missing2.setSequence(9L);
+    missing2.setSequence(maxSequence + 2);
     transmissionLog.add(missing2);
 
     return transmissionLog;


### PR DESCRIPTION
Related to [AB#1356](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1356)

#### User changes
- None

#### Superuser changes
- None

#### Admin changes
- None

#### System admin changes
- [ ] application.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
- [x] described the user behavior in PR body
- [x] referenced/updated all related issues
- [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
- [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
- [x] added and/or updated unit tests
- [ ] added and/or updated e2e tests
- [ ] added and/or updated data migrations
- [ ] updated documentation
- [x] resolved all build errors and warnings
- [ ] opened debt issues for anything not resolved here
