### PR TITLE
Update dependency io.github.borewit:svg-sanitizer to 0.3.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -143,7 +143,7 @@ dependencies {
 	// For inferring MIME types of attachments
 	implementation 'org.apache.tika:tika-core:3.1.0'
         // For sanitizing SVG uploads
-        implementation 'io.github.borewit:svg-sanitizer:0.2.1'
+        implementation 'io.github.borewit:svg-sanitizer:0.3.1'
 
 	// For parsing HTML to check for 'empty' input
 	implementation 'org.jsoup:jsoup:1.19.1'


### PR DESCRIPTION
This allows the style element in SVG (with restrictions), which prevents breaking such SVGs when uploaded.

Related release notes: https://github.com/Borewit/svg-sanitizer/releases/tag/v0.3.1