### PR TITLE
Prevent infinite loop on task filter

### DIFF
--- a/client/src/components/advancedSearch/TaskFilter.tsx
+++ b/client/src/components/advancedSearch/TaskFilter.tsx
@@ -133,9 +133,29 @@ const HierarchicalOverlayTable = ({
   const topLevelItems = items.filter(task => !task.parentTask)
   const nonTopLevelItems = items.filter(task => task.parentTask)
   nonTopLevelItems.forEach(task => {
-    const parent = task.ascendantTasks.find(ascendant => ascendant.parentTask === null)
-    if (!topLevelItems.some(item => item.uuid === parent.uuid)) {
-      topLevelItems.push(parent)
+    // if the top-level of each non-top-level tasks are not in the topLevelItems,
+    // it means they were queried through a search,
+    // so we need to get them, add them to the topLevelItems,
+    // and expand all the tasks leading up to them
+    const topLevelItem = task.ascendantTasks.find(
+      ascendant => ascendant.parentTask === null
+    )
+    if (!topLevelItems.some(item => item.uuid === topLevelItem.uuid)) {
+      topLevelItems.push(topLevelItem)
+      task.ascendantTasks.forEach(ascendant => {
+        const isTopLevel = ascendant.parentTask === null
+        // adding the top-level task to the topLevelItems
+        if (
+          isTopLevel &&
+          !topLevelItems.some(item => item.uuid === ascendant.uuid)
+        ) {
+          topLevelItems.push(ascendant)
+        }
+        // expanding the ascendant task leading up to the task
+        if (!expandedItems.has(ascendant.uuid)) {
+          handleExpand(ascendant)
+        }
+      })
     }
   })
   const flattenedItems = buildFlattenedList(topLevelItems)

--- a/client/src/components/advancedSearch/TaskFilter.tsx
+++ b/client/src/components/advancedSearch/TaskFilter.tsx
@@ -18,8 +18,15 @@ const taskFields = `
   childrenTasks(query: { pageSize: 1 }) {
     uuid
   }
-  parentTask {
+  ascendantTasks {
     uuid
+    shortName
+    parentTask {
+      uuid
+    }
+    childrenTasks {
+      uuid
+    }
   }
   descendantTasks {
     uuid
@@ -124,6 +131,13 @@ const HierarchicalOverlayTable = ({
   }
 
   const topLevelItems = items.filter(task => !task.parentTask)
+  const nonTopLevelItems = items.filter(task => task.parentTask)
+  nonTopLevelItems.forEach(task => {
+    const parent = task.ascendantTasks.find(ascendant => ascendant.parentTask === null)
+    if (!topLevelItems.some(item => item.uuid === parent.uuid)) {
+      topLevelItems.push(parent)
+    }
+  })
   const flattenedItems = buildFlattenedList(topLevelItems)
 
   const enhancedRenderRow = task => {

--- a/client/tests/webdriver/baseSpecs/searchFilters/taskFilter.spec.js
+++ b/client/tests/webdriver/baseSpecs/searchFilters/taskFilter.spec.js
@@ -1,0 +1,31 @@
+import { expect } from "chai"
+import TaskFilter from "../../pages/searchFilters/taskFilter.page"
+
+describe("When using the task filter on the reports search", () => {
+  it("Should show all the tasks", async() => {
+    await TaskFilter.open()
+    await TaskFilter.openTaskFilter()
+
+    expect(await TaskFilter.getTaskCount()).to.equal(13)
+
+    await TaskFilter.openAllCollpasedTasks()
+    // depending on the test run sequence, one more task may have been created
+    expect(await TaskFilter.getTaskCount()).to.be.oneOf([50, 51])
+  })
+
+  it("Should show only the filtered tasks", async() => {
+    await TaskFilter.searchTasks("Milestone the First in EF 1.1")
+    expect(await TaskFilter.getTaskCount()).to.equal(3)
+    // the tasks should already load expanded, so it should yield the same result
+    await TaskFilter.openAllCollpasedTasks()
+    expect(await TaskFilter.getTaskCount()).to.equal(3)
+    await TaskFilter.closeTaskFilter()
+
+    await TaskFilter.searchTasks("TAAC")
+    expect(await TaskFilter.getTaskCount()).to.equal(1)
+    // the only task should now expand, leading to a bigger task count
+    await TaskFilter.openAllCollpasedTasks()
+    expect(await TaskFilter.getTaskCount()).to.equal(7)
+    await TaskFilter.closeTaskFilter()
+  })
+})

--- a/client/tests/webdriver/pages/searchFilters/taskFilter.page.js
+++ b/client/tests/webdriver/pages/searchFilters/taskFilter.page.js
@@ -1,0 +1,84 @@
+import Page from "../page"
+
+class TaskFilter extends Page {
+  async openTaskFilter() {
+    const searchLink = await browser.$(
+      ".search-popover-target.bp5-popover-target"
+    )
+    await searchLink.waitForDisplayed()
+    await searchLink.click()
+
+    const reportsButton = await browser.$(
+      '.btn-group > button[value="REPORTS"]'
+    )
+    await reportsButton.waitForDisplayed()
+    await reportsButton.click()
+
+    const removeFilterButtons = await browser.$$(
+      '.form-group button[title="Remove this filter"]'
+    )
+    for (const removeFilterButton of removeFilterButtons) {
+      await removeFilterButton.waitForDisplayed()
+      await removeFilterButton.click()
+    }
+
+    const addFilterButton = await browser.$("#addFilterDropdown")
+    await addFilterButton.waitForDisplayed()
+    await addFilterButton.click()
+
+    const withinObjectiveButton = await browser.$("a*=Within Objective")
+    await withinObjectiveButton.click()
+  }
+
+  async getTaskCount() {
+    const openFilterButton = await browser.$("input[name='taskUuid']")
+    await openFilterButton.waitForDisplayed()
+    await openFilterButton.click()
+
+    await browser.waitUntil(
+      async() =>
+        await (await browser.$("#taskUuid-popover tbody")).isDisplayed()
+    )
+    const taskRows = await browser.$$("#taskUuid-popover tbody > tr")
+    return taskRows.length
+  }
+
+  async openAllCollpasedTasks() {
+    await browser.waitUntil(
+      async() =>
+        await (await browser.$("#taskUuid-popover tbody")).isDisplayed()
+    )
+    let expandibleTasks = await browser.$$(
+      "#taskUuid-popover .bp5-icon-chevron-right"
+    )
+    while (expandibleTasks.length > 0) {
+      for (const task of expandibleTasks) {
+        await task.click()
+      }
+      expandibleTasks = await browser.$$(
+        "#taskUuid-popover .bp5-icon-chevron-right"
+      )
+    }
+  }
+
+  async searchTasks(searchText) {
+    const openFilterButton = await browser.$("input[name='taskUuid']")
+    await openFilterButton.waitForDisplayed()
+    await openFilterButton.click()
+    await browser.keys(searchText)
+    await browser.waitUntil(
+      async() =>
+        await (await browser.$("#taskUuid-popover tbody")).isDisplayed()
+    )
+  }
+
+  async closeTaskFilter() {
+    await browser.pause(2000)
+    const closeButton = await browser.$(".bp5-icon.bp5-icon-cross")
+    await closeButton.waitForDisplayed()
+    await closeButton.click()
+    await browser.pause(2000)
+  }
+}
+
+export default new TaskFilter()


### PR DESCRIPTION
Whenever a search was made on the task filter, and that search returned items that were not top-level items, the component had no way to display the path up until that task.
Now we're retrieving the information about the ascendant tasks so we can build the tree upwards.

Closes [AB#1373](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1373)

#### User changes
- Be able to properly search for any specific tasks

#### Superuser changes
- None

#### Admin changes
- None

#### System admin changes
- [ ] application.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
- [x] described the user behavior in PR body
- [x] referenced/updated all related issues
- [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
- [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
- [ ] added and/or updated unit tests
- [x] added and/or updated e2e tests
- [ ] added and/or updated data migrations
- [ ] updated documentation
- [x] resolved all build errors and warnings
- [ ] opened debt issues for anything not resolved here
