### PR TITLE
Adjust spacings in organization diagram

### DIFF
--- a/client/src/components/graphs/OrganizationalChart.tsx
+++ b/client/src/components/graphs/OrganizationalChart.tsx
@@ -485,7 +485,7 @@ const OrganizationFlowChart = ({
       (containerH - DIAGRAM_PADDING * 2) / graphH
     )
 
-    // Get final dimensions, width can't be lower than container width
+    // get final dimensions, width can't be lower than container width
     const scaledW = Math.max(containerW, graphW * zoom + DIAGRAM_PADDING * 2)
     const scaledH = graphH * zoom + DIAGRAM_PADDING * 2
     setDiagramWidth(scaledW)
@@ -535,7 +535,7 @@ const OrganizationFlowChart = ({
         <div>
           <label htmlFor="depthInput">Depth:</label>
           <div className="depth-controls">
-            <Button onClick={decreaseDepthLimit}>
+            <Button onClick={decreaseDepthLimit} disabled={depthLimit === 0}>
               <Icon icon={IconNames.REMOVE} />
             </Button>
             <input
@@ -547,7 +547,10 @@ const OrganizationFlowChart = ({
               max={maxDepth}
               style={{ width: "3em" }}
             />
-            <Button onClick={increaseDepthLimit}>
+            <Button
+              onClick={increaseDepthLimit}
+              disabled={depthLimit === maxDepth}
+            >
               <Icon icon={IconNames.ADD} />
             </Button>
           </div>

--- a/client/src/components/graphs/OrganizationalChart.tsx
+++ b/client/src/components/graphs/OrganizationalChart.tsx
@@ -133,6 +133,7 @@ const TEXT_GAP = 10
 const NODE_WIDTH = ORG_AVATAR_WIDTH / 2 + TEXT_GAP + TEXT_WIDTH
 const NODE_HEIGHT = 60
 const VERTICAL_SPACING = 20
+const NODE_SPACING = 10
 const HORIZONTAL_SPACING = 10
 const LEVEL_INDENT = 60
 const PERSON_AVATAR_HEIGHT = 42
@@ -338,7 +339,10 @@ const OrganizationFlowChart = ({
       if (children.length > 0) {
         let childX = currentX + (isRoot ? 0 : LEVEL_INDENT)
         let childY =
-          currentY + NODE_HEIGHT + positions.length * PERSON_AVATAR_HEIGHT
+          currentY +
+          NODE_HEIGHT +
+          positions.length * PERSON_AVATAR_HEIGHT +
+          NODE_SPACING
         children.forEach(child => {
           // first level nodes are placed horizontally
           if (isRoot) {
@@ -387,7 +391,7 @@ const OrganizationFlowChart = ({
           })
 
           if (!isRoot) {
-            childY += NODE_HEIGHT + VERTICAL_SPACING
+            childY += NODE_HEIGHT + VERTICAL_SPACING + NODE_SPACING
           }
         })
       }

--- a/client/src/components/graphs/OrganizationalChart.tsx
+++ b/client/src/components/graphs/OrganizationalChart.tsx
@@ -533,15 +533,11 @@ const OrganizationFlowChart = ({
           Export Image
         </Button>
       </ControlsContainer>
-      <div
+      <DivS
         ref={chartRef}
-        style={{
-          width: width ? `${width}px` : "100%",
-          height: diagramHeight.current
-            ? `${diagramHeight.current}px`
-            : "100vh",
-          backgroundColor: BACKGROUND_COLOR
-        }}
+        width={width ? `${width}px` : "100%"}
+        height={diagramHeight.current ? `${diagramHeight.current}px` : "100vh"}
+        backgroundColor={BACKGROUND_COLOR}
       >
         <ReactFlow
           nodes={nodes}
@@ -553,7 +549,7 @@ const OrganizationFlowChart = ({
           preventScrolling={false}
           proOptions={{ hideAttribution: true }}
         />
-      </div>
+      </DivS>
     </>
   )
 }
@@ -693,31 +689,55 @@ const CustomOrgLinkS = styled.div`
     overflow: hidden;
   }
 `
+const LinkToOrgS = styled(LinkTo)`
+  margin: auto;
+  padding-left: 5px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  /* limit to max. 3 lines */
+  line-clamp: 3;
+  /* legacy WebKit fallback */
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+`
+const LinkToPersonS = styled(LinkTo)`
+  display: inline-block;
+  max-width: ${TEXT_WIDTH}px;
+  padding: 5px 0 5px 5px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  vertical-align: middle;
+`
+const HandleS = styled(Handle)`
+  opacity: 0;
+  left: ${props => props.left};
+  top: ${props => props.top};
+`
+
+const DivS = styled.div`
+  width: ${props => props.width};
+  max-width: ${props => props.maxWidth};
+  min-width: ${props => props.minWidth};
+  height: ${props => props.height};
+  padding-left: ${props => props.paddingLeft};
+  background-color: ${props => props.backgroundColor};
+`
 
 const CustomNode = ({
   data: { organization, symbolValues, depth, positions, showSymbol }
 }: NodeProps) => (
-  <div
-    style={{
-      width: NODE_WIDTH,
-      height: NODE_HEIGHT + positions.length * PERSON_AVATAR_HEIGHT,
-      display: "flex",
-      flexDirection: "column"
-    }}
+  <DivS
+    className="d-flex flex-column"
+    width={`${NODE_WIDTH}px`}
+    height={`${NODE_HEIGHT + positions.length * PERSON_AVATAR_HEIGHT}px`}
   >
-    <div
-      style={{
-        display: "flex"
-      }}
-    >
-      <div
-        style={{
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "center",
-          minWidth: ORG_AVATAR_WIDTH,
-          height: NODE_HEIGHT
-        }}
+    <div className="d-flex">
+      <DivS
+        className="d-flex align-items-center justify-content-center"
+        minWidth={`${ORG_AVATAR_WIDTH}px`}
+        height={`${NODE_HEIGHT}px`}
       >
         {(showSymbol && (
           <App6Symbol
@@ -734,63 +754,41 @@ const CustomNode = ({
             style={{ backgroundColor: BACKGROUND_COLOR }}
           />
         )}
-      </div>
+      </DivS>
       <CustomOrgLinkS>
-        <LinkTo
+        <LinkToOrgS
           modelType="Organization"
           model={organization}
           showAvatar={false}
           showIcon={false}
-          style={{
-            display: "-webkit-box",
-            WebkitLineClamp: 3,
-            WebkitBoxOrient: "vertical",
-            margin: "auto",
-            paddingLeft: 5
-          }}
         />
       </CustomOrgLinkS>
     </div>
     {positions.length > 0 && (
-      <div
-        style={{
-          paddingLeft: ORG_AVATAR_WIDTH / 2
-        }}
-      >
+      <DivS paddingLeft={`${ORG_AVATAR_WIDTH / 2}px`}>
         {positions.map(person => (
-          <LinkTo
+          <LinkToPersonS
             key={person.uuid}
             modelType="Person"
             model={person}
             showIcon={false}
-            style={{
-              display: "inline-block",
-              maxWidth: TEXT_WIDTH,
-              padding: "5px 0px 5px 5px",
-              whiteSpace: "nowrap",
-              overflow: "hidden",
-              textOverflow: "ellipsis",
-              verticalAlign: "middle"
-            }}
           />
         ))}
-      </div>
+      </DivS>
     )}
-    <Handle
+    <HandleS
       type="source"
       position={Position.Bottom}
-      style={{ opacity: 0, top: NODE_HEIGHT / 2, left: ORG_AVATAR_WIDTH / 2 }}
+      left={`${ORG_AVATAR_WIDTH / 2}px`}
+      top={`${NODE_HEIGHT / 2}px`}
     />
-    <Handle
+    <HandleS
       type="target"
       position={depth > 1 ? Position.Left : Position.Top}
-      style={{
-        opacity: 0,
-        left: depth === 1 ? ORG_AVATAR_WIDTH / 2 : -ARROW_INDENT,
-        top: depth === 1 ? 0 : NODE_HEIGHT / 2
-      }}
+      left={`${depth === 1 ? ORG_AVATAR_WIDTH / 2 : -ARROW_INDENT}px`}
+      top={`${depth === 1 ? 0 : NODE_HEIGHT / 2}px`}
     />
-  </div>
+  </DivS>
 )
 
 const CustomRootEdge = ({

--- a/client/src/components/graphs/OrganizationalChart.tsx
+++ b/client/src/components/graphs/OrganizationalChart.tsx
@@ -686,6 +686,13 @@ const ControlsContainer = styled.div`
     }
   }
 `
+const CustomOrgLinkS = styled.div`
+  span {
+    display: flex;
+    height: ${NODE_HEIGHT}px;
+    overflow: hidden;
+  }
+`
 
 const CustomNode = ({
   data: { organization, symbolValues, depth, positions, showSymbol }
@@ -728,18 +735,21 @@ const CustomNode = ({
           />
         )}
       </div>
-      <LinkTo
-        modelType="Organization"
-        model={organization}
-        showAvatar={false}
-        showIcon={false}
-        style={{
-          minHeight: NODE_HEIGHT,
-          display: "flex",
-          padding: "5px 0px 5px 5px",
-          alignItems: "center"
-        }}
-      />
+      <CustomOrgLinkS>
+        <LinkTo
+          modelType="Organization"
+          model={organization}
+          showAvatar={false}
+          showIcon={false}
+          style={{
+            display: "-webkit-box",
+            WebkitLineClamp: 3,
+            WebkitBoxOrient: "vertical",
+            margin: "auto",
+            paddingLeft: 5
+          }}
+        />
+      </CustomOrgLinkS>
     </div>
     {positions.length > 0 && (
       <div


### PR DESCRIPTION
If the organization name was too long, the LinkTo would overlap both the organization below and above it.
- This should not happen now as the LinkTo is trimmed to its explicit height
- That should be equivalent to up to 3 "lines" of the organization's long name
- Additionally added more spacing between nodes

Closes #1361

#### User changes
- Should be able to see organization names more clearly

#### Superuser changes
- None

#### Admin changes
- None

#### System admin changes
- [ ] application.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
- [x] described the user behavior in PR body
- [x] referenced/updated all related issues
- [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
- [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
- [ ] added and/or updated unit tests
- [ ] added and/or updated e2e tests
- [ ] added and/or updated data migrations
- [ ] updated documentation
- [x] resolved all build errors and warnings
- [ ] opened debt issues for anything not resolved here
