### PR TITLE
Show navigation warning when leaving any merge page

### DIFF
--- a/client/src/components/MergeField.tsx
+++ b/client/src/components/MergeField.tsx
@@ -1,5 +1,6 @@
 import styled from "@emotion/styled"
 import _get from "lodash/get"
+import _has from "lodash/has"
 import _isEqual from "lodash/isEqual"
 import {
   ALIGN_OPTIONS,
@@ -59,6 +60,8 @@ const MergeField = ({
   const canAutoMerge = useMemo(
     () =>
       autoMerge &&
+      _has(mergeState[MERGE_SIDES.LEFT], fieldName) &&
+      _has(mergeState[MERGE_SIDES.RIGHT], fieldName) &&
       _isEqual(
         _get(mergeState[MERGE_SIDES.LEFT], fieldName),
         _get(mergeState[MERGE_SIDES.RIGHT], fieldName)

--- a/client/src/pages/admin/merge/MergeLocations.tsx
+++ b/client/src/pages/admin/merge/MergeLocations.tsx
@@ -16,6 +16,7 @@ import {
   DEFAULT_CUSTOM_FIELDS_PARENT,
   MODEL_TO_OBJECT_TYPE
 } from "components/Model"
+import NavigationWarning from "components/NavigationWarning"
 import {
   jumpToTop,
   mapPageDispatchersToProps,
@@ -65,6 +66,7 @@ const MergeLocations = ({ pageDispatchers }: MergeLocationsProps) => {
   const navigate = useNavigate()
   const { state } = useLocation()
   const initialLeftUuid = state?.initialLeftUuid
+  const [isDirty, setIsDirty] = useState(false)
   const [saveError, setSaveError] = useState(null)
   const [saveWarning, setSaveWarning] = useState(null)
   const [locationFormat, setLocationFormat] = useState(Location.locationFormat)
@@ -104,10 +106,15 @@ const MergeLocations = ({ pageDispatchers }: MergeLocationsProps) => {
     } else {
       setSaveWarning(null)
     }
+    setIsDirty(false)
   }, [location1, location2])
+  useEffect(() => {
+    setIsDirty(!!mergedLocation)
+  }, [mergedLocation])
 
   return (
     <Container fluid>
+      <NavigationWarning isBlocking={isDirty} />
       <Row>
         <Messages error={saveError} warning={saveWarning} />
         <h4>Merge Locations Tool</h4>
@@ -322,7 +329,10 @@ const MergeLocations = ({ pageDispatchers }: MergeLocationsProps) => {
         <Button
           style={{ width: "98%", margin: "16px 1%" }}
           variant="primary"
-          onClick={mergeLocations}
+          onClick={() => {
+            setIsDirty(false)
+            mergeLocations()
+          }}
           disabled={mergeState.notAllSet()}
         >
           Merge Locations
@@ -355,6 +365,7 @@ const MergeLocations = ({ pageDispatchers }: MergeLocationsProps) => {
         }
       })
       .catch(error => {
+        setIsDirty(true)
         setSaveError(error)
         jumpToTop()
       })

--- a/client/src/pages/admin/merge/MergeOrganizations.tsx
+++ b/client/src/pages/admin/merge/MergeOrganizations.tsx
@@ -22,6 +22,7 @@ import {
   GRAPHQL_NOTES_FIELDS,
   MODEL_TO_OBJECT_TYPE
 } from "components/Model"
+import NavigationWarning from "components/NavigationWarning"
 import {
   jumpToTop,
   mapPageDispatchersToProps,
@@ -43,7 +44,7 @@ import useMergeObjects, {
   setMergeable
 } from "mergeUtils"
 import { Location, Organization } from "models"
-import React, { useState } from "react"
+import React, { useEffect, useState } from "react"
 import { Button, Col, Container, Form, Row } from "react-bootstrap"
 import { connect } from "react-redux"
 import { useLocation, useNavigate } from "react-router-dom"
@@ -192,6 +193,7 @@ const MergeOrganizations = ({ pageDispatchers }: MergeOrganizationsProps) => {
   const navigate = useNavigate()
   const { state } = useLocation()
   const initialLeftUuid = state?.initialLeftUuid
+  const [isDirty, setIsDirty] = useState(false)
   const [saveError, setSaveError] = useState(null)
   const [mergeState, dispatchMergeActions] = useMergeObjects(
     MODEL_TO_OBJECT_TYPE.Organization
@@ -221,8 +223,16 @@ const MergeOrganizations = ({ pageDispatchers }: MergeOrganizationsProps) => {
     !Location.hasCoordinates(organization1?.location) &&
     !Location.hasCoordinates(organization2?.location)
 
+  useEffect(() => {
+    setIsDirty(false)
+  }, [organization1, organization2])
+  useEffect(() => {
+    setIsDirty(!!mergedOrganization)
+  }, [mergedOrganization])
+
   return (
     <Container fluid>
+      <NavigationWarning isBlocking={isDirty} />
       <Row>
         <Messages error={saveError} />
         <h4>Merge Organizations Tool</h4>
@@ -484,7 +494,10 @@ const MergeOrganizations = ({ pageDispatchers }: MergeOrganizationsProps) => {
         <Button
           style={{ width: "98%", margin: "16px 1%" }}
           intent="primary"
-          onClick={mergeOrganizations}
+          onClick={() => {
+            setIsDirty(false)
+            mergeOrganizations()
+          }}
           disabled={mergeState.notAllSet()}
         >
           Merge Organizations
@@ -522,6 +535,7 @@ const MergeOrganizations = ({ pageDispatchers }: MergeOrganizationsProps) => {
       })
       .catch(error => {
         setSaveError(error)
+        setIsDirty(true)
         jumpToTop()
       })
   }

--- a/client/src/pages/admin/merge/MergePeople.tsx
+++ b/client/src/pages/admin/merge/MergePeople.tsx
@@ -20,6 +20,7 @@ import {
   MODEL_TO_OBJECT_TYPE,
   SENSITIVE_CUSTOM_FIELDS_PARENT
 } from "components/Model"
+import NavigationWarning from "components/NavigationWarning"
 import {
   jumpToTop,
   mapPageDispatchersToProps,
@@ -41,7 +42,7 @@ import useMergeObjects, {
 } from "mergeUtils"
 import { Person } from "models"
 import moment from "moment"
-import React, { useState } from "react"
+import React, { useEffect, useState } from "react"
 import { Button, Col, Container, Form, Row } from "react-bootstrap"
 import { connect } from "react-redux"
 import { useLocation, useNavigate } from "react-router-dom"
@@ -71,6 +72,7 @@ const MergePeople = ({ pageDispatchers }: MergePeopleProps) => {
   const navigate = useNavigate()
   const { state } = useLocation()
   const initialLeftUuid = state?.initialLeftUuid
+  const [isDirty, setIsDirty] = useState(false)
   const [saveError, setSaveError] = useState(null)
   const [showHistoryModal, setShowHistoryModal] = useState(false)
   const [mergeState, dispatchMergeActions] = useMergeObjects(
@@ -97,8 +99,16 @@ const MergePeople = ({ pageDispatchers }: MergePeopleProps) => {
   const person2 = mergeState[MERGE_SIDES.RIGHT]
   const mergedPerson = mergeState.merged
 
+  useEffect(() => {
+    setIsDirty(false)
+  }, [person1, person2])
+  useEffect(() => {
+    setIsDirty(!!mergedPerson)
+  }, [mergedPerson])
+
   return (
     <Container fluid>
+      <NavigationWarning isBlocking={isDirty} />
       <Row>
         <Messages error={saveError} />
         <h4>Merge People Tool</h4>
@@ -413,7 +423,10 @@ const MergePeople = ({ pageDispatchers }: MergePeopleProps) => {
         <Button
           style={{ width: "98%", margin: "16px 1%" }}
           intent="primary"
-          onClick={mergePeople}
+          onClick={() => {
+            setIsDirty(false)
+            mergePeople()
+          }}
           disabled={mergeState.notAllSet()}
         >
           Merge People
@@ -441,6 +454,7 @@ const MergePeople = ({ pageDispatchers }: MergePeopleProps) => {
         }
       })
       .catch(error => {
+        setIsDirty(true)
         setSaveError(error)
         jumpToTop()
       })

--- a/client/src/pages/admin/merge/MergePositions.tsx
+++ b/client/src/pages/admin/merge/MergePositions.tsx
@@ -18,6 +18,7 @@ import {
   DEFAULT_CUSTOM_FIELDS_PARENT,
   MODEL_TO_OBJECT_TYPE
 } from "components/Model"
+import NavigationWarning from "components/NavigationWarning"
 import {
   jumpToTop,
   mapPageDispatchersToProps,
@@ -41,7 +42,7 @@ import useMergeObjects, {
 import { Location, Position } from "models"
 import OrganizationsAdministrated from "pages/positions/OrganizationsAdministrated"
 import PreviousPeople from "pages/positions/PreviousPeople"
-import React, { useState } from "react"
+import React, { useEffect, useState } from "react"
 import { Button, Col, Container, Form, Row } from "react-bootstrap"
 import { connect } from "react-redux"
 import { useLocation, useNavigate } from "react-router-dom"
@@ -70,6 +71,7 @@ const MergePositions = ({ pageDispatchers }: MergePositionsProps) => {
   const navigate = useNavigate()
   const { state } = useLocation()
   const initialLeftUuid = state?.initialLeftUuid
+  const [isDirty, setIsDirty] = useState(false)
   const [saveError, setSaveError] = useState(null)
   const [showHistoryModal, setShowHistoryModal] = useState(false)
   const [mergeState, dispatchMergeActions] = useMergeObjects(
@@ -99,8 +101,16 @@ const MergePositions = ({ pageDispatchers }: MergePositionsProps) => {
     !Location.hasCoordinates(position1?.location) &&
     !Location.hasCoordinates(position2?.location)
 
+  useEffect(() => {
+    setIsDirty(false)
+  }, [position1, position2])
+  useEffect(() => {
+    setIsDirty(!!mergedPosition)
+  }, [mergedPosition])
+
   return (
     <Container fluid>
+      <NavigationWarning isBlocking={isDirty} />
       <Row>
         <Messages error={saveError} />
         <h4>Merge Positions Tool</h4>
@@ -376,7 +386,10 @@ const MergePositions = ({ pageDispatchers }: MergePositionsProps) => {
         <Button
           style={{ width: "98%", margin: "16px 1%" }}
           variant="primary"
-          onClick={mergePositions}
+          onClick={() => {
+            setIsDirty(false)
+            mergePositions()
+          }}
           disabled={mergeState.notAllSet()}
         >
           Merge Positions
@@ -408,6 +421,7 @@ const MergePositions = ({ pageDispatchers }: MergePositionsProps) => {
         }
       })
       .catch(error => {
+        setIsDirty(true)
         setSaveError(error)
         jumpToTop()
       })

--- a/client/tests/webdriver/baseSpecs/mergeLocations.spec.js
+++ b/client/tests/webdriver/baseSpecs/mergeLocations.spec.js
@@ -100,6 +100,46 @@ describe("Merge locations error", () => {
 })
 
 describe("Merge locations page", () => {
+  it("Should display a warning when leaving the page with unsaved changes", async() => {
+    await MergeLocations.openPage()
+    await (await MergeLocations.getTitle()).waitForExist()
+    await (await MergeLocations.getTitle()).waitForDisplayed()
+    await (
+      await MergeLocations.getLeftLocationField()
+    ).setValue(EXAMPLE_LOCATIONS.leftCountry.search)
+    await MergeLocations.waitForAdvancedSelectLoading(
+      EXAMPLE_LOCATIONS.leftCountry.fullName
+    )
+    await (await MergeLocations.getFirstItemFromAdvancedSelect()).click()
+    // attempt to leave when only one location is selected, should allow to leave
+    await (await $("#anet-logo")).click()
+    // eslint-disable-next-line no-unused-expressions
+    expect(await (await $(".modal-dialog")).isExisting()).to.be.false
+
+    await MergeLocations.openPage()
+    await (await MergeLocations.getTitle()).waitForExist()
+    await (await MergeLocations.getTitle()).waitForDisplayed()
+    await (
+      await MergeLocations.getLeftLocationField()
+    ).setValue(EXAMPLE_LOCATIONS.leftCountry.search)
+    await MergeLocations.waitForAdvancedSelectLoading(
+      EXAMPLE_LOCATIONS.leftCountry.fullName
+    )
+    await (await MergeLocations.getFirstItemFromAdvancedSelect()).click()
+    await (
+      await MergeLocations.getRightLocationField()
+    ).setValue(EXAMPLE_LOCATIONS.right.search)
+    await MergeLocations.waitForAdvancedSelectLoading(
+      EXAMPLE_LOCATIONS.right.fullName
+    )
+    await (await MergeLocations.getFirstItemFromAdvancedSelect()).click()
+    // attempt to leave when both locations are selected, should show warning
+    await (await $("#anet-logo")).click()
+    const modalDialog = await $(".modal-dialog")
+    // eslint-disable-next-line no-unused-expressions
+    expect(await modalDialog.isExisting()).to.be.true
+    await $(".btn-danger").click()
+  })
   it("Should be able to select to incompatible locations to merge", async() => {
     await MergeLocations.openPage()
     await (await MergeLocations.getTitle()).waitForExist()

--- a/client/tests/webdriver/baseSpecs/mergeOrganizations.spec.js
+++ b/client/tests/webdriver/baseSpecs/mergeOrganizations.spec.js
@@ -80,6 +80,49 @@ describe("Merge organizations error", () => {
 })
 
 describe("Merge organizations page", () => {
+  it("Should display a warning when leaving the page with unsaved changes", async() => {
+    await MergeOrganizations.openPage()
+    await (await MergeOrganizations.getTitle()).waitForExist()
+    await (await MergeOrganizations.getTitle()).waitForDisplayed()
+    await (await MergeOrganizations.getLeftOrganizationField()).click()
+    await (
+      await MergeOrganizations.getLeftOrganizationField()
+    ).setValue(EXAMPLE_ORGANIZATIONS.validLeft.search)
+    await MergeOrganizations.waitForAdvancedSelectLoading(
+      EXAMPLE_ORGANIZATIONS.validLeft.displayedName
+    )
+    await (await MergeOrganizations.getFirstItemFromAdvancedSelect()).click()
+    // attempt to leave when only one org is selected, should allow to leave
+    await (await $("#anet-logo")).click()
+    // eslint-disable-next-line no-unused-expressions
+    expect(await (await $(".modal-dialog")).isExisting()).to.be.false
+
+    await MergeOrganizations.openPage()
+    await (await MergeOrganizations.getTitle()).waitForExist()
+    await (await MergeOrganizations.getTitle()).waitForDisplayed()
+    await (await MergeOrganizations.getLeftOrganizationField()).click()
+    await (
+      await MergeOrganizations.getLeftOrganizationField()
+    ).setValue(EXAMPLE_ORGANIZATIONS.validLeft.search)
+    await MergeOrganizations.waitForAdvancedSelectLoading(
+      EXAMPLE_ORGANIZATIONS.validLeft.displayedName
+    )
+    await (await MergeOrganizations.getFirstItemFromAdvancedSelect()).click()
+    await (await MergeOrganizations.getRightOrganizationField()).click()
+    await (
+      await MergeOrganizations.getRightOrganizationField()
+    ).setValue(EXAMPLE_ORGANIZATIONS.validRight.search)
+    await MergeOrganizations.waitForAdvancedSelectLoading(
+      EXAMPLE_ORGANIZATIONS.validRight.displayedName
+    )
+    // attempt to leave when both orgs are selected, should show warning
+    await (await MergeOrganizations.getFirstItemFromAdvancedSelect()).click()
+    await (await $("#anet-logo")).click()
+    const modalDialog = await $(".modal-dialog")
+    // eslint-disable-next-line no-unused-expressions
+    expect(await modalDialog.isExisting()).to.be.true
+    await $(".btn-danger").click()
+  })
   it("Should display field values of the left organization", async() => {
     await MergeOrganizations.openPage()
     await (await MergeOrganizations.getTitle()).waitForExist()

--- a/client/tests/webdriver/baseSpecs/mergePeople.spec.js
+++ b/client/tests/webdriver/baseSpecs/mergePeople.spec.js
@@ -88,6 +88,46 @@ const EXAMPLE_PEOPLE = {
 }
 
 describe("Merge people who are both non-users", () => {
+  it("Should display a warning when leaving the page with unsaved changes", async() => {
+    await MergePeople.openPage()
+    await (await MergePeople.getTitle()).waitForExist()
+    await (await MergePeople.getTitle()).waitForDisplayed()
+    await (
+      await MergePeople.getLeftPersonField()
+    ).setValue(EXAMPLE_PEOPLE.validLeft.search)
+    await MergePeople.waitForAdvancedSelectLoading(
+      EXAMPLE_PEOPLE.validLeft.fullName
+    )
+    await (await MergePeople.getFirstItemFromAdvancedSelect()).click()
+    // attempt to leave when only one person is selected, should allow to leave
+    await (await $("#anet-logo")).click()
+    // eslint-disable-next-line no-unused-expressions
+    expect(await (await $(".modal-dialog")).isExisting()).to.be.false
+
+    await MergePeople.openPage()
+    await (await MergePeople.getTitle()).waitForExist()
+    await (await MergePeople.getTitle()).waitForDisplayed()
+    await (
+      await MergePeople.getLeftPersonField()
+    ).setValue(EXAMPLE_PEOPLE.validLeft.search)
+    await MergePeople.waitForAdvancedSelectLoading(
+      EXAMPLE_PEOPLE.validLeft.fullName
+    )
+    await (await MergePeople.getFirstItemFromAdvancedSelect()).click()
+    await (
+      await MergePeople.getRightPersonField()
+    ).setValue(EXAMPLE_PEOPLE.validRight.search)
+    await MergePeople.waitForAdvancedSelectLoading(
+      EXAMPLE_PEOPLE.validRight.fullName
+    )
+    await (await MergePeople.getFirstItemFromAdvancedSelect()).click()
+    // attempt to leave when both people are selected, should show warning
+    await (await $("#anet-logo")).click()
+    const modalDialog = await $(".modal-dialog")
+    // eslint-disable-next-line no-unused-expressions
+    expect(await modalDialog.isExisting()).to.be.true
+    await $(".btn-danger").click()
+  })
   it("Should display fields values of the left person", async() => {
     // Open merge people page.
     await MergePeople.openPage()

--- a/client/tests/webdriver/baseSpecs/mergePositions.spec.js
+++ b/client/tests/webdriver/baseSpecs/mergePositions.spec.js
@@ -50,6 +50,46 @@ const EXAMPLE_POSITIONS = {
 }
 
 describe("Merge positions page", () => {
+  it("Should display a warning when leaving the page with unsaved changes", async() => {
+    await MergePositions.openPage()
+    await (await MergePositions.getTitle()).waitForExist()
+    await (await MergePositions.getTitle()).waitForDisplayed()
+    await (
+      await MergePositions.getLeftPositionField()
+    ).setValue(EXAMPLE_POSITIONS.validLeft.search)
+    await MergePositions.waitForAdvancedSelectLoading(
+      EXAMPLE_POSITIONS.validLeft.fullName
+    )
+    await (await MergePositions.getFirstItemFromAdvancedSelect()).click()
+    // attempt to leave when only one position is selected, should allow to leave
+    await (await $("#anet-logo")).click()
+    // eslint-disable-next-line no-unused-expressions
+    expect(await (await $(".modal-dialog")).isExisting()).to.be.false
+
+    await MergePositions.openPage()
+    await (await MergePositions.getTitle()).waitForExist()
+    await (await MergePositions.getTitle()).waitForDisplayed()
+    await (
+      await MergePositions.getLeftPositionField()
+    ).setValue(EXAMPLE_POSITIONS.validLeft.search)
+    await MergePositions.waitForAdvancedSelectLoading(
+      EXAMPLE_POSITIONS.validLeft.fullName
+    )
+    await (await MergePositions.getFirstItemFromAdvancedSelect()).click()
+    await (
+      await MergePositions.getRightPositionField()
+    ).setValue(EXAMPLE_POSITIONS.validRight.search)
+    await MergePositions.waitForAdvancedSelectLoading(
+      EXAMPLE_POSITIONS.validRight.fullName
+    )
+    await (await MergePositions.getFirstItemFromAdvancedSelect()).click()
+    // attempt to leave when both positions are selected, should show warning
+    await (await $("#anet-logo")).click()
+    const modalDialog = await $(".modal-dialog")
+    // eslint-disable-next-line no-unused-expressions
+    expect(await modalDialog.isExisting()).to.be.true
+    await $(".btn-danger").click()
+  })
   it("Should display fields values of the left position", async() => {
     // Open merge positions page.
     await MergePositions.openPage()


### PR DESCRIPTION
Prevent admins losing their changes if leaving a merge page without merging.

Closes [AB#1169](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1169)

#### User changes
- None

#### Superuser changes
- None

#### Admin changes
- Whenever an admin is merging 2 entities and clicks to move outside of the page, they will have to confirm they want to leave.

#### System admin changes
- [ ] application.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
- [x] described the user behavior in PR body
- [x] referenced/updated all related issues
- [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
- [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
- [ ] added and/or updated unit tests
- [x] added and/or updated e2e tests
- [ ] added and/or updated data migrations
- [ ] updated documentation
- [x] resolved all build errors and warnings
- [ ] opened debt issues for anything not resolved here
