### PR TITLE
Remove redundant parent tasks

### DIFF
--- a/client/src/components/BreadcrumbTrail.tsx
+++ b/client/src/components/BreadcrumbTrail.tsx
@@ -48,10 +48,13 @@ export const BreadcrumbTrail = ({
       {trail.map((node, i) => (
         <React.Fragment key={node.uuid}>
           {i > 0 && " » "}
+          {i === 0 && hideParents && (
+            <span style={{ paddingLeft: 10, paddingRight: 10 }}>»</span>
+          )}
           <LinkTo
             modelType={modelType}
             model={node}
-            showIcon={i === 0}
+            showIcon={i === 0 && !hideParents}
             isLink={isLink}
             style={style}
           />

--- a/client/src/components/BreadcrumbTrail.tsx
+++ b/client/src/components/BreadcrumbTrail.tsx
@@ -22,6 +22,7 @@ interface BreadcrumbTrailProps {
   ascendantObjects?: any[]
   parentField: string
   isLink?: boolean
+  hideParents?: boolean
   style?: any
 }
 
@@ -31,6 +32,7 @@ export const BreadcrumbTrail = ({
   ascendantObjects,
   parentField,
   isLink,
+  hideParents,
   style
 }: BreadcrumbTrailProps) => {
   const trail = utils.getAscendantObjectsAsList(
@@ -38,6 +40,9 @@ export const BreadcrumbTrail = ({
     ascendantObjects,
     parentField
   )
+  if (hideParents) {
+    trail.splice(0, trail.length - 1)
+  }
   return (
     <span>
       {trail.map((node, i) => (

--- a/client/src/components/EventMatrix.tsx
+++ b/client/src/components/EventMatrix.tsx
@@ -430,7 +430,7 @@ const EventMatrix = ({
                         leaf={task}
                         ascendantObjects={task.ascendantTasks}
                         parentField="parentTask"
-                        hideParents={taskUuid!== task.uuid}
+                        hideParents={taskUuid !== task.uuid}
                       />
                     </td>
                     <td>{getEvent(taskEvents, 0, task)}</td>

--- a/client/src/components/EventMatrix.tsx
+++ b/client/src/components/EventMatrix.tsx
@@ -430,7 +430,7 @@ const EventMatrix = ({
                         leaf={task}
                         ascendantObjects={task.ascendantTasks}
                         parentField="parentTask"
-                        hideParents
+                        hideParents={taskUuid!== task.uuid}
                       />
                     </td>
                     <td>{getEvent(taskEvents, 0, task)}</td>

--- a/client/src/components/EventMatrix.tsx
+++ b/client/src/components/EventMatrix.tsx
@@ -430,6 +430,7 @@ const EventMatrix = ({
                         leaf={task}
                         ascendantObjects={task.ascendantTasks}
                         parentField="parentTask"
+                        hideParents
                       />
                     </td>
                     <td>{getEvent(taskEvents, 0, task)}</td>


### PR DESCRIPTION
Whenever viewing the sync matrix of an objective/task, the children tasks shouldn't need the full path displayed in the breadcrumbs, as it adds too much clutter.
It should only display the last task in the chain

Closes AB#1360

#### User changes
- Should have a more concise view of the Event Matrix

#### Superuser changes
- None

#### Admin changes
- None

#### System admin changes
- [ ] application.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
- [x] described the user behavior in PR body
- [x] referenced/updated all related issues
- [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
- [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
- [ ] added and/or updated unit tests
- [ ] added and/or updated e2e tests
- [ ] added and/or updated data migrations
- [ ] updated documentation
- [x] resolved all build errors and warnings
- [ ] opened debt issues for anything not resolved here
