### PR TITLE
Prevent admins from picking identical objects for merging

### DIFF
--- a/client/src/components/advancedSelectWidget/AdvancedSelect.tsx
+++ b/client/src/components/advancedSelectWidget/AdvancedSelect.tsx
@@ -102,6 +102,7 @@ export interface AdvancedSelectProps {
   extraAddon?: React.ReactNode
   value?: any | any[]
   valueKey?: string
+  disabledValue?: any | any[]
   renderSelected?: React.ReactElement
   overlayTable?: React.ReactElement // how to render the selected items
   overlayColumns: string[] // search results component for in the overlay
@@ -134,6 +135,7 @@ const AdvancedSelect = ({
   extraAddon,
   value,
   valueKey = "uuid",
+  disabledValue,
   renderSelected,
   overlayTable: OverlayTable,
   overlayColumns,
@@ -358,6 +360,7 @@ const AdvancedSelect = ({
                               items={items}
                               pageNum={pageNum}
                               selectedItems={value}
+                              disabledItems={disabledValue}
                               valueKey={valueKey}
                               handleAddItem={item => {
                                 handleAddItem(item)

--- a/client/src/components/advancedSelectWidget/AdvancedSelectOverlayTable.tsx
+++ b/client/src/components/advancedSelectWidget/AdvancedSelectOverlayTable.tsx
@@ -12,6 +12,7 @@ interface AdvancedSelectOverlayTableProps {
   valueKey: string
   pageNum?: number
   selectedItems: any[]
+  disabledItems: any[]
   handleAddItem?: (...args: unknown[]) => unknown
   handleRemoveItem?: (...args: unknown[]) => unknown
   columns: string[]
@@ -26,6 +27,7 @@ const AdvancedSelectOverlayTable = ({
   valueKey,
   pageNum,
   selectedItems = [],
+  disabledItems = [],
   handleAddItem,
   handleRemoveItem,
   columns,
@@ -33,6 +35,7 @@ const AdvancedSelectOverlayTable = ({
   selectItemComponent
 }: AdvancedSelectOverlayTableProps) => {
   const selectedItemsUuids = selectedItems.map(a => a[valueKey])
+  const disabledItemsUuids = disabledItems.map(a => a.uuid)
   return (
     <Table responsive hover striped>
       <thead>
@@ -49,26 +52,30 @@ const AdvancedSelectOverlayTable = ({
           const isSelected = Object.hasOwn(item, "isSelected")
             ? item.isSelected
             : selectedItemsUuids.includes(item.uuid)
-          const disabled = item.disabled
-          const handleClick = () =>
-            isSelected ? handleRemoveItem(item) : handleAddItem(item)
-          const renderSelectComponent = React.cloneElement(
-            selectItemComponent,
-            {
+          const isDisabled = disabledItemsUuids.includes(item.uuid)
+          const disableSelection = item.disabled
+          const handleClick = isDisabled
+            ? null
+            : () => (isSelected ? handleRemoveItem(item) : handleAddItem(item))
+          const style = isDisabled
+            ? null
+            : {
+              cursor: disableSelection ? "auto" : "pointer",
+              pointerEvents: disableSelection ? "none" : "all"
+            }
+          const renderSelectComponent = isDisabled
+            ? null
+            : React.cloneElement(selectItemComponent, {
               name: fieldName,
               checked: isSelected,
-              disabled,
+              disabled: disableSelection,
               onChange: () => null
-            }
-          )
+            })
           return (
             <tr
               key={`${item.uuid}-${pageNum}-${i}`}
               onClick={handleClick}
-              style={{
-                cursor: disabled ? "auto" : "pointer",
-                pointerEvents: disabled ? "none" : "all"
-              }}
+              style={style}
             >
               <td style={{ textAlign: "center" }}>{renderSelectComponent}</td>
               {renderRow(item)}
@@ -82,15 +89,18 @@ const AdvancedSelectOverlayTable = ({
 
 interface AdvancedSingleSelectOverlayTableBaseProps {
   selectedItems?: any | any[]
+  disabledItems?: any | any[]
 }
 
 const AdvancedSingleSelectOverlayTableBase = ({
   selectedItems,
+  disabledItems,
   ...otherProps
 }: AdvancedSingleSelectOverlayTableBaseProps) => (
   <AdvancedSelectOverlayTable
     {...otherProps}
     selectedItems={_isEmpty(selectedItems) ? [] : [selectedItems]}
+    disabledItems={_isEmpty(disabledItems) ? [] : [disabledItems]}
     selectItemComponent={<Form.Check type="radio" />}
   />
 )

--- a/client/src/components/advancedSelectWidget/AdvancedSingleSelect.tsx
+++ b/client/src/components/advancedSelectWidget/AdvancedSingleSelect.tsx
@@ -10,12 +10,14 @@ import RemoveButton from "../RemoveButton"
 interface AdvancedSingleSelectProps extends AdvancedSelectProps {
   value?: any
   valueFunc?: (...args: unknown[]) => unknown
+  disabledValue?: any
   showRemoveButton: boolean
 }
 
 const AdvancedSingleSelect = ({
   value = {},
   valueFunc = (v, k) => v?.[k],
+  disabledValue = {},
   overlayTable = AdvancedSingleSelectOverlayTable,
   showRemoveButton = true,
   ...props
@@ -24,6 +26,7 @@ const AdvancedSingleSelect = ({
     <AdvancedSelect
       value={value}
       valueFunc={valueFunc}
+      disabledValue={disabledValue}
       overlayTable={overlayTable}
       {...props}
       handleAddItem={handleAddItem}

--- a/client/src/pages/admin/merge/MergeLocations.tsx
+++ b/client/src/pages/admin/merge/MergeLocations.tsx
@@ -32,6 +32,7 @@ import useMergeObjects, {
   areAllSet,
   getActionButton,
   getLeafletMap,
+  getOtherSide,
   MERGE_SIDES,
   selectAllFields,
   setAMergedField,
@@ -438,6 +439,7 @@ const LocationColumn = ({
   locationFormatLabel
 }: LocationColumnProps) => {
   const location = mergeState[align]
+  const otherSide = mergeState[getOtherSide(align)]
   const hideWhenEmpty =
     !Location.hasCoordinates(mergeState[MERGE_SIDES.LEFT]) &&
     !Location.hasCoordinates(mergeState[MERGE_SIDES.RIGHT])
@@ -450,6 +452,7 @@ const LocationColumn = ({
           fieldName="location"
           placeholder="Select a location to merge"
           value={location}
+          disabledValue={otherSide}
           overlayColumns={["Name"]}
           overlayRenderRow={LocationOverlayRow}
           filterDefs={getLocationFilters()}

--- a/client/src/pages/admin/merge/MergeOrganizations.tsx
+++ b/client/src/pages/admin/merge/MergeOrganizations.tsx
@@ -37,6 +37,7 @@ import useMergeObjects, {
   areAllSet,
   getActionButton,
   getLeafletMap,
+  getOtherSide,
   MERGE_SIDES,
   mergedOrganizationIsValid,
   selectAllFields,
@@ -581,6 +582,7 @@ const OrganizationColumn = ({
   dispatchMergeActions
 }: OrganizationColumnProps) => {
   const organization = mergeState[align]
+  const otherSide = mergeState[getOtherSide(align)]
   const hideWhenEmpty =
     !Location.hasCoordinates(mergeState[MERGE_SIDES.LEFT]?.location) &&
     !Location.hasCoordinates(mergeState[MERGE_SIDES.RIGHT]?.location)
@@ -596,6 +598,7 @@ const OrganizationColumn = ({
           fieldName="organization"
           placeholder="Select an organization to merge"
           value={organization}
+          disabledValue={otherSide}
           overlayColumns={["Organization"]}
           overlayRenderRow={OrganizationSimpleOverlayRow}
           filterDefs={organizationsFilters}

--- a/client/src/pages/admin/merge/MergePeople.tsx
+++ b/client/src/pages/admin/merge/MergePeople.tsx
@@ -34,6 +34,7 @@ import useMergeObjects, {
   ALIGN_OPTIONS,
   areAllSet,
   getActionButton,
+  getOtherSide,
   MERGE_SIDES,
   mergedPersonIsValid,
   selectAllFields,
@@ -491,6 +492,7 @@ const PersonColumn = ({
   dispatchMergeActions
 }: PersonColumnProps) => {
   const person = mergeState[align]
+  const otherSide = mergeState[getOtherSide(align)]
   const idForPerson = label.replace(/\s+/g, "")
 
   return (
@@ -503,6 +505,7 @@ const PersonColumn = ({
           fieldName="person"
           placeholder="Select a person to merge"
           value={person}
+          disabledValue={otherSide}
           overlayColumns={["name"]}
           overlayRenderRow={PersonSimpleOverlayRow}
           filterDefs={peopleFilters}

--- a/client/src/pages/admin/merge/MergePositions.tsx
+++ b/client/src/pages/admin/merge/MergePositions.tsx
@@ -492,6 +492,7 @@ const PositionColumn = ({
   dispatchMergeActions
 }: PositionColumnProps) => {
   const position = mergeState[align]
+  const otherSide = mergeState[getOtherSide(align)]
   const hideWhenEmpty =
     !Location.hasCoordinates(mergeState[MERGE_SIDES.LEFT]?.location) &&
     !Location.hasCoordinates(mergeState[MERGE_SIDES.RIGHT]?.location)
@@ -506,6 +507,7 @@ const PositionColumn = ({
           fieldName="position"
           placeholder="Select a position to merge"
           value={position}
+          disabledValue={otherSide}
           overlayColumns={["Position", "Organization", "Current Occupant"]}
           overlayRenderRow={PositionOverlayRow}
           filterDefs={getPositionFilters(mergeState, align)}

--- a/client/tests/webdriver/baseSpecs/mergeLocations.spec.js
+++ b/client/tests/webdriver/baseSpecs/mergeLocations.spec.js
@@ -140,7 +140,7 @@ describe("Merge locations page", () => {
     expect(await modalDialog.isExisting()).to.be.true
     await $(".btn-danger").click()
   })
-  it("Should be able to select to incompatible locations to merge", async() => {
+  it("Should display fields values of the left location", async() => {
     await MergeLocations.openPage()
     await (await MergeLocations.getTitle()).waitForExist()
     await (await MergeLocations.getTitle()).waitForDisplayed()
@@ -165,7 +165,24 @@ describe("Merge locations page", () => {
     expect(
       await (await MergeLocations.getColumnContent("left", "Type")).getText()
     ).to.eq(EXAMPLE_LOCATIONS.leftCountry.type)
+  })
 
+  it("Should not allow to select the same location", async() => {
+    await (
+      await MergeLocations.getRightLocationField()
+    ).setValue(EXAMPLE_LOCATIONS.leftCountry.search)
+    await MergeLocations.waitForAdvancedSelectLoading(
+      EXAMPLE_LOCATIONS.leftCountry.fullName
+    )
+    // eslint-disable-next-line no-unused-expressions
+    expect(
+      await (
+        await MergeLocations.getFirstItemRadioButtonFromAdvancedSelect()
+      ).isExisting()
+    ).to.be.false
+  })
+
+  it("Should be able to select to incompatible locations to merge", async() => {
     await (
       await MergeLocations.getRightLocationField()
     ).setValue(EXAMPLE_LOCATIONS.right.search)

--- a/client/tests/webdriver/baseSpecs/mergeOrganizations.spec.js
+++ b/client/tests/webdriver/baseSpecs/mergeOrganizations.spec.js
@@ -167,11 +167,12 @@ describe("Merge organizations page", () => {
     await MergeOrganizations.waitForAdvancedSelectLoading(
       EXAMPLE_ORGANIZATIONS.validLeft.displayedName
     )
-    await (await MergeOrganizations.getFirstItemFromAdvancedSelect()).click()
-
-    await (
-      await MergeOrganizations.getSameOrganizationsToast()
-    ).waitForDisplayed()
+    // eslint-disable-next-line no-unused-expressions
+    expect(
+      await (
+        await MergeOrganizations.getFirstItemRadioButtonFromAdvancedSelect()
+      ).isExisting()
+    ).to.be.false
   })
 
   it("Should display field values of the right organization", async() => {

--- a/client/tests/webdriver/baseSpecs/mergePeople.spec.js
+++ b/client/tests/webdriver/baseSpecs/mergePeople.spec.js
@@ -198,9 +198,12 @@ describe("Merge people who are both non-users", () => {
     await MergePeople.waitForAdvancedSelectLoading(
       EXAMPLE_PEOPLE.validLeft.fullName
     )
-    await (await MergePeople.getFirstItemFromAdvancedSelect()).click()
-
-    await (await MergePeople.getSamePositionsToast()).waitForDisplayed()
+    // eslint-disable-next-line no-unused-expressions
+    expect(
+      await (
+        await MergePeople.getFirstItemRadioButtonFromAdvancedSelect()
+      ).isExisting()
+    ).to.be.false
   })
 
   it("Should display fields values of the right person", async() => {

--- a/client/tests/webdriver/baseSpecs/mergePositions.spec.js
+++ b/client/tests/webdriver/baseSpecs/mergePositions.spec.js
@@ -155,9 +155,12 @@ describe("Merge positions page", () => {
     await MergePositions.waitForAdvancedSelectLoading(
       EXAMPLE_POSITIONS.validLeft.fullName
     )
-    await (await MergePositions.getFirstItemFromAdvancedSelect()).click()
-
-    await (await MergePositions.getSamePositionsToast()).waitForDisplayed()
+    // eslint-disable-next-line no-unused-expressions
+    expect(
+      await (
+        await MergePositions.getFirstItemRadioButtonFromAdvancedSelect()
+      ).isExisting()
+    ).to.be.false
   })
 
   it("Should not allow to select two occupied positions", async() => {

--- a/client/tests/webdriver/pages/mergeLocations.page.js
+++ b/client/tests/webdriver/pages/mergeLocations.page.js
@@ -33,6 +33,12 @@ class MergeLocations extends Page {
     )
   }
 
+  async getFirstItemRadioButtonFromAdvancedSelect() {
+    return browser.$(
+      "table > tbody > tr:first-child > td:first-child > input.form-check-input"
+    )
+  }
+
   async getMergeLocationsButton() {
     return browser.$('//button[text()="Merge Locations"]')
   }

--- a/client/tests/webdriver/pages/mergeOrganizations.page.js
+++ b/client/tests/webdriver/pages/mergeOrganizations.page.js
@@ -25,6 +25,12 @@ class MergeOrganizations extends Page {
     )
   }
 
+  async getFirstItemRadioButtonFromAdvancedSelect() {
+    return browser.$(
+      "table > tbody > tr:first-child > td:first-child > input.form-check-input"
+    )
+  }
+
   async getAdvancedSelectPopover() {
     return browser.$(".bp5-popover-content")
   }
@@ -37,10 +43,6 @@ class MergeOrganizations extends Page {
 
   async getMergeOrganizationsButton() {
     return browser.$('//button[text()="Merge Organizations"]')
-  }
-
-  async getSameOrganizationsToast() {
-    return browser.$('//div[text()="Please select different organizations"]')
   }
 
   async getOrganizationHeaderFromPopover() {

--- a/client/tests/webdriver/pages/mergePeople.page.js
+++ b/client/tests/webdriver/pages/mergePeople.page.js
@@ -35,8 +35,10 @@ class MergePeople extends Page {
     return browser.$("table > tbody > tr:first-child > td:nth-child(2) > span")
   }
 
-  async getSamePositionsToast() {
-    return browser.$('//div[text()="Please select different people"]')
+  async getFirstItemRadioButtonFromAdvancedSelect() {
+    return browser.$(
+      "table > tbody > tr:first-child > td:first-child > input.form-check-input"
+    )
   }
 
   async getMergePeopleButton() {

--- a/client/tests/webdriver/pages/mergePositions.page.js
+++ b/client/tests/webdriver/pages/mergePositions.page.js
@@ -37,6 +37,12 @@ class MergePositions extends Page {
     )
   }
 
+  async getFirstItemRadioButtonFromAdvancedSelect() {
+    return browser.$(
+      "table > tbody > tr:first-child > td:first-child > input.form-check-input"
+    )
+  }
+
   async getEditAssociatedPositionsButton() {
     return browser.$('//button[text()="Edit Associated Positions"]')
   }
@@ -55,10 +61,6 @@ class MergePositions extends Page {
 
   async getMergePositionsButton() {
     return browser.$('//button[text()="Merge Positions"]')
-  }
-
-  async getSamePositionsToast() {
-    return browser.$('//div[text()="Please select different positions"]')
   }
 
   async getOccupiedPositionsToast() {


### PR DESCRIPTION
When an admin tried to merge two objects with the exact same name, it was very hard to pick the two different ones on the left and right side, and if they happened to pick the same one on both sides, they merely got a warning to pick two different objects.

Closes [AB#1365](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1365)

#### User changes
- None

#### Superuser changes
- None

#### Admin changes
- It is no longer possible to pick the same object on both sides of a merge, making it easier to pick different objects with the same name that you want to merge.

#### System admin changes
- [ ] application.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
- [x] described the user behavior in PR body
- [x] referenced/updated all related issues
- [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
- [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
- [ ] added and/or updated unit tests
- [x] added and/or updated e2e tests
- [ ] added and/or updated data migrations
- [ ] updated documentation
- [x] resolved all build errors and warnings
- [ ] opened debt issues for anything not resolved here