### PR TITLE
Support multiple domain usernames per user

### DIFF
--- a/anet-dictionary.yml
+++ b/anet-dictionary.yml
@@ -647,8 +647,8 @@ fields:
       placeholder: Last name
     user:
       label: ANET user
-    domainUsername:
-      label: Domain username
+    users:
+      label: User accounts
     position:
       label: Current Position
       placeholder: Fill in the person's current position
@@ -1331,7 +1331,7 @@ fields:
         - position
         - prevPositions
         - user
-        - domainUsername
+        - users
         - authorizationGroups
         - emailAddresses
         - multipleButtons

--- a/client/src/components/UserInputTable.tsx
+++ b/client/src/components/UserInputTable.tsx
@@ -1,0 +1,85 @@
+import {
+  getFormGroupValidationState,
+  getHelpBlock
+} from "components/FieldHelper"
+import RemoveButton from "components/RemoveButton"
+import { Field, FieldArray } from "formik"
+import _get from "lodash/get"
+import React from "react"
+import { Button, Table } from "react-bootstrap"
+import Settings from "settings"
+
+interface UserInputTableProps {
+  fieldArrayName?: string
+  users: any[]
+}
+
+const UserInputTable = ({
+  fieldArrayName = "users",
+  users
+}: UserInputTableProps) => {
+  return (
+    <FieldArray name="users">
+      {({ form, remove, push }) => (
+        <>
+          {_get(users, "length", 0) === 0 ? (
+            <em className="clearfix">No domain username found</em>
+          ) : (
+            <Table striped hover responsive>
+              <thead>
+                <tr>
+                  <th>Domain username</th>
+                </tr>
+              </thead>
+              <tbody>
+                {users.map((u, i) => {
+                  const fieldName = `${fieldArrayName}.${i}.domainUsername`
+                  const { className } = getFormGroupValidationState(
+                    fieldName,
+                    form,
+                    "form-control"
+                  )
+                  return (
+                    <tr key={u.uuid}>
+                      <td className="input-group">
+                        <Field
+                          className={className}
+                          name={fieldName}
+                          value={u.domainUsername}
+                        />
+                        <RemoveButton
+                          id={`clear-${fieldName}`}
+                          title="Remove domain username"
+                          onClick={() => remove(i)}
+                        />
+                        {getHelpBlock(fieldName, form)}
+                      </td>
+                    </tr>
+                  )
+                })}
+              </tbody>
+            </Table>
+          )}
+          <Button
+            onClick={() => push({ domainUsername: "" })}
+            variant="secondary"
+            id={`add${fieldArrayName}Button`}
+          >
+            Add a domain username
+          </Button>
+        </>
+      )}
+    </FieldArray>
+  )
+
+  function clearUser(fieldName, form, replace, i) {
+    const user = users[i]
+    if (user) {
+      user.domainUsername = ""
+      replace(i, user)
+      form.setFieldTouched(fieldName)
+    }
+  }
+}
+
+export default UserInputTable

--- a/client/src/components/UserTable.tsx
+++ b/client/src/components/UserTable.tsx
@@ -1,0 +1,34 @@
+import _get from "lodash/get"
+import React from "react"
+import { Table } from "react-bootstrap"
+import utils from "utils"
+
+interface UserTableProps {
+  label: string
+  users?: any[]
+}
+
+const UserTable = ({ label, users }: UserTableProps) => {
+  if (_get(users, "length", 0) === 0) {
+    return <em>No {label.toLowerCase()} available</em>
+  }
+
+  return (
+    <Table striped hover responsive>
+      <thead>
+        <tr>
+          <th>Domain username</th>
+        </tr>
+      </thead>
+      <tbody>
+        {users.map(u => (
+          <tr key={u.uuid}>
+            <td>{u.domainUsername}</td>
+          </tr>
+        ))}
+      </tbody>
+    </Table>
+  )
+}
+
+export default UserTable

--- a/client/src/components/previews/PersonPreview.tsx
+++ b/client/src/components/previews/PersonPreview.tsx
@@ -13,6 +13,7 @@ import {
 } from "components/Model"
 import PreviousPositions from "components/PreviousPositions"
 import RichTextEditor from "components/RichTextEditor"
+import UserTable from "components/UserTable"
 import { Person, Position } from "models"
 import moment from "moment"
 import React, { useContext } from "react"
@@ -31,7 +32,10 @@ const GQL_GET_PERSON = gql`
       pendingVerification
       phoneNumber
       user
-      domainUsername
+      users {
+        uuid
+        domainUsername
+      }
       biography
       obsoleteCountry
       country {
@@ -159,8 +163,13 @@ const PersonPreview = ({ className, uuid }: PersonPreviewProps) => {
                 />
                 <DictionaryField
                   wrappedComponent={PreviewField}
-                  dictProps={Settings.fields.person.domainUsername}
-                  value={person.domainUsername}
+                  dictProps={Settings.fields.person.users}
+                  value={
+                    <UserTable
+                      label={Settings.fields.person.users.label}
+                      users={person.users}
+                    />
+                  }
                 />
               </>
             )}

--- a/client/src/models/Person.ts
+++ b/client/src/models/Person.ts
@@ -74,11 +74,15 @@ export default class Person extends Model {
         .boolean()
         .default(false)
         .label(Settings.fields.person.user?.label),
-      domainUsername: yup
-        .string()
+      users: yup
+        .array()
+        .of(
+          yup.object().shape({
+            address: yup.string().nullable()
+          })
+        )
         .nullable()
-        .default("")
-        .label(Settings.fields.person.domainUsername?.label),
+        .default([]),
       emailAddresses: yupEmailAddressesWithValidation(
         "emailAddress",
         "emailAddress error",
@@ -177,7 +181,10 @@ export default class Person extends Model {
     pendingVerification
     phoneNumber
     user
-    domainUsername
+    users {
+      uuid
+      domainUsername
+    }
     biography
     obsoleteCountry
     country {
@@ -349,7 +356,7 @@ export default class Person extends Model {
     if (this.rank) {
       return this.rank + " " + militaryName
     } else {
-      return militaryName || this.domainUsername || this.uuid
+      return militaryName || this.uuid
     }
   }
 

--- a/client/src/pages/admin/merge/MergePeople.tsx
+++ b/client/src/pages/admin/merge/MergePeople.tsx
@@ -30,6 +30,7 @@ import {
 } from "components/Page"
 import PreviousPositions from "components/PreviousPositions"
 import RichTextEditor from "components/RichTextEditor"
+import UserTable from "components/UserTable"
 import useMergeObjects, {
   ALIGN_OPTIONS,
   areAllSet,
@@ -198,10 +199,15 @@ const MergePeople = ({ pageDispatchers }: MergePeopleProps) => {
               />
               <DictionaryField
                 wrappedComponent={MergeField}
-                dictProps={Settings.fields.person.domainUsername}
-                value={mergedPerson.domainUsername}
+                dictProps={Settings.fields.person.users}
+                value={
+                  <UserTable
+                    label={Settings.fields.person.users.label}
+                    users={mergedPerson.users}
+                  />
+                }
                 align={ALIGN_OPTIONS.CENTER}
-                fieldName="domainUsername"
+                fieldName="users"
                 mergeState={mergeState}
                 dispatchMergeActions={dispatchMergeActions}
               />
@@ -469,10 +475,7 @@ const ColTitle = styled(Form.Group)`
 
 const peopleFilters = {
   allPersons: {
-    label: "All",
-    queryVars: {
-      pendingVerification: false
-    }
+    label: "All"
   }
 }
 
@@ -583,13 +586,18 @@ const PersonColumn = ({
           />
           <DictionaryField
             wrappedComponent={MergeField}
-            dictProps={Settings.fields.person.domainUsername}
-            fieldName="domainUsername"
-            value={person.domainUsername}
+            dictProps={Settings.fields.person.users}
+            fieldName="users"
+            value={
+              <UserTable
+                label={Settings.fields.person.users.label}
+                users={person.users}
+              />
+            }
             align={align}
             action={() => {
               dispatchMergeActions(
-                setAMergedField("domainUsername", person.domainUsername, align)
+                setAMergedField("users", person.users, align)
               )
             }}
             mergeState={mergeState}

--- a/client/src/pages/onboarding/Show.tsx
+++ b/client/src/pages/onboarding/Show.tsx
@@ -140,7 +140,7 @@ const OnboardingShow = ({ pageDispatchers }: OnboardingShowProps) => {
       user: {
         accessCond: false
       },
-      domainUsername: {
+      users: {
         accessCond: false
       }
     }

--- a/client/src/pages/people/Compact.tsx
+++ b/client/src/pages/people/Compact.tsx
@@ -33,6 +33,7 @@ import {
 } from "components/Page"
 import RichTextEditor from "components/RichTextEditor"
 import SimpleMultiCheckboxDropdown from "components/SimpleMultiCheckboxDropdown"
+import UserTable from "components/UserTable"
 import { Field, Formik } from "formik"
 import _isEmpty from "lodash/isEmpty"
 import { Person } from "models"
@@ -55,7 +56,10 @@ const GQL_GET_PERSON = gql`
       pendingVerification
       phoneNumber
       user
-      domainUsername
+      users {
+        uuid
+        domainUsername
+      }
       biography
       obsoleteCountry
       country {
@@ -339,7 +343,7 @@ const CompactPersonView = ({ pageDispatchers }: CompactPersonViewProps) => {
     const mappedNonCustomFields = mapNonCustomFields()
     // map fields that have privileged access check to the condition
     const privilegedAccessedFields = {
-      domainUsername: {
+      users: {
         accessCond: isAdmin
       }
     }
@@ -403,6 +407,12 @@ const CompactPersonView = ({ pageDispatchers }: CompactPersonViewProps) => {
     const humanValuesExceptions = {
       biography: <RichTextEditor readOnly value={person.biography} />,
       user: utils.formatBoolean(person.user),
+      users: (
+        <UserTable
+          label={Settings.fields.person.users.label}
+          users={person.users}
+        />
+      ),
       emailAddresses: (
         <EmailAddressTable
           label={Settings.fields.person.emailAddresses.label}

--- a/client/src/pages/people/Edit.tsx
+++ b/client/src/pages/people/Edit.tsx
@@ -37,7 +37,10 @@ const GQL_GET_PERSON = gql`
       phoneNumber
       pendingVerification
       user
-      domainUsername
+      users {
+        uuid
+        domainUsername
+      }
       biography
       obsoleteCountry
       country {

--- a/client/src/pages/people/Form.tsx
+++ b/client/src/pages/people/Form.tsx
@@ -28,6 +28,7 @@ import { jumpToTop } from "components/Page"
 import RichTextEditor from "components/RichTextEditor"
 import SimilarObjectsModal from "components/SimilarObjectsModal"
 import TriggerableConfirm from "components/TriggerableConfirm"
+import UserInputTable from "components/UserInputTable"
 import { FastField, Field, Form, Formik } from "formik"
 import _isEmpty from "lodash/isEmpty"
 import _isEqual from "lodash/isEqual"
@@ -510,15 +511,16 @@ const PersonForm = ({
                         {values.user && (
                           <DictionaryField
                             wrappedComponent={FastField}
-                            dictProps={Settings.fields.person.domainUsername}
-                            name="domainUsername"
-                            component={FieldHelper.InputField}
+                            as="div"
+                            dictProps={Settings.fields.person.users}
+                            component={FieldHelper.SpecialField}
                             extraColElem={
                               <span className="text-danger">
-                                Be careful when changing this field; you might
-                                lock someone out or create duplicate accounts.
+                                Be careful when editing this field; you might
+                                lock someone out.
                               </span>
                             }
+                            widget={<UserInputTable users={values.users} />}
                           />
                         )}
                       </>

--- a/client/tests/e2e/permissions.js
+++ b/client/tests/e2e/permissions.js
@@ -252,8 +252,8 @@ test.serial("checking admin permissions", async t => {
   await driver.wait(until.elementIsVisible($userInput), shortWaitMs)
   const $userButton = await $('label[for="user_true"]')
   await $userButton.click()
-  const $domainUsernameInput = await $("#domainUsername")
-  await driver.wait(until.elementIsVisible($domainUsernameInput), shortWaitMs)
+  const $addusersButton = await $("#addusersButton")
+  await driver.wait(until.elementIsVisible($addusersButton), shortWaitMs)
 
   // Cancel Create Person
   const $cancelButton = await driver.findElement(

--- a/client/tests/sim/stories/PersonStories.js
+++ b/client/tests/sim/stories/PersonStories.js
@@ -40,6 +40,13 @@ function personName(gender, locale) {
   }
 }
 
+function createUsers(domainUsername) {
+  if (domainUsername) {
+    return [{ domainUsername }]
+  }
+  return null
+}
+
 async function randomPerson(isUser, status) {
   const gender = fuzzy.withProbability(0.1)
     ? "NOT SPECIFIED"
@@ -102,7 +109,7 @@ async function randomPerson(isUser, status) {
     endOfTourDate: () => faker.date.future(),
     biography: async() => await createHtmlParagraphs(),
     user: () => isUser,
-    domainUsername: () => domainUsername,
+    users: () => createUsers(domainUsername),
     emailAddresses: () => createEmailAddresses(isUser, email)
   }
 }
@@ -110,7 +117,6 @@ async function randomPerson(isUser, status) {
 function modifiedPerson() {
   return {
     name: identity,
-    domainUsername: identity,
     status: identity,
     country: identity,
     rank: identity,
@@ -119,6 +125,7 @@ function modifiedPerson() {
     endOfTourDate: () => faker.date.future(),
     biography: async() => await createHtmlParagraphs(),
     user: identity,
+    users: identity,
     emailAddresses: (value, instance) => {
       const name = Person.parseFullName(instance.name)
       const email = faker.internet.displayName({
@@ -140,7 +147,7 @@ const _createPerson = async function(user, isUser, status) {
   await personGenerator.status.always()
   await personGenerator.rank.always()
   await personGenerator.user.always()
-  await personGenerator.domainUsername.always()
+  await personGenerator.users.always()
   await personGenerator.country.always()
   await personGenerator.gender.always()
   await personGenerator.endOfTourDate.always()
@@ -202,7 +209,11 @@ const updatePerson = async function(user) {
             endOfTourDate
             gender
             name
-            domainUsername
+            user
+            users {
+              uuid
+              domainUsername
+            }
             phoneNumber
             rank
             role
@@ -218,7 +229,8 @@ const updatePerson = async function(user) {
   const person = people && people[0]
   const personGenerator = await populate(person, modifiedPerson())
   await personGenerator.name.rarely()
-  await personGenerator.domainUsername.never()
+  await personGenerator.user.never()
+  await personGenerator.users.never()
   await personGenerator.phoneNumber.sometimes()
   await personGenerator.rank.sometimes()
   await personGenerator.country.never()

--- a/client/tests/sim/stories/PositionStories.js
+++ b/client/tests/sim/stories/PositionStories.js
@@ -151,10 +151,12 @@ const _createPosition = async function(user) {
   const person = await getRandomObject(
     "people",
     {},
-    "uuid domainUsername",
+    "uuid users { domainUsername }",
     randomObject =>
       randomObject?.uuid === user.uuid ||
-      randomObject?.domainUsername === specialUser.name
+      (randomObject?.users ?? []).some(
+        u => u.domainUsername === specialUser.name
+      )
   )
   const location = await getRandomObject("locations", {
     type: Location.LOCATION_TYPES.POINT_LOCATION
@@ -485,8 +487,10 @@ const deletePersonFromPosition = async function(user) {
             name
             type
             person {
-              domainUsername
               name
+              users {
+                domainUsername
+              }
             }
           }
         }
@@ -504,7 +508,9 @@ const deletePersonFromPosition = async function(user) {
   ).data.positionList.list.filter(
     p =>
       p.person &&
-      p.person.domainUsername !== specialUser.name &&
+      !(p.person.users ?? []).some(
+        u => u.domainUsername === specialUser.name
+      ) &&
       p.type !== Position.TYPE.ADMINISTRATOR
   )
   const position = faker.helpers.arrayElement(positions)

--- a/client/tests/sim/stories/afghanSurnames.js
+++ b/client/tests/sim/stories/afghanSurnames.js
@@ -1,12 +1,12 @@
 const names = [
-  { name: "ACHAKZAI", ethnicGroup: ["Pashto"] },
-  { name: "AFGHAN", ethnicGroup: ["Dari"] },
-  { name: "AFGHANZADA", ethnicGroup: ["Persian", "Dari"] },
-  { name: "AHMADZAI", ethnicGroup: ["Pashto"] },
-  { name: "AKHTAR", ethnicGroup: ["Urdu", "Indian", "Bengali", "Pashto"] },
-  { name: "ALAKOZAI", ethnicGroup: ["Pashto"] },
+  { name: "Achakzai", ethnicGroup: ["Pashto"] },
+  { name: "Afghan", ethnicGroup: ["Dari"] },
+  { name: "Afghanzada", ethnicGroup: ["Persian", "Dari"] },
+  { name: "Ahmadzai", ethnicGroup: ["Pashto"] },
+  { name: "Akhtar", ethnicGroup: ["Urdu", "Indian", "Bengali", "Pashto"] },
+  { name: "Alakozai", ethnicGroup: ["Pashto"] },
   {
-    name: "ALAM",
+    name: "Alam",
     ethnicGroup: [
       "Bengali",
       "Indian",
@@ -18,21 +18,21 @@ const names = [
       "Dari"
     ]
   },
-  { name: "ALIZAI", ethnicGroup: ["Pashto"] },
-  { name: "ANWARZAI", ethnicGroup: ["Pashto"] },
-  { name: "AURAKZAI", ethnicGroup: ["Pashto"] },
-  { name: "AYOUBI", ethnicGroup: ["Persian", "Pashto", "Arabic"] },
-  { name: "AYUBI", ethnicGroup: ["Persian", "Pashto", "Urdu"] },
-  { name: "BARAKZAI", ethnicGroup: ["Pashto"] },
-  { name: "DAWLATZAI", ethnicGroup: ["Pashto", "Dari"] },
-  { name: "DURANI", ethnicGroup: ["Pashto"] },
-  { name: "DURRANI", ethnicGroup: ["Pashto"] },
+  { name: "Alizai", ethnicGroup: ["Pashto"] },
+  { name: "Anwarzai", ethnicGroup: ["Pashto"] },
+  { name: "Aurakzai", ethnicGroup: ["Pashto"] },
+  { name: "Ayoubi", ethnicGroup: ["Persian", "Pashto", "Arabic"] },
+  { name: "Ayubi", ethnicGroup: ["Persian", "Pashto", "Urdu"] },
+  { name: "Barakzai", ethnicGroup: ["Pashto"] },
+  { name: "Dawlatzai", ethnicGroup: ["Pashto", "Dari"] },
+  { name: "Durani", ethnicGroup: ["Pashto"] },
+  { name: "Durrani", ethnicGroup: ["Pashto"] },
   {
-    name: "FAROOQ",
+    name: "Farooq",
     ethnicGroup: ["Urdu", "Indian", "Bengali", "Pashto", "Arabic"]
   },
   {
-    name: "GUL",
+    name: "Gul",
     ethnicGroup: [
       "Pakistani",
       "Pashto",
@@ -43,9 +43,9 @@ const names = [
       "Persian"
     ]
   },
-  { name: "HABIBZAI", ethnicGroup: ["Pashto"] },
+  { name: "Habibzai", ethnicGroup: ["Pashto"] },
   {
-    name: "HAIDER",
+    name: "Haider",
     ethnicGroup: [
       "Urdu",
       "Punjabi",
@@ -56,12 +56,12 @@ const names = [
       "Arabic"
     ]
   },
-  { name: "HASANZAI", ethnicGroup: ["Pashto"] },
-  { name: "HASSANZAI", ethnicGroup: ["Pashto"] },
-  { name: "HUSSAINI", ethnicGroup: ["Persian", "Dari", "Urdu", "Arabic"] },
-  { name: "IBRAHIMI", ethnicGroup: ["Pashto", "Arabic", "Albanian"] },
+  { name: "Hasanzai", ethnicGroup: ["Pashto"] },
+  { name: "Hassanzai", ethnicGroup: ["Pashto"] },
+  { name: "Hussaini", ethnicGroup: ["Persian", "Dari", "Urdu", "Arabic"] },
+  { name: "Ibrahimi", ethnicGroup: ["Pashto", "Arabic", "Albanian"] },
   {
-    name: "IQBAL",
+    name: "Iqbal",
     ethnicGroup: [
       "Urdu",
       "Bengali",
@@ -73,9 +73,9 @@ const names = [
       "Indonesian"
     ]
   },
-  { name: "ISHAQZAI", ethnicGroup: ["Pashto"] },
+  { name: "Ishaqzai", ethnicGroup: ["Pashto"] },
   {
-    name: "KABIR",
+    name: "Kabir",
     ethnicGroup: [
       "Bengali",
       "Nigerian",
@@ -85,9 +85,9 @@ const names = [
       "Persian"
     ]
   },
-  { name: "KARZAI", ethnicGroup: ["Dari"] },
+  { name: "Karzai", ethnicGroup: ["Dari"] },
   {
-    name: "KHAN",
+    name: "Khan",
     ethnicGroup: [
       "Punjabi",
       "Pashto",
@@ -99,10 +99,10 @@ const names = [
       "Bengali"
     ]
   },
-  { name: "KUMAKI", ethnicGroup: ["Pashto"] },
-  { name: "MALIKZAI", ethnicGroup: ["Pashto"] },
+  { name: "Kumaki", ethnicGroup: ["Pashto"] },
+  { name: "Malikzai", ethnicGroup: ["Pashto"] },
   {
-    name: "MOHAMMAD",
+    name: "Mohammad",
     ethnicGroup: [
       "Indian",
       "Bengali",
@@ -113,11 +113,11 @@ const names = [
       "Punjabi"
     ]
   },
-  { name: "MOHAMMADZAI", ethnicGroup: ["Pashto"] },
-  { name: "NABIZADA", ethnicGroup: ["Persian", "Dari"] },
-  { name: "NIAZAI", ethnicGroup: ["Pashto"] },
+  { name: "Mohammadzai", ethnicGroup: ["Pashto"] },
+  { name: "Nabizada", ethnicGroup: ["Persian", "Dari"] },
+  { name: "Niazai", ethnicGroup: ["Pashto"] },
   {
-    name: "NOOR",
+    name: "Noor",
     ethnicGroup: [
       "Pakistani",
       "Urdu",
@@ -130,46 +130,46 @@ const names = [
       "Muslim"
     ]
   },
-  { name: "NOORZAI", ethnicGroup: ["Pashto"] },
-  { name: "NURISTANI", ethnicGroup: ["Dari"] },
-  { name: "OMARZAI", ethnicGroup: ["Pashto"] },
-  { name: "ORAKZAI", ethnicGroup: ["Pashto", "Pakistani"] },
-  { name: "PATHAN", ethnicGroup: ["Indian", "Bengali", "Urdu", "Pashto"] },
-  { name: "POPALZAI", ethnicGroup: ["Pashto"] },
-  { name: "POYA", ethnicGroup: ["Dari"] },
-  { name: "QURAISHI", ethnicGroup: ["Persian", "Pashto", "Urdu", "Indian"] },
+  { name: "Noorzai", ethnicGroup: ["Pashto"] },
+  { name: "Nuristani", ethnicGroup: ["Dari"] },
+  { name: "Omarzai", ethnicGroup: ["Pashto"] },
+  { name: "Orakzai", ethnicGroup: ["Pashto", "Pakistani"] },
+  { name: "Pathan", ethnicGroup: ["Indian", "Bengali", "Urdu", "Pashto"] },
+  { name: "Popalzai", ethnicGroup: ["Pashto"] },
+  { name: "Poya", ethnicGroup: ["Dari"] },
+  { name: "Quraishi", ethnicGroup: ["Persian", "Pashto", "Urdu", "Indian"] },
   {
-    name: "QURESHI",
+    name: "Qureshi",
     ethnicGroup: ["Sindhi", "Urdu", "Punjabi", "Pashto", "Balochi", "Indian"]
   },
   {
-    name: "RAHMAN",
+    name: "Rahman",
     ethnicGroup: ["Bengali", "Indian", "Urdu", "Malay", "Pashto", "Arabic"]
   },
-  { name: "RAHMANZAI", ethnicGroup: ["Pashto"] },
+  { name: "Rahmanzai", ethnicGroup: ["Pashto"] },
   {
-    name: "RASUL",
+    name: "Rasul",
     ethnicGroup: ["Urdu", "Pashto", "Bengali", "Indian", "Arabic", "Indonesian"]
   },
   {
-    name: "REHMAN",
+    name: "Rehman",
     ethnicGroup: ["Urdu", "Punjabi", "Sindhi", "Indian", "Bengali", "Pashto"]
   },
-  { name: "SADOZAI", ethnicGroup: ["Pashto", "Balochi"] },
-  { name: "SAFI", ethnicGroup: ["Pashto", "Dari", "Pakistani"] },
+  { name: "Sadozai", ethnicGroup: ["Pashto", "Balochi"] },
+  { name: "Safi", ethnicGroup: ["Pashto", "Dari", "Pakistani"] },
   {
-    name: "SALEEM",
+    name: "Saleem",
     ethnicGroup: ["Urdu", "Punjabi", "Arabic", "Indian", "Pashto"]
   },
-  { name: "SEDIQI", ethnicGroup: ["Dari", "Persian"] },
-  { name: "SHAHNAWAZ", ethnicGroup: ["Dari"] },
-  { name: "SHAHZAD", ethnicGroup: ["Urdu", "Pashto"] },
-  { name: "SHERKHANZAI", ethnicGroup: ["Dari"] },
-  { name: "SHERZAI", ethnicGroup: ["Pashto"] },
-  { name: "SHINWARI", ethnicGroup: ["Pashto"] },
-  { name: "SHIRZAI", ethnicGroup: ["Pashto"] },
+  { name: "Sediqi", ethnicGroup: ["Dari", "Persian"] },
+  { name: "Shahnawaz", ethnicGroup: ["Dari"] },
+  { name: "Shahzad", ethnicGroup: ["Urdu", "Pashto"] },
+  { name: "Sherkhanzai", ethnicGroup: ["Dari"] },
+  { name: "Sherzai", ethnicGroup: ["Pashto"] },
+  { name: "Shinwari", ethnicGroup: ["Pashto"] },
+  { name: "Shirzai", ethnicGroup: ["Pashto"] },
   {
-    name: "SIDDIQUE",
+    name: "Siddique",
     ethnicGroup: [
       "Punjabi",
       "Urdu",
@@ -181,7 +181,7 @@ const names = [
     ]
   },
   {
-    name: "SIDDIQUI",
+    name: "Siddiqui",
     ethnicGroup: [
       "Urdu",
       "Sindhi",
@@ -192,10 +192,10 @@ const names = [
       "Indian"
     ]
   },
-  { name: "SIDIQI", ethnicGroup: ["Pashto", "Persian", "Dari"] },
-  { name: "STANIKZAI", ethnicGroup: ["Pashto"] },
+  { name: "Sidiqi", ethnicGroup: ["Pashto", "Persian", "Dari"] },
+  { name: "Stanikzai", ethnicGroup: ["Pashto"] },
   {
-    name: "ULLAH",
+    name: "Ullah",
     ethnicGroup: [
       "Pakistani",
       "Pashto",
@@ -207,16 +207,16 @@ const names = [
       "Indian"
     ]
   },
-  { name: "WALI", ethnicGroup: ["Urdu", "Pashto", "Bengali", "Arabic"] },
-  { name: "WARDAK", ethnicGroup: ["Pashto"] },
-  { name: "YOUSAFZAI", ethnicGroup: ["Pashto"] },
-  { name: "YOUSUFZAI", ethnicGroup: ["Pashto"] },
-  { name: "YUSUFI", ethnicGroup: ["Dari", "Tajik", "Urdu"] },
-  { name: "YUSUFZAI", ethnicGroup: ["Pashto", "Dari"] },
-  { name: "ZADRAN", ethnicGroup: ["Pashto"] },
-  { name: "ZAHID", ethnicGroup: ["Urdu", "Punjabi", "Bengali", "Dari"] },
-  { name: "ZAHIR", ethnicGroup: ["Bengali", "Muslim", "Arabic", "Dari"] },
-  { name: "ZALMAI", ethnicGroup: ["Dari", "Pashto"] },
-  { name: "ZAZAI", ethnicGroup: ["Pashto", "Dari"] }
+  { name: "Wali", ethnicGroup: ["Urdu", "Pashto", "Bengali", "Arabic"] },
+  { name: "Wardak", ethnicGroup: ["Pashto"] },
+  { name: "Yousafzai", ethnicGroup: ["Pashto"] },
+  { name: "Yousufzai", ethnicGroup: ["Pashto"] },
+  { name: "Yusufi", ethnicGroup: ["Dari", "Tajik", "Urdu"] },
+  { name: "Yusufzai", ethnicGroup: ["Pashto", "Dari"] },
+  { name: "Zadran", ethnicGroup: ["Pashto"] },
+  { name: "Zahid", ethnicGroup: ["Urdu", "Punjabi", "Bengali", "Dari"] },
+  { name: "Zahir", ethnicGroup: ["Bengali", "Muslim", "Arabic", "Dari"] },
+  { name: "Zalmai", ethnicGroup: ["Dari", "Pashto"] },
+  { name: "Zazai", ethnicGroup: ["Pashto", "Dari"] }
 ]
 export default names

--- a/insertBaseData-psql.sql
+++ b/insertBaseData-psql.sql
@@ -5,14 +5,20 @@ TRUNCATE TABLE "approvalSteps" CASCADE;
 TRUNCATE TABLE "approvers" CASCADE;
 TRUNCATE TABLE "assessmentRelatedObjects" CASCADE;
 TRUNCATE TABLE "assessments" CASCADE;
-TRUNCATE TABLE "attachments" CASCADE;
 TRUNCATE TABLE "attachmentRelatedObjects" CASCADE;
+TRUNCATE TABLE "attachments" CASCADE;
+TRUNCATE TABLE "authorizationGroupAdministrativePositions" CASCADE;
 TRUNCATE TABLE "authorizationGroupRelatedObjects" CASCADE;
 TRUNCATE TABLE "authorizationGroups" CASCADE;
 TRUNCATE TABLE "comments" CASCADE;
 TRUNCATE TABLE "customSensitiveInformation" CASCADE;
 TRUNCATE TABLE "emailAddresses" CASCADE;
 TRUNCATE TABLE "entityAvatars" CASCADE;
+TRUNCATE TABLE "eventOrganizations" CASCADE;
+TRUNCATE TABLE "eventPeople" CASCADE;
+TRUNCATE TABLE "eventTasks" CASCADE;
+TRUNCATE TABLE "events" CASCADE;
+TRUNCATE TABLE "eventSeries" CASCADE;
 TRUNCATE TABLE "jobHistory" CASCADE;
 TRUNCATE TABLE "locationRelationships" CASCADE;
 TRUNCATE TABLE "martImportedReports" CASCADE;
@@ -22,16 +28,16 @@ TRUNCATE TABLE "notes" CASCADE;
 TRUNCATE TABLE "organizationAdministrativePositions" CASCADE;
 TRUNCATE TABLE "organizations" CASCADE;
 TRUNCATE TABLE "pendingEmails" CASCADE;
-TRUNCATE TABLE "people" CASCADE;
 TRUNCATE TABLE "peoplePositions" CASCADE;
+TRUNCATE TABLE "people" CASCADE;
 TRUNCATE TABLE "positionRelationships" CASCADE;
 TRUNCATE TABLE "positions" CASCADE;
 TRUNCATE TABLE "reportActions" CASCADE;
 TRUNCATE TABLE "reportAuthorizationGroups" CASCADE;
 TRUNCATE TABLE "reportPeople" CASCADE;
 TRUNCATE TABLE "reportTasks" CASCADE;
-TRUNCATE TABLE "reports" CASCADE;
 TRUNCATE TABLE "reportsSensitiveInformation" CASCADE;
+TRUNCATE TABLE "reports" CASCADE;
 TRUNCATE TABLE "savedSearches" CASCADE;
 TRUNCATE TABLE "subscriptionUpdates" CASCADE;
 TRUNCATE TABLE "subscriptions" CASCADE;
@@ -39,6 +45,7 @@ TRUNCATE TABLE "taskResponsiblePositions" CASCADE;
 TRUNCATE TABLE "taskTaskedOrganizations" CASCADE;
 TRUNCATE TABLE "tasks" CASCADE;
 TRUNCATE TABLE "userActivities" CASCADE;
+TRUNCATE TABLE "users" CASCADE;
 
 -- Countries are inserted by the migrations!
 DELETE FROM "locations" WHERE type != 'PAC';
@@ -47,49 +54,82 @@ DELETE FROM "locations" WHERE type != 'PAC';
 SET time zone 'UTC';
 
 -- Create people
-INSERT INTO people (uuid, name, status, "phoneNumber", rank, biography, "user", "domainUsername", "countryUuid", gender, "endOfTourDate", "createdAt", "updatedAt") VALUES
+INSERT INTO people (uuid, name, status, "phoneNumber", rank, biography, "user", "countryUuid", gender, "endOfTourDate", "createdAt", "updatedAt") VALUES
 -- Advisors
-  ('b5d495af-44d5-4c35-851a-1039352a8307', 'Jackson, Jack', 0, '123-456-78960', 'OF-9', 'Jack is an advisor in EF 2.1', true, 'jack', (SELECT uuid FROM locations WHERE type = 'PAC' AND name = 'Germany'), 'MALE', CURRENT_TIMESTAMP + INTERVAL '1 year', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
-  ('a9d65d96-d107-45c3-bbaa-1133a354335b', 'Elizawell, Elizabeth', 0, '+1-777-7777', 'OF-2', 'Elizabeth is a test advisor we have in the database who is in EF 1.1', true, 'elizabeth', (SELECT uuid FROM locations WHERE type = 'PAC' AND name = 'United States'), 'FEMALE', CURRENT_TIMESTAMP + INTERVAL '1 year', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
-  ('00b19ebf-0d4d-4b0f-93c8-9023ccb59c49', 'Solenoid, Selena', 0, '+1-111-1111', 'CIV', 'Selena is a test advisor in EF 1.2', true, 'selena', (SELECT uuid FROM locations WHERE type = 'PAC' AND name = 'United States'), 'FEMALE', CURRENT_TIMESTAMP + INTERVAL '1 year', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
-  ('df9c7381-56ac-4bc5-8e24-ec524bccd7e9', 'Erinson, Erin', 0, '+9-23-2323-2323', 'CIV', 'Erin is an Advisor in EF 2.2 who can approve reports', true, 'erin', (SELECT uuid FROM locations WHERE type = 'PAC' AND name = 'Australia'), 'FEMALE', CURRENT_TIMESTAMP + INTERVAL '1 year', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
-  ('1ad0c049-6ce8-4890-84f6-5e6a364764c4', 'Reinton, Reina', 0, '+23-23-11222', 'CIV', 'Reina is an Advisor in EF 2.2', true, 'reina', (SELECT uuid FROM locations WHERE type = 'PAC' AND name = 'Italy'), 'FEMALE', CURRENT_TIMESTAMP + INTERVAL '1 year', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
-  ('39d02d26-49eb-43b5-9cec-344777213a67', 'Dvisor, A', 0, '+444-44-4444', 'OF-2', 'A Dvisor was born for this job', true, 'advisor', (SELECT uuid FROM locations WHERE type = 'PAC' AND name = 'Canada'), 'FEMALE', CURRENT_TIMESTAMP + INTERVAL '1 year', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
-  ('31cba227-f6c6-49e9-9483-fce441bea624', 'Bratton, Creed', 0, '+444-44-4444', 'CIV', 'Let me first settle in.', true, 'creed', (SELECT uuid FROM locations WHERE type = 'PAC' AND name = 'United States'), 'MALE', CURRENT_TIMESTAMP + INTERVAL '1 year', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
-  ('d4e1ae87-e519-4ec6-b0a4-5c3b19a0183e', 'Malone, Kevin', 0, '+444-44-4444', 'CIV', 'Sometimes numbers just dont add up.', true, 'kevin', (SELECT uuid FROM locations WHERE type = 'PAC' AND name = 'United States'), 'FEMALE', CURRENT_TIMESTAMP + INTERVAL '1 year', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
-  ('02fdbd68-866f-457a-990c-fbd79bc9b96c', 'Guist, Lin', 0, '+444-44-4444', 'CIV', 'Lin can speak so many languages', true, 'lin', (SELECT uuid FROM locations WHERE type = 'PAC' AND name = 'United States'), 'FEMALE', CURRENT_TIMESTAMP + INTERVAL '1 year', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
-  ('bcd9d5e4-bf6c-42de-9246-8116f2b23bdc', 'Preter, Inter', 0, '+444-44-4444', 'CIV', 'Inter is fluent in various languages', true, 'inter', (SELECT uuid FROM locations WHERE type = 'PAC' AND name = 'United States'), 'MALE', CURRENT_TIMESTAMP + INTERVAL '1 year', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
-  ('c71f707a-667f-4713-9552-8510d69a308b', 'Rogers, Ben', 0, '+99-9999-9999', 'CIV', NULL, true, NULL, (SELECT uuid FROM locations WHERE type = 'PAC' AND name = 'Italy'), 'MALE', NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
-  ('c033862b-a4ef-4043-acd5-a2b399a10f00', 'Rivers, Kevin', 0, '+99-9999-9999', 'CIV', NULL, true, NULL, (SELECT uuid FROM locations WHERE type = 'PAC' AND name = 'Italy'), 'MALE', NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+  ('b5d495af-44d5-4c35-851a-1039352a8307', 'Jackson, Jack', 0, '123-456-78960', 'OF-9', 'Jack is an advisor in EF 2.1', true, (SELECT uuid FROM locations WHERE type = 'PAC' AND name = 'Germany'), 'MALE', CURRENT_TIMESTAMP + INTERVAL '1 year', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+  ('a9d65d96-d107-45c3-bbaa-1133a354335b', 'Elizawell, Elizabeth', 0, '+1-777-7777', 'OF-2', 'Elizabeth is a test advisor we have in the database who is in EF 1.1', true, (SELECT uuid FROM locations WHERE type = 'PAC' AND name = 'United States'), 'FEMALE', CURRENT_TIMESTAMP + INTERVAL '1 year', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+  ('00b19ebf-0d4d-4b0f-93c8-9023ccb59c49', 'Solenoid, Selena', 0, '+1-111-1111', 'CIV', 'Selena is a test advisor in EF 1.2', true, (SELECT uuid FROM locations WHERE type = 'PAC' AND name = 'United States'), 'FEMALE', CURRENT_TIMESTAMP + INTERVAL '1 year', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+  ('df9c7381-56ac-4bc5-8e24-ec524bccd7e9', 'Erinson, Erin', 0, '+9-23-2323-2323', 'CIV', 'Erin is an Advisor in EF 2.2 who can approve reports', true, (SELECT uuid FROM locations WHERE type = 'PAC' AND name = 'Australia'), 'FEMALE', CURRENT_TIMESTAMP + INTERVAL '1 year', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+  ('1ad0c049-6ce8-4890-84f6-5e6a364764c4', 'Reinton, Reina', 0, '+23-23-11222', 'CIV', 'Reina is an Advisor in EF 2.2', true, (SELECT uuid FROM locations WHERE type = 'PAC' AND name = 'Italy'), 'FEMALE', CURRENT_TIMESTAMP + INTERVAL '1 year', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+  ('39d02d26-49eb-43b5-9cec-344777213a67', 'Dvisor, A', 0, '+444-44-4444', 'OF-2', 'A Dvisor was born for this job', true, (SELECT uuid FROM locations WHERE type = 'PAC' AND name = 'Canada'), 'FEMALE', CURRENT_TIMESTAMP + INTERVAL '1 year', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+  ('31cba227-f6c6-49e9-9483-fce441bea624', 'Bratton, Creed', 0, '+444-44-4444', 'CIV', 'Let me first settle in.', true, (SELECT uuid FROM locations WHERE type = 'PAC' AND name = 'United States'), 'MALE', CURRENT_TIMESTAMP + INTERVAL '1 year', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+  ('d4e1ae87-e519-4ec6-b0a4-5c3b19a0183e', 'Malone, Kevin', 0, '+444-44-4444', 'CIV', 'Sometimes numbers just dont add up.', true, (SELECT uuid FROM locations WHERE type = 'PAC' AND name = 'United States'), 'FEMALE', CURRENT_TIMESTAMP + INTERVAL '1 year', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+  ('02fdbd68-866f-457a-990c-fbd79bc9b96c', 'Guist, Lin', 0, '+444-44-4444', 'CIV', 'Lin can speak so many languages', true, (SELECT uuid FROM locations WHERE type = 'PAC' AND name = 'United States'), 'FEMALE', CURRENT_TIMESTAMP + INTERVAL '1 year', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+  ('bcd9d5e4-bf6c-42de-9246-8116f2b23bdc', 'Preter, Inter', 0, '+444-44-4444', 'CIV', 'Inter is fluent in various languages', true, (SELECT uuid FROM locations WHERE type = 'PAC' AND name = 'United States'), 'MALE', CURRENT_TIMESTAMP + INTERVAL '1 year', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+  ('c71f707a-667f-4713-9552-8510d69a308b', 'Rogers, Ben', 0, '+99-9999-9999', 'CIV', NULL, true, (SELECT uuid FROM locations WHERE type = 'PAC' AND name = 'Italy'), 'MALE', NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+  ('c033862b-a4ef-4043-acd5-a2b399a10f00', 'Rivers, Kevin', 0, '+99-9999-9999', 'CIV', NULL, true, (SELECT uuid FROM locations WHERE type = 'PAC' AND name = 'Italy'), 'MALE', NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
 -- Advisors with no position for testing
-  ('bdd91de7-09c7-4f09-97e4-d3325bb92dab', 'Noposition, Ihave', 0, '+444-44-4545', 'OF-2', 'I need a career change', true, 'nopos', (SELECT uuid FROM locations WHERE type = 'PAC' AND name = 'Canada'), 'FEMALE', CURRENT_TIMESTAMP + INTERVAL '1 year', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
-  ('7914ceba-7f89-493b-bd03-eee7e19c60a8', 'Reportguy, Ima', 0, '+444-44-4545', 'CIV', 'I need a career change', true, 'reportguy', (SELECT uuid FROM locations WHERE type = 'PAC' AND name = 'France'), 'MALE', CURRENT_TIMESTAMP + INTERVAL '1 year', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
-  ('d9f3ee10-6e01-4d57-9916-67978608e9ba', 'Reportgirl, Ima', 0, '+444-44-4545', 'CIV', 'I need a career change', true, 'reportgirl', (SELECT uuid FROM locations WHERE type = 'PAC' AND name = 'Mexico'), 'FEMALE', CURRENT_TIMESTAMP + INTERVAL '1 year', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
-  ('7a15d0cc-520f-451c-80d8-399b4642c852', 'Beau, Yoshie', 0, '+1-202-7320', 'CIV', NULL, true, 'yoshie', (SELECT uuid FROM locations WHERE type = 'PAC' AND name = 'United States'), 'FEMALE', CURRENT_TIMESTAMP + INTERVAL '1 year', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
-  ('f73f5cc9-69fd-4ceb-81b9-a0a840914bd8', 'Sharton, Shardul', 1, '+99-9999-9999', 'CIV', NULL, false, NULL, (SELECT uuid FROM locations WHERE type = 'PAC' AND name = 'Italy'), 'MALE', NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+  ('bdd91de7-09c7-4f09-97e4-d3325bb92dab', 'Noposition, Ihave', 0, '+444-44-4545', 'OF-2', 'I need a career change', true, (SELECT uuid FROM locations WHERE type = 'PAC' AND name = 'Canada'), 'FEMALE', CURRENT_TIMESTAMP + INTERVAL '1 year', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+  ('7914ceba-7f89-493b-bd03-eee7e19c60a8', 'Reportguy, Ima', 0, '+444-44-4545', 'CIV', 'I need a career change', true, (SELECT uuid FROM locations WHERE type = 'PAC' AND name = 'France'), 'MALE', CURRENT_TIMESTAMP + INTERVAL '1 year', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+  ('d9f3ee10-6e01-4d57-9916-67978608e9ba', 'Reportgirl, Ima', 0, '+444-44-4545', 'CIV', 'I need a career change', true, (SELECT uuid FROM locations WHERE type = 'PAC' AND name = 'Mexico'), 'FEMALE', CURRENT_TIMESTAMP + INTERVAL '1 year', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+  ('7a15d0cc-520f-451c-80d8-399b4642c852', 'Beau, Yoshie', 0, '+1-202-7320', 'CIV', NULL, true, (SELECT uuid FROM locations WHERE type = 'PAC' AND name = 'United States'), 'FEMALE', CURRENT_TIMESTAMP + INTERVAL '1 year', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+  ('f73f5cc9-69fd-4ceb-81b9-a0a840914bd8', 'Sharton, Shardul', 1, '+99-9999-9999', 'CIV', NULL, false, (SELECT uuid FROM locations WHERE type = 'PAC' AND name = 'Italy'), 'MALE', NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
 -- Interlocutors
-  ('90fa5784-9e63-4353-8119-357bcd88e287', 'Steveson, Steve', 0, '+011-232-12324', 'OF-4', 'this is a sample person who could be a Interlocutor!', false, NULL, (SELECT uuid FROM locations WHERE type = 'PAC' AND name = 'Afghanistan'), 'MALE', NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
-  ('6866ce4d-1f8c-4f78-bdc2-4767e9a859b0', 'Rogwell, Roger', 0, '+1-412-7324', 'OF-3', 'Roger is another test person we have in the database', false, NULL, (SELECT uuid FROM locations WHERE type = 'PAC' AND name = 'Afghanistan'), 'MALE', NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
-  ('237e8bf7-2ae4-4d49-b7c8-eca6a92d4767', 'Topferness, Christopf', 0, '+1-422222222', 'CIV', 'Christopf works in the MoD Office', false, NULL, (SELECT uuid FROM locations WHERE type = 'PAC' AND name = 'Afghanistan'), 'MALE', NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
-  ('5fa54ffd-cc90-493a-b4b1-73e9c4568177', 'Chrisville, Chris', 0, '+1-412-7324', 'OF-3', 'Chris is another test person we have in the database', false, NULL, (SELECT uuid FROM locations WHERE type = 'PAC' AND name = 'Afghanistan'), 'MALE', NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
-  ('0c5a8ba7-7436-47fd-bead-b8393246a300', 'Kyleson, Kyle', 0, '+1-412-7324', 'CIV', 'Kyle is another test person we have in the database', false, NULL, (SELECT uuid FROM locations WHERE type = 'PAC' AND name = 'Afghanistan'), 'MALE', NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
-  ('cebeb179-2a64-4d0c-a06b-76e68f80b5e5', 'Bemerged, Myposwill', 0, '+1-412-7324', 'CIV', 'Myposwill is a test person whose position will be merged', false, NULL, (SELECT uuid FROM locations WHERE type = 'PAC' AND name = 'Afghanistan'), 'MALE', NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
-  ('3cb2076c-5317-47fe-86ad-76f298993917', 'Merged, Duplicate Winner', 0, '+1-234-5678', 'CIV', 'Winner is a test person who will be merged', false, NULL, (SELECT uuid FROM locations WHERE type = 'PAC' AND name = 'Afghanistan'), 'MALE', NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
-  ('c725aef3-cdd1-4baf-ac72-f28219b234e9', 'Merged, Duplicate Loser', 0, NULL, 'CTR', 'Loser is a test person who will be merged', false, NULL, (SELECT uuid FROM locations WHERE type = 'PAC' AND name = 'Afghanistan'), 'FEMALE', NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
-  ('7d90bf90-b3b1-4e99-84bf-5e50b9dcc9d6', 'Huntman, Hunter', 0, '+1-412-9314', 'CIV', NULL, false, NULL, (SELECT uuid FROM locations WHERE type = 'PAC' AND name = 'United States'), 'MALE', NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
-  ('33f708e0-bf7c-47a0-baf1-730afa4f0c98', 'Nicholson, Nick', 0, '+1-202-7324', 'CIV', NULL, true, 'nick', (SELECT uuid FROM locations WHERE type = 'PAC' AND name = 'United States'), 'MALE', CURRENT_TIMESTAMP + INTERVAL '1 year', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+  ('90fa5784-9e63-4353-8119-357bcd88e287', 'Steveson, Steve', 0, '+011-232-12324', 'OF-4', 'this is a sample person who could be a Interlocutor!', false, (SELECT uuid FROM locations WHERE type = 'PAC' AND name = 'Afghanistan'), 'MALE', NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+  ('6866ce4d-1f8c-4f78-bdc2-4767e9a859b0', 'Rogwell, Roger', 0, '+1-412-7324', 'OF-3', 'Roger is another test person we have in the database', false, (SELECT uuid FROM locations WHERE type = 'PAC' AND name = 'Afghanistan'), 'MALE', NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+  ('237e8bf7-2ae4-4d49-b7c8-eca6a92d4767', 'Topferness, Christopf', 0, '+1-422222222', 'CIV', 'Christopf works in the MoD Office', false, (SELECT uuid FROM locations WHERE type = 'PAC' AND name = 'Afghanistan'), 'MALE', NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+  ('5fa54ffd-cc90-493a-b4b1-73e9c4568177', 'Chrisville, Chris', 0, '+1-412-7324', 'OF-3', 'Chris is another test person we have in the database', false, (SELECT uuid FROM locations WHERE type = 'PAC' AND name = 'Afghanistan'), 'MALE', NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+  ('0c5a8ba7-7436-47fd-bead-b8393246a300', 'Kyleson, Kyle', 0, '+1-412-7324', 'CIV', 'Kyle is another test person we have in the database', false, (SELECT uuid FROM locations WHERE type = 'PAC' AND name = 'Afghanistan'), 'MALE', NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+  ('cebeb179-2a64-4d0c-a06b-76e68f80b5e5', 'Bemerged, Myposwill', 0, '+1-412-7324', 'CIV', 'Myposwill is a test person whose position will be merged', false, (SELECT uuid FROM locations WHERE type = 'PAC' AND name = 'Afghanistan'), 'MALE', NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+  ('3cb2076c-5317-47fe-86ad-76f298993917', 'Merged, Duplicate Winner', 0, '+1-234-5678', 'CIV', 'Winner is a test person who will be merged', false, (SELECT uuid FROM locations WHERE type = 'PAC' AND name = 'Afghanistan'), 'MALE', NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+  ('c725aef3-cdd1-4baf-ac72-f28219b234e9', 'Merged, Duplicate Loser', 0, NULL, 'CTR', 'Loser is a test person who will be merged', false, (SELECT uuid FROM locations WHERE type = 'PAC' AND name = 'Afghanistan'), 'FEMALE', NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+  ('7d90bf90-b3b1-4e99-84bf-5e50b9dcc9d6', 'Huntman, Hunter', 0, '+1-412-9314', 'CIV', NULL, false, (SELECT uuid FROM locations WHERE type = 'PAC' AND name = 'United States'), 'MALE', NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+  ('33f708e0-bf7c-47a0-baf1-730afa4f0c98', 'Nicholson, Nick', 0, '+1-202-7324', 'CIV', NULL, true, (SELECT uuid FROM locations WHERE type = 'PAC' AND name = 'United States'), 'MALE', CURRENT_TIMESTAMP + INTERVAL '1 year', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
 -- Superusers
-  ('98fa4da5-ec99-457b-a4bc-2aa9064e2ca7', 'Bobtown, Bob', 0, '+1-444-7324', 'CIV', 'Bob is a Superuser in EF 1.1', true, 'bob', (SELECT uuid FROM locations WHERE type = 'PAC' AND name = 'United States'), 'MALE', CURRENT_TIMESTAMP + INTERVAL '1 year', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
-  ('ff0cec0b-8eca-48ee-82fe-addce6136f3b', 'Henderson, Henry', 0, '+2-456-7324', 'OF-6', 'Henry is a Superuser in EF 2.1', true, 'henry', (SELECT uuid FROM locations WHERE type = 'PAC' AND name = 'United States'), 'MALE', CURRENT_TIMESTAMP + INTERVAL '1 year', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
-  ('19fe53bb-90f4-4482-abfc-d85b85deabd9', 'Jacobson, Jacob', 0, '+2-456-7324', 'CIV', 'Jacob is a Superuser in EF 2.2', true, 'jacob', (SELECT uuid FROM locations WHERE type = 'PAC' AND name = 'Italy'), 'MALE', CURRENT_TIMESTAMP + INTERVAL '1 year', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
-  ('f683335a-91e3-4788-aa3f-9eed384f4ac1', 'Beccabon, Rebecca', 0, '+2-456-7324', 'CTR', 'Rebecca is a Superuser in EF 2.2', true, 'rebecca', (SELECT uuid FROM locations WHERE type = 'PAC' AND name = 'Germany'), 'FEMALE', CURRENT_TIMESTAMP + INTERVAL '1 year', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
-  ('1a557db0-5af5-4ea3-b926-28b5f2e88bf7', 'Anderson, Andrew', 0, '+1-412-7324', 'CIV', 'Andrew is the EF 1 Manager', true, 'andrew', (SELECT uuid FROM locations WHERE type = 'PAC' AND name = 'United States'), 'MALE', CURRENT_TIMESTAMP + INTERVAL '1 year', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
-  ('ad442c97-ca89-4c63-9a4d-336f17ca856b', 'Schrute, Dwight', 0, '+1-412-7324', 'CIV', 'Beets & Battlestar Galactica.', true, 'dwight', (SELECT uuid FROM locations WHERE type = 'PAC' AND name = 'United States'), 'MALE', CURRENT_TIMESTAMP + INTERVAL '1 year', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
-  ('b6754f19-b67e-4603-bfe6-af8c61760eef', 'Halpert, Jim', 0, '+1-412-7324', 'CIV', 'Lets prank dwight.', true, 'jim', (SELECT uuid FROM locations WHERE type = 'PAC' AND name = 'United States'), 'MALE', CURRENT_TIMESTAMP + INTERVAL '1 year', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
-  ('c94abd40-21ba-4592-9ce4-95e6c2cfd912', 'Linton, Billie', 0, '+1-264-7324', 'CIV', 'Billie is a powerful superuser', true, 'billie', (SELECT uuid FROM locations WHERE type = 'PAC' AND name = 'Anguilla'), 'FEMALE', CURRENT_TIMESTAMP + INTERVAL '1 year', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+  ('98fa4da5-ec99-457b-a4bc-2aa9064e2ca7', 'Bobtown, Bob', 0, '+1-444-7324', 'CIV', 'Bob is a Superuser in EF 1.1', true, (SELECT uuid FROM locations WHERE type = 'PAC' AND name = 'United States'), 'MALE', CURRENT_TIMESTAMP + INTERVAL '1 year', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+  ('ff0cec0b-8eca-48ee-82fe-addce6136f3b', 'Henderson, Henry', 0, '+2-456-7324', 'OF-6', 'Henry is a Superuser in EF 2.1', true, (SELECT uuid FROM locations WHERE type = 'PAC' AND name = 'United States'), 'MALE', CURRENT_TIMESTAMP + INTERVAL '1 year', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+  ('19fe53bb-90f4-4482-abfc-d85b85deabd9', 'Jacobson, Jacob', 0, '+2-456-7324', 'CIV', 'Jacob is a Superuser in EF 2.2', true, (SELECT uuid FROM locations WHERE type = 'PAC' AND name = 'Italy'), 'MALE', CURRENT_TIMESTAMP + INTERVAL '1 year', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+  ('f683335a-91e3-4788-aa3f-9eed384f4ac1', 'Beccabon, Rebecca', 0, '+2-456-7324', 'CTR', 'Rebecca is a Superuser in EF 2.2', true, (SELECT uuid FROM locations WHERE type = 'PAC' AND name = 'Germany'), 'FEMALE', CURRENT_TIMESTAMP + INTERVAL '1 year', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+  ('1a557db0-5af5-4ea3-b926-28b5f2e88bf7', 'Anderson, Andrew', 0, '+1-412-7324', 'CIV', 'Andrew is the EF 1 Manager', true, (SELECT uuid FROM locations WHERE type = 'PAC' AND name = 'United States'), 'MALE', CURRENT_TIMESTAMP + INTERVAL '1 year', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+  ('ad442c97-ca89-4c63-9a4d-336f17ca856b', 'Schrute, Dwight', 0, '+1-412-7324', 'CIV', 'Beets & Battlestar Galactica.', true, (SELECT uuid FROM locations WHERE type = 'PAC' AND name = 'United States'), 'MALE', CURRENT_TIMESTAMP + INTERVAL '1 year', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+  ('b6754f19-b67e-4603-bfe6-af8c61760eef', 'Halpert, Jim', 0, '+1-412-7324', 'CIV', 'Lets prank dwight.', true, (SELECT uuid FROM locations WHERE type = 'PAC' AND name = 'United States'), 'MALE', CURRENT_TIMESTAMP + INTERVAL '1 year', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+  ('c94abd40-21ba-4592-9ce4-95e6c2cfd912', 'Linton, Billie', 0, '+1-264-7324', 'CIV', 'Billie is a powerful superuser', true, (SELECT uuid FROM locations WHERE type = 'PAC' AND name = 'Anguilla'), 'FEMALE', CURRENT_TIMESTAMP + INTERVAL '1 year', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
 -- Administrators
-  ('87fdbc6a-3109-4e11-9702-a894d6ca31ef', 'Dmin, Arthur', '0', NULL, 'CIV', 'An administrator', true, 'arthur', (SELECT uuid FROM locations WHERE type = 'PAC' AND name = 'Albania'), 'MALE', CURRENT_TIMESTAMP + INTERVAL '1 year', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
-  ('46ba6a73-0cd7-4efb-8e99-215e98cc5987', 'Scott, Michael', '0', NULL, 'CIV', 'Worlds best boss.', true, 'michael', (SELECT uuid FROM locations WHERE type = 'PAC' AND name = 'United States'), 'MALE', CURRENT_TIMESTAMP + INTERVAL '1 year', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+  ('87fdbc6a-3109-4e11-9702-a894d6ca31ef', 'Dmin, Arthur', '0', NULL, 'CIV', 'An administrator', true, (SELECT uuid FROM locations WHERE type = 'PAC' AND name = 'Albania'), 'MALE', CURRENT_TIMESTAMP + INTERVAL '1 year', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+  ('46ba6a73-0cd7-4efb-8e99-215e98cc5987', 'Scott, Michael', '0', NULL, 'CIV', 'Worlds best boss.', true, (SELECT uuid FROM locations WHERE type = 'PAC' AND name = 'United States'), 'MALE', CURRENT_TIMESTAMP + INTERVAL '1 year', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+
+-- Create users
+INSERT INTO users (uuid, "domainUsername", "personUuid", "createdAt", "updatedAt") VALUES
+-- Advisors
+  (uuid_generate_v4(), 'jack', 'b5d495af-44d5-4c35-851a-1039352a8307', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+  (uuid_generate_v4(), 'elizabeth', 'a9d65d96-d107-45c3-bbaa-1133a354335b', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+  (uuid_generate_v4(), 'selena', '00b19ebf-0d4d-4b0f-93c8-9023ccb59c49', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+  (uuid_generate_v4(), 'erin', 'df9c7381-56ac-4bc5-8e24-ec524bccd7e9', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+  (uuid_generate_v4(), 'reina', '1ad0c049-6ce8-4890-84f6-5e6a364764c4', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+  (uuid_generate_v4(), 'advisor', '39d02d26-49eb-43b5-9cec-344777213a67', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+  (uuid_generate_v4(), 'creed', '31cba227-f6c6-49e9-9483-fce441bea624', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+  (uuid_generate_v4(), 'kevin', 'd4e1ae87-e519-4ec6-b0a4-5c3b19a0183e', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+  (uuid_generate_v4(), 'lin', '02fdbd68-866f-457a-990c-fbd79bc9b96c', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+  (uuid_generate_v4(), 'inter', 'bcd9d5e4-bf6c-42de-9246-8116f2b23bdc', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+-- Advisors with no position for testing
+  (uuid_generate_v4(), 'nopos', 'bdd91de7-09c7-4f09-97e4-d3325bb92dab', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+  (uuid_generate_v4(), 'reportguy', '7914ceba-7f89-493b-bd03-eee7e19c60a8', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+  (uuid_generate_v4(), 'reportgirl', 'd9f3ee10-6e01-4d57-9916-67978608e9ba', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+  (uuid_generate_v4(), 'yoshie', '7a15d0cc-520f-451c-80d8-399b4642c852', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+-- Interlocutors
+  (uuid_generate_v4(), 'nick', '33f708e0-bf7c-47a0-baf1-730afa4f0c98', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+-- Superusers
+  (uuid_generate_v4(), 'bob', '98fa4da5-ec99-457b-a4bc-2aa9064e2ca7', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+  (uuid_generate_v4(), 'henry', 'ff0cec0b-8eca-48ee-82fe-addce6136f3b', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+  (uuid_generate_v4(), 'jacob', '19fe53bb-90f4-4482-abfc-d85b85deabd9', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+  (uuid_generate_v4(), 'rebecca', 'f683335a-91e3-4788-aa3f-9eed384f4ac1', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+  (uuid_generate_v4(), 'andrew', '1a557db0-5af5-4ea3-b926-28b5f2e88bf7', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+  (uuid_generate_v4(), 'dwight', 'ad442c97-ca89-4c63-9a4d-336f17ca856b', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+  (uuid_generate_v4(), 'jim', 'b6754f19-b67e-4603-bfe6-af8c61760eef', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+  (uuid_generate_v4(), 'billie', 'c94abd40-21ba-4592-9ce4-95e6c2cfd912', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+-- Administrators
+  (uuid_generate_v4(), 'arthur', '87fdbc6a-3109-4e11-9702-a894d6ca31ef', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+  (uuid_generate_v4(), 'michael', '46ba6a73-0cd7-4efb-8e99-215e98cc5987', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
 
 UPDATE people
 SET "customFields"='{"invisibleCustomFields":["formCustomFields.textareaFieldName","formCustomFields.numberFieldName"],"arrayFieldName":[],"nlt_dt":null,"nlt":null,"colourOptions":"","inputFieldName":"Lorem ipsum dolor sit amet","multipleButtons":[],"placeOfResidence":null,"placeOfBirth":null}'
@@ -321,98 +361,98 @@ INSERT INTO "emailAddresses" (network, address, "relatedObjectType", "relatedObj
 
 -- Put Andrew in the EF 1 Manager Billet
 INSERT INTO "peoplePositions" ("positionUuid", "personUuid", "createdAt") VALUES
-  ((SELECT uuid from positions where name = 'EF 1 Manager'), (SELECT uuid from people where "domainUsername" = 'andrew'), '2020-01-01');
-UPDATE positions SET "currentPersonUuid" = (SELECT uuid from people where "domainUsername" = 'andrew') WHERE name = 'EF 1 Manager';
+  ((SELECT uuid from positions where name = 'EF 1 Manager'), '1a557db0-5af5-4ea3-b926-28b5f2e88bf7', '2020-01-01');
+UPDATE positions SET "currentPersonUuid" = '1a557db0-5af5-4ea3-b926-28b5f2e88bf7' WHERE name = 'EF 1 Manager';
 
 -- Put Bob into the Superuser Billet in EF 1.1
 INSERT INTO "peoplePositions" ("positionUuid", "personUuid", "createdAt") VALUES
-  ((SELECT uuid from positions where name = 'EF 1.1 Superuser'), (SELECT uuid from people where "domainUsername" = 'bob'), '2020-01-01');
-UPDATE positions SET "currentPersonUuid" = (SELECT uuid from people where "domainUsername" = 'bob') WHERE name = 'EF 1.1 Superuser';
+  ((SELECT uuid from positions where name = 'EF 1.1 Superuser'), '98fa4da5-ec99-457b-a4bc-2aa9064e2ca7', '2020-01-01');
+UPDATE positions SET "currentPersonUuid" = '98fa4da5-ec99-457b-a4bc-2aa9064e2ca7' WHERE name = 'EF 1.1 Superuser';
 
 -- Put Henry into the Superuser Billet in EF 2.1
 INSERT INTO "peoplePositions" ("positionUuid", "personUuid", "createdAt") VALUES
-  ((SELECT uuid from positions where name = 'EF 2.1 Superuser'), (SELECT uuid from people where "domainUsername" = 'henry'), '2020-01-01');
-UPDATE positions SET "currentPersonUuid" = (SELECT uuid from people where "domainUsername" = 'henry') WHERE name = 'EF 2.1 Superuser';
+  ((SELECT uuid from positions where name = 'EF 2.1 Superuser'), 'ff0cec0b-8eca-48ee-82fe-addce6136f3b', '2020-01-01');
+UPDATE positions SET "currentPersonUuid" = 'ff0cec0b-8eca-48ee-82fe-addce6136f3b' WHERE name = 'EF 2.1 Superuser';
 
 -- Rotate an advisor through a billet ending up with Jack in the EF 2.1 Advisor B Billet
 INSERT INTO "peoplePositions" ("positionUuid", "personUuid", "createdAt") VALUES
-  ((SELECT uuid from positions where name = 'EF 2.1 Advisor B'), (SELECT uuid from people where "domainUsername" = 'erin'), '2020-01-01');
-UPDATE positions SET "currentPersonUuid" = (SELECT uuid from people where "domainUsername" = 'erin') WHERE name = 'EF 2.1 Advisor B';
+  ((SELECT uuid from positions where name = 'EF 2.1 Advisor B'), 'df9c7381-56ac-4bc5-8e24-ec524bccd7e9', '2020-01-01');
+UPDATE positions SET "currentPersonUuid" = 'df9c7381-56ac-4bc5-8e24-ec524bccd7e9' WHERE name = 'EF 2.1 Advisor B';
 UPDATE "peoplePositions" SET "endedAt" = '2021-01-01' WHERE "positionUuid" = (SELECT uuid from positions where name = 'EF 2.1 Advisor B');
 INSERT INTO "peoplePositions" ("positionUuid", "personUuid", "createdAt") VALUES
-  ((SELECT uuid from positions where name = 'EF 2.1 Advisor B'), (SELECT uuid from people where "domainUsername" = 'jack'), '2021-01-01');
-UPDATE positions SET "currentPersonUuid" = (SELECT uuid from people where "domainUsername" = 'jack') WHERE name = 'EF 2.1 Advisor B';
+  ((SELECT uuid from positions where name = 'EF 2.1 Advisor B'), 'b5d495af-44d5-4c35-851a-1039352a8307', '2021-01-01');
+UPDATE positions SET "currentPersonUuid" = 'b5d495af-44d5-4c35-851a-1039352a8307' WHERE name = 'EF 2.1 Advisor B';
 
 -- Rotate advisors through billets ending up with Dvisor in the EF 2.2 Advisor Sewing Facilities Billet and Selena in the EF 1.2 Advisor Billet
 INSERT INTO "peoplePositions" ("positionUuid", "personUuid", "createdAt") VALUES
-  ((SELECT uuid from positions where name = 'EF 1.2 Advisor'), (SELECT uuid from people where "domainUsername" = 'advisor'), '2020-01-01');
+  ((SELECT uuid from positions where name = 'EF 1.2 Advisor'), '39d02d26-49eb-43b5-9cec-344777213a67', '2020-01-01');
 INSERT INTO "peoplePositions" ("positionUuid", "personUuid", "createdAt") VALUES
-  ((SELECT uuid from positions where name = 'EF 2.2 Advisor Sewing Facilities'), (SELECT uuid from people where "domainUsername" = 'selena'), '2020-01-01');
+  ((SELECT uuid from positions where name = 'EF 2.2 Advisor Sewing Facilities'), '00b19ebf-0d4d-4b0f-93c8-9023ccb59c49', '2020-01-01');
 
 UPDATE "peoplePositions" SET "endedAt" = '2021-01-01' WHERE "positionUuid" = (SELECT uuid from positions where name = 'EF 1.2 Advisor');
 UPDATE "peoplePositions" SET "endedAt" = '2021-01-01' WHERE "positionUuid" = (SELECT uuid from positions where name = 'EF 2.2 Advisor Sewing Facilities');
 
 INSERT INTO "peoplePositions" ("positionUuid", "personUuid", "createdAt") VALUES
-  ((SELECT uuid from positions where name = 'EF 2.2 Advisor Sewing Facilities'), (SELECT uuid from people where "domainUsername" = 'advisor'), '2021-01-01');
-UPDATE positions SET "currentPersonUuid" = (SELECT uuid from people where "domainUsername" = 'advisor') WHERE name = 'EF 2.2 Advisor Sewing Facilities';
+  ((SELECT uuid from positions where name = 'EF 2.2 Advisor Sewing Facilities'), '39d02d26-49eb-43b5-9cec-344777213a67', '2021-01-01');
+UPDATE positions SET "currentPersonUuid" = '39d02d26-49eb-43b5-9cec-344777213a67' WHERE name = 'EF 2.2 Advisor Sewing Facilities';
 INSERT INTO "peoplePositions" ("positionUuid", "personUuid", "createdAt") VALUES
-  ((SELECT uuid from positions where name = 'EF 1.2 Advisor'), (SELECT uuid from people where "domainUsername" = 'selena'), '2021-01-01');
-UPDATE positions SET "currentPersonUuid" = (SELECT uuid from people where "domainUsername" = 'selena') WHERE name = 'EF 1.2 Advisor';
+  ((SELECT uuid from positions where name = 'EF 1.2 Advisor'), '00b19ebf-0d4d-4b0f-93c8-9023ccb59c49', '2021-01-01');
+UPDATE positions SET "currentPersonUuid" = '00b19ebf-0d4d-4b0f-93c8-9023ccb59c49' WHERE name = 'EF 1.2 Advisor';
 
 -- Put Elizabeth into the EF 1.1 Advisor A Billet
 INSERT INTO "peoplePositions" ("positionUuid", "personUuid", "createdAt") VALUES
-  ((SELECT uuid from positions where name = 'EF 1.1 Advisor A'), (SELECT uuid from people where "domainUsername" = 'elizabeth'), '2020-01-01');
-UPDATE positions SET "currentPersonUuid" = (SELECT uuid from people where "domainUsername" = 'elizabeth') WHERE name = 'EF 1.1 Advisor A';
+  ((SELECT uuid from positions where name = 'EF 1.1 Advisor A'), 'a9d65d96-d107-45c3-bbaa-1133a354335b', '2020-01-01');
+UPDATE positions SET "currentPersonUuid" = 'a9d65d96-d107-45c3-bbaa-1133a354335b' WHERE name = 'EF 1.1 Advisor A';
 
 -- Put Reina into the EF 2.2 Advisor C Billet
 INSERT INTO "peoplePositions" ("positionUuid", "personUuid", "createdAt") VALUES
-  ((SELECT uuid from positions where name = 'EF 2.2 Advisor C'), (SELECT uuid from people where "domainUsername" = 'reina'), '2020-01-01');
-UPDATE positions SET "currentPersonUuid" = (SELECT uuid from people where "domainUsername" = 'reina') WHERE name = 'EF 2.2 Advisor C';
+  ((SELECT uuid from positions where name = 'EF 2.2 Advisor C'), '1ad0c049-6ce8-4890-84f6-5e6a364764c4', '2020-01-01');
+UPDATE positions SET "currentPersonUuid" = '1ad0c049-6ce8-4890-84f6-5e6a364764c4' WHERE name = 'EF 2.2 Advisor C';
 
 -- Put Erin into the EF 2.2 Advisor D Billet
 INSERT INTO "peoplePositions" ("positionUuid", "personUuid", "createdAt") VALUES
-  ((SELECT uuid from positions where name = 'EF 2.2 Advisor D'), (SELECT uuid from people where "domainUsername" = 'erin'), '2020-01-01');
-UPDATE positions SET "currentPersonUuid" = (SELECT uuid from people where "domainUsername" = 'erin') WHERE name = 'EF 2.2 Advisor D';
+  ((SELECT uuid from positions where name = 'EF 2.2 Advisor D'), 'df9c7381-56ac-4bc5-8e24-ec524bccd7e9', '2020-01-01');
+UPDATE positions SET "currentPersonUuid" = 'df9c7381-56ac-4bc5-8e24-ec524bccd7e9' WHERE name = 'EF 2.2 Advisor D';
 
 -- Put Jacob in the EF 2.2 Superuser Billet
 INSERT INTO "peoplePositions" ("positionUuid", "personUuid", "createdAt") VALUES
-  ((SELECT uuid from positions where name = 'EF 2.2 Superuser'), (SELECT uuid from people where "domainUsername" = 'jacob'), '2020-01-01');
-UPDATE positions SET "currentPersonUuid" = (SELECT uuid from people where "domainUsername" = 'jacob') WHERE name = 'EF 2.2 Superuser';
+  ((SELECT uuid from positions where name = 'EF 2.2 Superuser'), '19fe53bb-90f4-4482-abfc-d85b85deabd9', '2020-01-01');
+UPDATE positions SET "currentPersonUuid" = '19fe53bb-90f4-4482-abfc-d85b85deabd9' WHERE name = 'EF 2.2 Superuser';
 
 -- Put Rebecca in the EF 2.2 Final Reviewer Position
 INSERT INTO "peoplePositions" ("positionUuid", "personUuid", "createdAt") VALUES
-  ((SELECT uuid from positions where name = 'EF 2.2 Final Reviewer'), (SELECT uuid from people where "domainUsername" = 'rebecca'), '2020-01-01');
-UPDATE positions SET "currentPersonUuid" = (SELECT uuid from people where "domainUsername" = 'rebecca') WHERE name = 'EF 2.2 Final Reviewer';
+  ((SELECT uuid from positions where name = 'EF 2.2 Final Reviewer'), 'f683335a-91e3-4788-aa3f-9eed384f4ac1', '2020-01-01');
+UPDATE positions SET "currentPersonUuid" = 'f683335a-91e3-4788-aa3f-9eed384f4ac1' WHERE name = 'EF 2.2 Final Reviewer';
 
 -- Put Arthur into the Admin Billet
 INSERT INTO "peoplePositions" ("positionUuid", "personUuid", "createdAt") VALUES
-  ((SELECT uuid from positions where name = 'ANET Administrator'), (SELECT uuid from people where "domainUsername" = 'arthur'), '2020-01-01');
-UPDATE positions SET "currentPersonUuid" = (SELECT uuid from people where "domainUsername" = 'arthur') WHERE name = 'ANET Administrator';
+  ((SELECT uuid from positions where name = 'ANET Administrator'), '87fdbc6a-3109-4e11-9702-a894d6ca31ef', '2020-01-01');
+UPDATE positions SET "currentPersonUuid" = '87fdbc6a-3109-4e11-9702-a894d6ca31ef' WHERE name = 'ANET Administrator';
 
 -- Put Creed into the EF 5.1 Quality Ensurance
 INSERT INTO "peoplePositions" ("positionUuid", "personUuid", "createdAt") VALUES
-  ((SELECT uuid from positions where name = 'EF 5.1 Advisor Quality Assurance'), (SELECT uuid from people where "domainUsername" = 'creed'), '2020-01-01');
-UPDATE positions SET "currentPersonUuid" = (SELECT uuid from people where "domainUsername" = 'creed') WHERE name = 'EF 5.1 Advisor Quality Assurance';
+  ((SELECT uuid from positions where name = 'EF 5.1 Advisor Quality Assurance'), '31cba227-f6c6-49e9-9483-fce441bea624', '2020-01-01');
+UPDATE positions SET "currentPersonUuid" = '31cba227-f6c6-49e9-9483-fce441bea624' WHERE name = 'EF 5.1 Advisor Quality Assurance';
 
 -- Put Kevin into the EF 5.1 Accounting
 INSERT INTO "peoplePositions" ("positionUuid", "personUuid", "createdAt") VALUES
-  ((SELECT uuid from positions where name = 'EF 5.1 Advisor Accounting'), (SELECT uuid from people where "domainUsername" = 'kevin'), '2020-01-01');
-UPDATE positions SET "currentPersonUuid" = (SELECT uuid from people where "domainUsername" = 'kevin') WHERE name = 'EF 5.1 Advisor Accounting';
+  ((SELECT uuid from positions where name = 'EF 5.1 Advisor Accounting'), 'd4e1ae87-e519-4ec6-b0a4-5c3b19a0183e', '2020-01-01');
+UPDATE positions SET "currentPersonUuid" = 'd4e1ae87-e519-4ec6-b0a4-5c3b19a0183e' WHERE name = 'EF 5.1 Advisor Accounting';
 
 -- Put Jim into the EF 5.1 Sales 1
 INSERT INTO "peoplePositions" ("positionUuid", "personUuid", "createdAt") VALUES
-  ((SELECT uuid from positions where name = 'EF 5.1 Superuser Sales 1'), (SELECT uuid from people where "domainUsername" = 'jim'), '2020-01-01');
-UPDATE positions SET "currentPersonUuid" = (SELECT uuid from people where "domainUsername" = 'jim') WHERE name = 'EF 5.1 Superuser Sales 1';
+  ((SELECT uuid from positions where name = 'EF 5.1 Superuser Sales 1'), 'b6754f19-b67e-4603-bfe6-af8c61760eef', '2020-01-01');
+UPDATE positions SET "currentPersonUuid" = 'b6754f19-b67e-4603-bfe6-af8c61760eef' WHERE name = 'EF 5.1 Superuser Sales 1';
 
 -- Put Dwight into the EF 5.1 Sales 2
 INSERT INTO "peoplePositions" ("positionUuid", "personUuid", "createdAt") VALUES
-  ((SELECT uuid from positions where name = 'EF 5.1 Superuser Sales 2'), (SELECT uuid from people where "domainUsername" = 'dwight'), '2020-01-01');
-UPDATE positions SET "currentPersonUuid" = (SELECT uuid from people where "domainUsername" = 'dwight') WHERE name = 'EF 5.1 Superuser Sales 2';
+  ((SELECT uuid from positions where name = 'EF 5.1 Superuser Sales 2'), 'ad442c97-ca89-4c63-9a4d-336f17ca856b', '2020-01-01');
+UPDATE positions SET "currentPersonUuid" = 'ad442c97-ca89-4c63-9a4d-336f17ca856b' WHERE name = 'EF 5.1 Superuser Sales 2';
 
 -- Put Michael into the EF 5 Admin
 INSERT INTO "peoplePositions" ("positionUuid", "personUuid", "createdAt") VALUES
-  ((SELECT uuid from positions where name = 'EF 5 Admin'), (SELECT uuid from people where "domainUsername" = 'michael'), '2020-01-01');
-UPDATE positions SET "currentPersonUuid" = (SELECT uuid from people where "domainUsername" = 'michael') WHERE name = 'EF 5 Admin';
+  ((SELECT uuid from positions where name = 'EF 5 Admin'), '46ba6a73-0cd7-4efb-8e99-215e98cc5987', '2020-01-01');
+UPDATE positions SET "currentPersonUuid" = '46ba6a73-0cd7-4efb-8e99-215e98cc5987' WHERE name = 'EF 5 Admin';
 
 -- Put Kevin Rivers into the EF 6 Approver
 INSERT INTO "peoplePositions" ("positionUuid", "personUuid", "createdAt") VALUES
@@ -426,28 +466,28 @@ UPDATE positions SET "currentPersonUuid" = (SELECT uuid from people where name =
 
 -- Put Nick into the EF 9 Advisor
 INSERT INTO "peoplePositions" ("positionUuid", "personUuid", "createdAt") VALUES
-  ((SELECT uuid from positions where name = 'EF 9 Advisor'), (SELECT uuid from people where "domainUsername" = 'nick'), '2020-01-01');
-UPDATE positions SET "currentPersonUuid" = (SELECT uuid from people where "domainUsername" = 'nick') WHERE name = 'EF 9 Advisor';
+  ((SELECT uuid from positions where name = 'EF 9 Advisor'), '33f708e0-bf7c-47a0-baf1-730afa4f0c98', '2020-01-01');
+UPDATE positions SET "currentPersonUuid" = '33f708e0-bf7c-47a0-baf1-730afa4f0c98' WHERE name = 'EF 9 Advisor';
 
 -- Put Yoshie Beau into the EF 9 Approver
 INSERT INTO "peoplePositions" ("positionUuid", "personUuid", "createdAt") VALUES
-  ((SELECT uuid from positions where name = 'EF 9 Approver'), (SELECT uuid from people where "domainUsername" = 'yoshie'), '2020-01-01');
-UPDATE positions SET "currentPersonUuid" = (SELECT uuid from people where "domainUsername" = 'yoshie') WHERE name = 'EF 9 Approver';
+  ((SELECT uuid from positions where name = 'EF 9 Approver'), '7a15d0cc-520f-451c-80d8-399b4642c852', '2020-01-01');
+UPDATE positions SET "currentPersonUuid" = '7a15d0cc-520f-451c-80d8-399b4642c852' WHERE name = 'EF 9 Approver';
 
 -- Put Billie into the EF 9 Superuser
 INSERT INTO "peoplePositions" ("positionUuid", "personUuid", "createdAt") VALUES
-  ((SELECT uuid from positions where name = 'EF 9 Superuser'), (SELECT uuid from people where "domainUsername" = 'billie'), '2020-01-01');
-UPDATE positions SET "currentPersonUuid" = (SELECT uuid from people where "domainUsername" = 'billie') WHERE name = 'EF 9 Superuser';
+  ((SELECT uuid from positions where name = 'EF 9 Superuser'), 'c94abd40-21ba-4592-9ce4-95e6c2cfd912', '2020-01-01');
+UPDATE positions SET "currentPersonUuid" = 'c94abd40-21ba-4592-9ce4-95e6c2cfd912' WHERE name = 'EF 9 Superuser';
 
 -- Put Lin into the LNG Advisor A
 INSERT INTO "peoplePositions" ("positionUuid", "personUuid", "createdAt") VALUES
-  ((SELECT uuid from positions where name = 'LNG Advisor A'), (SELECT uuid from people where "domainUsername" = 'lin'), '2020-01-01');
-UPDATE positions SET "currentPersonUuid" = (SELECT uuid from people where "domainUsername" = 'lin') WHERE name = 'LNG Advisor A';
+  ((SELECT uuid from positions where name = 'LNG Advisor A'), '02fdbd68-866f-457a-990c-fbd79bc9b96c', '2020-01-01');
+UPDATE positions SET "currentPersonUuid" = '02fdbd68-866f-457a-990c-fbd79bc9b96c' WHERE name = 'LNG Advisor A';
 
 -- Put Inter into the LNG Advisor B
 INSERT INTO "peoplePositions" ("positionUuid", "personUuid", "createdAt") VALUES
-  ((SELECT uuid from positions where name = 'LNG Advisor B'), (SELECT uuid from people where "domainUsername" = 'inter'), '2020-01-01');
-UPDATE positions SET "currentPersonUuid" = (SELECT uuid from people where "domainUsername" = 'inter') WHERE name = 'LNG Advisor B';
+  ((SELECT uuid from positions where name = 'LNG Advisor B'), 'bcd9d5e4-bf6c-42de-9246-8116f2b23bdc', '2020-01-01');
+UPDATE positions SET "currentPersonUuid" = 'bcd9d5e4-bf6c-42de-9246-8116f2b23bdc' WHERE name = 'LNG Advisor B';
 
 -- Top-level organizations
 INSERT INTO organizations(uuid, "shortName", "longName", app6context, "app6standardIdentity", "app6symbolSet", "createdAt", "updatedAt") VALUES
@@ -860,7 +900,7 @@ INSERT INTO reports (uuid, "createdAt", "updatedAt", "locationUuid", intent, tex
   (SELECT uuid FROM organizations where "shortName" = 'EF 2.1'), (SELECT uuid FROM organizations WHERE "longName" LIKE 'Ministry of Defense'));
 INSERT INTO "reportPeople" ("personUuid", "reportUuid", "isPrimary", "isAuthor", "isInterlocutor") VALUES
   ((SELECT uuid FROM people where name = 'Steveson, Steve'), '9bb1861c-1f55-4a1b-bd3d-3c1f56d739b5', TRUE, FALSE, TRUE),
-  ((SELECT uuid FROM people where "domainUsername" = 'jack'), '9bb1861c-1f55-4a1b-bd3d-3c1f56d739b5', TRUE, TRUE, FALSE);
+  ('b5d495af-44d5-4c35-851a-1039352a8307', '9bb1861c-1f55-4a1b-bd3d-3c1f56d739b5', TRUE, TRUE, FALSE);
 
 INSERT INTO reports (uuid, "createdAt", "updatedAt", "locationUuid", intent, text, "keyOutcomes", "nextSteps", state, "engagementDate", duration, atmosphere, "advisorOrganizationUuid", "interlocutorOrganizationUuid") VALUES
   ('86e4cf7e-c0ae-4bd9-b1ad-f2c65ca0f600', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, (select uuid from locations where name='General Hospital'), 'Run through FY2016 Numbers on tool usage',
@@ -871,7 +911,7 @@ INSERT INTO reports (uuid, "createdAt", "updatedAt", "locationUuid", intent, tex
 INSERT INTO "reportPeople" ("personUuid", "reportUuid", "isPrimary", "isAuthor", "isInterlocutor") VALUES
   ((SELECT uuid FROM people where name = 'Steveson, Steve'), '86e4cf7e-c0ae-4bd9-b1ad-f2c65ca0f600', TRUE, FALSE, TRUE),
   ((SELECT uuid FROM people where name = 'Rogwell, Roger'), '86e4cf7e-c0ae-4bd9-b1ad-f2c65ca0f600', FALSE, FALSE, TRUE),
-  ((SELECT uuid FROM people where "domainUsername" = 'jack'), '86e4cf7e-c0ae-4bd9-b1ad-f2c65ca0f600', TRUE, TRUE, FALSE);
+  ('b5d495af-44d5-4c35-851a-1039352a8307', '86e4cf7e-c0ae-4bd9-b1ad-f2c65ca0f600', TRUE, TRUE, FALSE);
 INSERT INTO "reportTasks" ("taskUuid", "reportUuid") VALUES
   ((SELECT uuid from tasks where "shortName" = '1.1.A'), '86e4cf7e-c0ae-4bd9-b1ad-f2c65ca0f600'),
   ((SELECT uuid from tasks where "shortName" = '1.1.B'), '86e4cf7e-c0ae-4bd9-b1ad-f2c65ca0f600');
@@ -884,7 +924,7 @@ INSERT INTO reports (uuid, "createdAt", "updatedAt", "locationUuid", intent, tex
   (SELECT uuid FROM organizations where "shortName" = 'EF 2.1'), (SELECT uuid FROM organizations WHERE "longName" LIKE 'Ministry of Defense'));
 INSERT INTO "reportPeople" ("personUuid", "reportUuid", "isPrimary", "isAuthor", "isInterlocutor") VALUES
   ((SELECT uuid FROM people where name = 'Steveson, Steve'), '3e717721-d675-4ff3-b687-533b50978f9e', TRUE, FALSE, TRUE),
-  ((SELECT uuid FROM people where "domainUsername" = 'jack'), '3e717721-d675-4ff3-b687-533b50978f9e', TRUE, TRUE, FALSE);
+  ('b5d495af-44d5-4c35-851a-1039352a8307', '3e717721-d675-4ff3-b687-533b50978f9e', TRUE, TRUE, FALSE);
 INSERT INTO "reportTasks" ("taskUuid", "reportUuid") VALUES
   ((SELECT uuid from tasks where "shortName" = '1.1.C'), '3e717721-d675-4ff3-b687-533b50978f9e');
 
@@ -896,7 +936,7 @@ INSERT INTO reports (uuid, "createdAt", "updatedAt", "locationUuid", intent, tex
   (SELECT uuid FROM organizations where "shortName" = 'EF 2.1'), (SELECT uuid FROM organizations WHERE "longName" LIKE 'Ministry of Defense'));
 INSERT INTO "reportPeople" ("personUuid", "reportUuid", "isPrimary", "isAuthor", "isInterlocutor") VALUES
   ((SELECT uuid FROM people where name = 'Steveson, Steve'), '5d11abd0-242b-41ef-8420-a931d19ee513', TRUE, FALSE, TRUE),
-  ((SELECT uuid FROM people where "domainUsername" = 'jack'), '5d11abd0-242b-41ef-8420-a931d19ee513', TRUE, TRUE, FALSE);
+  ('b5d495af-44d5-4c35-851a-1039352a8307', '5d11abd0-242b-41ef-8420-a931d19ee513', TRUE, TRUE, FALSE);
 INSERT INTO "reportTasks" ("taskUuid", "reportUuid") VALUES
   ((SELECT uuid from tasks where "shortName" = '1.1.A'), '5d11abd0-242b-41ef-8420-a931d19ee513');
 
@@ -907,8 +947,8 @@ INSERT INTO reports (uuid, "createdAt", "updatedAt", "locationUuid", intent, tex
   (SELECT uuid FROM organizations where "shortName" = 'EF 2.1'), (SELECT uuid FROM organizations WHERE "longName" LIKE 'Ministry of Defense'));
 INSERT INTO "reportPeople" ("personUuid", "reportUuid", "isPrimary", "isAuthor", "isInterlocutor") VALUES
   ((SELECT uuid FROM people where name = 'Steveson, Steve'), 'ee0fc732-e6ed-4c53-9d74-a8ac1d8f3ccd', TRUE, FALSE, TRUE),
-  ((SELECT uuid FROM people where "domainUsername" = 'bob'), 'ee0fc732-e6ed-4c53-9d74-a8ac1d8f3ccd', TRUE, FALSE, FALSE),
-  ((SELECT uuid FROM people where "domainUsername" = 'jack'), 'ee0fc732-e6ed-4c53-9d74-a8ac1d8f3ccd', FALSE, TRUE, FALSE);
+  ('98fa4da5-ec99-457b-a4bc-2aa9064e2ca7', 'ee0fc732-e6ed-4c53-9d74-a8ac1d8f3ccd', TRUE, FALSE, FALSE),
+  ('b5d495af-44d5-4c35-851a-1039352a8307', 'ee0fc732-e6ed-4c53-9d74-a8ac1d8f3ccd', FALSE, TRUE, FALSE);
 INSERT INTO "reportTasks" ("taskUuid", "reportUuid") VALUES
   ((SELECT uuid from tasks where "shortName" = '1.1.B'), 'ee0fc732-e6ed-4c53-9d74-a8ac1d8f3ccd');
 
@@ -920,7 +960,7 @@ INSERT INTO reports (uuid, "createdAt", "updatedAt", "locationUuid", intent, tex
   (SELECT uuid FROM organizations where "shortName" = 'EF 2.1'), (SELECT uuid FROM organizations WHERE "longName" LIKE 'Ministry of Defense'));
 INSERT INTO "reportPeople" ("personUuid", "reportUuid", "isPrimary", "isAuthor", "isInterlocutor") VALUES
   ((SELECT uuid FROM people where name = 'Rogwell, Roger'), 'c9884c73-31c5-441e-ad6b-350513e28b84', TRUE, FALSE, TRUE),
-  ((SELECT uuid FROM people where "domainUsername" = 'jack'), 'c9884c73-31c5-441e-ad6b-350513e28b84', TRUE, TRUE, FALSE);
+  ('b5d495af-44d5-4c35-851a-1039352a8307', 'c9884c73-31c5-441e-ad6b-350513e28b84', TRUE, TRUE, FALSE);
 INSERT INTO "reportTasks" ("taskUuid", "reportUuid") VALUES
   ((SELECT uuid from tasks where "shortName" = '1.1.A'), 'c9884c73-31c5-441e-ad6b-350513e28b84');
 
@@ -931,7 +971,7 @@ INSERT INTO reports (uuid, "createdAt", "updatedAt", "locationUuid", intent, tex
   (SELECT uuid FROM organizations where "shortName" = 'EF 2.1'), (SELECT uuid FROM organizations WHERE "longName" LIKE 'Ministry of Defense'));
 INSERT INTO "reportPeople" ("personUuid", "reportUuid", "isPrimary", "isAuthor", "isInterlocutor") VALUES
   ((SELECT uuid FROM people where name = 'Steveson, Steve'), '5f681376-6eac-464d-8d46-02ff89d45071', TRUE, FALSE, TRUE),
-  ((SELECT uuid FROM people where "domainUsername" = 'jack'), '5f681376-6eac-464d-8d46-02ff89d45071', TRUE, TRUE, FALSE);
+  ('b5d495af-44d5-4c35-851a-1039352a8307', '5f681376-6eac-464d-8d46-02ff89d45071', TRUE, TRUE, FALSE);
 INSERT INTO "reportTasks" ("taskUuid", "reportUuid") VALUES
   ((SELECT uuid from tasks where "shortName" = '1.1.C'), '5f681376-6eac-464d-8d46-02ff89d45071');
 
@@ -942,7 +982,7 @@ INSERT INTO reports (uuid, "createdAt", "updatedAt", "locationUuid", intent, tex
   (SELECT uuid FROM organizations where "shortName" = 'EF 2.1'), (SELECT uuid FROM organizations WHERE "longName" LIKE 'Ministry of Defense'));
 INSERT INTO "reportPeople" ("personUuid", "reportUuid", "isPrimary", "isAuthor", "isInterlocutor") VALUES
   ((SELECT uuid FROM people where name = 'Steveson, Steve'), '5367a91a-9f70-469d-b0a4-69990ea8ac82', TRUE, FALSE, TRUE),
-  ((SELECT uuid FROM people where "domainUsername" = 'jack'), '5367a91a-9f70-469d-b0a4-69990ea8ac82', TRUE, TRUE, FALSE);
+  ('b5d495af-44d5-4c35-851a-1039352a8307', '5367a91a-9f70-469d-b0a4-69990ea8ac82', TRUE, TRUE, FALSE);
 INSERT INTO "reportTasks" ("taskUuid", "reportUuid") VALUES
   ((SELECT uuid from tasks where "shortName" = '1.1.A'), '5367a91a-9f70-469d-b0a4-69990ea8ac82');
 
@@ -953,7 +993,7 @@ INSERT INTO reports (uuid, "createdAt", "updatedAt", "locationUuid", intent, tex
   (SELECT uuid FROM organizations where "shortName" = 'EF 1.1'), (SELECT uuid FROM organizations WHERE "longName" LIKE 'Ministry of Defense'));
 INSERT INTO "reportPeople" ("personUuid", "reportUuid", "isPrimary", "isAuthor", "isInterlocutor") VALUES
   ((SELECT uuid FROM people where name = 'Rogwell, Roger'), '3e0ef6c9-68ed-43cf-8beb-d24c1c59c7a5', TRUE, FALSE, TRUE),
-  ((SELECT uuid FROM people where "domainUsername" = 'elizabeth'), '3e0ef6c9-68ed-43cf-8beb-d24c1c59c7a5', TRUE, TRUE, FALSE);
+  ('a9d65d96-d107-45c3-bbaa-1133a354335b', '3e0ef6c9-68ed-43cf-8beb-d24c1c59c7a5', TRUE, TRUE, FALSE);
 INSERT INTO "reportTasks" ("taskUuid", "reportUuid") VALUES
   ((SELECT uuid from tasks where "shortName" = '2.A'), '3e0ef6c9-68ed-43cf-8beb-d24c1c59c7a5');
 
@@ -964,7 +1004,7 @@ INSERT INTO reports (uuid, "createdAt", "updatedAt", "locationUuid", intent, tex
   (SELECT uuid FROM organizations where "shortName" = 'EF 1.1'), (SELECT uuid FROM organizations WHERE "longName" LIKE 'Ministry of Defense'));
 INSERT INTO "reportPeople" ("personUuid", "reportUuid", "isPrimary", "isAuthor", "isInterlocutor") VALUES
   ((SELECT uuid FROM people where name = 'Rogwell, Roger'), 'e5319bc4-91f2-473b-92c7-e796bc84b169', TRUE, FALSE, TRUE),
-  ((SELECT uuid FROM people where "domainUsername" = 'elizabeth'), 'e5319bc4-91f2-473b-92c7-e796bc84b169', TRUE, TRUE, FALSE);
+  ('a9d65d96-d107-45c3-bbaa-1133a354335b', 'e5319bc4-91f2-473b-92c7-e796bc84b169', TRUE, TRUE, FALSE);
 INSERT INTO "reportTasks" ("taskUuid", "reportUuid") VALUES
   ((SELECT uuid from tasks where "shortName" = '2.A'), 'e5319bc4-91f2-473b-92c7-e796bc84b169');
 
@@ -975,8 +1015,8 @@ INSERT INTO reports (uuid, "createdAt", "updatedAt", "locationUuid", intent, tex
   (SELECT uuid FROM organizations where "shortName" = 'EF 2.2'), (SELECT uuid FROM organizations WHERE "longName" LIKE 'Ministry of Defense'));
 INSERT INTO "reportPeople" ("personUuid", "reportUuid", "isPrimary", "isAuthor", "isInterlocutor") VALUES
   ((SELECT uuid FROM people where name = 'Topferness, Christopf'), 'a766b3f1-4705-43c1-b62a-ca4e3bb4dce3', TRUE, FALSE, TRUE),
-  ((SELECT uuid FROM people where "domainUsername" = 'erin'), 'a766b3f1-4705-43c1-b62a-ca4e3bb4dce3', TRUE, TRUE, FALSE),
-  ((SELECT uuid FROM people where "domainUsername" = 'reina'), 'a766b3f1-4705-43c1-b62a-ca4e3bb4dce3', FALSE, FALSE, FALSE);
+  ('df9c7381-56ac-4bc5-8e24-ec524bccd7e9', 'a766b3f1-4705-43c1-b62a-ca4e3bb4dce3', TRUE, TRUE, FALSE),
+  ('1ad0c049-6ce8-4890-84f6-5e6a364764c4', 'a766b3f1-4705-43c1-b62a-ca4e3bb4dce3', FALSE, FALSE, FALSE);
 INSERT INTO "reportTasks" ("taskUuid", "reportUuid") VALUES
   ((SELECT uuid from tasks where "shortName" = '1.1.B'), 'a766b3f1-4705-43c1-b62a-ca4e3bb4dce3');
 INSERT INTO "reportsSensitiveInformation" (uuid, "createdAt", "updatedAt", text, "reportUuid") VALUES
@@ -989,7 +1029,7 @@ INSERT INTO reports (uuid, "createdAt", "updatedAt", "locationUuid", intent, tex
   (SELECT uuid FROM organizations where "shortName" = 'EF 2.2'), (SELECT uuid FROM organizations WHERE "longName" LIKE 'Ministry of Defense'));
 INSERT INTO "reportPeople" ("personUuid", "reportUuid", "isPrimary", "isAuthor", "isInterlocutor") VALUES
   ((SELECT uuid FROM people where name = 'Topferness, Christopf'), '91cac8ff-dca5-4cf5-bf2c-dd72aa3685f8', TRUE, FALSE, TRUE),
-  ((SELECT uuid FROM people where "domainUsername" = 'erin'), '91cac8ff-dca5-4cf5-bf2c-dd72aa3685f8', TRUE, TRUE, FALSE);
+  ('df9c7381-56ac-4bc5-8e24-ec524bccd7e9', '91cac8ff-dca5-4cf5-bf2c-dd72aa3685f8', TRUE, TRUE, FALSE);
 INSERT INTO "reportTasks" ("taskUuid", "reportUuid") VALUES
   ((SELECT uuid from tasks where "shortName" = '1.1.B'), '91cac8ff-dca5-4cf5-bf2c-dd72aa3685f8');
 
@@ -1000,7 +1040,7 @@ INSERT INTO reports (uuid, "createdAt", "updatedAt", "locationUuid", intent, tex
   (SELECT uuid FROM organizations where "shortName" = 'EF 2.2'), (SELECT uuid FROM organizations WHERE "longName" LIKE 'Ministry of Interior'));
 INSERT INTO "reportPeople" ("personUuid", "reportUuid", "isPrimary", "isAuthor", "isInterlocutor") VALUES
   ((SELECT uuid FROM people where name = 'Topferness, Christopf'), '3fa48376-0519-48ba-8d91-2fa18c7a040f', TRUE, FALSE, TRUE),
-  ((SELECT uuid FROM people where "domainUsername" = 'erin'), '3fa48376-0519-48ba-8d91-2fa18c7a040f', TRUE, TRUE, FALSE);
+  ('df9c7381-56ac-4bc5-8e24-ec524bccd7e9', '3fa48376-0519-48ba-8d91-2fa18c7a040f', TRUE, TRUE, FALSE);
 INSERT INTO "reportTasks" ("taskUuid", "reportUuid") VALUES
   ((SELECT uuid from tasks where "shortName" = '1.1.B'), '3fa48376-0519-48ba-8d91-2fa18c7a040f');
 
@@ -1010,7 +1050,7 @@ INSERT INTO reports (uuid, "createdAt", "updatedAt", "locationUuid", intent, tex
   'Reschedule Meeting','', 4, CURRENT_TIMESTAMP, 0, 1,
   (SELECT uuid FROM organizations where "shortName" = 'EF 2.2'), (SELECT uuid FROM organizations WHERE "longName" LIKE 'Ministry of Interior'));
 INSERT INTO "reportPeople" ("personUuid", "reportUuid", "isPrimary", "isAuthor", "isInterlocutor") VALUES
-  ((SELECT uuid FROM people where "domainUsername" = 'erin'), 'a485a567-3e21-4219-9de7-2704c20a6f71', TRUE, TRUE, FALSE);
+  ('df9c7381-56ac-4bc5-8e24-ec524bccd7e9', 'a485a567-3e21-4219-9de7-2704c20a6f71', TRUE, TRUE, FALSE);
 
 INSERT INTO reports (uuid, "createdAt", "updatedAt", "locationUuid", intent, text, "nextSteps", "keyOutcomes", state, "engagementDate", atmosphere, "advisorOrganizationUuid", "interlocutorOrganizationUuid","customFields") VALUES
   ('59be259b-30b9-4d04-9e21-e8ceb58cbe9c', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, (SELECT uuid from locations where name='General Hospital'), 'A test report from Arthur', '',
@@ -1018,9 +1058,9 @@ INSERT INTO reports (uuid, "createdAt", "updatedAt", "locationUuid", intent, tex
   (SELECT uuid FROM organizations where "shortName" = 'ANET Administrators'), (SELECT uuid FROM organizations WHERE "longName" LIKE 'Ministry of Interior'),
    '{"invisibleCustomFields":["formCustomFields.trainingEvent","formCustomFields.numberTrained","formCustomFields.levelTrained","formCustomFields.trainingDate","formCustomFields.assetsUsed"],"itemsAgreed":[],"echelons":"Ut enim ad minim veniam","systemProcess":"","multipleButtons":["advise"],"additionalEngagementNeeded":[],"relatedObject":null,"relatedReport":null}');
 INSERT INTO "reportPeople" ("personUuid", "reportUuid", "isPrimary", "isAuthor", "isInterlocutor") VALUES
-  ((SELECT uuid FROM people where "domainUsername" = 'arthur'), '59be259b-30b9-4d04-9e21-e8ceb58cbe9c', TRUE, TRUE, FALSE),
+  ('87fdbc6a-3109-4e11-9702-a894d6ca31ef', '59be259b-30b9-4d04-9e21-e8ceb58cbe9c', TRUE, TRUE, FALSE),
   ((SELECT uuid FROM people where name = 'Sharton, Shardul'), '59be259b-30b9-4d04-9e21-e8ceb58cbe9c', TRUE, FALSE, TRUE),
-  ((SELECT uuid FROM people where "domainUsername" = 'lin'), '59be259b-30b9-4d04-9e21-e8ceb58cbe9c', FALSE, FALSE, FALSE),
+  ('02fdbd68-866f-457a-990c-fbd79bc9b96c', '59be259b-30b9-4d04-9e21-e8ceb58cbe9c', FALSE, FALSE, FALSE),
   ((SELECT uuid FROM people where name = 'Kyleson, Kyle'), '59be259b-30b9-4d04-9e21-e8ceb58cbe9c', FALSE, FALSE, TRUE),
   ((SELECT uuid FROM people where name = 'Chrisville, Chris'), '59be259b-30b9-4d04-9e21-e8ceb58cbe9c', FALSE, FALSE, TRUE);
 INSERT INTO "reportTasks" ("taskUuid", "reportUuid") VALUES
@@ -1032,9 +1072,9 @@ INSERT INTO reports (uuid, "createdAt", "updatedAt", "locationUuid", intent, tex
   'keep on testing!', 'check the classification', 0, CURRENT_TIMESTAMP + INTERVAL '1 minute', 0,
   (SELECT uuid FROM organizations where "shortName" = 'ANET Administrators'), (SELECT uuid FROM organizations WHERE "longName" LIKE 'Ministry of Interior'), 'NU');
 INSERT INTO "reportPeople" ("personUuid", "reportUuid", "isPrimary", "isAuthor", "isInterlocutor") VALUES
-  ((SELECT uuid FROM people where "domainUsername" = 'arthur'), 'c3008f90-6a27-4343-b278-827a0a0dc6bf', TRUE, TRUE, FALSE),
+  ('87fdbc6a-3109-4e11-9702-a894d6ca31ef', 'c3008f90-6a27-4343-b278-827a0a0dc6bf', TRUE, TRUE, FALSE),
   ((SELECT uuid FROM people where name = 'Sharton, Shardul'), 'c3008f90-6a27-4343-b278-827a0a0dc6bf', TRUE, FALSE, TRUE),
-  ((SELECT uuid FROM people where "domainUsername" = 'lin'), 'c3008f90-6a27-4343-b278-827a0a0dc6bf', FALSE, FALSE, FALSE),
+  ('02fdbd68-866f-457a-990c-fbd79bc9b96c', 'c3008f90-6a27-4343-b278-827a0a0dc6bf', FALSE, FALSE, FALSE),
   ((SELECT uuid FROM people where name = 'Kyleson, Kyle'), 'c3008f90-6a27-4343-b278-827a0a0dc6bf', FALSE, FALSE, TRUE),
   ((SELECT uuid FROM people where name = 'Chrisville, Chris'), 'c3008f90-6a27-4343-b278-827a0a0dc6bf', FALSE, FALSE, TRUE);
 
@@ -1043,7 +1083,7 @@ INSERT INTO reports (uuid, "createdAt", "updatedAt", "locationUuid", intent, tex
   'I need to edit this report so unpublish it please','have reports in organizations', 2, CURRENT_TIMESTAMP + INTERVAL '1 minute', 0,
   (SELECT uuid FROM organizations where "shortName" = 'ANET Administrators'), (SELECT uuid FROM organizations WHERE "longName" LIKE 'Ministry of Interior'));
 INSERT INTO "reportPeople" ("personUuid", "reportUuid", "isPrimary", "isAuthor", "isInterlocutor") VALUES
-  ((SELECT uuid FROM people where "domainUsername" = 'arthur'), 'bb9dad1a-1c6c-45de-91e8-aecda261d21e', TRUE, TRUE, FALSE),
+  ('87fdbc6a-3109-4e11-9702-a894d6ca31ef', 'bb9dad1a-1c6c-45de-91e8-aecda261d21e', TRUE, TRUE, FALSE),
   ((SELECT uuid FROM people where name = 'Sharton, Shardul'), 'bb9dad1a-1c6c-45de-91e8-aecda261d21e', TRUE, FALSE, TRUE);
 INSERT INTO "reportTasks" ("taskUuid", "reportUuid") VALUES
   ((SELECT uuid from tasks where "shortName" = '1.2.A'), 'bb9dad1a-1c6c-45de-91e8-aecda261d21e'),
@@ -1055,8 +1095,8 @@ INSERT INTO reports (uuid, "createdAt", "updatedAt", "locationUuid", intent, tex
   'Keep testing', 0, '2022-08-25', 0,
   (SELECT uuid FROM organizations where "shortName" = 'EF 2.1'), (SELECT uuid FROM organizations WHERE "longName" LIKE 'Ministry of Defense'));
 INSERT INTO "reportPeople" ("personUuid", "reportUuid", "isPrimary", "isAuthor", "isInterlocutor") VALUES
-  ((SELECT uuid FROM people where "domainUsername" = 'arthur'), '34265a98-7f82-4f16-b132-abcb60d307ad', TRUE, TRUE, FALSE),
-  ((SELECT uuid FROM people where "domainUsername" = 'jack'), '34265a98-7f82-4f16-b132-abcb60d307ad', FALSE, FALSE, FALSE);
+  ('87fdbc6a-3109-4e11-9702-a894d6ca31ef', '34265a98-7f82-4f16-b132-abcb60d307ad', TRUE, TRUE, FALSE),
+  ('b5d495af-44d5-4c35-851a-1039352a8307', '34265a98-7f82-4f16-b132-abcb60d307ad', FALSE, FALSE, FALSE);
 
 -- Erin's Draft report
 INSERT INTO reports (uuid, "createdAt", "updatedAt", "locationUuid", intent, text, "nextSteps", "keyOutcomes", state, "engagementDate", atmosphere, "advisorOrganizationUuid", "interlocutorOrganizationUuid", "customFields") VALUES
@@ -1066,7 +1106,7 @@ INSERT INTO reports (uuid, "createdAt", "updatedAt", "locationUuid", intent, tex
   '{"invisibleCustomFields":["formCustomFields.trainingEvent","formCustomFields.numberTrained","formCustomFields.levelTrained","formCustomFields.trainingDate","formCustomFields.systemProcess","formCustomFields.echelons","formCustomFields.itemsAgreed","formCustomFields.assetsUsed"],"multipleButtons":[],"additionalEngagementNeeded":[],"relatedObject":null,"relatedReport":null}');
 INSERT INTO "reportPeople" ("personUuid", "reportUuid", "isPrimary", "isAuthor", "isInterlocutor") VALUES
   ((SELECT uuid FROM people where name = 'Topferness, Christopf'), '530b735e-1134-4daa-9e87-4491c888a4f7', TRUE, FALSE, TRUE),
-  ((SELECT uuid FROM people where "domainUsername" = 'erin'), '530b735e-1134-4daa-9e87-4491c888a4f7', TRUE, TRUE, FALSE);
+  ('df9c7381-56ac-4bc5-8e24-ec524bccd7e9', '530b735e-1134-4daa-9e87-4491c888a4f7', TRUE, TRUE, FALSE);
 INSERT INTO "reportTasks" ("taskUuid", "reportUuid") VALUES
   ((SELECT uuid from tasks where "shortName" = '2.A'), '530b735e-1134-4daa-9e87-4491c888a4f7');
 
@@ -1156,7 +1196,7 @@ INSERT INTO reports (uuid, "createdAt", "updatedAt", "locationUuid", intent, tex
   (SELECT uuid FROM organizations where "shortName" = 'EF 2.1'), (SELECT uuid FROM organizations WHERE "longName" LIKE 'Ministry of Defense'));
 INSERT INTO "reportPeople" ("personUuid", "reportUuid", "isPrimary", "isAuthor", "isInterlocutor") VALUES
   ((SELECT uuid FROM people where name = 'Steveson, Steve'), '8655bf58-4452-4ac0-9221-70b035d8eb7e', TRUE, FALSE, TRUE),
-  ((SELECT uuid FROM people where "domainUsername" = 'jack'), '8655bf58-4452-4ac0-9221-70b035d8eb7e', TRUE, TRUE, FALSE);
+  ('b5d495af-44d5-4c35-851a-1039352a8307', '8655bf58-4452-4ac0-9221-70b035d8eb7e', TRUE, TRUE, FALSE);
 
 -- Authorization groups
 INSERT INTO "authorizationGroups" (uuid, name, description, status, "distributionList", "forSensitiveInformation", "createdAt", "updatedAt") VALUES
@@ -1510,7 +1550,7 @@ INSERT INTO "accessTokens" (uuid, name, description, "tokenHash", "createdAt", "
 -- Test data for assessments
 
 -- Reports for task assessments
-INSERT INTO public.reports ("createdAt", "updatedAt", intent, exsum, text, "nextSteps", state, "engagementDate", atmosphere, "atmosphereDetails", "keyOutcomes", "cancelledReason", "releasedAt", uuid, "advisorOrganizationUuid", "approvalStepUuid", "locationUuid", "interlocutorOrganizationUuid", "legacyId", duration, "customFields", classification) VALUES
+INSERT INTO reports ("createdAt", "updatedAt", intent, exsum, text, "nextSteps", state, "engagementDate", atmosphere, "atmosphereDetails", "keyOutcomes", "cancelledReason", "releasedAt", uuid, "advisorOrganizationUuid", "approvalStepUuid", "locationUuid", "interlocutorOrganizationUuid", "legacyId", duration, "customFields", classification) VALUES
   (CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 'Test assessment taskOnceReport', NULL, '<p>test</p>', 'test', 2, CURRENT_TIMESTAMP, 1, '', 'test', NULL, CURRENT_TIMESTAMP, '4915d7b7-6857-4324-98eb-f7be5b0ed170', 'a267a964-e9a1-4dfd-baa4-0c57d35a6212', NULL, '0855fb0a-995e-4a79-a132-4024ee2983ff', NULL, NULL, NULL, '{"invisibleCustomFields":["formCustomFields.trainingEvent","formCustomFields.numberTrained","formCustomFields.levelTrained","formCustomFields.trainingDate","formCustomFields.systemProcess","formCustomFields.echelons","formCustomFields.itemsAgreed","formCustomFields.assetsUsed"],"multipleButtons":[],"additionalEngagementNeeded":[],"relatedObject":null,"relatedReport":null,"gridLocation":{}}', NULL),
   (CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 'Test assessment taskOnceReport with questionFor11B', NULL, '<p>test</p>', 'test', 2, CURRENT_TIMESTAMP, 1, '', 'test', NULL, CURRENT_TIMESTAMP, '7676b6ca-c0b2-46a2-9b92-0d255d2532eb', 'a267a964-e9a1-4dfd-baa4-0c57d35a6212', NULL, '0855fb0a-995e-4a79-a132-4024ee2983ff', NULL, NULL, NULL, '{"invisibleCustomFields":["formCustomFields.trainingEvent","formCustomFields.numberTrained","formCustomFields.levelTrained","formCustomFields.trainingDate","formCustomFields.systemProcess","formCustomFields.echelons","formCustomFields.itemsAgreed","formCustomFields.assetsUsed"],"multipleButtons":[],"additionalEngagementNeeded":[],"relatedObject":null,"relatedReport":null,"gridLocation":{}}', NULL),
   (CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 'Test assessment task11COnceReport with questionForNegative', NULL, '<p>test</p>', 'test', 2, CURRENT_TIMESTAMP, 2, '', 'test', NULL, CURRENT_TIMESTAMP, '17c518f6-4444-48d9-b63b-7da7e2023ecc', 'a267a964-e9a1-4dfd-baa4-0c57d35a6212', NULL, '0855fb0a-995e-4a79-a132-4024ee2983ff', NULL, NULL, NULL, '{"invisibleCustomFields":["formCustomFields.trainingEvent","formCustomFields.numberTrained","formCustomFields.levelTrained","formCustomFields.trainingDate","formCustomFields.systemProcess","formCustomFields.echelons","formCustomFields.itemsAgreed","formCustomFields.assetsUsed"],"multipleButtons":[],"additionalEngagementNeeded":[],"relatedObject":null,"relatedReport":null,"gridLocation":{}}', NULL),
@@ -1519,7 +1559,7 @@ INSERT INTO public.reports ("createdAt", "updatedAt", intent, exsum, text, "next
   (CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 'Test assessment taskOnceReportRestricted', NULL, '<p>test</p>', 'test', 2, CURRENT_TIMESTAMP, 1, '', 'test', NULL, CURRENT_TIMESTAMP, 'e4498f99-8473-4d42-a86c-557b495ebd6c', 'a267a964-e9a1-4dfd-baa4-0c57d35a6212', NULL, '0855fb0a-995e-4a79-a132-4024ee2983ff', NULL, NULL, NULL, '{"invisibleCustomFields":["formCustomFields.trainingEvent","formCustomFields.numberTrained","formCustomFields.levelTrained","formCustomFields.trainingDate","formCustomFields.systemProcess","formCustomFields.echelons","formCustomFields.itemsAgreed","formCustomFields.assetsUsed"],"multipleButtons":[],"additionalEngagementNeeded":[],"relatedObject":null,"relatedReport":null,"gridLocation":{}}', NULL);
 
 -- Report tasks for task assessments
-INSERT INTO public."reportTasks" ("reportUuid", "taskUuid") VALUES
+INSERT INTO "reportTasks" ("reportUuid", "taskUuid") VALUES
   ('e4498f99-8473-4d42-a86c-557b495ebd6c', '42afd501-1a2c-4758-9da5-f996b2c97156'),
   ('7676b6ca-c0b2-46a2-9b92-0d255d2532eb', '1b5eb36b-456c-46b7-ae9e-1c89e9075292'),
   ('b0bea024-48bf-4d30-914a-a19d6c39d82c', '0701a964-5d79-4090-8f35-a40856556675'),
@@ -1528,7 +1568,7 @@ INSERT INTO public."reportTasks" ("reportUuid", "taskUuid") VALUES
   ('4915d7b7-6857-4324-98eb-f7be5b0ed170', '2200a820-c4c7-4c9c-946c-f0c9c9e045c5');
 
 -- Report people for task assessments
-INSERT INTO public."reportPeople" ("isPrimary", "personUuid", "reportUuid", "isAttendee", "isAuthor", "isInterlocutor") VALUES
+INSERT INTO "reportPeople" ("isPrimary", "personUuid", "reportUuid", "isAttendee", "isAuthor", "isInterlocutor") VALUES
   (true, 'b5d495af-44d5-4c35-851a-1039352a8307', 'e4498f99-8473-4d42-a86c-557b495ebd6c', true, true, false),
   (true, 'b5d495af-44d5-4c35-851a-1039352a8307', '4915d7b7-6857-4324-98eb-f7be5b0ed170', true, true, false),
   (true, 'b5d495af-44d5-4c35-851a-1039352a8307', '7676b6ca-c0b2-46a2-9b92-0d255d2532eb', true, true, false),
@@ -1537,7 +1577,7 @@ INSERT INTO public."reportPeople" ("isPrimary", "personUuid", "reportUuid", "isA
   (true, 'b5d495af-44d5-4c35-851a-1039352a8307', '17c518f6-4444-48d9-b63b-7da7e2023ecc', true, true, false);
 
 -- Report actions for task assessments
-INSERT INTO public."reportActions" ("createdAt", type, "approvalStepUuid", "personUuid", "reportUuid", planned) VALUES
+INSERT INTO "reportActions" ("createdAt", type, "approvalStepUuid", "personUuid", "reportUuid", planned) VALUES
   (CURRENT_TIMESTAMP, 2, NULL, 'b5d495af-44d5-4c35-851a-1039352a8307', '4915d7b7-6857-4324-98eb-f7be5b0ed170', false),
   (CURRENT_TIMESTAMP, 2, NULL, 'b5d495af-44d5-4c35-851a-1039352a8307', '17c518f6-4444-48d9-b63b-7da7e2023ecc', false),
   (CURRENT_TIMESTAMP, 2, NULL, 'b5d495af-44d5-4c35-851a-1039352a8307', '764a393a-a292-40c5-8f96-28263dc906c0', false),
@@ -1564,7 +1604,7 @@ INSERT INTO public."reportActions" ("createdAt", type, "approvalStepUuid", "pers
   (CURRENT_TIMESTAMP, 3, NULL, '87fdbc6a-3109-4e11-9702-a894d6ca31ef', 'e4498f99-8473-4d42-a86c-557b495ebd6c', false);
 
 -- Notes for task assessments
-INSERT INTO public.assessments (uuid, "authorUuid", "assessmentValues", "createdAt", "updatedAt", "assessmentKey") VALUES
+INSERT INTO assessments (uuid, "authorUuid", "assessmentValues", "createdAt", "updatedAt", "assessmentKey") VALUES
   ('473f9fa0-ade9-4f59-aa1c-6c06890d9f49', 'b5d495af-44d5-4c35-851a-1039352a8307', '{"issues":"<p>Test assessment taskSemiannuallyRestricted</p>","__recurrence":"semiannually","__periodStart":"' || to_char(date_trunc('quarter', CURRENT_TIMESTAMP) + INTERVAL '-12 month', 'YYYY-MM-DD') || '"}', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 'fields.task.assessments.taskSemiannuallyRestricted'),
   ('3f22f63e-cd7b-4cbf-9fa7-66fb53fe4a4e', '87fdbc6a-3109-4e11-9702-a894d6ca31ef', '{"status":"GREEN","issues":"<p>Test assessment taskMonthly</p>","__recurrence":"monthly","__periodStart":"' || to_char(date_trunc('month', CURRENT_TIMESTAMP) + INTERVAL '-2 month', 'YYYY-MM-DD') || '"}', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 'fields.task.assessments.taskMonthly'),
   ('b79c0643-6bdc-4813-b567-404313043d92', '87fdbc6a-3109-4e11-9702-a894d6ca31ef', '{"status":"AMBER","issues":"<p>Test assessment taskMonthly with questionFor11B</p>","questionFor11B":"Test assessment taskMonthly with questionFor11B","__recurrence":"monthly","__periodStart":"' || to_char(date_trunc('month', CURRENT_TIMESTAMP) + INTERVAL '-2 month', 'YYYY-MM-DD') || '"}', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 'fields.task.assessments.taskMonthly'),
@@ -1585,7 +1625,7 @@ INSERT INTO public.assessments (uuid, "authorUuid", "assessmentValues", "created
   ('ef3bb6b5-6ab2-48ba-a9be-5515446fd0a3', 'b5d495af-44d5-4c35-851a-1039352a8307', '{"requiredQuestion":"Test assessment task11COnceReport with questionForNegative","questionForNegative":"Test assessment task11COnceReport with questionForNegative","__recurrence":"once","__relatedObjectType":"report"}', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 'fields.task.assessments.task11COnceReport');
 
 -- Note related objects for task assessments
-INSERT INTO public."assessmentRelatedObjects" ("assessmentUuid", "relatedObjectType", "relatedObjectUuid") VALUES
+INSERT INTO "assessmentRelatedObjects" ("assessmentUuid", "relatedObjectType", "relatedObjectUuid") VALUES
   ('473f9fa0-ade9-4f59-aa1c-6c06890d9f49', 'tasks', '4831e09b-2bbb-4717-9bfa-91071e62260a'),
   ('3f22f63e-cd7b-4cbf-9fa7-66fb53fe4a4e', 'tasks', '9b9f4205-0721-4893-abf8-69e020d4db23'),
   ('b79c0643-6bdc-4813-b567-404313043d92', 'tasks', '1b5eb36b-456c-46b7-ae9e-1c89e9075292'),
@@ -1620,7 +1660,7 @@ INSERT INTO public."assessmentRelatedObjects" ("assessmentUuid", "relatedObjectT
   ('140ec8fe-29f5-4132-b565-4ad76c3a9acc', 'reports', '764a393a-a292-40c5-8f96-28263dc906c0');
 
 -- Reports for person assessments
-INSERT INTO public.reports ("createdAt", "updatedAt", intent, exsum, text, "nextSteps", state, "engagementDate", atmosphere, "atmosphereDetails", "keyOutcomes", "cancelledReason", "releasedAt", uuid, "advisorOrganizationUuid", "approvalStepUuid", "locationUuid", "interlocutorOrganizationUuid", "legacyId", duration, "customFields", classification) VALUES
+INSERT INTO reports ("createdAt", "updatedAt", intent, exsum, text, "nextSteps", state, "engagementDate", atmosphere, "atmosphereDetails", "keyOutcomes", "cancelledReason", "releasedAt", uuid, "advisorOrganizationUuid", "approvalStepUuid", "locationUuid", "interlocutorOrganizationUuid", "legacyId", duration, "customFields", classification) VALUES
   (CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 'Test assessment personOnceReportLinguist with questionForLin', NULL, '<p>test</p>', 'test', 2, CURRENT_TIMESTAMP, 1, '', 'test', NULL, CURRENT_TIMESTAMP, '216afd92-ba73-479d-ac59-ade83ab38b36', 'a267a964-e9a1-4dfd-baa4-0c57d35a6212', NULL, '0855fb0a-995e-4a79-a132-4024ee2983ff', NULL, NULL, NULL, '{"invisibleCustomFields":["formCustomFields.trainingEvent","formCustomFields.numberTrained","formCustomFields.levelTrained","formCustomFields.trainingDate","formCustomFields.systemProcess","formCustomFields.echelons","formCustomFields.itemsAgreed","formCustomFields.assetsUsed"],"multipleButtons":[],"additionalEngagementNeeded":[],"relatedObject":null,"relatedReport":null,"gridLocation":{}}', NULL),
   (CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 'Test assessment personOnceReportLinguist with questionForNegative and questionForLin', NULL, '<p>test</p>', 'test', 2, CURRENT_TIMESTAMP, 2, '', 'test', NULL, CURRENT_TIMESTAMP, 'afad83a1-85d9-4a3d-a090-351b11a9edce', 'a267a964-e9a1-4dfd-baa4-0c57d35a6212', NULL, '0855fb0a-995e-4a79-a132-4024ee2983ff', NULL, NULL, NULL, '{"invisibleCustomFields":["formCustomFields.trainingEvent","formCustomFields.numberTrained","formCustomFields.levelTrained","formCustomFields.trainingDate","formCustomFields.systemProcess","formCustomFields.echelons","formCustomFields.itemsAgreed","formCustomFields.assetsUsed"],"multipleButtons":[],"additionalEngagementNeeded":[],"relatedObject":null,"relatedReport":null,"gridLocation":{}}', NULL),
   (CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 'Test assessment interlocutorOnceReport', NULL, '<p>test</p>', 'test', 2, CURRENT_TIMESTAMP, 1, '', 'test', NULL, CURRENT_TIMESTAMP, 'b6555ac2-5385-449c-bc03-d790d7c5ac3a', 'a267a964-e9a1-4dfd-baa4-0c57d35a6212', NULL, '0855fb0a-995e-4a79-a132-4024ee2983ff', NULL, NULL, NULL, '{"invisibleCustomFields":["formCustomFields.trainingEvent","formCustomFields.numberTrained","formCustomFields.levelTrained","formCustomFields.trainingDate","formCustomFields.systemProcess","formCustomFields.echelons","formCustomFields.itemsAgreed","formCustomFields.assetsUsed"],"multipleButtons":[],"additionalEngagementNeeded":[],"relatedObject":null,"relatedReport":null,"gridLocation":{}}', NULL),
@@ -1631,7 +1671,7 @@ INSERT INTO public.reports ("createdAt", "updatedAt", intent, exsum, text, "next
   (CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 'Test assessment personOnceReportLinguist with questionForNegative', NULL, '<p>test</p>', 'test', 2, CURRENT_TIMESTAMP, 2, '', 'test', NULL, CURRENT_TIMESTAMP, 'dcafe728-4017-4854-9212-dc87b4d19cb7', 'a267a964-e9a1-4dfd-baa4-0c57d35a6212', NULL, '0855fb0a-995e-4a79-a132-4024ee2983ff', NULL, NULL, NULL, '{"invisibleCustomFields":["formCustomFields.trainingEvent","formCustomFields.numberTrained","formCustomFields.levelTrained","formCustomFields.trainingDate","formCustomFields.systemProcess","formCustomFields.echelons","formCustomFields.itemsAgreed","formCustomFields.assetsUsed"],"multipleButtons":[],"additionalEngagementNeeded":[],"relatedObject":null,"relatedReport":null,"gridLocation":{}}', NULL);
 
 -- Report tasks for person assessments
-INSERT INTO public."reportTasks" ("reportUuid", "taskUuid") VALUES
+INSERT INTO "reportTasks" ("reportUuid", "taskUuid") VALUES
   ('cfbf2fd1-6bbb-4570-a5c4-8ad7b8635486', '076793eb-9950-4ea6-bbd5-2d8b8827828c'),
   ('dcafe728-4017-4854-9212-dc87b4d19cb7', '076793eb-9950-4ea6-bbd5-2d8b8827828c'),
   ('216afd92-ba73-479d-ac59-ade83ab38b36', '076793eb-9950-4ea6-bbd5-2d8b8827828c'),
@@ -1642,7 +1682,7 @@ INSERT INTO public."reportTasks" ("reportUuid", "taskUuid") VALUES
   ('9db10db0-794a-488d-a636-55e7195e9167', '076793eb-9950-4ea6-bbd5-2d8b8827828c');
 
 -- Report people for person assessments
-INSERT INTO public."reportPeople" ("isPrimary", "personUuid", "reportUuid", "isAttendee", "isAuthor", "isInterlocutor") VALUES
+INSERT INTO "reportPeople" ("isPrimary", "personUuid", "reportUuid", "isAttendee", "isAuthor", "isInterlocutor") VALUES
   (true, 'b5d495af-44d5-4c35-851a-1039352a8307', 'cfbf2fd1-6bbb-4570-a5c4-8ad7b8635486', true, true, false),
   (false, 'bcd9d5e4-bf6c-42de-9246-8116f2b23bdc', 'cfbf2fd1-6bbb-4570-a5c4-8ad7b8635486', true, false, false),
   (false, 'bcd9d5e4-bf6c-42de-9246-8116f2b23bdc', 'dcafe728-4017-4854-9212-dc87b4d19cb7', true, false, false),
@@ -1661,7 +1701,7 @@ INSERT INTO public."reportPeople" ("isPrimary", "personUuid", "reportUuid", "isA
   (true, '0c5a8ba7-7436-47fd-bead-b8393246a300', '9db10db0-794a-488d-a636-55e7195e9167', true, false, true);
 
 -- Report actions for person assessments
-INSERT INTO public."reportActions" ("createdAt", type, "approvalStepUuid", "personUuid", "reportUuid", planned) VALUES
+INSERT INTO "reportActions" ("createdAt", type, "approvalStepUuid", "personUuid", "reportUuid", planned) VALUES
   (CURRENT_TIMESTAMP, 2, NULL, 'b5d495af-44d5-4c35-851a-1039352a8307', 'cfbf2fd1-6bbb-4570-a5c4-8ad7b8635486', false),
   (CURRENT_TIMESTAMP, 0, '2489d0ec-cdb8-484e-be02-fda7f5e8ed8d', '87fdbc6a-3109-4e11-9702-a894d6ca31ef', 'cfbf2fd1-6bbb-4570-a5c4-8ad7b8635486', false),
   (CURRENT_TIMESTAMP, 0, (SELECT uuid FROM "approvalSteps" WHERE "relatedObjectUuid" = '076793eb-9950-4ea6-bbd5-2d8b8827828c'), '87fdbc6a-3109-4e11-9702-a894d6ca31ef', 'cfbf2fd1-6bbb-4570-a5c4-8ad7b8635486', false),
@@ -1696,7 +1736,7 @@ INSERT INTO public."reportActions" ("createdAt", type, "approvalStepUuid", "pers
   (CURRENT_TIMESTAMP, 3, NULL, '87fdbc6a-3109-4e11-9702-a894d6ca31ef', '9db10db0-794a-488d-a636-55e7195e9167', false);
 
 -- Notes for person assessments
-INSERT INTO public.assessments (uuid, "authorUuid", "assessmentValues", "createdAt", "updatedAt", "assessmentKey") VALUES
+INSERT INTO assessments (uuid, "authorUuid", "assessmentValues", "createdAt", "updatedAt", "assessmentKey") VALUES
   ('9402cdc5-cd59-4c3d-a17d-807b5f5ad2b8', 'b5d495af-44d5-4c35-851a-1039352a8307', '{"question1":"1","__recurrence":"once","__relatedObjectType":"report"}', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 'fields.regular.person.assessments.interlocutorOnceReport'),
   ('6cd909f7-e861-4f4e-8cae-38dfc98c19d9', 'b5d495af-44d5-4c35-851a-1039352a8307', '{"question1":"1","question4":["yes"],"__recurrence":"once","__relatedObjectType":"report"}', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 'fields.regular.person.assessments.interlocutorOnceReport'),
   ('3c7929a6-330d-48eb-8eff-e7ef3e765391', 'b5d495af-44d5-4c35-851a-1039352a8307', '{"question1":"1","question3":["yes"],"__recurrence":"once","__relatedObjectType":"report"}', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 'fields.regular.person.assessments.interlocutorOnceReport'),
@@ -1717,7 +1757,7 @@ INSERT INTO public.assessments (uuid, "authorUuid", "assessmentValues", "created
   ('2fbaedc0-8783-4fe2-8411-ed41ffa45f5a', 'b5d495af-44d5-4c35-851a-1039352a8307', '{"requiredQuestion":"Test assessment personOnceReportLinguistLin with questionForLin","__recurrence":"once","__relatedObjectType":"report"}', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 'fields.regular.person.assessments.personOnceReportLinguistLin');
 
 -- Note related objects for person assessments
-INSERT INTO public."assessmentRelatedObjects" ("assessmentUuid", "relatedObjectType", "relatedObjectUuid") VALUES
+INSERT INTO "assessmentRelatedObjects" ("assessmentUuid", "relatedObjectType", "relatedObjectUuid") VALUES
   ('9ce0ad6d-5a40-40db-a56c-b0c8f4e3a517', 'people', '1a557db0-5af5-4ea3-b926-28b5f2e88bf7'),
   ('d6ef3959-614c-409c-8d27-449954afa61e', 'people', '1a557db0-5af5-4ea3-b926-28b5f2e88bf7'),
   ('b494790b-445c-4174-8c60-3257f988d2c4', 'people', '1a557db0-5af5-4ea3-b926-28b5f2e88bf7'),
@@ -1758,6 +1798,8 @@ INSERT INTO "martImportedReports" ("sequence", "personUuid", "reportUuid", "succ
 -- Update the link-text indexes
 REFRESH MATERIALIZED VIEW CONCURRENTLY "mv_lts_attachments";
 -- authorizationGroups currently have no links
+REFRESH MATERIALIZED VIEW CONCURRENTLY "mv_lts_events";
+REFRESH MATERIALIZED VIEW CONCURRENTLY "mv_lts_eventSeries";
 REFRESH MATERIALIZED VIEW CONCURRENTLY "mv_lts_locations";
 REFRESH MATERIALIZED VIEW CONCURRENTLY "mv_lts_organizations";
 REFRESH MATERIALIZED VIEW CONCURRENTLY "mv_lts_people";
@@ -1768,6 +1810,8 @@ REFRESH MATERIALIZED VIEW CONCURRENTLY "mv_lts_tasks";
 -- Update the full-text indexes
 REFRESH MATERIALIZED VIEW CONCURRENTLY "mv_fts_attachments";
 REFRESH MATERIALIZED VIEW CONCURRENTLY "mv_fts_authorizationGroups";
+REFRESH MATERIALIZED VIEW CONCURRENTLY "mv_fts_events";
+REFRESH MATERIALIZED VIEW CONCURRENTLY "mv_fts_eventSeries";
 REFRESH MATERIALIZED VIEW CONCURRENTLY "mv_fts_locations";
 REFRESH MATERIALIZED VIEW CONCURRENTLY "mv_fts_organizations";
 REFRESH MATERIALIZED VIEW CONCURRENTLY "mv_fts_people";
@@ -1775,44 +1819,3 @@ REFRESH MATERIALIZED VIEW CONCURRENTLY "mv_fts_positions";
 REFRESH MATERIALIZED VIEW CONCURRENTLY "mv_fts_reports";
 REFRESH MATERIALIZED VIEW CONCURRENTLY "mv_fts_tasks";
 
--- LEAVE THIS AS LAST STATEMENT
--- Truncate all the dates (on reports etc.) to dates that could have been generated by
--- Java (millisecond precision) rather than by the database itself (microsecond precision)
-UPDATE reports SET
-  "createdAt"=date_trunc('milliseconds', "createdAt"),
-  "updatedAt"=date_trunc('milliseconds', "updatedAt"),
-  "releasedAt"=date_trunc('milliseconds', "releasedAt"),
-  "engagementDate"=date_trunc('second', "engagementDate");
-UPDATE people SET
-  "createdAt"=date_trunc('milliseconds', "createdAt"),
-  "updatedAt"=date_trunc('milliseconds', "updatedAt"),
-  "endOfTourDate"=date_trunc('second', "endOfTourDate");
-UPDATE positions SET
-  "createdAt"=date_trunc('milliseconds', "createdAt"),
-  "updatedAt"=date_trunc('milliseconds', "updatedAt");
-UPDATE "peoplePositions" SET
-  "createdAt"=date_trunc('milliseconds', "createdAt"),
-  "endedAt"=date_trunc('milliseconds', "endedAt");
-UPDATE organizations SET
-  "createdAt"=date_trunc('milliseconds', "createdAt"),
-  "updatedAt"=date_trunc('milliseconds', "updatedAt");
-UPDATE tasks SET
-  "createdAt"=date_trunc('milliseconds', "createdAt"),
-  "updatedAt"=date_trunc('milliseconds', "updatedAt"),
-  "plannedCompletion"=date_trunc('second', "updatedAt"),
-  "projectedCompletion"=date_trunc('second', "updatedAt");
-UPDATE locations SET
-  "createdAt"=date_trunc('milliseconds', "createdAt"),
-  "updatedAt"=date_trunc('milliseconds', "updatedAt");
-UPDATE "authorizationGroups" SET
-  "createdAt"=date_trunc('milliseconds', "createdAt"),
-  "updatedAt"=date_trunc('milliseconds', "updatedAt");
-UPDATE notes SET
-  "createdAt"=date_trunc('milliseconds', "createdAt"),
-  "updatedAt"=date_trunc('milliseconds', "updatedAt");
-UPDATE attachments SET
-  "createdAt"=date_trunc('milliseconds', "createdAt"),
-  "updatedAt"=date_trunc('milliseconds', "updatedAt");
-UPDATE assessments SET
-  "createdAt"=date_trunc('milliseconds', "createdAt"),
-  "updatedAt"=date_trunc('milliseconds', "updatedAt");

--- a/src/main/java/mil/dds/anet/AnetObjectEngine.java
+++ b/src/main/java/mil/dds/anet/AnetObjectEngine.java
@@ -46,6 +46,7 @@ import mil.dds.anet.database.SubscriptionDao;
 import mil.dds.anet.database.SubscriptionUpdateDao;
 import mil.dds.anet.database.TaskDao;
 import mil.dds.anet.database.UserActivityDao;
+import mil.dds.anet.database.UserDao;
 import mil.dds.anet.utils.AuthUtils;
 import mil.dds.anet.utils.BatchingUtils;
 import mil.dds.anet.utils.DaoUtils;
@@ -165,6 +166,10 @@ public class AnetObjectEngine {
 
   public AssessmentDao getAssessmentDao() {
     return ApplicationContextProvider.getBean(AssessmentDao.class);
+  }
+
+  public UserDao getUserDao() {
+    return ApplicationContextProvider.getBean(UserDao.class);
   }
 
   public CompletableFuture<Boolean> canUserApproveStep(GraphQLContext context, String userUuid,

--- a/src/main/java/mil/dds/anet/beans/Person.java
+++ b/src/main/java/mil/dds/anet/beans/Person.java
@@ -75,9 +75,8 @@ public class Person extends AbstractEmailableAnetBean
   @GraphQLQuery
   @GraphQLInputField
   private String biography;
-  @GraphQLQuery
-  @GraphQLInputField
-  private String domainUsername;
+  // annotated below
+  private List<User> users;
   // annotated below
   private Position position;
   // annotated below
@@ -227,13 +226,26 @@ public class Person extends AbstractEmailableAnetBean
     this.biography = Utils.trimStringReturnNull(biography);
   }
 
+  @GraphQLQuery(name = "users")
   @AllowUnverifiedUsers
-  public String getDomainUsername() {
-    return domainUsername;
+  public CompletableFuture<List<User>> loadUsers(@GraphQLRootContext GraphQLContext context) {
+    if (users != null) {
+      return CompletableFuture.completedFuture(users);
+    } else {
+      return engine().getUserDao().getUsersForPerson(context, uuid).thenApply(o -> {
+        users = o;
+        return o;
+      });
+    }
   }
 
-  public void setDomainUsername(String domainUsername) {
-    this.domainUsername = domainUsername;
+  public List<User> getUsers() {
+    return users;
+  }
+
+  @GraphQLInputField(name = "users")
+  public void setUsers(List<User> users) {
+    this.users = users;
   }
 
   @GraphQLQuery(name = "position")
@@ -406,7 +418,6 @@ public class Person extends AbstractEmailableAnetBean
         && Objects.equals(other.getUser(), user)
         && Objects.equals(other.getPhoneNumber(), phoneNumber)
         && Objects.equals(other.getRank(), rank) && Objects.equals(other.getBiography(), biography)
-        && Objects.equals(other.getDomainUsername(), domainUsername)
         && Objects.equals(other.getPendingVerification(), pendingVerification)
         && Objects.equals(other.getCode(), code)
         && (createdAt != null ? createdAt.equals(other.getCreatedAt())
@@ -418,7 +429,7 @@ public class Person extends AbstractEmailableAnetBean
   @Override
   public int hashCode() {
     return Objects.hash(super.hashCode(), uuid, name, status, user, phoneNumber, rank, biography,
-        domainUsername, pendingVerification, code, createdAt, updatedAt);
+        pendingVerification, code, createdAt, updatedAt);
   }
 
   @Override

--- a/src/main/java/mil/dds/anet/beans/User.java
+++ b/src/main/java/mil/dds/anet/beans/User.java
@@ -1,0 +1,31 @@
+package mil.dds.anet.beans;
+
+import io.leangen.graphql.annotations.GraphQLInputField;
+import io.leangen.graphql.annotations.GraphQLQuery;
+import mil.dds.anet.graphql.AllowUnverifiedUsers;
+import mil.dds.anet.views.AbstractAnetBean;
+
+public class User extends AbstractAnetBean {
+  @GraphQLQuery
+  @GraphQLInputField
+  private String domainUsername;
+  // Not exposed through GraphQL
+  private String personUuid;
+
+  @AllowUnverifiedUsers
+  public String getDomainUsername() {
+    return domainUsername;
+  }
+
+  public void setDomainUsername(String domainUsername) {
+    this.domainUsername = domainUsername;
+  }
+
+  public String getPersonUuid() {
+    return personUuid;
+  }
+
+  public void setPersonUuid(String personUuid) {
+    this.personUuid = personUuid;
+  }
+}

--- a/src/main/java/mil/dds/anet/commands/InitializationCommand.java
+++ b/src/main/java/mil/dds/anet/commands/InitializationCommand.java
@@ -9,6 +9,7 @@ import mil.dds.anet.beans.ApprovalStep;
 import mil.dds.anet.beans.Organization;
 import mil.dds.anet.beans.Person;
 import mil.dds.anet.beans.Position;
+import mil.dds.anet.beans.User;
 import mil.dds.anet.beans.WithStatus.Status;
 import mil.dds.anet.beans.search.OrganizationSearchQuery;
 import mil.dds.anet.beans.search.PersonSearchQuery;
@@ -114,13 +115,18 @@ public class InitializationCommand {
     adminPos.setRole(Position.PositionRole.MEMBER);
     adminPos = engine.getPositionDao().insert(adminPos);
 
-    // Create admin user
+    // Create admin person
     Person admin = new Person();
     admin.setName(adminFullName);
-    admin.setDomainUsername(adminDomainUsername);
     admin.setUser(true);
     admin = engine.getPersonDao().insert(admin);
     engine.getPositionDao().setPersonInPosition(admin.getUuid(), adminPos.getUuid());
+
+    // Create admin user
+    User user = new User();
+    user.setDomainUsername(adminDomainUsername);
+    user.setPersonUuid(admin.getUuid());
+    engine.getUserDao().insert(user);
 
     // Create default approval workflow
     final ApprovalStep defaultStep = new ApprovalStep();

--- a/src/main/java/mil/dds/anet/database/UserDao.java
+++ b/src/main/java/mil/dds/anet/database/UserDao.java
@@ -1,0 +1,133 @@
+package mil.dds.anet.database;
+
+import graphql.GraphQLContext;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import mil.dds.anet.beans.Person;
+import mil.dds.anet.beans.User;
+import mil.dds.anet.beans.search.AbstractSearchQuery;
+import mil.dds.anet.database.mappers.UserMapper;
+import mil.dds.anet.utils.DaoUtils;
+import mil.dds.anet.utils.FkDataLoaderKey;
+import mil.dds.anet.utils.ResponseUtils;
+import mil.dds.anet.utils.Utils;
+import mil.dds.anet.views.ForeignKeyFetcher;
+import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.core.statement.UnableToExecuteStatementException;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+public class UserDao extends AnetBaseDao<User, AbstractSearchQuery<?>> {
+  public static final String[] fields =
+      {"uuid", "domainUsername", "personUuid", "createdAt", "updatedAt"};
+  public static final String TABLE_NAME = "users";
+  public static final String USER_FIELDS = DaoUtils.buildFieldAliases(TABLE_NAME, fields, true);
+  private static final String DUPLICATE_USER_DOMAIN_USERNAME =
+      "Another user is already using domain username \"%s\".";
+
+  public UserDao(DatabaseHandler databaseHandler) {
+    super(databaseHandler);
+  }
+
+  @Override
+  public User getByUuid(String uuid) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public List<User> getByIds(List<String> uuids) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Transactional
+  public User insertInternal(User u) {
+    final Handle handle = getDbHandle();
+    try {
+      final String sql =
+          "/* userInsert */ INSERT INTO users (uuid, \"domainUsername\", \"personUuid\", "
+              + "\"createdAt\", \"updatedAt\") "
+              + "VALUES (:uuid, :domainUsername, :personUuid, :createdAt, :updatedAt)";
+      handle.createUpdate(sql).bindBean(u)
+          .bind("createdAt", DaoUtils.asLocalDateTime(u.getCreatedAt()))
+          .bind("updatedAt", DaoUtils.asLocalDateTime(u.getUpdatedAt())).execute();
+      return u;
+    } catch (UnableToExecuteStatementException e) {
+      throw ResponseUtils.handleSqlException(e,
+          String.format(DUPLICATE_USER_DOMAIN_USERNAME, u.getDomainUsername()));
+    } finally {
+      closeDbHandle(handle);
+    }
+  }
+
+  @Transactional
+  public int updateInternal(User u) {
+    final Handle handle = getDbHandle();
+    try {
+      return handle
+          .createUpdate("/* updateUser */ UPDATE users "
+              + "SET \"domainUsername\" = :domainUsername, \"personUuid\" = :personUuid, "
+              + "\"updatedAt\" = :updatedAt WHERE uuid = :uuid")
+          .bindBean(u).bind("updatedAt", DaoUtils.asLocalDateTime(u.getUpdatedAt())).execute();
+    } catch (UnableToExecuteStatementException e) {
+      throw ResponseUtils.handleSqlException(e,
+          String.format(DUPLICATE_USER_DOMAIN_USERNAME, u.getDomainUsername()));
+    } finally {
+      closeDbHandle(handle);
+    }
+  }
+
+  @Transactional
+  public int deleteInternal(String uuid) {
+    final Handle handle = getDbHandle();
+    try {
+      return handle.createUpdate("/* deleteUser */ DELETE FROM users WHERE uuid = :uuid")
+          .bind("uuid", uuid).execute();
+    } finally {
+      closeDbHandle(handle);
+    }
+  }
+
+  @Transactional
+  public void updateUsers(Person person, List<User> users) {
+    final Person existing = engine().getPersonDao().getByUuid(person.getUuid());
+    Utils.updateElementsByUuid(existing.loadUsers(engine().getContext()).join(),
+        Utils.orIfNull(users, List.of()),
+        // Create new user:
+        newUser -> {
+          if (!Utils.isEmptyOrNull(newUser.getDomainUsername())) {
+            newUser.setPersonUuid(person.getUuid());
+            insert(newUser);
+          }
+        },
+        // Delete old user:
+        oldUser -> delete(DaoUtils.getUuid(oldUser)),
+        // Update existing user:
+        updatedUser -> {
+          if (Utils.isEmptyOrNull(updatedUser.getDomainUsername())) {
+            delete(DaoUtils.getUuid(updatedUser));
+          } else {
+            updatedUser.setPersonUuid(person.getUuid());
+            update(updatedUser);
+          }
+        });
+  }
+
+  public CompletableFuture<List<User>> getUsersForPerson(GraphQLContext context,
+      String personUuid) {
+    return new ForeignKeyFetcher<User>().load(context, FkDataLoaderKey.USER_PERSON, personUuid);
+  }
+
+  class UsersBatcher extends ForeignKeyBatcher<User> {
+    private static final String SQL = "/* batch.getUsersForPerson */ SELECT " + USER_FIELDS
+        + "FROM users WHERE users.\"personUuid\" IN ( <foreignKeys> ) ORDER BY \"domainUsername\"";
+
+    public UsersBatcher() {
+      super(UserDao.this.databaseHandler, SQL, "foreignKeys", new UserMapper(), "users_personUuid");
+    }
+  }
+
+  public List<List<User>> getUsers(List<String> foreignKeys) {
+    return new UserDao.UsersBatcher().getByForeignKeys(foreignKeys);
+  }
+}

--- a/src/main/java/mil/dds/anet/database/mappers/PersonMapper.java
+++ b/src/main/java/mil/dds/anet/database/mappers/PersonMapper.java
@@ -2,8 +2,10 @@ package mil.dds.anet.database.mappers;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.List;
 import mil.dds.anet.beans.Person;
 import mil.dds.anet.beans.Position;
+import mil.dds.anet.beans.User;
 import org.jdbi.v3.core.mapper.RowMapper;
 import org.jdbi.v3.core.statement.StatementContext;
 
@@ -15,6 +17,10 @@ public class PersonMapper implements RowMapper<Person> {
 
     if (MapperUtils.containsColumnNamed(rs, "positions_uuid")) {
       p.setPosition(PositionMapper.fillInFields(new Position(), rs));
+    }
+
+    if (MapperUtils.containsColumnNamed(rs, "users_uuid")) {
+      p.setUsers(List.of(UserMapper.fillInFields(new User(), rs)));
     }
 
     if (MapperUtils.containsColumnNamed(rs, "totalCount")) {
@@ -40,7 +46,6 @@ public class PersonMapper implements RowMapper<Person> {
     a.setEndOfTourDate(MapperUtils.getInstantAsLocalDateTime(rs, "people_endOfTourDate"));
     a.setRank(MapperUtils.getOptionalString(rs, "people_rank"));
     a.setBiography(MapperUtils.getOptionalString(rs, "people_biography"));
-    a.setDomainUsername(MapperUtils.getOptionalString(rs, "people_domainUsername"));
     a.setPendingVerification(MapperUtils.getOptionalBoolean(rs, "people_pendingVerification"));
 
     return a;

--- a/src/main/java/mil/dds/anet/database/mappers/UserMapper.java
+++ b/src/main/java/mil/dds/anet/database/mappers/UserMapper.java
@@ -1,0 +1,28 @@
+package mil.dds.anet.database.mappers;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import mil.dds.anet.beans.User;
+import org.jdbi.v3.core.mapper.RowMapper;
+import org.jdbi.v3.core.statement.StatementContext;
+
+public class UserMapper implements RowMapper<User> {
+
+  @Override
+  public User map(ResultSet rs, StatementContext ctx) throws SQLException {
+    // This hits when we do a join but there's no User record.
+    if (rs.getObject("users_uuid") == null) {
+      return null;
+    }
+
+    return fillInFields(new User(), rs);
+  }
+
+  public static User fillInFields(User u, ResultSet rs) throws SQLException {
+    MapperUtils.setCommonBeanFields(u, rs, "users");
+    u.setUuid(rs.getString("users_uuid"));
+    u.setDomainUsername(rs.getString("users_domainUsername"));
+    u.setPersonUuid(rs.getString("users_personUuid"));
+    return u;
+  }
+}

--- a/src/main/java/mil/dds/anet/utils/BatchingUtils.java
+++ b/src/main/java/mil/dds/anet/utils/BatchingUtils.java
@@ -29,6 +29,7 @@ import mil.dds.anet.beans.ReportPerson;
 import mil.dds.anet.beans.ReportSensitiveInformation;
 import mil.dds.anet.beans.Subscription;
 import mil.dds.anet.beans.Task;
+import mil.dds.anet.beans.User;
 import mil.dds.anet.beans.search.OrganizationSearchQuery;
 import mil.dds.anet.beans.search.PositionSearchQuery;
 import mil.dds.anet.beans.search.ReportSearchQuery;
@@ -345,6 +346,11 @@ public final class BatchingUtils {
         DataLoaderFactory.newDataLoader(
             (BatchLoader<String, List<Organization>>) foreignKeys -> CompletableFuture.supplyAsync(
                 () -> engine.getTaskDao().getTaskedOrganizations(foreignKeys), dispatcherService),
+            dataLoaderOptions));
+    dataLoaderRegistry.register(FkDataLoaderKey.USER_PERSON.toString(),
+        DataLoaderFactory.newDataLoader(
+            (BatchLoader<String, List<User>>) foreignKeys -> CompletableFuture
+                .supplyAsync(() -> engine.getUserDao().getUsers(foreignKeys), dispatcherService),
             dataLoaderOptions));
   }
 

--- a/src/main/java/mil/dds/anet/utils/FkDataLoaderKey.java
+++ b/src/main/java/mil/dds/anet/utils/FkDataLoaderKey.java
@@ -33,4 +33,5 @@ public enum FkDataLoaderKey {
   REPORT_TASKS, // report.tasks
   TASK_RESPONSIBLE_POSITIONS, // task.responsiblePositions
   TASK_TASKED_ORGANIZATIONS, // task.taskedOrganizations
+  USER_PERSON, // user.person
 }

--- a/src/main/java/mil/dds/anet/views/UserActivityFilter.java
+++ b/src/main/java/mil/dds/anet/views/UserActivityFilter.java
@@ -30,7 +30,7 @@ public class UserActivityFilter extends OncePerRequestFilter {
       final Activity activity = new Activity(ResponseUtils.getRemoteAddr(request),
           ResponseUtils.getReferer(request), DaoUtils.getCurrentMinute());
       ApplicationContextProvider.getEngine().getPersonDao()
-          .logActivitiesByDomainUsername(person.getDomainUsername(), activity);
+          .logActivitiesByPersonUuid(DaoUtils.getUuid(person), activity);
       // Store this request in the database (only once per minute)
       final Position position = person.getPosition();
       final UserActivity userActivity = new UserActivity(person.getUuid(),

--- a/src/main/resources/anet-schema.yml
+++ b/src/main/resources/anet-schema.yml
@@ -917,7 +917,7 @@ properties:
       person:
         type: object
         additionalProperties: false
-        required: [status, firstName, lastName, position, prevPositions, domainUsername,
+        required: [status, firstName, lastName, position, prevPositions, users,
                    emailAddresses, phoneNumber, country, code, rank, ranks, gender, endOfTourDate,
                    biography, authorizationGroups]
         properties:
@@ -933,8 +933,8 @@ properties:
             "$ref": "#/$defs/labeledField"
           user:
             "$ref": "#/$defs/inputField"
-          domainUsername:
-            "$ref": "#/$defs/inputField"
+          users:
+            "$ref": "#/$defs/labeledField"
           emailAddresses:
             "$ref": "#/$defs/restrictableLabeledField"
           phoneNumber:

--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -6402,6 +6402,55 @@
 		</addColumn>
 	</changeSet>
 
+	<changeSet id="add-multiple-users-per-person" author="gjvoosten">
+		<!-- Create new table -->
+		<createTable tableName="users">
+			<column name="uuid" type="${uuid_type}">
+				<constraints primaryKey="true" nullable="false" />
+			</column>
+			<column name="domainUsername" type="varchar(512)">
+				<constraints nullable="false" />
+			</column>
+			<column name="personUuid" type="${uuid_type}">
+				<constraints nullable="false" />
+			</column>
+			<column name="createdAt" type="datetime" />
+			<column name="updatedAt" type="datetime" />
+		</createTable>
+
+		<addForeignKeyConstraint
+			constraintName="FK_users_person"
+			baseTableName="users"
+			baseColumnNames="personUuid"
+			referencedTableName="people"
+			referencedColumnNames="uuid"
+			onDelete="CASCADE" onUpdate="NO ACTION"
+		/>
+		<createIndex
+			tableName="users"
+			indexName="IDX_users_domainUsername">
+			<column name="domainUsername" />
+		</createIndex>
+		<addUniqueConstraint
+			tableName="users"
+			columnNames="domainUsername"
+			constraintName="UQ_UsersDomainUsername"
+		/>
+
+		<!-- Migrate existing domainUsername -->
+		<sql>
+			INSERT INTO users (uuid, "domainUsername", "personUuid")
+			SELECT ${uuid_function}, "domainUsername", uuid
+			FROM people
+			WHERE TRIM("domainUsername") != '';
+		</sql>
+
+		<!-- Drop old domainUsername column -->
+		<sql>
+			ALTER TABLE people DROP COLUMN "domainUsername" CASCADE;
+		</sql>
+	</changeSet>
+
 	<!-- Keep this change set as the last one in the change log;
 	     it will be re-run whenever it changes. -->
 	<changeSet id="set-up-full-text-search" runOnChange="true" author="gjvoosten">
@@ -6464,6 +6513,7 @@
 			ALTER TABLE positions DROP COLUMN IF EXISTS core_text;
 			ALTER TABLE reports DROP COLUMN IF EXISTS core_text;
 			ALTER TABLE tasks DROP COLUMN IF EXISTS core_text;
+			ALTER TABLE users DROP COLUMN IF EXISTS core_text;
 
 			<!-- Drop more_text columns -->
 			ALTER TABLE attachments DROP COLUMN IF EXISTS more_text;
@@ -6702,6 +6752,11 @@
 						|| to_tsvector('simple', coalesce(tasks."longName", '')), ${fts_high})
 				) STORED;
 
+			ALTER TABLE users
+				ADD COLUMN core_text tsvector GENERATED ALWAYS AS (
+					setweight(to_tsvector('simple', coalesce(users."domainUsername", '')), ${fts_low})
+				) STORED;
+
 			<!-- Add generated more_text columns -->
 			ALTER TABLE attachments
 				ADD COLUMN more_text tsvector GENERATED ALWAYS AS (
@@ -6745,7 +6800,6 @@
 
 			ALTER TABLE people
 				ADD COLUMN more_text tsvector GENERATED ALWAYS AS (
-					setweight(to_tsvector('simple', coalesce(people."domainUsername", '')), ${fts_high}) ||
 					setweight(to_tsvector('simple', coalesce(people."phoneNumber", '')), ${fts_high}) ||
 					setweight(to_tsvector(${fts_config}, coalesce(people.biography, ''))
 						|| to_tsvector('simple', coalesce(people.biography, '')), ${fts_low}) ||
@@ -7101,6 +7155,7 @@
 					|| coalesce(tsvector_agg(assessments.core_text), ''::tsvector)
 					|| coalesce(tsvector_agg(notes.core_text), ''::tsvector)
 					|| coalesce(tsvector_agg("emailAddresses".core_text), ''::tsvector)
+					|| coalesce(tsvector_agg(users.core_text), ''::tsvector)
 			FROM people
 			LEFT JOIN mv_lts_people ON people.uuid = mv_lts_people.uuid
 			LEFT JOIN positions ON positions."currentPersonUuid" = people.uuid
@@ -7113,6 +7168,7 @@
 			LEFT JOIN notes ON notes.uuid = "noteRelatedObjects"."noteUuid"
 			LEFT JOIN "emailAddresses" ON "emailAddresses"."relatedObjectType" = 'people'
 				AND "emailAddresses"."relatedObjectUuid" = people.uuid
+			LEFT JOIN users ON users."personUuid" = people.uuid
 			GROUP BY people.uuid
 			WITH DATA;
 			CREATE UNIQUE INDEX "UQ_mv_fts_people_uuid" ON mv_fts_people(uuid);

--- a/src/test/java/mil/dds/anet/test/emails/AccountDeactivationWorkerTest.java
+++ b/src/test/java/mil/dds/anet/test/emails/AccountDeactivationWorkerTest.java
@@ -13,6 +13,7 @@ import mil.dds.anet.beans.AnetEmail;
 import mil.dds.anet.beans.EmailAddress;
 import mil.dds.anet.beans.Person;
 import mil.dds.anet.beans.Position;
+import mil.dds.anet.beans.User;
 import mil.dds.anet.beans.WithStatus;
 import mil.dds.anet.beans.lists.AnetBeanList;
 import mil.dds.anet.config.AnetDictionary;
@@ -166,7 +167,11 @@ class AccountDeactivationWorkerTest extends AbstractResourceTest {
         new EmailAddress(Utils.getEmailNetworkForNotifications(), email);
     testPerson.setEmailAddresses(List.of(emailAddress));
     testPerson.setStatus(WithStatus.Status.ACTIVE);
-    testPerson.setDomainUsername(domainName);
+    final User testUser = new User();
+    testUser.setUuid(UUID.randomUUID().toString());
+    testUser.setDomainUsername(domainName);
+    testUser.setPersonUuid(testPerson.getUuid());
+    testPerson.setUsers(List.of(testUser));
     testPerson.setPosition(new Position());
     return testPerson;
   }

--- a/src/test/java/mil/dds/anet/test/integration/db/FutureEngagementWorkerTest.java
+++ b/src/test/java/mil/dds/anet/test/integration/db/FutureEngagementWorkerTest.java
@@ -178,7 +178,7 @@ class FutureEngagementWorkerTest extends AbstractResourceTest {
         getFutureDate(), null, Lists.newArrayList(advisor, interlocutor)));
 
     // Submit the report
-    withCredentials(author.getDomainUsername(),
+    withCredentials(getDomainUsername(author),
         t -> mutationExecutor.submitReport("", draftReport.getUuid()));
     // This planned report gets approved automatically
     final Report submittedReport = testReportState(draftReport.getUuid(), ReportState.APPROVED);
@@ -200,7 +200,7 @@ class FutureEngagementWorkerTest extends AbstractResourceTest {
     final Report redraftedReport = testReportDraft(updatedReport.getUuid());
 
     // Submit the report
-    withCredentials(author.getDomainUsername(),
+    withCredentials(getDomainUsername(author),
         t -> mutationExecutor.submitReport("", redraftedReport.getUuid()));
     // This should send an email to the approver
     expectedIds.add("jacob");

--- a/src/test/java/mil/dds/anet/test/integration/db/MergedEntityWorkerTest.java
+++ b/src/test/java/mil/dds/anet/test/integration/db/MergedEntityWorkerTest.java
@@ -298,7 +298,7 @@ class MergedEntityWorkerTest extends AbstractResourceTest {
         .withReportText(getRichText(ReportDao.TABLE_NAME, testOldUuid))
         .withCustomFields(getJsonString(ReportDao.TABLE_NAME, testOldUuid))
         .withReportSensitiveInformation(rsiInput).build();
-    final Report created = withCredentials(author.getDomainUsername(),
+    final Report created = withCredentials(getDomainUsername(author),
         t -> mutationExecutor.createReport(ReportResourceTest.FIELDS, input));
     assertContains(created.getReportText(), testOldUuid);
     assertContains(created.getCustomFields(), testOldUuid);
@@ -308,7 +308,7 @@ class MergedEntityWorkerTest extends AbstractResourceTest {
     runMergedEntityWorker(testOldUuid, testNewUuid);
 
     // assert that the entity refs have been updated
-    final Report updated = withCredentials(author.getDomainUsername(),
+    final Report updated = withCredentials(getDomainUsername(author),
         t -> queryExecutor.report(ReportResourceTest.FIELDS, created.getUuid()));
     assertDoesNotContain(updated.getReportText(), testOldUuid);
     assertDoesNotContain(updated.getCustomFields(), testOldUuid);
@@ -318,7 +318,7 @@ class MergedEntityWorkerTest extends AbstractResourceTest {
     assertContains(updated.getReportSensitiveInformation().getText(), testNewUuid);
 
     // clean up
-    withCredentials(author.getDomainUsername(),
+    withCredentials(getDomainUsername(author),
         t -> mutationExecutor.deleteReport("", updated.getUuid()));
   }
 

--- a/src/test/java/mil/dds/anet/test/integration/utils/TestBeans.java
+++ b/src/test/java/mil/dds/anet/test/integration/utils/TestBeans.java
@@ -12,6 +12,7 @@ import mil.dds.anet.beans.Report;
 import mil.dds.anet.beans.Report.Atmosphere;
 import mil.dds.anet.beans.Report.ReportState;
 import mil.dds.anet.beans.ReportPerson;
+import mil.dds.anet.beans.User;
 import mil.dds.anet.utils.DaoUtils;
 
 public class TestBeans {
@@ -23,7 +24,9 @@ public class TestBeans {
     p.setRank("CIV");
     p.setStatus(Person.Status.ACTIVE);
     p.setBiography("");
-    p.setDomainUsername("test-" + UUID.randomUUID());
+    User u = new User();
+    u.setDomainUsername("test-" + UUID.randomUUID());
+    p.setUsers(List.of(u));
     p.setGender("Male");
     p.setEndOfTourDate(
         ZonedDateTime.of(2036, 8, 1, 0, 0, 0, 0, DaoUtils.getServerNativeZoneId()).toInstant());

--- a/src/test/java/mil/dds/anet/test/resources/AdminResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/AdminResourceTest.java
@@ -79,15 +79,15 @@ class AdminResourceTest extends AbstractResourceTest {
     final Position position = user.getPosition();
     final boolean isAdmin = position.getType() == PositionType.ADMINISTRATOR;
 
-    final List<AdminSetting> settings = withCredentials(user.getDomainUsername(),
-        t -> queryExecutor.adminSettings("{ key value }"));
+    final List<AdminSetting> settings =
+        withCredentials(getDomainUsername(user), t -> queryExecutor.adminSettings("{ key value }"));
     final List<AdminSettingInput> input = settings.stream()
         .map(
             as -> AdminSettingInput.builder().withKey(as.getKey()).withValue(as.getValue()).build())
         .toList();
 
     try {
-      final Integer nrUpdated = withCredentials(user.getDomainUsername(),
+      final Integer nrUpdated = withCredentials(getDomainUsername(user),
           t -> mutationExecutor.saveAdminSettings("", input));
       if (isAdmin) {
         assertThat(nrUpdated).isEqualTo(input.size());
@@ -105,11 +105,11 @@ class AdminResourceTest extends AbstractResourceTest {
     final boolean isAdmin = user.getPosition().getType() == PositionType.ADMINISTRATOR;
 
     // Cache a person
-    personDao.findByDomainUsername(user.getDomainUsername(), true);
+    personDao.findByDomainUsername(getDomainUsername(user), true);
 
     try {
       final String result =
-          withCredentials(user.getDomainUsername(), t -> mutationExecutor.clearCache(""));
+          withCredentials(getDomainUsername(user), t -> mutationExecutor.clearCache(""));
       if (isAdmin) {
         assertThat(result).isEqualTo(AnetConstants.USERCACHE_MESSAGE);
       } else {
@@ -127,7 +127,7 @@ class AdminResourceTest extends AbstractResourceTest {
 
     try {
       final String result =
-          withCredentials(user.getDomainUsername(), t -> mutationExecutor.reloadDictionary(""));
+          withCredentials(getDomainUsername(user), t -> mutationExecutor.reloadDictionary(""));
       if (isAdmin) {
         assertThat(result).isEqualTo(AnetConstants.DICTIONARY_RELOAD_MESSAGE);
       } else {
@@ -141,15 +141,14 @@ class AdminResourceTest extends AbstractResourceTest {
   }
 
   private void recentActivities(Person user) {
-    final String recentActivityFields =
-        "user { uuid rank name domainUsername } activity { time ip request }";
+    final String recentActivityFields = "user { uuid rank name } activity { time ip request }";
     final String fields =
         String.format("{ byActivity { %1$s } byUser { %1$s } }", recentActivityFields);
     final boolean isAdmin = user.getPosition().getType() == PositionType.ADMINISTRATOR;
 
     try {
       final RecentActivities recentActivities =
-          withCredentials(user.getDomainUsername(), t -> queryExecutor.recentActivities(fields));
+          withCredentials(getDomainUsername(user), t -> queryExecutor.recentActivities(fields));
       if (isAdmin) {
         assertThat(recentActivities.getByUser()).isNotEmpty();
         assertThat(recentActivities.getByActivity()).isNotEmpty();

--- a/src/test/java/mil/dds/anet/test/resources/AssessmentResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/AssessmentResourceTest.java
@@ -343,12 +343,12 @@ class AssessmentResourceTest extends AbstractResourceTest {
         succeedAssessmentCreate(adminUser, testAssessmentInputAdmin);
 
     // - F: read it as someone not in the read and write auth.groups
-    final Person bobPerson = withCredentials(getBobBobtown().getDomainUsername(),
+    final Person bobPerson = withCredentials(getDomainUsername(getBobBobtown()),
         t -> queryExecutor.person(PERSON_FIELDS, interlocutorPersonUuid));
     assertAssessments(bobPerson.getAssessments(), Collections.emptyList(), assessmentKey, 1);
 
     // - S: read it as someone in the read auth.groups
-    final Person erinPerson = withCredentials(getRegularUser().getDomainUsername(),
+    final Person erinPerson = withCredentials(getDomainUsername(getRegularUser()),
         t -> queryExecutor.person(PERSON_FIELDS, interlocutorPersonUuid));
     final List<Assessment> testAssessments = erinPerson.getAssessments();
     assertAssessments(testAssessments, testAssessmentInputs, assessmentKey, 1);
@@ -387,7 +387,7 @@ class AssessmentResourceTest extends AbstractResourceTest {
     succeedAssessmentDelete(jackUser, updatedAssessmentAdmin);
     assertThat(updatedAssessmentsInput.remove(updatedAssessmentInputAdmin)).isTrue();
     assertAssessments(
-        withCredentials(getRegularUser().getDomainUsername(),
+        withCredentials(getDomainUsername(getRegularUser()),
             t -> queryExecutor.person(PERSON_FIELDS, interlocutorPersonUuid)).getAssessments(),
         updatedAssessmentsInput, assessmentKey, 1);
 
@@ -395,7 +395,7 @@ class AssessmentResourceTest extends AbstractResourceTest {
     succeedAssessmentDelete(adminUser, updatedAssessmentJack);
     assertThat(updatedAssessmentsInput.remove(updatedAssessmentInputJack)).isTrue();
     assertAssessments(
-        withCredentials(getRegularUser().getDomainUsername(),
+        withCredentials(getDomainUsername(getRegularUser()),
             t -> queryExecutor.person(PERSON_FIELDS, interlocutorPersonUuid)).getAssessments(),
         updatedAssessmentsInput, assessmentKey, 1);
   }
@@ -491,28 +491,28 @@ class AssessmentResourceTest extends AbstractResourceTest {
 
     // - F: create without relatedObjects
     AssessmentInput testAssessmentInputFail = createAssessment(assessmentKey, "test", recurrence);
-    failAssessmentCreate(getRegularUser().getDomainUsername(), testAssessmentInputFail);
+    failAssessmentCreate(getDomainUsername(getRegularUser()), testAssessmentInputFail);
 
     // - F: create for a report
     final GenericRelatedObjectInput testReportNroInput =
         createAssessmentRelatedObject(ReportDao.TABLE_NAME, TEST_REPORT_UUID);
     testAssessmentInputFail =
         createAssessment(assessmentKey, "test", recurrence, testReportNroInput);
-    failAssessmentCreate(getRegularUser().getDomainUsername(), testAssessmentInputFail);
+    failAssessmentCreate(getDomainUsername(getRegularUser()), testAssessmentInputFail);
 
     // - F: create for a report and a person
     final GenericRelatedObjectInput testInterlocutorNroInput =
         createAssessmentRelatedObject(PersonDao.TABLE_NAME, TEST_COUNTERPART_PERSON_UUID);
     testAssessmentInputFail = createAssessment(assessmentKey, "test", recurrence,
         testReportNroInput, testInterlocutorNroInput);
-    failAssessmentCreate(getRegularUser().getDomainUsername(), testAssessmentInputFail);
+    failAssessmentCreate(getDomainUsername(getRegularUser()), testAssessmentInputFail);
 
     // - S: create for a person as someone with counterpart not in the write auth.groups
     final AssessmentInput testAssessmentInput =
         createAssessment(assessmentKey, "erin", recurrence, testInterlocutorNroInput);
     final List<AssessmentInput> testAssessmentInputs = Lists.newArrayList(testAssessmentInput);
     final Assessment createdAssessment =
-        succeedAssessmentCreate(getRegularUser().getDomainUsername(), testAssessmentInput);
+        succeedAssessmentCreate(getDomainUsername(getRegularUser()), testAssessmentInput);
 
     // - F: create for a person as someone without counterpart not in the write auth.groups
     testAssessmentInputFail =
@@ -534,12 +534,12 @@ class AssessmentResourceTest extends AbstractResourceTest {
         succeedAssessmentCreate(adminUser, testAssessmentInputAdmin);
 
     // - F: read it as someone not in the read and write auth.groups
-    final Person bobPerson = withCredentials(getBobBobtown().getDomainUsername(),
+    final Person bobPerson = withCredentials(getDomainUsername(getBobBobtown()),
         t -> queryExecutor.person(PERSON_FIELDS, TEST_COUNTERPART_PERSON_UUID));
     assertAssessments(bobPerson.getAssessments(), Collections.emptyList(), assessmentKey, 1);
 
     // - S: read it as someone in the read auth.groups
-    final Person reinaPerson = withCredentials(getReinaReinton().getDomainUsername(),
+    final Person reinaPerson = withCredentials(getDomainUsername(getReinaReinton()),
         t -> queryExecutor.person(PERSON_FIELDS, TEST_COUNTERPART_PERSON_UUID));
     assertAssessments(reinaPerson.getAssessments(), testAssessmentInputs, assessmentKey, 1);
 
@@ -555,7 +555,7 @@ class AssessmentResourceTest extends AbstractResourceTest {
     final List<AssessmentInput> updatedAssessmentsInput =
         Lists.newArrayList(updatedAssessmentInput);
     final Assessment updatedAssessment =
-        succeedAssessmentUpdate(getRegularUser().getDomainUsername(), updatedAssessmentInput);
+        succeedAssessmentUpdate(getDomainUsername(getRegularUser()), updatedAssessmentInput);
 
     // - F: update it as someone without counterpart not in the write auth.groups
     final AssessmentInput updatedAssessmentInputReina = getAssessmentInput(createdAssessment);
@@ -584,9 +584,9 @@ class AssessmentResourceTest extends AbstractResourceTest {
     failAssessmentDelete("reina", updatedAssessment);
 
     // - S: delete it as someone with counterpart not in the write auth.groups
-    succeedAssessmentDelete(getRegularUser().getDomainUsername(), updatedAssessment);
+    succeedAssessmentDelete(getDomainUsername(getRegularUser()), updatedAssessment);
     assertThat(updatedAssessmentsInput.remove(updatedAssessmentInput)).isTrue();
-    assertAssessments(withCredentials(getReinaReinton().getDomainUsername(),
+    assertAssessments(withCredentials(getDomainUsername(getReinaReinton()),
         t -> queryExecutor.person(PERSON_FIELDS, TEST_COUNTERPART_PERSON_UUID)).getAssessments(),
         updatedAssessmentsInput, assessmentKey, 1);
 
@@ -594,14 +594,14 @@ class AssessmentResourceTest extends AbstractResourceTest {
     // assessment author shouldn't matter
     succeedAssessmentDelete(jackUser, updatedAssessmentAdmin);
     assertThat(updatedAssessmentsInput.remove(updatedAssessmentInputAdmin)).isTrue();
-    assertAssessments(withCredentials(getReinaReinton().getDomainUsername(),
+    assertAssessments(withCredentials(getDomainUsername(getReinaReinton()),
         t -> queryExecutor.person(PERSON_FIELDS, TEST_COUNTERPART_PERSON_UUID)).getAssessments(),
         updatedAssessmentsInput, assessmentKey, 1);
 
     // - S: delete it as admin
     succeedAssessmentDelete(adminUser, updatedAssessmentJack);
     assertThat(updatedAssessmentsInput.remove(updatedAssessmentInputJack)).isTrue();
-    assertAssessments(withCredentials(getReinaReinton().getDomainUsername(),
+    assertAssessments(withCredentials(getDomainUsername(getReinaReinton()),
         t -> queryExecutor.person(PERSON_FIELDS, TEST_COUNTERPART_PERSON_UUID)).getAssessments(),
         updatedAssessmentsInput, assessmentKey, 1);
   }
@@ -628,10 +628,10 @@ class AssessmentResourceTest extends AbstractResourceTest {
         createAssessment(assessmentKey, "erin", recurrence, testPersonNroInput);
     final List<AssessmentInput> testAssessmentInputs = Lists.newArrayList(testAssessmentInput);
     final Assessment createdAssessment =
-        succeedAssessmentCreate(getRegularUser().getDomainUsername(), testAssessmentInput);
+        succeedAssessmentCreate(getDomainUsername(getRegularUser()), testAssessmentInput);
 
     // - S: read it with no read auth.groups defined in the dictionary
-    final Person andrewPerson = withCredentials(getAndrewAnderson().getDomainUsername(),
+    final Person andrewPerson = withCredentials(getDomainUsername(getAndrewAnderson()),
         t -> queryExecutor.person(PERSON_FIELDS, TEST_COUNTERPART_PERSON_UUID));
     assertAssessments(andrewPerson.getAssessments(), testAssessmentInputs, assessmentKey, 1);
 
@@ -650,7 +650,7 @@ class AssessmentResourceTest extends AbstractResourceTest {
     final List<AssessmentInput> updatedAssessmentsInput =
         Lists.newArrayList(updatedAssessmentInput);
     final Assessment updatedAssessment =
-        succeedAssessmentUpdate(getRegularUser().getDomainUsername(), updatedAssessmentInput);
+        succeedAssessmentUpdate(getDomainUsername(getRegularUser()), updatedAssessmentInput);
 
     // - F: delete it as someone without counterpart and with empty write auth.groups defined in the
     // dictionary
@@ -658,9 +658,9 @@ class AssessmentResourceTest extends AbstractResourceTest {
 
     // - S: delete it as someone with counterpart and with empty write auth.groups defined in the
     // dictionary
-    succeedAssessmentDelete(getRegularUser().getDomainUsername(), updatedAssessment);
+    succeedAssessmentDelete(getDomainUsername(getRegularUser()), updatedAssessment);
     assertThat(updatedAssessmentsInput.remove(updatedAssessmentInput)).isTrue();
-    assertAssessments(withCredentials(getAndrewAnderson().getDomainUsername(),
+    assertAssessments(withCredentials(getDomainUsername(getAndrewAnderson()),
         t -> queryExecutor.person(PERSON_FIELDS, TEST_COUNTERPART_PERSON_UUID)).getAssessments(),
         updatedAssessmentsInput, assessmentKey, 1);
   }
@@ -680,10 +680,10 @@ class AssessmentResourceTest extends AbstractResourceTest {
         createAssessment(assessmentKey, "andrew", recurrence, testPersonNroInput);
     final List<AssessmentInput> testAssessmentInputs = Lists.newArrayList(testAssessmentInput);
     final Assessment createdAssessment =
-        succeedAssessmentCreate(getRegularUser().getDomainUsername(), testAssessmentInput);
+        succeedAssessmentCreate(getDomainUsername(getRegularUser()), testAssessmentInput);
 
     // - S: read it with no auth.groups defined in the dictionary
-    final Person andrewPerson = withCredentials(getAndrewAnderson().getDomainUsername(),
+    final Person andrewPerson = withCredentials(getDomainUsername(getAndrewAnderson()),
         t -> queryExecutor.person(PERSON_FIELDS, TEST_COUNTERPART_PERSON_UUID));
     assertAssessments(andrewPerson.getAssessments(), testAssessmentInputs, assessmentKey, 1);
 
@@ -696,13 +696,13 @@ class AssessmentResourceTest extends AbstractResourceTest {
     final List<AssessmentInput> updatedAssessmentsInput =
         Lists.newArrayList(updatedAssessmentInput);
     final Assessment updatedAssessment =
-        succeedAssessmentUpdate(getRegularUser().getDomainUsername(), updatedAssessmentInput);
+        succeedAssessmentUpdate(getDomainUsername(getRegularUser()), updatedAssessmentInput);
 
     // - S: delete it as someone without counterpart and with no auth.groups defined in the
     // dictionary
     succeedAssessmentDelete("andrew", updatedAssessment);
     assertThat(updatedAssessmentsInput.remove(updatedAssessmentInput)).isTrue();
-    assertAssessments(withCredentials(getAndrewAnderson().getDomainUsername(),
+    assertAssessments(withCredentials(getDomainUsername(getAndrewAnderson()),
         t -> queryExecutor.person(PERSON_FIELDS, TEST_COUNTERPART_PERSON_UUID)).getAssessments(),
         updatedAssessmentsInput, assessmentKey, 1);
   }
@@ -716,28 +716,28 @@ class AssessmentResourceTest extends AbstractResourceTest {
 
     // - F: create without relatedObjects
     AssessmentInput testAssessmentInputFail = createAssessment(assessmentKey, "test", recurrence);
-    failAssessmentCreate(taskResponsible.getDomainUsername(), testAssessmentInputFail);
+    failAssessmentCreate(getDomainUsername(taskResponsible), testAssessmentInputFail);
 
     // - F: create for a report
     final GenericRelatedObjectInput testReportNroInput =
         createAssessmentRelatedObject(ReportDao.TABLE_NAME, TEST_REPORT_UUID);
     testAssessmentInputFail =
         createAssessment(assessmentKey, "test", recurrence, testReportNroInput);
-    failAssessmentCreate(taskResponsible.getDomainUsername(), testAssessmentInputFail);
+    failAssessmentCreate(getDomainUsername(taskResponsible), testAssessmentInputFail);
 
     // - F: create for a report and a task
     final GenericRelatedObjectInput testTaskNroInput =
         createAssessmentRelatedObject(TaskDao.TABLE_NAME, TEST_TASK_12A_UUID);
     testAssessmentInputFail =
         createAssessment(assessmentKey, "test", recurrence, testReportNroInput, testTaskNroInput);
-    failAssessmentCreate(taskResponsible.getDomainUsername(), testAssessmentInputFail);
+    failAssessmentCreate(getDomainUsername(taskResponsible), testAssessmentInputFail);
 
     // - S: create for a task as someone with task permission not in the write auth.groups
     final AssessmentInput testAssessmentInput =
         createAssessment(assessmentKey, "andrew", recurrence, testTaskNroInput);
     final List<AssessmentInput> testAssessmentInputs = Lists.newArrayList(testAssessmentInput);
     final Assessment createdAssessment =
-        succeedAssessmentCreate(taskResponsible.getDomainUsername(), testAssessmentInput);
+        succeedAssessmentCreate(getDomainUsername(taskResponsible), testAssessmentInput);
 
     // - F: create for a task as someone without task permission not in the write auth.groups
     testAssessmentInputFail = createAssessment(assessmentKey, "erin", recurrence, testTaskNroInput);
@@ -758,12 +758,12 @@ class AssessmentResourceTest extends AbstractResourceTest {
         succeedAssessmentCreate(adminUser, testAssessmentInputAdmin);
 
     // - F: read it as someone not in the read and write auth.groups
-    final Task bobTask = withCredentials(getBobBobtown().getDomainUsername(),
+    final Task bobTask = withCredentials(getDomainUsername(getBobBobtown()),
         t -> queryExecutor.task(TASK_FIELDS, TEST_TASK_12A_UUID));
     assertAssessments(bobTask.getAssessments(), Collections.emptyList(), assessmentKey, 1);
 
     // - S: read it as someone in the read auth.groups
-    final Task erinTask = withCredentials(getRegularUser().getDomainUsername(),
+    final Task erinTask = withCredentials(getDomainUsername(getRegularUser()),
         t -> queryExecutor.task(TASK_FIELDS, TEST_TASK_12A_UUID));
     assertAssessments(erinTask.getAssessments(), testAssessmentInputs, assessmentKey, 1);
 
@@ -779,7 +779,7 @@ class AssessmentResourceTest extends AbstractResourceTest {
     final List<AssessmentInput> updatedAssessmentsInput =
         Lists.newArrayList(updatedAssessmentInput);
     final Assessment updatedAssessment =
-        succeedAssessmentUpdate(taskResponsible.getDomainUsername(), updatedAssessmentInput);
+        succeedAssessmentUpdate(getDomainUsername(taskResponsible), updatedAssessmentInput);
 
     // - F: update it as someone without task permission not in the write auth.groups
     final AssessmentInput updatedAssessmentInputErin = getAssessmentInput(createdAssessment);
@@ -808,10 +808,10 @@ class AssessmentResourceTest extends AbstractResourceTest {
     failAssessmentDelete("erin", createdAssessment);
 
     // - S: delete it as someone with task permission not in the write auth.groups
-    succeedAssessmentDelete(taskResponsible.getDomainUsername(), updatedAssessment);
+    succeedAssessmentDelete(getDomainUsername(taskResponsible), updatedAssessment);
     assertThat(updatedAssessmentsInput.remove(updatedAssessmentInput)).isTrue();
     assertAssessments(
-        withCredentials(getRegularUser().getDomainUsername(),
+        withCredentials(getDomainUsername(getRegularUser()),
             t -> queryExecutor.task(TASK_FIELDS, TEST_TASK_12A_UUID)).getAssessments(),
         updatedAssessmentsInput, assessmentKey, 1);
 
@@ -820,7 +820,7 @@ class AssessmentResourceTest extends AbstractResourceTest {
     succeedAssessmentDelete(jackUser, updatedAssessmentAdmin);
     assertThat(updatedAssessmentsInput.remove(updatedAssessmentInputAdmin)).isTrue();
     assertAssessments(
-        withCredentials(getRegularUser().getDomainUsername(),
+        withCredentials(getDomainUsername(getRegularUser()),
             t -> queryExecutor.task(TASK_FIELDS, TEST_TASK_12A_UUID)).getAssessments(),
         updatedAssessmentsInput, assessmentKey, 1);
 
@@ -828,7 +828,7 @@ class AssessmentResourceTest extends AbstractResourceTest {
     succeedAssessmentDelete(adminUser, updatedAssessmentJack);
     assertThat(updatedAssessmentsInput.remove(updatedAssessmentInputJack)).isTrue();
     assertAssessments(
-        withCredentials(getRegularUser().getDomainUsername(),
+        withCredentials(getDomainUsername(getRegularUser()),
             t -> queryExecutor.task(TASK_FIELDS, TEST_TASK_12A_UUID)).getAssessments(),
         updatedAssessmentsInput, assessmentKey, 1);
   }
@@ -856,10 +856,10 @@ class AssessmentResourceTest extends AbstractResourceTest {
         createAssessment(assessmentKey, "andrew", recurrence, testTaskNroInput);
     final List<AssessmentInput> testAssessmentInputs = Lists.newArrayList(testAssessmentInput);
     final Assessment createdAssessment =
-        succeedAssessmentCreate(taskResponsible.getDomainUsername(), testAssessmentInput);
+        succeedAssessmentCreate(getDomainUsername(taskResponsible), testAssessmentInput);
 
     // - S: read it with no read auth.groups defined in the dictionary
-    final Task erinTask = withCredentials(getRegularUser().getDomainUsername(),
+    final Task erinTask = withCredentials(getDomainUsername(getRegularUser()),
         t -> queryExecutor.task(TASK_FIELDS, TEST_TASK_12A_UUID));
     assertAssessments(erinTask.getAssessments(), testAssessmentInputs, assessmentKey, 1);
 
@@ -878,7 +878,7 @@ class AssessmentResourceTest extends AbstractResourceTest {
     final List<AssessmentInput> updatedAssessmentsInput =
         Lists.newArrayList(updatedAssessmentInput);
     final Assessment updatedAssessment =
-        succeedAssessmentUpdate(taskResponsible.getDomainUsername(), updatedAssessmentInput);
+        succeedAssessmentUpdate(getDomainUsername(taskResponsible), updatedAssessmentInput);
 
     // - F: delete it as someone without task permission and with empty write auth.groups defined in
     // the dictionary
@@ -886,10 +886,10 @@ class AssessmentResourceTest extends AbstractResourceTest {
 
     // - S: delete it as someone with task permission and with empty write auth.groups defined in
     // the dictionary
-    succeedAssessmentDelete(taskResponsible.getDomainUsername(), updatedAssessment);
+    succeedAssessmentDelete(getDomainUsername(taskResponsible), updatedAssessment);
     assertThat(updatedAssessmentsInput.remove(updatedAssessmentInput)).isTrue();
     assertAssessments(
-        withCredentials(getRegularUser().getDomainUsername(),
+        withCredentials(getDomainUsername(getRegularUser()),
             t -> queryExecutor.task(TASK_FIELDS, TEST_TASK_12A_UUID)).getAssessments(),
         updatedAssessmentsInput, assessmentKey, 1);
   }
@@ -911,7 +911,7 @@ class AssessmentResourceTest extends AbstractResourceTest {
     final Assessment createdAssessment = succeedAssessmentCreate("erin", testAssessmentInput);
 
     // - S: read it with no auth.groups defined in the dictionary
-    final Task erinTask = withCredentials(getRegularUser().getDomainUsername(),
+    final Task erinTask = withCredentials(getDomainUsername(getRegularUser()),
         t -> queryExecutor.task(TASK_FIELDS, TEST_TASK_12A_UUID));
     assertAssessments(erinTask.getAssessments(), testAssessmentInputs, assessmentKey, 1);
 
@@ -930,7 +930,7 @@ class AssessmentResourceTest extends AbstractResourceTest {
     succeedAssessmentDelete("erin", updatedAssessment);
     assertThat(updatedAssessmentsInput.remove(updatedAssessmentInput)).isTrue();
     assertAssessments(
-        withCredentials(getRegularUser().getDomainUsername(),
+        withCredentials(getDomainUsername(getRegularUser()),
             t -> queryExecutor.task(TASK_FIELDS, TEST_TASK_12A_UUID)).getAssessments(),
         updatedAssessmentsInput, assessmentKey, 1);
   }
@@ -949,48 +949,48 @@ class AssessmentResourceTest extends AbstractResourceTest {
             .withReportPeople(getReportPeopleInput(
                 Lists.newArrayList(interlocutor, personToReportAuthor(reportAuthor))))
             .withTasks(Lists.newArrayList(taskInput)).build();
-    final Report createdReport = withCredentials(reportAuthor.getDomainUsername(),
+    final Report createdReport = withCredentials(getDomainUsername(reportAuthor),
         t -> mutationExecutor.createReport(REPORT_FIELDS, reportInput));
     final String reportUuid = createdReport.getUuid();
 
     // - F: create without relatedObjects
     AssessmentInput testAssessmentInputFail = createAssessment(assessmentKey, "test", recurrence);
-    failAssessmentCreate(reportAuthor.getDomainUsername(), testAssessmentInputFail);
+    failAssessmentCreate(getDomainUsername(reportAuthor), testAssessmentInputFail);
 
     // - F: create for a report
     final GenericRelatedObjectInput testReportNroInput =
         createAssessmentRelatedObject(ReportDao.TABLE_NAME, reportUuid);
     testAssessmentInputFail =
         createAssessment(assessmentKey, "test", recurrence, testReportNroInput);
-    failAssessmentCreate(reportAuthor.getDomainUsername(), testAssessmentInputFail);
+    failAssessmentCreate(getDomainUsername(reportAuthor), testAssessmentInputFail);
 
     // - F: create for a person
     final GenericRelatedObjectInput testAdvisorNroInput =
         createAssessmentRelatedObject(PersonDao.TABLE_NAME, reportAuthor.getUuid());
     testAssessmentInputFail =
         createAssessment(assessmentKey, "test", recurrence, testAdvisorNroInput);
-    failAssessmentCreate(reportAuthor.getDomainUsername(), testAssessmentInputFail);
+    failAssessmentCreate(getDomainUsername(reportAuthor), testAssessmentInputFail);
 
     // - F: create for a task
     final GenericRelatedObjectInput testTaskNroInput =
         createAssessmentRelatedObject(TaskDao.TABLE_NAME, taskUuid);
     testAssessmentInputFail = createAssessment(assessmentKey, "test", recurrence, testTaskNroInput);
-    failAssessmentCreate(reportAuthor.getDomainUsername(), testAssessmentInputFail);
+    failAssessmentCreate(getDomainUsername(reportAuthor), testAssessmentInputFail);
 
     // - F: create for two reports
     testAssessmentInputFail =
         createAssessment(assessmentKey, "test", recurrence, testReportNroInput, testReportNroInput);
-    failAssessmentCreate(reportAuthor.getDomainUsername(), testAssessmentInputFail);
+    failAssessmentCreate(getDomainUsername(reportAuthor), testAssessmentInputFail);
 
     // - F: create for a person and a task
     testAssessmentInputFail =
         createAssessment(assessmentKey, "test", recurrence, testAdvisorNroInput, testTaskNroInput);
-    failAssessmentCreate(reportAuthor.getDomainUsername(), testAssessmentInputFail);
+    failAssessmentCreate(getDomainUsername(reportAuthor), testAssessmentInputFail);
 
     // - F: create for a report, a person and a task
     testAssessmentInputFail = createAssessment(assessmentKey, "test", recurrence,
         testReportNroInput, testAdvisorNroInput, testTaskNroInput);
-    failAssessmentCreate(reportAuthor.getDomainUsername(), testAssessmentInputFail);
+    failAssessmentCreate(getDomainUsername(reportAuthor), testAssessmentInputFail);
 
     // - F: create as non-author for a report and a person
     testAssessmentInputFail = createAssessment(assessmentKey, "test", recurrence,
@@ -1002,7 +1002,7 @@ class AssessmentResourceTest extends AbstractResourceTest {
         createAssessmentRelatedObject(ReportDao.TABLE_NAME, "non-existing");
     testAssessmentInputFail = createAssessment(assessmentKey, "test", recurrence,
         testInvalidReportNroInput, forPerson ? testAdvisorNroInput : testTaskNroInput);
-    failAssessmentCreate(reportAuthor.getDomainUsername(), testAssessmentInputFail);
+    failAssessmentCreate(getDomainUsername(reportAuthor), testAssessmentInputFail);
 
     // - S: create as author for a report and a person/task
     final AssessmentInput testAssessmentInputAuthor = createAssessment(assessmentKey, "author",
@@ -1010,7 +1010,7 @@ class AssessmentResourceTest extends AbstractResourceTest {
     final List<AssessmentInput> testAssessmentInputs =
         Lists.newArrayList(testAssessmentInputAuthor);
     final Assessment createdAssessmentAuthor =
-        succeedAssessmentCreate(reportAuthor.getDomainUsername(), testAssessmentInputAuthor);
+        succeedAssessmentCreate(getDomainUsername(reportAuthor), testAssessmentInputAuthor);
 
     // - S: create as someone else in the write auth.groups
     final AssessmentInput testAssessmentInputJack = createAssessment(assessmentKey, "jack",
@@ -1027,18 +1027,18 @@ class AssessmentResourceTest extends AbstractResourceTest {
         succeedAssessmentCreate(adminUser, testAssessmentInputAdmin);
 
     // - S: read it as author
-    final Report updatedReport = withCredentials(reportAuthor.getDomainUsername(),
+    final Report updatedReport = withCredentials(getDomainUsername(reportAuthor),
         t -> queryExecutor.report(REPORT_FIELDS, reportUuid));
     final List<Assessment> testAssessments = updatedReport.getAssessments();
     assertAssessments(testAssessments, testAssessmentInputs, assessmentKey, 2);
 
     // - S: read it as someone else in the read auth.groups
-    final Report erinReport = withCredentials(getRegularUser().getDomainUsername(),
+    final Report erinReport = withCredentials(getDomainUsername(getRegularUser()),
         t -> queryExecutor.report(REPORT_FIELDS, reportUuid));
     assertAssessments(erinReport.getAssessments(), testAssessmentInputs, assessmentKey, 2);
 
     // - F: read it as someone else not in the read and write auth.groups
-    final Report bobReport = withCredentials(getBobBobtown().getDomainUsername(),
+    final Report bobReport = withCredentials(getDomainUsername(getBobBobtown()),
         t -> queryExecutor.report(REPORT_FIELDS, reportUuid));
     assertAssessments(bobReport.getAssessments(), Collections.emptyList(), assessmentKey, 2);
 
@@ -1061,7 +1061,7 @@ class AssessmentResourceTest extends AbstractResourceTest {
     final List<AssessmentInput> updatedAssessmentsInput =
         Lists.newArrayList(updatedAssessmentInputAuthor);
     final Assessment updatedAssessmentAuthor =
-        succeedAssessmentUpdate(reportAuthor.getDomainUsername(), updatedAssessmentInputAuthor);
+        succeedAssessmentUpdate(getDomainUsername(reportAuthor), updatedAssessmentInputAuthor);
 
     // - S: update it as someone else in the write auth.groups
     // assessment author shouldn't matter
@@ -1084,10 +1084,10 @@ class AssessmentResourceTest extends AbstractResourceTest {
     failAssessmentDelete("erin", updatedAssessmentAuthor);
 
     // - S: delete it as author
-    succeedAssessmentDelete(reportAuthor.getDomainUsername(), updatedAssessmentAuthor);
+    succeedAssessmentDelete(getDomainUsername(reportAuthor), updatedAssessmentAuthor);
     assertThat(updatedAssessmentsInput.remove(updatedAssessmentInputAuthor)).isTrue();
     assertAssessments(
-        withCredentials(getRegularUser().getDomainUsername(),
+        withCredentials(getDomainUsername(getRegularUser()),
             t -> queryExecutor.report(REPORT_FIELDS, reportUuid)).getAssessments(),
         updatedAssessmentsInput, assessmentKey, 2);
 
@@ -1096,7 +1096,7 @@ class AssessmentResourceTest extends AbstractResourceTest {
     succeedAssessmentDelete(jackUser, updatedAssessmentAdmin);
     assertThat(updatedAssessmentsInput.remove(updatedAssessmentInputAdmin)).isTrue();
     assertAssessments(
-        withCredentials(getRegularUser().getDomainUsername(),
+        withCredentials(getDomainUsername(getRegularUser()),
             t -> queryExecutor.report(REPORT_FIELDS, reportUuid)).getAssessments(),
         updatedAssessmentsInput, assessmentKey, 2);
 
@@ -1104,12 +1104,12 @@ class AssessmentResourceTest extends AbstractResourceTest {
     succeedAssessmentDelete(adminUser, updatedAssessmentJack);
     assertThat(updatedAssessmentsInput.remove(updatedAssessmentInputJack)).isTrue();
     assertAssessments(
-        withCredentials(getRegularUser().getDomainUsername(),
+        withCredentials(getDomainUsername(getRegularUser()),
             t -> queryExecutor.report(REPORT_FIELDS, reportUuid)).getAssessments(),
         updatedAssessmentsInput, assessmentKey, 2);
 
     // Delete the test report
-    withCredentials(reportAuthor.getDomainUsername(),
+    withCredentials(getDomainUsername(reportAuthor),
         t -> mutationExecutor.deleteReport("", reportUuid));
   }
 
@@ -1127,7 +1127,7 @@ class AssessmentResourceTest extends AbstractResourceTest {
             .withReportPeople(getReportPeopleInput(
                 Lists.newArrayList(interlocutor, personToReportAuthor(reportAuthor))))
             .withTasks(Lists.newArrayList(taskInput)).build();
-    final Report createdReport = withCredentials(reportAuthor.getDomainUsername(),
+    final Report createdReport = withCredentials(getDomainUsername(reportAuthor),
         t -> mutationExecutor.createReport(REPORT_FIELDS, reportInput));
 
     // - S: create as author for a report and a person
@@ -1142,7 +1142,7 @@ class AssessmentResourceTest extends AbstractResourceTest {
     final List<AssessmentInput> testAssessmentInputs =
         Lists.newArrayList(testAssessmentInputAuthor);
     final Assessment createdAssessmentAuthor =
-        succeedAssessmentCreate(reportAuthor.getDomainUsername(), testAssessmentInputAuthor);
+        succeedAssessmentCreate(getDomainUsername(reportAuthor), testAssessmentInputAuthor);
     assertAssessments(
         withCredentials(jackUser, t -> queryExecutor.report(REPORT_FIELDS, createdReport.getUuid()))
             .getAssessments(),
@@ -1158,7 +1158,7 @@ class AssessmentResourceTest extends AbstractResourceTest {
     failAssessmentDelete(jackUser, createdAssessmentAuthor);
 
     // - S: delete it as author
-    succeedAssessmentDelete(reportAuthor.getDomainUsername(), createdAssessmentAuthor);
+    succeedAssessmentDelete(getDomainUsername(reportAuthor), createdAssessmentAuthor);
     testAssessmentInputs.remove(testAssessmentInputAuthor);
     assertAssessments(
         withCredentials(jackUser, t -> queryExecutor.report(REPORT_FIELDS, createdReport.getUuid()))
@@ -1166,7 +1166,7 @@ class AssessmentResourceTest extends AbstractResourceTest {
         testAssessmentInputs, assessmentKey, 2);
 
     // Delete the test report
-    withCredentials(reportAuthor.getDomainUsername(),
+    withCredentials(getDomainUsername(reportAuthor),
         t -> mutationExecutor.deleteReport("", createdReport.getUuid()));
   }
 
@@ -1184,7 +1184,7 @@ class AssessmentResourceTest extends AbstractResourceTest {
             .withReportPeople(getReportPeopleInput(
                 Lists.newArrayList(interlocutor, personToReportAuthor(reportAuthor))))
             .withTasks(Lists.newArrayList(taskInput)).build();
-    final Report createdReport = withCredentials(reportAuthor.getDomainUsername(),
+    final Report createdReport = withCredentials(getDomainUsername(reportAuthor),
         t -> mutationExecutor.createReport(REPORT_FIELDS, reportInput));
 
     // - S: create as author for a report and a person
@@ -1199,7 +1199,7 @@ class AssessmentResourceTest extends AbstractResourceTest {
     final List<AssessmentInput> testAssessmentInputs =
         Lists.newArrayList(testAssessmentInputAuthor);
     final Assessment createdAssessmentAuthor =
-        succeedAssessmentCreate(reportAuthor.getDomainUsername(), testAssessmentInputAuthor);
+        succeedAssessmentCreate(getDomainUsername(reportAuthor), testAssessmentInputAuthor);
     assertAssessments(
         withCredentials(jackUser, t -> queryExecutor.report(REPORT_FIELDS, createdReport.getUuid()))
             .getAssessments(),
@@ -1215,7 +1215,7 @@ class AssessmentResourceTest extends AbstractResourceTest {
     succeedAssessmentDelete(jackUser, createdAssessmentAuthor);
 
     // Delete the test report
-    withCredentials(reportAuthor.getDomainUsername(),
+    withCredentials(getDomainUsername(reportAuthor),
         t -> mutationExecutor.deleteReport("", createdReport.getUuid()));
   }
 
@@ -1234,16 +1234,16 @@ class AssessmentResourceTest extends AbstractResourceTest {
             .withReportPeople(getReportPeopleInput(
                 Lists.newArrayList(interlocutor, personToPrimaryReportAuthor(reportAuthor))))
             .withTasks(Lists.newArrayList(taskInput)).build();
-    final Report createdReport = withCredentials(reportAuthor.getDomainUsername(),
+    final Report createdReport = withCredentials(getDomainUsername(reportAuthor),
         t -> mutationExecutor.createReport(REPORT_FIELDS, reportInput));
     final String reportUuid = createdReport.getUuid();
-    final int nrSubmitted = withCredentials(reportAuthor.getDomainUsername(),
+    final int nrSubmitted = withCredentials(getDomainUsername(reportAuthor),
         t -> mutationExecutor.submitReport("", reportUuid));
     assertThat(nrSubmitted).isOne();
 
     // - F: create without relatedObjects
     AssessmentInput testAssessmentInputFail = createAssessment(assessmentKey, "test", recurrence);
-    failUpdateReportAssessments(reportAuthor.getDomainUsername(), reportUuid,
+    failUpdateReportAssessments(getDomainUsername(reportAuthor), reportUuid,
         testAssessmentInputFail);
 
     // - F: create for a report
@@ -1251,7 +1251,7 @@ class AssessmentResourceTest extends AbstractResourceTest {
         createAssessmentRelatedObject(ReportDao.TABLE_NAME, reportUuid);
     testAssessmentInputFail =
         createAssessment(assessmentKey, "test", recurrence, testReportNroInput);
-    failUpdateReportAssessments(reportAuthor.getDomainUsername(), reportUuid,
+    failUpdateReportAssessments(getDomainUsername(reportAuthor), reportUuid,
         testAssessmentInputFail);
 
     // - F: create for a person
@@ -1259,32 +1259,32 @@ class AssessmentResourceTest extends AbstractResourceTest {
         createAssessmentRelatedObject(PersonDao.TABLE_NAME, reportAuthor.getUuid());
     testAssessmentInputFail =
         createAssessment(assessmentKey, "test", recurrence, testAdvisorNroInput);
-    failUpdateReportAssessments(reportAuthor.getDomainUsername(), reportUuid,
+    failUpdateReportAssessments(getDomainUsername(reportAuthor), reportUuid,
         testAssessmentInputFail);
 
     // - F: create for a task
     final GenericRelatedObjectInput testTaskNroInput =
         createAssessmentRelatedObject(TaskDao.TABLE_NAME, taskUuid);
     testAssessmentInputFail = createAssessment(assessmentKey, "test", recurrence, testTaskNroInput);
-    failUpdateReportAssessments(reportAuthor.getDomainUsername(), reportUuid,
+    failUpdateReportAssessments(getDomainUsername(reportAuthor), reportUuid,
         testAssessmentInputFail);
 
     // - F: create for two reports
     testAssessmentInputFail =
         createAssessment(assessmentKey, "test", recurrence, testReportNroInput, testReportNroInput);
-    failUpdateReportAssessments(reportAuthor.getDomainUsername(), reportUuid,
+    failUpdateReportAssessments(getDomainUsername(reportAuthor), reportUuid,
         testAssessmentInputFail);
 
     // - F: create for a person and a task
     testAssessmentInputFail =
         createAssessment(assessmentKey, "test", recurrence, testAdvisorNroInput, testTaskNroInput);
-    failUpdateReportAssessments(reportAuthor.getDomainUsername(), reportUuid,
+    failUpdateReportAssessments(getDomainUsername(reportAuthor), reportUuid,
         testAssessmentInputFail);
 
     // - F: create for a report, a person and a task
     testAssessmentInputFail = createAssessment(assessmentKey, "test", recurrence,
         testReportNroInput, testAdvisorNroInput, testTaskNroInput);
-    failUpdateReportAssessments(reportAuthor.getDomainUsername(), reportUuid,
+    failUpdateReportAssessments(getDomainUsername(reportAuthor), reportUuid,
         testAssessmentInputFail);
 
     // - F: create as non-author for a report and a person
@@ -1297,7 +1297,7 @@ class AssessmentResourceTest extends AbstractResourceTest {
         createAssessmentRelatedObject(ReportDao.TABLE_NAME, "non-existing");
     testAssessmentInputFail = createAssessment(assessmentKey, "test", recurrence,
         testInvalidReportNroInput, forPerson ? testAdvisorNroInput : testTaskNroInput);
-    failUpdateReportAssessments(reportAuthor.getDomainUsername(), reportUuid,
+    failUpdateReportAssessments(getDomainUsername(reportAuthor), reportUuid,
         testAssessmentInputFail);
 
     // - F: create for a report and a person/task, against a non-existing report
@@ -1305,20 +1305,20 @@ class AssessmentResourceTest extends AbstractResourceTest {
         recurrence, testReportNroInput, forPerson ? testAdvisorNroInput : testTaskNroInput);
     testAssessmentInputFail =
         createAssessment(assessmentKey, "test", recurrence, testInvalidReportNroInput);
-    failUpdateReportAssessments(reportAuthor.getDomainUsername(), "non-existing",
+    failUpdateReportAssessments(getDomainUsername(reportAuthor), "non-existing",
         testAssessmentInputFail);
 
     // - S: create as author for a report and a person
     final List<AssessmentInput> testAssessmentInputs =
         Lists.newArrayList(testAssessmentInputAuthor);
-    succeedUpdateReportAssessments(reportAuthor.getDomainUsername(), reportUuid,
+    succeedUpdateReportAssessments(getDomainUsername(reportAuthor), reportUuid,
         testAssessmentInputAuthor);
 
     // - S: create as approver
     final AssessmentInput testAssessmentInputApprover = createAssessment(assessmentKey, "approver",
         recurrence, testReportNroInput, testAdvisorNroInput);
     testAssessmentInputs.add(testAssessmentInputApprover);
-    succeedUpdateReportAssessments(reportApprover.getDomainUsername(), reportUuid,
+    succeedUpdateReportAssessments(getDomainUsername(reportApprover), reportUuid,
         testAssessmentInputAuthor, testAssessmentInputApprover);
 
     // - S: create as someone else in the write auth.groups
@@ -1336,23 +1336,23 @@ class AssessmentResourceTest extends AbstractResourceTest {
         testAssessmentInputApprover, testAssessmentInputJack, testAssessmentInputAdmin);
 
     // - S: read it as author
-    final Report updatedReport = withCredentials(reportAuthor.getDomainUsername(),
+    final Report updatedReport = withCredentials(getDomainUsername(reportAuthor),
         t -> queryExecutor.report(REPORT_FIELDS, reportUuid));
     final List<Assessment> testAssessments = updatedReport.getAssessments();
     assertAssessments(testAssessments, testAssessmentInputs, assessmentKey, 2);
 
     // - S: read it as approver
-    final Report approverReport = withCredentials(reportApprover.getDomainUsername(),
+    final Report approverReport = withCredentials(getDomainUsername(reportApprover),
         t -> queryExecutor.report(REPORT_FIELDS, reportUuid));
     assertAssessments(approverReport.getAssessments(), testAssessmentInputs, assessmentKey, 2);
 
     // - S: read it as someone else in the read auth.groups
-    final Report erinReport = withCredentials(getRegularUser().getDomainUsername(),
+    final Report erinReport = withCredentials(getDomainUsername(getRegularUser()),
         t -> queryExecutor.report(REPORT_FIELDS, reportUuid));
     assertAssessments(erinReport.getAssessments(), testAssessmentInputs, assessmentKey, 2);
 
     // - F: read it as someone else not in the read and write auth.groups
-    final Report bobReport = withCredentials(getBobBobtown().getDomainUsername(),
+    final Report bobReport = withCredentials(getDomainUsername(getBobBobtown()),
         t -> queryExecutor.report(REPORT_FIELDS, reportUuid));
     assertAssessments(bobReport.getAssessments(), Collections.emptyList(), assessmentKey, 2);
 
@@ -1370,7 +1370,7 @@ class AssessmentResourceTest extends AbstractResourceTest {
     final AssessmentInput updatedAssessmentInputAuthor = createdAssessmentsInput.get(0);
     updatedAssessmentInputAuthor
         .setAssessmentValues(createAssessmentValues("updated by author", recurrence));
-    succeedUpdateReportAssessments(reportAuthor.getDomainUsername(), reportUuid,
+    succeedUpdateReportAssessments(getDomainUsername(reportAuthor), reportUuid,
         Iterables.toArray(createdAssessmentsInput, AssessmentInput.class));
 
     // - S: update it as approver
@@ -1378,7 +1378,7 @@ class AssessmentResourceTest extends AbstractResourceTest {
     final AssessmentInput updatedAssessmentInputApprover = createdAssessmentsInput.get(2);
     updatedAssessmentInputApprover
         .setAssessmentValues(createAssessmentValues("updated by approver", recurrence));
-    succeedUpdateReportAssessments(reportApprover.getDomainUsername(), reportUuid,
+    succeedUpdateReportAssessments(getDomainUsername(reportApprover), reportUuid,
         Iterables.toArray(createdAssessmentsInput, AssessmentInput.class));
 
     // - S: update it as someone else in the write auth.groups
@@ -1399,25 +1399,25 @@ class AssessmentResourceTest extends AbstractResourceTest {
     failUpdateReportAssessments("erin", reportUuid);
 
     // - S: delete it as author
-    final List<Assessment> updatedAssessments = withCredentials(reportAuthor.getDomainUsername(),
+    final List<Assessment> updatedAssessments = withCredentials(getDomainUsername(reportAuthor),
         t -> queryExecutor.report(REPORT_FIELDS, reportUuid)).getAssessments();
     final List<AssessmentInput> updatedAssessmentsInput = getAssessmentsInput(updatedAssessments);
     Collections.reverse(updatedAssessmentsInput);
     assertThat(updatedAssessmentsInput.remove(0)).isNotNull();
-    succeedUpdateReportAssessments(reportAuthor.getDomainUsername(), reportUuid,
+    succeedUpdateReportAssessments(getDomainUsername(reportAuthor), reportUuid,
         Iterables.toArray(updatedAssessmentsInput, AssessmentInput.class));
     assertAssessments(
-        withCredentials(reportAuthor.getDomainUsername(),
+        withCredentials(getDomainUsername(reportAuthor),
             t -> queryExecutor.report(REPORT_FIELDS, reportUuid)).getAssessments(),
         updatedAssessmentsInput, assessmentKey, 2);
 
     // - S: delete it as approver
     // assessment author shouldn't matter
     assertThat(updatedAssessmentsInput.remove(2)).isNotNull();
-    succeedUpdateReportAssessments(reportApprover.getDomainUsername(), reportUuid,
+    succeedUpdateReportAssessments(getDomainUsername(reportApprover), reportUuid,
         Iterables.toArray(updatedAssessmentsInput, AssessmentInput.class));
     assertAssessments(
-        withCredentials(reportAuthor.getDomainUsername(),
+        withCredentials(getDomainUsername(reportAuthor),
             t -> queryExecutor.report(REPORT_FIELDS, reportUuid)).getAssessments(),
         updatedAssessmentsInput, assessmentKey, 2);
 
@@ -1426,7 +1426,7 @@ class AssessmentResourceTest extends AbstractResourceTest {
     succeedUpdateReportAssessments(jackUser, reportUuid,
         Iterables.toArray(updatedAssessmentsInput, AssessmentInput.class));
     assertAssessments(
-        withCredentials(reportAuthor.getDomainUsername(),
+        withCredentials(getDomainUsername(reportAuthor),
             t -> queryExecutor.report(REPORT_FIELDS, reportUuid)).getAssessments(),
         updatedAssessmentsInput, assessmentKey, 2);
 
@@ -1435,18 +1435,18 @@ class AssessmentResourceTest extends AbstractResourceTest {
     succeedUpdateReportAssessments(adminUser, reportUuid,
         Iterables.toArray(updatedAssessmentsInput, AssessmentInput.class));
     assertAssessments(
-        withCredentials(reportAuthor.getDomainUsername(),
+        withCredentials(getDomainUsername(reportAuthor),
             t -> queryExecutor.report(REPORT_FIELDS, reportUuid)).getAssessments(),
         updatedAssessmentsInput, assessmentKey, 2);
 
     // Get the test report
-    final Report report = withCredentials(reportAuthor.getDomainUsername(),
+    final Report report = withCredentials(getDomainUsername(reportAuthor),
         t -> queryExecutor.report(REPORT_FIELDS, reportUuid));
     // Update it as author so it goes back to draft
-    withCredentials(reportAuthor.getDomainUsername(),
+    withCredentials(getDomainUsername(reportAuthor),
         t -> mutationExecutor.updateReport(REPORT_FIELDS, getReportInput(report), false));
     // Then delete it
-    final int nrDeleted = withCredentials(reportAuthor.getDomainUsername(),
+    final int nrDeleted = withCredentials(getDomainUsername(reportAuthor),
         t -> mutationExecutor.deleteReport("", reportUuid));
     assertThat(nrDeleted).isOne();
   }
@@ -1465,10 +1465,10 @@ class AssessmentResourceTest extends AbstractResourceTest {
             .withReportPeople(getReportPeopleInput(
                 Lists.newArrayList(interlocutor, personToPrimaryReportAuthor(reportAuthor))))
             .withTasks(Lists.newArrayList(taskInput)).build();
-    final Report createdReport = withCredentials(reportAuthor.getDomainUsername(),
+    final Report createdReport = withCredentials(getDomainUsername(reportAuthor),
         t -> mutationExecutor.createReport(REPORT_FIELDS, reportInput));
     final String reportUuid = createdReport.getUuid();
-    final int nrSubmitted = withCredentials(reportAuthor.getDomainUsername(),
+    final int nrSubmitted = withCredentials(getDomainUsername(reportAuthor),
         t -> mutationExecutor.submitReport("", reportUuid));
     assertThat(nrSubmitted).isOne();
 
@@ -1483,7 +1483,7 @@ class AssessmentResourceTest extends AbstractResourceTest {
         recurrence, testReportNroInput, forPerson ? testInterlocutorNroInput : testTaskNroInput);
     final List<AssessmentInput> testAssessmentInputs =
         Lists.newArrayList(testAssessmentInputAuthor);
-    succeedUpdateReportAssessments(reportAuthor.getDomainUsername(), reportUuid,
+    succeedUpdateReportAssessments(getDomainUsername(reportAuthor), reportUuid,
         testAssessmentInputAuthor);
 
     // - S: read it as someone else with no read auth.groups defined in the dictionary
@@ -1504,7 +1504,7 @@ class AssessmentResourceTest extends AbstractResourceTest {
     failUpdateReportAssessments(jackUser, reportUuid);
 
     // - S: delete it as author
-    succeedUpdateReportAssessments(reportAuthor.getDomainUsername(), reportUuid);
+    succeedUpdateReportAssessments(getDomainUsername(reportAuthor), reportUuid);
     testAssessmentInputs.remove(testAssessmentInputAuthor);
     assertAssessments(
         withCredentials(jackUser, t -> queryExecutor.report(REPORT_FIELDS, reportUuid))
@@ -1512,13 +1512,13 @@ class AssessmentResourceTest extends AbstractResourceTest {
         testAssessmentInputs, assessmentKey, 2);
 
     // Get the test report
-    final Report report = withCredentials(reportAuthor.getDomainUsername(),
+    final Report report = withCredentials(getDomainUsername(reportAuthor),
         t -> queryExecutor.report(REPORT_FIELDS, reportUuid));
     // Update it as author so it goes back to draft
-    withCredentials(reportAuthor.getDomainUsername(),
+    withCredentials(getDomainUsername(reportAuthor),
         t -> mutationExecutor.updateReport(REPORT_FIELDS, getReportInput(report), false));
     // Then delete it
-    final int nrDeleted = withCredentials(reportAuthor.getDomainUsername(),
+    final int nrDeleted = withCredentials(getDomainUsername(reportAuthor),
         t -> mutationExecutor.deleteReport("", reportUuid));
     assertThat(nrDeleted).isOne();
   }
@@ -1537,10 +1537,10 @@ class AssessmentResourceTest extends AbstractResourceTest {
             .withReportPeople(getReportPeopleInput(
                 Lists.newArrayList(interlocutor, personToPrimaryReportAuthor(reportAuthor))))
             .withTasks(Lists.newArrayList(taskInput)).build();
-    final Report createdReport = withCredentials(reportAuthor.getDomainUsername(),
+    final Report createdReport = withCredentials(getDomainUsername(reportAuthor),
         t -> mutationExecutor.createReport(REPORT_FIELDS, reportInput));
     final String reportUuid = createdReport.getUuid();
-    final int nrSubmitted = withCredentials(reportAuthor.getDomainUsername(),
+    final int nrSubmitted = withCredentials(getDomainUsername(reportAuthor),
         t -> mutationExecutor.submitReport("", reportUuid));
     assertThat(nrSubmitted).isOne();
 
@@ -1555,7 +1555,7 @@ class AssessmentResourceTest extends AbstractResourceTest {
         recurrence, testReportNroInput, forPerson ? testInterlocutorNroInput : testTaskNroInput);
     final List<AssessmentInput> testAssessmentInputs =
         Lists.newArrayList(testAssessmentInputAuthor);
-    succeedUpdateReportAssessments(reportAuthor.getDomainUsername(), reportUuid,
+    succeedUpdateReportAssessments(getDomainUsername(reportAuthor), reportUuid,
         testAssessmentInputAuthor);
 
     // - S: read it as someone else with no auth.groups defined in the dictionary
@@ -1573,7 +1573,7 @@ class AssessmentResourceTest extends AbstractResourceTest {
         Iterables.toArray(updatedAssessmentsInput, AssessmentInput.class));
 
     // - S: delete it as someone else with no auth.groups defined in the dictionary
-    succeedUpdateReportAssessments(reportAuthor.getDomainUsername(), reportUuid);
+    succeedUpdateReportAssessments(getDomainUsername(reportAuthor), reportUuid);
     testAssessmentInputs.remove(testAssessmentInputAuthor);
     assertAssessments(
         withCredentials(jackUser, t -> queryExecutor.report(REPORT_FIELDS, reportUuid))
@@ -1581,13 +1581,13 @@ class AssessmentResourceTest extends AbstractResourceTest {
         testAssessmentInputs, assessmentKey, 2);
 
     // Get the test report
-    final Report report = withCredentials(reportAuthor.getDomainUsername(),
+    final Report report = withCredentials(getDomainUsername(reportAuthor),
         t -> queryExecutor.report(REPORT_FIELDS, reportUuid));
     // Update it as author so it goes back to draft
-    withCredentials(reportAuthor.getDomainUsername(),
+    withCredentials(getDomainUsername(reportAuthor),
         t -> mutationExecutor.updateReport(REPORT_FIELDS, getReportInput(report), false));
     // Then delete it
-    final int nrDeleted = withCredentials(reportAuthor.getDomainUsername(),
+    final int nrDeleted = withCredentials(getDomainUsername(reportAuthor),
         t -> mutationExecutor.deleteReport("", reportUuid));
     assertThat(nrDeleted).isOne();
   }

--- a/src/test/java/mil/dds/anet/test/resources/AttachmentResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/AttachmentResourceTest.java
@@ -868,7 +868,7 @@ public class AttachmentResourceTest extends AbstractResourceTest {
   void myAttachments() {
     final Person jack = getJackJackson();
     final AnetBeanList_Attachment jackAttachments =
-        getAttachments(jack.getDomainUsername(), jack.getUuid());
+        getAttachments(getDomainUsername(jack), jack.getUuid());
 
     assertThat(jackAttachments.getList()).isNotEmpty();
     assertThat(jackAttachments.getList().stream()

--- a/src/test/java/mil/dds/anet/test/resources/AuthorizationGroupResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/AuthorizationGroupResourceTest.java
@@ -55,7 +55,7 @@ class AuthorizationGroupResourceTest extends AbstractResourceTest {
   void testCreateAsSuperuser() {
     final AuthorizationGroupInput authorizationGroupInput = getAuthorizationGroupInput();
     try {
-      withCredentials(getSuperuser().getDomainUsername(),
+      withCredentials(getDomainUsername(getSuperuser()),
           t -> mutationExecutor.createAuthorizationGroup(FIELDS, authorizationGroupInput));
       fail("Expected an Exception");
     } catch (Exception expectedException) {
@@ -115,7 +115,7 @@ class AuthorizationGroupResourceTest extends AbstractResourceTest {
     updatedAuthorizationGroupInput.setForSensitiveInformation(true);
     updatedAuthorizationGroupInput.getAuthorizationGroupRelatedObjects().remove(0);
     updatedAuthorizationGroupInput.getAdministrativePositions().remove(0);
-    final Integer nrUpdated = withCredentials(getSuperuser().getDomainUsername(),
+    final Integer nrUpdated = withCredentials(getDomainUsername(getSuperuser()),
         t -> mutationExecutor.updateAuthorizationGroup("", updatedAuthorizationGroupInput));
     assertThat(nrUpdated).isOne();
     final AuthorizationGroup updatedAuthorizationGroup = withCredentials(adminUser,

--- a/src/test/java/mil/dds/anet/test/resources/EntityAvatarResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/EntityAvatarResourceTest.java
@@ -36,7 +36,7 @@ class EntityAvatarResourceTest extends AbstractResourceTest {
 
     // Regular user can not do this
     try {
-      withCredentials(getRegularUser().getDomainUsername(),
+      withCredentials(getDomainUsername(getRegularUser()),
           t -> mutationExecutor.createOrUpdateEntityAvatar("", newEntityAvatarInput));
       fail("Expected exception creating entity avatar");
     } catch (Exception expectedException) {
@@ -44,7 +44,7 @@ class EntityAvatarResourceTest extends AbstractResourceTest {
     }
 
     // Superuser can do this
-    Integer numRows = withCredentials(getSuperuser().getDomainUsername(),
+    Integer numRows = withCredentials(getDomainUsername(getSuperuser()),
         t -> mutationExecutor.createOrUpdateEntityAvatar("", newEntityAvatarInput));
     assertThat(numRows).isOne();
 
@@ -146,7 +146,7 @@ class EntityAvatarResourceTest extends AbstractResourceTest {
   void testPersonAvatar() {
     final Person erin = getRegularUser();
 
-    Person retPerson = withCredentials(getRegularUser().getDomainUsername(),
+    Person retPerson = withCredentials(getDomainUsername(getRegularUser()),
         t -> queryExecutor.person(FIELDS, erin.getUuid()));
     assertThat(retPerson).isNotNull();
     assertThat(retPerson.getAttachments()).isNotEmpty();
@@ -159,10 +159,10 @@ class EntityAvatarResourceTest extends AbstractResourceTest {
             .withCropHeight(1).withCropLeft(2).withCropWidth(3).withCropTop(4).build();
 
     // Set own avatar
-    Integer nrUpdated = withCredentials(erin.getDomainUsername(),
+    Integer nrUpdated = withCredentials(getDomainUsername(erin),
         t -> mutationExecutor.createOrUpdateEntityAvatar("", newEntityAvatarInput));
     assertThat(nrUpdated).isOne();
-    retPerson = withCredentials(getRegularUser().getDomainUsername(),
+    retPerson = withCredentials(getDomainUsername(getRegularUser()),
         t -> queryExecutor.person(FIELDS, erin.getUuid()));
     assertThat(retPerson.getEntityAvatar()).isNotNull();
     assertThat(retPerson.getEntityAvatar().getAttachmentUuid()).isEqualTo(attachment.getUuid());
@@ -180,7 +180,7 @@ class EntityAvatarResourceTest extends AbstractResourceTest {
     nrUpdated = withCredentials("rebecca",
         t -> mutationExecutor.deleteEntityAvatar("", PersonDao.TABLE_NAME, erin.getUuid()));
     assertThat(nrUpdated).isOne();
-    retPerson = withCredentials(getRegularUser().getDomainUsername(),
+    retPerson = withCredentials(getDomainUsername(getRegularUser()),
         t -> queryExecutor.person(FIELDS, erin.getUuid()));
     assertThat(retPerson.getEntityAvatar()).isNull();
 
@@ -188,16 +188,16 @@ class EntityAvatarResourceTest extends AbstractResourceTest {
     nrUpdated = withCredentials(adminUser,
         t -> mutationExecutor.createOrUpdateEntityAvatar("", newEntityAvatarInput));
     assertThat(nrUpdated).isOne();
-    retPerson = withCredentials(getRegularUser().getDomainUsername(),
+    retPerson = withCredentials(getDomainUsername(getRegularUser()),
         t -> queryExecutor.person(FIELDS, erin.getUuid()));
     assertThat(retPerson.getEntityAvatar()).isNotNull();
     assertThat(retPerson.getEntityAvatar().getAttachmentUuid()).isEqualTo(attachment.getUuid());
 
     // Erase own avatar again
-    nrUpdated = withCredentials(erin.getDomainUsername(),
+    nrUpdated = withCredentials(getDomainUsername(erin),
         t -> mutationExecutor.deleteEntityAvatar("", PersonDao.TABLE_NAME, erin.getUuid()));
     assertThat(nrUpdated).isOne();
-    retPerson = withCredentials(getRegularUser().getDomainUsername(),
+    retPerson = withCredentials(getDomainUsername(getRegularUser()),
         t -> queryExecutor.person(FIELDS, erin.getUuid()));
     assertThat(retPerson.getEntityAvatar()).isNull();
   }
@@ -215,7 +215,7 @@ class EntityAvatarResourceTest extends AbstractResourceTest {
 
     // Regular user can not do this
     try {
-      withCredentials(getRegularUser().getDomainUsername(),
+      withCredentials(getDomainUsername(getRegularUser()),
           t -> mutationExecutor.createOrUpdateEntityAvatar("", newEntityAvatarInput));
       fail("Expected exception creating entity avatar");
     } catch (Exception expectedException) {
@@ -232,7 +232,7 @@ class EntityAvatarResourceTest extends AbstractResourceTest {
     }
 
     // The organization's superuser can do this
-    Integer numRows = withCredentials(getAndrewAnderson().getDomainUsername(),
+    Integer numRows = withCredentials(getDomainUsername(getAndrewAnderson()),
         t -> mutationExecutor.createOrUpdateEntityAvatar("", newEntityAvatarInput));
     assertThat(numRows).isOne();
 

--- a/src/test/java/mil/dds/anet/test/resources/GraphQlResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/GraphQlResourceTest.java
@@ -44,14 +44,14 @@ class GraphQlResourceTest extends AbstractResourceTest {
       fail("Unexpected Exception", e);
     }
     try {
-      withCredentials(getSuperuser().getDomainUsername(),
+      withCredentials(getDomainUsername(getSuperuser()),
           t -> queryExecutor.exec(introspectionQuery));
       fail("Expected an Exception");
     } catch (Exception expectedException) {
       // OK
     }
     try {
-      withCredentials(getRegularUser().getDomainUsername(),
+      withCredentials(getDomainUsername(getRegularUser()),
           t -> queryExecutor.exec(introspectionQuery));
       fail("Expected an Exception");
     } catch (Exception expectedException) {

--- a/src/test/java/mil/dds/anet/test/resources/LocationResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/LocationResourceTest.java
@@ -95,7 +95,7 @@ public class LocationResourceTest extends AbstractResourceTest {
   private void createLocation(Person user, boolean shouldSucceed) {
     final LocationInput lInput = TestData.createLocationInput("The Boat Dock2", 43.21, -87.65);
     try {
-      final Location l = withCredentials(user.getDomainUsername(),
+      final Location l = withCredentials(getDomainUsername(user),
           t -> mutationExecutor.createLocation(FIELDS, lInput));
       if (shouldSucceed) {
         assertThat(l).isNotNull();
@@ -125,14 +125,14 @@ public class LocationResourceTest extends AbstractResourceTest {
     final boolean isSuperuser = position.getType() == PositionType.SUPERUSER;
     final LocationSearchQueryInput query =
         LocationSearchQueryInput.builder().withText("Police").build();
-    final AnetBeanList_Location searchObjects = withCredentials(user.getDomainUsername(),
+    final AnetBeanList_Location searchObjects = withCredentials(getDomainUsername(user),
         t -> queryExecutor.locationList(getListFields(FIELDS), query));
     assertThat(searchObjects).isNotNull();
     assertThat(searchObjects.getList()).isNotEmpty();
     final Location l = searchObjects.getList().get(0);
 
     try {
-      final Integer nrUpdated = withCredentials(user.getDomainUsername(),
+      final Integer nrUpdated = withCredentials(getDomainUsername(user),
           t -> mutationExecutor.updateLocation("", getLocationInput(l)));
       if (isSuperuser) {
         assertThat(nrUpdated).isEqualTo(1);

--- a/src/test/java/mil/dds/anet/test/resources/MartImportedReportsResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/MartImportedReportsResourceTest.java
@@ -20,7 +20,7 @@ class MartImportedReportsResourceTest extends AbstractResourceTest {
     final boolean isAdmin = user.getPosition().getType() == PositionType.ADMINISTRATOR;
 
     try {
-      final var martImportedReports = withCredentials(user.getDomainUsername(),
+      final var martImportedReports = withCredentials(getDomainUsername(user),
           t -> queryExecutor.martImportedReports(getListFields(
               "{ sequence person { uuid } report { uuid } receivedAt submittedAt success errors }"),
               0, 0));

--- a/src/test/java/mil/dds/anet/test/resources/NoteResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/NoteResourceTest.java
@@ -170,7 +170,7 @@ class NoteResourceTest extends AbstractResourceTest {
     assertFreeTextNotes(interlocutorPerson.getNotes(), testNoteInputs, 1);
 
     // - S: read it as someone else
-    final Person bobPerson = withCredentials(getBobBobtown().getDomainUsername(),
+    final Person bobPerson = withCredentials(getDomainUsername(getBobBobtown()),
         t -> queryExecutor.person(PERSON_FIELDS, interlocutorPersonUuid));
     assertFreeTextNotes(bobPerson.getNotes(), testNoteInputs, 1);
 

--- a/src/test/java/mil/dds/anet/test/resources/OrganizationResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/OrganizationResourceTest.java
@@ -470,8 +470,8 @@ public class OrganizationResourceTest extends AbstractResourceTest {
     final Organization org = succeedCreateOrganization(adminUser, orgInput);
 
     succeedUpdateOrganization(adminUser, getOrganizationInput(org));
-    failUpdateOrganization(superuser.getDomainUsername(), getOrganizationInput(org));
-    failUpdateOrganization(regularUser.getDomainUsername(), getOrganizationInput(org));
+    failUpdateOrganization(getDomainUsername(superuser), getOrganizationInput(org));
+    failUpdateOrganization(getDomainUsername(regularUser), getOrganizationInput(org));
   }
 
   @Test
@@ -485,7 +485,7 @@ public class OrganizationResourceTest extends AbstractResourceTest {
             .withLongName("Advisor Organization for Testing Superusers").withStatus(Status.ACTIVE)
             .withIdentificationCode(UUID.randomUUID().toString())
             .withLocation(getLocationInput(getGeneralHospital())).build();
-    failCreateOrganization(superuser.getDomainUsername(), orgInput);
+    failCreateOrganization(getDomainUsername(superuser), orgInput);
     final Organization parentOrg = succeedCreateOrganization(adminUser, orgInput);
 
     final OrganizationInput childOrgInput = OrganizationInput.builder()
@@ -493,28 +493,28 @@ public class OrganizationResourceTest extends AbstractResourceTest {
         .withStatus(Status.ACTIVE).withIdentificationCode(UUID.randomUUID().toString())
         .withParentOrg(getOrganizationInput(parentOrg))
         .withLocation(getLocationInput(getGeneralHospital())).build();
-    failCreateOrganization(superuser.getDomainUsername(), childOrgInput);
+    failCreateOrganization(getDomainUsername(superuser), childOrgInput);
 
     // Set superuser as responsible for the parent organization
     parentOrg.setAdministratingPositions(Lists.newArrayList(superuserPosition));
     succeedUpdateOrganization(adminUser, getOrganizationInput(parentOrg));
 
     final Organization createdChildOrg =
-        succeedCreateOrganization(superuser.getDomainUsername(), childOrgInput);
+        succeedCreateOrganization(getDomainUsername(superuser), childOrgInput);
 
     // Can edit the child of their responsible organization
     createdChildOrg.setShortName("Updated Child Organization");
-    succeedUpdateOrganization(superuser.getDomainUsername(), getOrganizationInput(createdChildOrg));
+    succeedUpdateOrganization(getDomainUsername(superuser), getOrganizationInput(createdChildOrg));
 
     // Superusers cannot update their own organizations if they're not responsible
     final Organization superuserOrg = withCredentials(adminUser,
         t -> queryExecutor.organization(FIELDS, superuserPosition.getOrganization().getUuid()));
-    failUpdateOrganization(superuser.getDomainUsername(), getOrganizationInput(superuserOrg));
+    failUpdateOrganization(getDomainUsername(superuser), getOrganizationInput(superuserOrg));
 
     // Given responsibility now they can edit their organization
     superuserOrg.setAdministratingPositions(Lists.newArrayList(superuserPosition));
     succeedUpdateOrganization(adminUser, getOrganizationInput(superuserOrg));
-    succeedUpdateOrganization(superuser.getDomainUsername(), getOrganizationInput(superuserOrg));
+    succeedUpdateOrganization(getDomainUsername(superuser), getOrganizationInput(superuserOrg));
 
     // Remove position
     superuserOrg.setAdministratingPositions(new ArrayList<>());
@@ -611,7 +611,7 @@ public class OrganizationResourceTest extends AbstractResourceTest {
     final Organization createdChildOrg = succeedCreateOrganization(adminUser, childOrgInput);
 
     createdChildOrg.setParentOrg(null);
-    failUpdateOrganization(superuser.getDomainUsername(), getOrganizationInput(createdChildOrg));
+    failUpdateOrganization(getDomainUsername(superuser), getOrganizationInput(createdChildOrg));
     createdChildOrg.setParentOrg(createdParentOrg);
 
     // Set superuser as responsible for the child organization
@@ -620,14 +620,14 @@ public class OrganizationResourceTest extends AbstractResourceTest {
 
     // Cannot set parent as null because they're not responsible for the parent organization
     createdChildOrg.setParentOrg(null);
-    failUpdateOrganization(superuser.getDomainUsername(), getOrganizationInput(createdChildOrg));
+    failUpdateOrganization(getDomainUsername(superuser), getOrganizationInput(createdChildOrg));
     createdChildOrg.setParentOrg(createdParentOrg);
     // Set superuser as responsible for the parent organization
     createdParentOrg.setAdministratingPositions(Lists.newArrayList(superuserPosition));
     succeedUpdateOrganization(adminUser, getOrganizationInput(createdParentOrg));
     // Now superuser can set the parent organization as null
     createdChildOrg.setParentOrg(null);
-    succeedUpdateOrganization(superuser.getDomainUsername(), getOrganizationInput(createdChildOrg));
+    succeedUpdateOrganization(getDomainUsername(superuser), getOrganizationInput(createdChildOrg));
 
     final OrganizationInput newParentOrg =
         OrganizationInput.builder().withShortName("New Parent Organization")
@@ -640,7 +640,7 @@ public class OrganizationResourceTest extends AbstractResourceTest {
     // Cannot assign the new organization as the child's parent because they're not responsible for
     // the new organization
     createdChildOrg.setParentOrg(createdNewParentOrg);
-    failUpdateOrganization(superuser.getDomainUsername(), getOrganizationInput(createdChildOrg));
+    failUpdateOrganization(getDomainUsername(superuser), getOrganizationInput(createdChildOrg));
     // Revert previous change
     createdChildOrg.setParentOrg(createdParentOrg);
 
@@ -650,7 +650,7 @@ public class OrganizationResourceTest extends AbstractResourceTest {
 
     // Now they can assign the new parent
     createdChildOrg.setParentOrg(createdNewParentOrg);
-    succeedUpdateOrganization(superuser.getDomainUsername(), getOrganizationInput(createdChildOrg));
+    succeedUpdateOrganization(getDomainUsername(superuser), getOrganizationInput(createdChildOrg));
   }
 
   @Test
@@ -698,8 +698,8 @@ public class OrganizationResourceTest extends AbstractResourceTest {
             .withLongName("Advisor Organization for Regular User Test").withStatus(Status.ACTIVE)
             .withIdentificationCode(UUID.randomUUID().toString())
             .withLocation(getLocationInput(getGeneralHospital())).build();
-    failCreateOrganization(getRegularUser().getDomainUsername(), orgInput);
-    failUpdateOrganization(getRegularUser().getDomainUsername(), orgInput);
+    failCreateOrganization(getDomainUsername(getRegularUser()), orgInput);
+    failUpdateOrganization(getDomainUsername(getRegularUser()), orgInput);
   }
 
   private void failCreateOrganization(final String username, final OrganizationInput orgInput) {

--- a/src/test/java/mil/dds/anet/test/resources/PersonResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/PersonResourceTest.java
@@ -38,6 +38,7 @@ import mil.dds.anet.test.client.PositionType;
 import mil.dds.anet.test.client.RecurseStrategy;
 import mil.dds.anet.test.client.SortOrder;
 import mil.dds.anet.test.client.Status;
+import mil.dds.anet.test.client.UserInput;
 import mil.dds.anet.test.utils.UtilsTest;
 import mil.dds.anet.utils.DaoUtils;
 import org.junit.jupiter.api.Test;
@@ -57,7 +58,7 @@ public class PersonResourceTest extends AbstractResourceTest {
       "uuid name code type role status organization { uuid } %1$s", _EMAIL_ADDRESSES_FIELDS);
   private static final String _PERSON_FIELDS = String.format(
       "uuid name status user phoneNumber rank biography obsoleteCountry country { uuid name } code"
-          + " gender endOfTourDate domainUsername pendingVerification createdAt updatedAt"
+          + " gender endOfTourDate users { uuid domainUsername } pendingVerification createdAt updatedAt"
           + " customFields %1$s",
       _EMAIL_ADDRESSES_FIELDS);
   public static final String PERSON_FIELDS_ONLY_HISTORY =
@@ -79,10 +80,12 @@ public class PersonResourceTest extends AbstractResourceTest {
     assertThat(retPerson).isNotNull();
     assertThat(retPerson.getUuid()).isEqualTo(jack.getUuid());
 
+    final UserInput newUserInput =
+        UserInput.builder().withDomainUsername("testCreatePerson").build();
     final PersonInput newPersonInput = PersonInput.builder().withName("testCreatePerson Person")
         .withStatus(Status.ACTIVE)
-        // set user/domainUsername
-        .withUser(true).withDomainUsername("testCreatePerson")
+        // set user/users
+        .withUser(true).withUsers(List.of(newUserInput))
         // set HTML of biography
         .withBiography(UtilsTest.getCombinedHtmlTestCase().getInput())
         // set JSON of customFields
@@ -98,7 +101,7 @@ public class PersonResourceTest extends AbstractResourceTest {
     assertThat(newPerson.getName()).isEqualTo("testCreatePerson Person");
     // check that admin can set user/domainUsername
     assertThat(newPerson.getUser()).isTrue();
-    assertThat(newPerson.getDomainUsername()).isEqualTo("testCreatePerson");
+    assertThat(getDomainUsername(newPerson)).isEqualTo("testCreatePerson");
     // check that HTML of biography is sanitized after create
     assertThat(newPerson.getBiography()).isEqualTo(UtilsTest.getCombinedHtmlTestCase().getOutput());
     // check that JSON of customFields is sanitized after create
@@ -125,7 +128,7 @@ public class PersonResourceTest extends AbstractResourceTest {
     assertThat(retPerson.getName()).isEqualTo(updatedNewPersonInput.getName());
     assertThat(retPerson.getCode()).isEqualTo(updatedNewPersonInput.getCode());
     // check that admin can update domainUsername
-    assertThat(retPerson.getDomainUsername()).isEqualTo(updatedNewPersonInput.getDomainUsername());
+    assertThat(getDomainUsername(retPerson)).isEqualTo(getDomainUsername(updatedNewPersonInput));
     // check that HTML of biography is sanitized after update
     assertThat(retPerson.getBiography()).isEqualTo(UtilsTest.getCombinedHtmlTestCase().getOutput());
     // check that JSON of customFields is sanitized after update
@@ -150,9 +153,11 @@ public class PersonResourceTest extends AbstractResourceTest {
     assertThat(newPos).isNotNull();
     assertThat(newPos.getUuid()).isNotNull();
 
+    final UserInput newUser2Input =
+        UserInput.builder().withDomainUsername("testcreateperson").build();
     final PersonInput newPerson2Input =
         PersonInput.builder().withName("Namey McNameface").withStatus(Status.ACTIVE).withUser(true)
-            .withDomainUsername("testcreateperson").withPosition(getPositionInput(newPos)).build();
+            .withUsers(List.of(newUser2Input)).withPosition(getPositionInput(newPos)).build();
     final Person newPerson2 =
         withCredentials(adminUser, t -> mutationExecutor.createPerson(FIELDS, newPerson2Input));
     assertThat(newPerson2).isNotNull();
@@ -175,7 +180,7 @@ public class PersonResourceTest extends AbstractResourceTest {
     newPerson2.setPosition(newPos2);
     // A person cannot change their own position
     try {
-      withCredentials(newPerson2.getDomainUsername(),
+      withCredentials(getDomainUsername(newPerson2),
           t -> mutationExecutor.updatePerson("", getPersonInput(newPerson2)));
       fail("Expected an Exception");
     } catch (Exception expectedException) {
@@ -195,7 +200,7 @@ public class PersonResourceTest extends AbstractResourceTest {
     // Now newPerson2 who is a superuser, should NOT be able to edit newPerson
     // Because they are not in newPerson2's organization.
     try {
-      withCredentials(newPerson2.getDomainUsername(),
+      withCredentials(getDomainUsername(newPerson2),
           t -> mutationExecutor.updatePerson("", updatedNewPersonInput));
       fail("Expected an Exception");
     } catch (Exception expectedException) {
@@ -386,16 +391,17 @@ public class PersonResourceTest extends AbstractResourceTest {
     assertThat(retPos).isNotNull();
     assertThat(retPos.getUuid()).isNotNull();
 
+    final UserInput newUserInput =
+        UserInput.builder().withDomainUsername("namey_" + Instant.now().toEpochMilli()).build();
     final PersonInput newPersonInput =
         PersonInput.builder().withName("Namey McNameface").withStatus(Status.ACTIVE).withUser(true)
-            .withDomainUsername("namey_" + Instant.now().toEpochMilli())
-            .withPosition(getPositionInput(retPos)).build();
+            .withUsers(List.of(newUserInput)).withPosition(getPositionInput(retPos)).build();
     final Person retPerson =
         withCredentials(adminUser, t -> mutationExecutor.createPerson(FIELDS, newPersonInput));
     assertThat(retPerson).isNotNull();
     assertThat(retPerson.getUuid()).isNotNull();
     assertThat(retPerson.getStatus()).isEqualTo(Status.ACTIVE);
-    assertThat(retPerson.getDomainUsername()).isEqualTo(newPersonInput.getDomainUsername());
+    assertThat(getDomainUsername(retPerson)).isEqualTo(getDomainUsername(newPersonInput));
     assertThat(retPerson.getUser()).isEqualTo(newPersonInput.getUser());
     assertThat(retPerson.getPosition()).isNotNull();
 
@@ -407,7 +413,7 @@ public class PersonResourceTest extends AbstractResourceTest {
     final Person retPerson2 =
         withCredentials(adminUser, t -> queryExecutor.person(FIELDS, retPerson.getUuid()));
     assertThat(retPerson2.getStatus()).isEqualTo(Status.INACTIVE);
-    assertThat(retPerson2.getDomainUsername()).isEqualTo(retPerson.getDomainUsername());
+    assertThat(getDomainUsername(retPerson2)).isEqualTo(getDomainUsername(retPerson));
     assertThat(retPerson2.getUser()).isEqualTo(retPerson.getUser());
     assertThat(retPerson2.getPosition()).isNull();
   }
@@ -421,7 +427,7 @@ public class PersonResourceTest extends AbstractResourceTest {
     assertThat(noPosPerson).isNotNull();
     assertThat(noPosPerson.getUuid()).isEqualTo(noPosUuid);
     assertThat(noPosPerson.getUser()).isTrue();
-    assertThat(noPosPerson.getDomainUsername()).isEqualTo(noPosDomainUsername);
+    assertThat(getDomainUsername(noPosPerson)).isEqualTo(noPosDomainUsername);
 
     // Inactivate user nopos
     noPosPerson.setStatus(Status.INACTIVE);
@@ -432,14 +438,14 @@ public class PersonResourceTest extends AbstractResourceTest {
     final Person noPosInactive =
         withCredentials(adminUser, t -> queryExecutor.person(FIELDS, noPosUuid));
     assertThat(noPosInactive.getStatus()).isEqualTo(Status.INACTIVE);
-    assertThat(noPosInactive.getDomainUsername()).isEqualTo(noPosPerson.getDomainUsername());
+    assertThat(getDomainUsername(noPosInactive)).isEqualTo(getDomainUsername(noPosPerson));
     assertThat(noPosInactive.getUser()).isEqualTo(noPosPerson.getUser());
 
     // Reactivate user nopos by querying as nopos
     final Person noPosAuth = withCredentials(noPosDomainUsername, t -> queryExecutor.me(FIELDS));
     assertThat(noPosAuth.getStatus()).isEqualTo(Status.ACTIVE);
     assertThat(noPosAuth.getUser()).isTrue();
-    assertThat(noPosAuth.getDomainUsername()).isEqualTo(noPosPerson.getDomainUsername());
+    assertThat(getDomainUsername(noPosAuth)).isEqualTo(getDomainUsername(noPosPerson));
     assertThat(noPosAuth.getPendingVerification()).isTrue();
 
     // Until verified, user nopos should not be able to query other stuff
@@ -450,7 +456,7 @@ public class PersonResourceTest extends AbstractResourceTest {
     // Verify user nopos
     final PersonInput noPosReactivateInput = getPersonInput(noPosAuth);
     noPosReactivateInput.setUser(false);
-    noPosReactivateInput.setDomainUsername("erin");
+    noPosReactivateInput.getUsers().get(0).setDomainUsername("erin");
     noPosReactivateInput.setPendingVerification(false);
     nrUpdated = withCredentials(noPosDomainUsername,
         t -> mutationExecutor.updateMe("", noPosReactivateInput));
@@ -461,7 +467,7 @@ public class PersonResourceTest extends AbstractResourceTest {
         withCredentials(adminUser, t -> queryExecutor.person(FIELDS, noPosUuid));
     assertThat(noPosReactivated.getStatus()).isEqualTo(Status.ACTIVE);
     assertThat(noPosReactivated.getUser()).isTrue();
-    assertThat(noPosReactivated.getDomainUsername()).isEqualTo(noPosPerson.getDomainUsername());
+    assertThat(getDomainUsername(noPosReactivated)).isEqualTo(getDomainUsername(noPosPerson));
     assertThat(noPosReactivated.getPendingVerification()).isFalse();
 
     // User nopos should now be able to query other stuff again
@@ -473,14 +479,14 @@ public class PersonResourceTest extends AbstractResourceTest {
     // User nopos should not be able to change their own user/domainUsername
     final PersonInput noPosUpdatedInput = getPersonInput(noPosReactivated);
     noPosUpdatedInput.setUser(!noPosReactivated.getUser());
-    noPosUpdatedInput.setDomainUsername("erin");
+    noPosUpdatedInput.getUsers().get(0).setDomainUsername("erin");
     nrUpdated =
         withCredentials(noPosDomainUsername, t -> mutationExecutor.updateMe("", noPosUpdatedInput));
     assertThat(nrUpdated).isEqualTo(1);
     final Person noPosUpdated =
         withCredentials(adminUser, t -> queryExecutor.person(FIELDS, noPosUuid));
     assertThat(noPosUpdated.getUser()).isEqualTo(noPosPerson.getUser());
-    assertThat(noPosUpdated.getDomainUsername()).isEqualTo(noPosPerson.getDomainUsername());
+    assertThat(getDomainUsername(noPosUpdated)).isEqualTo(getDomainUsername(noPosPerson));
   }
 
   @Test
@@ -499,19 +505,20 @@ public class PersonResourceTest extends AbstractResourceTest {
     final Organization organization = position.getOrganization();
 
     // interlocutor
-    final PersonInput interlocutorInput =
-        PersonInput.builder().withName("Namey McNameface").withStatus(Status.ACTIVE).withUser(true)
-            .withDomainUsername("namey_" + Instant.now().toEpochMilli()).build();
+    final UserInput interlocutorUserInput =
+        UserInput.builder().withDomainUsername("namey_" + Instant.now().toEpochMilli()).build();
+    final PersonInput interlocutorInput = PersonInput.builder().withName("Namey McNameface")
+        .withStatus(Status.ACTIVE).withUser(true).withUsers(List.of(interlocutorUserInput)).build();
 
     try {
-      final Person p = withCredentials(user.getDomainUsername(),
+      final Person p = withCredentials(getDomainUsername(user),
           t -> mutationExecutor.createPerson(FIELDS, interlocutorInput));
       if (isSuperuser) {
         assertThat(p).isNotNull();
         assertThat(p.getUuid()).isNotNull();
         // only admins can set user/domainUsername
         assertThat(p.getUser()).isFalse();
-        assertThat(p.getDomainUsername()).isNull();
+        assertThat(getDomainUsername(p)).isNull();
       } else {
         fail("Expected an Exception");
       }
@@ -522,19 +529,21 @@ public class PersonResourceTest extends AbstractResourceTest {
     }
 
     // advisor with no position
+    final UserInput advisorNoPositionUserInput =
+        UserInput.builder().withDomainUsername("namey_" + Instant.now().toEpochMilli()).build();
     final PersonInput advisorNoPositionInput =
         PersonInput.builder().withName("Namey McNameface").withStatus(Status.ACTIVE).withUser(true)
-            .withDomainUsername("namey_" + Instant.now().toEpochMilli()).build();
+            .withUsers(List.of(advisorNoPositionUserInput)).build();
 
     try {
-      final Person anp = withCredentials(user.getDomainUsername(),
+      final Person anp = withCredentials(getDomainUsername(user),
           t -> mutationExecutor.createPerson(FIELDS, advisorNoPositionInput));
       if (isSuperuser) {
         assertThat(anp).isNotNull();
         assertThat(anp.getUuid()).isNotNull();
         // only admins can set user/domainUsername
         assertThat(anp.getUser()).isFalse();
-        assertThat(anp.getDomainUsername()).isNull();
+        assertThat(getDomainUsername(anp)).isNull();
       } else {
         fail("Expected an Exception");
       }
@@ -547,26 +556,27 @@ public class PersonResourceTest extends AbstractResourceTest {
     // advisor with position in own organization
     final PositionSearchQueryInput query = PositionSearchQueryInput.builder()
         .withOrganizationUuid(List.of(organization.getUuid())).withIsFilled(false).build();
-    final AnetBeanList_Position searchObjects = withCredentials(user.getDomainUsername(),
+    final AnetBeanList_Position searchObjects = withCredentials(getDomainUsername(user),
         t -> queryExecutor.positionList(getListFields(POSITION_FIELDS), query));
     assertThat(searchObjects).isNotNull();
     assertThat(searchObjects.getList()).isNotEmpty();
     final Position freePos = searchObjects.getList().get(0);
 
-    final PersonInput advisorPositionInput =
-        PersonInput.builder().withName("Namey McNameface").withStatus(Status.ACTIVE).withUser(true)
-            .withDomainUsername("namey_" + Instant.now().toEpochMilli())
-            .withPosition(getPositionInput(freePos)).build();
+    final UserInput advisorPositionUserInput =
+        UserInput.builder().withDomainUsername("namey_" + Instant.now().toEpochMilli()).build();
+    final PersonInput advisorPositionInput = PersonInput.builder().withName("Namey McNameface")
+        .withStatus(Status.ACTIVE).withUser(true).withUsers(List.of(advisorPositionUserInput))
+        .withPosition(getPositionInput(freePos)).build();
 
     try {
-      final Person ap = withCredentials(user.getDomainUsername(),
+      final Person ap = withCredentials(getDomainUsername(user),
           t -> mutationExecutor.createPerson(FIELDS, advisorPositionInput));
       if (isSuperuser) {
         assertThat(ap).isNotNull();
         assertThat(ap.getUuid()).isNotNull();
         // only admins can set user/domainUsername
         assertThat(ap.getUser()).isFalse();
-        assertThat(ap.getDomainUsername()).isNull();
+        assertThat(getDomainUsername(ap)).isNull();
       } else {
         fail("Expected an Exception");
       }
@@ -581,7 +591,7 @@ public class PersonResourceTest extends AbstractResourceTest {
     positionTypes.add(PositionType.REGULAR);
     final PositionSearchQueryInput query2 =
         PositionSearchQueryInput.builder().withType(positionTypes).withIsFilled(false).build();
-    final AnetBeanList_Position searchObjects2 = withCredentials(user.getDomainUsername(),
+    final AnetBeanList_Position searchObjects2 = withCredentials(getDomainUsername(user),
         t -> queryExecutor.positionList(getListFields(POSITION_FIELDS), query2));
     assertThat(searchObjects2).isNotNull();
     assertThat(searchObjects2.getList()).isNotEmpty();
@@ -590,13 +600,14 @@ public class PersonResourceTest extends AbstractResourceTest {
     assertThat(foundPos2).isPresent();
     final Position freePos2 = foundPos2.get();
 
-    final PersonInput advisorPosition2Input =
-        PersonInput.builder().withName("Namey McNameface").withStatus(Status.ACTIVE).withUser(true)
-            .withDomainUsername("namey_" + Instant.now().toEpochMilli())
-            .withPosition(getPositionInput(freePos2)).build();
+    final UserInput advisorPosition2UserInput =
+        UserInput.builder().withDomainUsername("namey_" + Instant.now().toEpochMilli()).build();
+    final PersonInput advisorPosition2Input = PersonInput.builder().withName("Namey McNameface")
+        .withStatus(Status.ACTIVE).withUser(true).withUsers(List.of(advisorPosition2UserInput))
+        .withPosition(getPositionInput(freePos2)).build();
 
     try {
-      withCredentials(user.getDomainUsername(),
+      withCredentials(getDomainUsername(user),
           t -> mutationExecutor.createPerson(FIELDS, advisorPosition2Input));
       fail("Expected an Exception");
     } catch (Exception expectedException) {

--- a/src/test/java/mil/dds/anet/test/resources/PositionResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/PositionResourceTest.java
@@ -437,10 +437,9 @@ public class PositionResourceTest extends AbstractResourceTest {
         PositionSearchQueryInput.builder().withHasPendingAssessments(true).build();
     final TaskSearchQueryInput responsibleTasksQuery =
         TaskSearchQueryInput.builder().withStatus(Status.ACTIVE).build();
-    final AnetBeanList_Position searchResults =
-        withCredentials(getRegularUser().getDomainUsername(),
-            t -> queryExecutor.positionList(getListFields(PA_FIELDS), query,
-                "responsibleTasksQuery", responsibleTasksQuery));
+    final AnetBeanList_Position searchResults = withCredentials(getDomainUsername(getRegularUser()),
+        t -> queryExecutor.positionList(getListFields(PA_FIELDS), query, "responsibleTasksQuery",
+            responsibleTasksQuery));
     assertThat(searchResults).isNotNull();
     final List<Position> list = searchResults.getList();
     assertThat(list).isNotEmpty();
@@ -469,10 +468,9 @@ public class PositionResourceTest extends AbstractResourceTest {
             .withOrgRecurseStrategy(RecurseStrategy.CHILDREN).build();
     final TaskSearchQueryInput responsibleTasksQuery =
         TaskSearchQueryInput.builder().withStatus(Status.ACTIVE).build();
-    final AnetBeanList_Position searchResults =
-        withCredentials(getRegularUser().getDomainUsername(),
-            t -> queryExecutor.positionList(getListFields(PA_FIELDS), query,
-                "responsibleTasksQuery", responsibleTasksQuery));
+    final AnetBeanList_Position searchResults = withCredentials(getDomainUsername(getRegularUser()),
+        t -> queryExecutor.positionList(getListFields(PA_FIELDS), query, "responsibleTasksQuery",
+            responsibleTasksQuery));
     assertThat(searchResults).isNotNull();
     final List<Position> list = searchResults.getList();
     assertThat(list).isNotEmpty();
@@ -631,14 +629,14 @@ public class PositionResourceTest extends AbstractResourceTest {
     final boolean isAdmin = position.getType() == PositionType.ADMINISTRATOR;
 
     // try to update a position from the user's org
-    final Organization userOrg = withCredentials(user.getDomainUsername(),
+    final Organization userOrg = withCredentials(getDomainUsername(user),
         t -> queryExecutor.organization(ORGANIZATION_FIELDS, position.getOrganization().getUuid()));
     final List<Position> userOrgPositions = userOrg.getPositions();
     assertThat(userOrgPositions).isNotNull();
     assertThat(userOrgPositions).isNotEmpty();
     final Position p1 = userOrgPositions.get(0);
     try {
-      final Integer nrUpdated = withCredentials(user.getDomainUsername(),
+      final Integer nrUpdated = withCredentials(getDomainUsername(user),
           t -> mutationExecutor.updatePosition("", getPositionInput(p1)));
       if (isAdmin) {
         assertThat(nrUpdated).isEqualTo(1);
@@ -666,7 +664,7 @@ public class PositionResourceTest extends AbstractResourceTest {
 
     // try to update the new position (not related to the user's organization)
     try {
-      final Integer nrUpdated = withCredentials(user.getDomainUsername(),
+      final Integer nrUpdated = withCredentials(getDomainUsername(user),
           t -> mutationExecutor.updatePosition("", getPositionInput(newPosition)));
       if (isAdmin) {
         assertThat(nrUpdated).isEqualTo(1);
@@ -684,7 +682,7 @@ public class PositionResourceTest extends AbstractResourceTest {
     try {
       p3.setType(PositionType.SUPERUSER);
       final Integer nrUpdated =
-          withCredentials(user.getDomainUsername(), t -> mutationExecutor.updatePosition("", p3));
+          withCredentials(getDomainUsername(user), t -> mutationExecutor.updatePosition("", p3));
       if (isAdmin) {
         assertThat(nrUpdated).isEqualTo(1);
       } else {

--- a/src/test/java/mil/dds/anet/test/resources/ReportResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/ReportResourceTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.fail;
 import java.lang.invoke.MethodHandles;
 import java.time.Instant;
 import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -72,6 +73,8 @@ import mil.dds.anet.test.client.Status;
 import mil.dds.anet.test.client.Task;
 import mil.dds.anet.test.client.TaskSearchQueryInput;
 import mil.dds.anet.test.client.TaskSearchSortBy;
+import mil.dds.anet.test.client.User;
+import mil.dds.anet.test.client.UserInput;
 import mil.dds.anet.test.utils.UtilsTest;
 import mil.dds.anet.utils.DaoUtils;
 import mil.dds.anet.utils.Utils;
@@ -94,7 +97,7 @@ public class ReportResourceTest extends AbstractResourceTest {
           _ORGANIZATION_FIELDS, _EMAIL_ADDRESSES_FIELDS);
   private static final String _PERSON_FIELDS =
       "uuid name status user phoneNumber rank biography obsoleteCountry country { uuid name }"
-          + " gender endOfTourDate domainUsername pendingVerification createdAt updatedAt";
+          + " gender endOfTourDate users { uuid domainUsername } pendingVerification createdAt updatedAt";
   private static final String PERSON_FIELDS =
       String.format("{ %1$s %2$s }", _PERSON_FIELDS, _EMAIL_ADDRESSES_FIELDS);
   private static final String REPORT_PEOPLE_FIELDS =
@@ -146,10 +149,11 @@ public class ReportResourceTest extends AbstractResourceTest {
     final EmailAddress emailAddress1 =
         EmailAddress.builder().withNetwork(Utils.getEmailNetworkForNotifications())
             .withAddress("testApprover1@example.com").build();
-    final Person approver1tpl = Person.builder().withDomainUsername("testapprover1")
+    final User user1 = User.builder().withDomainUsername("testapprover1").build();
+    final Person approver1tpl = Person.builder().withUser(true).withUsers(List.of(user1))
         .withEmailAddresses(List.of(emailAddress1)).withName("Test Approver 1")
         .withStatus(Status.ACTIVE).build();
-    final Person approver1 = findOrPutPersonInDb(approver1tpl);
+    final Person approver1 = findOrPutPersonInDb(getDomainUsername(approver1tpl), approver1tpl);
     if (Boolean.TRUE.equals(approver1.getPendingVerification())) {
       // Approve newly created user
       withCredentials(adminUser, t -> mutationExecutor.approvePerson("", approver1.getUuid()));
@@ -157,10 +161,11 @@ public class ReportResourceTest extends AbstractResourceTest {
     final EmailAddress emailAddress2 =
         EmailAddress.builder().withNetwork(Utils.getEmailNetworkForNotifications())
             .withAddress("testApprover2@example.com").build();
-    final Person approver2tpl = Person.builder().withDomainUsername("testapprover2")
+    final User user2 = User.builder().withDomainUsername("testapprover2").build();
+    final Person approver2tpl = Person.builder().withUser(true).withUsers(List.of(user2))
         .withEmailAddresses(List.of(emailAddress2)).withName("Test Approver 2")
         .withStatus(Status.ACTIVE).build();
-    final Person approver2 = findOrPutPersonInDb(approver2tpl);
+    final Person approver2 = findOrPutPersonInDb(getDomainUsername(approver2tpl), approver2tpl);
     if (Boolean.TRUE.equals(approver2.getPendingVerification())) {
       // Approve newly created user
       withCredentials(adminUser, t -> mutationExecutor.approvePerson("", approver2.getUuid()));
@@ -281,12 +286,12 @@ public class ReportResourceTest extends AbstractResourceTest {
         .withCustomFields(UtilsTest.getCombinedJsonTestCase().getInput())
         .withNextSteps("This is the next steps on a report")
         .withKeyOutcomes("These are the key outcomes of this engagement").build();
-    final Report created = withCredentials(author.getDomainUsername(),
+    final Report created = withCredentials(getDomainUsername(author),
         t -> mutationExecutor.createReport(FIELDS, rInput));
     assertThat(created).isNotNull();
     assertThat(created.getUuid()).isNotNull();
     // Retrieve the report and do some additional checks
-    final Report check = withCredentials(author.getDomainUsername(),
+    final Report check = withCredentials(getDomainUsername(author),
         t -> queryExecutor.report(FIELDS, created.getUuid()));
     assertThat(check.getState()).isEqualTo(ReportState.DRAFT);
     assertThat(check.getAdvisorOrg().getUuid()).isEqualTo(authorBillet.getOrganization().getUuid());
@@ -301,7 +306,7 @@ public class ReportResourceTest extends AbstractResourceTest {
 
     // Have another regular user try to submit the report
     try {
-      withCredentials(getRegularUser().getDomainUsername(),
+      withCredentials(getDomainUsername(getRegularUser()),
           t -> mutationExecutor.submitReport("", created.getUuid()));
       fail("Expected an Exception");
     } catch (Exception expectedException) {
@@ -310,7 +315,7 @@ public class ReportResourceTest extends AbstractResourceTest {
 
     // Have a superuser of another AO try to submit the report
     try {
-      withCredentials(getSuperuser().getDomainUsername(),
+      withCredentials(getDomainUsername(getSuperuser()),
           t -> mutationExecutor.submitReport("", created.getUuid()));
       fail("Expected an Exception");
     } catch (Exception expectedException) {
@@ -318,32 +323,32 @@ public class ReportResourceTest extends AbstractResourceTest {
     }
 
     // Have the author submit the report
-    int numRows = withCredentials(author.getDomainUsername(),
+    int numRows = withCredentials(getDomainUsername(author),
         t -> mutationExecutor.submitReport("", created.getUuid()));
     assertThat(numRows).isOne();
 
-    final Report returned1 = withCredentials(author.getDomainUsername(),
+    final Report returned1 = withCredentials(getDomainUsername(author),
         t -> queryExecutor.report(FIELDS, created.getUuid()));
     assertThat(returned1.getState()).isEqualTo(ReportState.PENDING_APPROVAL);
 
     // Verify that author can still edit the report
     returned1.setAtmosphereDetails("Everybody was super nice! Again!");
-    final Report r2 = withCredentials(author.getDomainUsername(),
+    final Report r2 = withCredentials(getDomainUsername(author),
         t -> mutationExecutor.updateReport(FIELDS, getReportInput(returned1), true));
     assertThat(r2.getAtmosphereDetails()).isEqualTo(returned1.getAtmosphereDetails());
 
     // Have the author submit the report, again
-    numRows = withCredentials(author.getDomainUsername(),
+    numRows = withCredentials(getDomainUsername(author),
         t -> mutationExecutor.submitReport("", created.getUuid()));
     assertThat(numRows).isOne();
 
-    final Report returned2 = withCredentials(author.getDomainUsername(),
+    final Report returned2 = withCredentials(getDomainUsername(author),
         t -> queryExecutor.report(FIELDS, created.getUuid()));
     assertThat(returned2.getState()).isEqualTo(ReportState.PENDING_APPROVAL);
 
     // The author should not be able to submit the report now
     try {
-      withCredentials(author.getDomainUsername(),
+      withCredentials(getDomainUsername(author),
           t -> mutationExecutor.submitReport("", returned2.getUuid()));
       fail("Expected an Exception");
     } catch (Exception expectedException) {
@@ -369,7 +374,7 @@ public class ReportResourceTest extends AbstractResourceTest {
     // Verify this shows up on the approver's list of pending documents
     final ReportSearchQueryInput pendingQuery =
         ReportSearchQueryInput.builder().withPendingApprovalOf(approver1.getUuid()).build();
-    AnetBeanList_Report pending = withCredentials(approver1.getDomainUsername(),
+    AnetBeanList_Report pending = withCredentials(getDomainUsername(approver1),
         t -> queryExecutor.reportList(getListFields(FIELDS), pendingQuery));
     assertThat(pending.getList().stream().map(Report::getUuid).collect(Collectors.toSet()))
         .contains(returned2.getUuid());
@@ -385,37 +390,37 @@ public class ReportResourceTest extends AbstractResourceTest {
     assertThat(reportAction.getStep().getUuid()).isEqualTo(releaseApprovalStep.getUuid());
 
     // Reject the report
-    numRows = withCredentials(approver1.getDomainUsername(), t -> mutationExecutor.rejectReport("",
+    numRows = withCredentials(getDomainUsername(approver1), t -> mutationExecutor.rejectReport("",
         TestData.createCommentInput("a test rejection"), created.getUuid()));
     assertThat(numRows).isOne();
 
     // Check on report status to verify it was rejected
-    final Report returned3 = withCredentials(author.getDomainUsername(),
+    final Report returned3 = withCredentials(getDomainUsername(author),
         t -> queryExecutor.report(FIELDS, created.getUuid()));
     assertThat(returned3.getState()).isEqualTo(ReportState.REJECTED);
     assertThat(returned3.getApprovalStep()).isNull();
 
     // Author needs to re-submit
-    numRows = withCredentials(author.getDomainUsername(),
+    numRows = withCredentials(getDomainUsername(author),
         t -> mutationExecutor.submitReport("", created.getUuid()));
     assertThat(numRows).isOne();
 
     // TODO: Approver modify the report *specifically change the attendees!*
 
     // Approve the report
-    numRows = withCredentials(approver1.getDomainUsername(),
+    numRows = withCredentials(getDomainUsername(approver1),
         t -> mutationExecutor.approveReport("", null, created.getUuid()));
     assertThat(numRows).isOne();
 
     // Check on Report status to verify it got moved forward
-    final Report returned4 = withCredentials(author.getDomainUsername(),
+    final Report returned4 = withCredentials(getDomainUsername(author),
         t -> queryExecutor.report(FIELDS, created.getUuid()));
     assertThat(returned4.getState()).isEqualTo(ReportState.PENDING_APPROVAL);
     assertThat(returned4.getApprovalStep().getUuid()).isEqualTo(releaseApprovalStep.getUuid());
 
     // Verify that the wrong person cannot approve this report.
     try {
-      withCredentials(approver1.getDomainUsername(),
+      withCredentials(getDomainUsername(approver1),
           t -> mutationExecutor.approveReport("", null, created.getUuid()));
       fail("Expected an Exception");
     } catch (Exception expectedException) {
@@ -423,19 +428,19 @@ public class ReportResourceTest extends AbstractResourceTest {
     }
 
     // Approve the report
-    numRows = withCredentials(approver2.getDomainUsername(),
+    numRows = withCredentials(getDomainUsername(approver2),
         t -> mutationExecutor.approveReport("", null, created.getUuid()));
     assertThat(numRows).isOne();
 
     // Check on Report status to verify it got moved forward
-    final Report returned5 = withCredentials(author.getDomainUsername(),
+    final Report returned5 = withCredentials(getDomainUsername(author),
         t -> queryExecutor.report(FIELDS, created.getUuid()));
     assertThat(returned5.getState()).isEqualTo(ReportState.APPROVED);
     assertThat(returned5.getApprovalStep()).isNull();
 
     // The author should not be able to submit the report now
     try {
-      withCredentials(author.getDomainUsername(),
+      withCredentials(getDomainUsername(author),
           t -> mutationExecutor.submitReport("", returned5.getUuid()));
       fail("Expected an Exception");
     } catch (Exception expectedException) {
@@ -460,17 +465,17 @@ public class ReportResourceTest extends AbstractResourceTest {
 
     // Post a comment on the report because it's awesome
     final Comment commentOne =
-        withCredentials(author.getDomainUsername(), t -> mutationExecutor.addComment(COMMENT_FIELDS,
+        withCredentials(getDomainUsername(author), t -> mutationExecutor.addComment(COMMENT_FIELDS,
             TestData.createCommentInput("This is a test comment one"), created.getUuid()));
     assertThat(commentOne.getUuid()).isNotNull();
     assertThat(commentOne.getAuthor().getUuid()).isEqualTo(author.getUuid());
 
-    final Comment commentTwo = withCredentials(approver1.getDomainUsername(),
+    final Comment commentTwo = withCredentials(getDomainUsername(approver1),
         t -> mutationExecutor.addComment(COMMENT_FIELDS,
             TestData.createCommentInput("This is a test comment two"), created.getUuid()));
     assertThat(commentTwo.getUuid()).isNotNull();
 
-    final Report returned6 = withCredentials(approver1.getDomainUsername(),
+    final Report returned6 = withCredentials(getDomainUsername(approver1),
         t -> queryExecutor.report(FIELDS, created.getUuid()));
     final List<Comment> commentsReturned = returned6.getComments();
     assertThat(commentsReturned).hasSize(3); // the rejection comment will be there as well.
@@ -494,7 +499,7 @@ public class ReportResourceTest extends AbstractResourceTest {
     final PersonSearchQueryInput queryPeople =
         PersonSearchQueryInput.builder().withStatus(Status.ACTIVE).withInMyReports(true)
             .withSortBy(PersonSearchSortBy.RECENT).withSortOrder(SortOrder.DESC).build();
-    final AnetBeanList_Person recentPeople = withCredentials(author.getDomainUsername(),
+    final AnetBeanList_Person recentPeople = withCredentials(getDomainUsername(author),
         t -> queryExecutor.personList(getListFields(PERSON_FIELDS), queryPeople));
     assertThat(recentPeople.getList().stream().map(Person::getUuid).collect(Collectors.toSet()))
         .contains(interlocutorPerson.getUuid());
@@ -502,7 +507,7 @@ public class ReportResourceTest extends AbstractResourceTest {
     final TaskSearchQueryInput queryTasks =
         TaskSearchQueryInput.builder().withStatus(Status.ACTIVE).withInMyReports(true)
             .withSortBy(TaskSearchSortBy.RECENT).withSortOrder(SortOrder.DESC).build();
-    final AnetBeanList_Task recentTasks = withCredentials(author.getDomainUsername(),
+    final AnetBeanList_Task recentTasks = withCredentials(getDomainUsername(author),
         t -> queryExecutor.taskList(getListFields(TASK_FIELDS), queryTasks));
     assertThat(recentTasks.getList().stream().map(Task::getUuid).collect(Collectors.toSet()))
         .contains(action.getUuid());
@@ -510,7 +515,7 @@ public class ReportResourceTest extends AbstractResourceTest {
     final LocationSearchQueryInput queryLocations =
         LocationSearchQueryInput.builder().withStatus(Status.ACTIVE).withInMyReports(true)
             .withSortBy(LocationSearchSortBy.RECENT).withSortOrder(SortOrder.DESC).build();
-    final AnetBeanList_Location recentLocations = withCredentials(author.getDomainUsername(),
+    final AnetBeanList_Location recentLocations = withCredentials(getDomainUsername(author),
         t -> queryExecutor.locationList(getListFields(LOCATION_FIELDS), queryLocations));
     assertThat(
         recentLocations.getList().stream().map(Location::getUuid).collect(Collectors.toSet()))
@@ -556,17 +561,19 @@ public class ReportResourceTest extends AbstractResourceTest {
     final EmailAddress emailAddress1 =
         EmailAddress.builder().withNetwork(Utils.getEmailNetworkForNotifications())
             .withAddress("testApprover1@example.com").build();
-    final Person approver1tpl = Person.builder().withDomainUsername("testapprover1")
+    final User user1 = User.builder().withDomainUsername("testapprover1").build();
+    final Person approver1tpl = Person.builder().withUser(true).withUsers(List.of(user1))
         .withEmailAddresses(List.of(emailAddress1)).withName("Test Approver 1")
         .withStatus(Status.ACTIVE).build();
-    final Person approver1 = findOrPutPersonInDb(approver1tpl);
+    final Person approver1 = findOrPutPersonInDb(getDomainUsername(approver1tpl), approver1tpl);
     final EmailAddress emailAddress2 =
         EmailAddress.builder().withNetwork(Utils.getEmailNetworkForNotifications())
             .withAddress("testApprover2@example.com").build();
-    final Person approver2tpl = Person.builder().withDomainUsername("testapprover2")
+    final User user2 = User.builder().withDomainUsername("testapprover2").build();
+    final Person approver2tpl = Person.builder().withUser(true).withUsers(List.of(user2))
         .withEmailAddresses(List.of(emailAddress2)).withName("Test Approver 2")
         .withStatus(Status.ACTIVE).build();
-    final Person approver2 = findOrPutPersonInDb(approver2tpl);
+    final Person approver2 = findOrPutPersonInDb(getDomainUsername(approver2tpl), approver2tpl);
 
     final PositionInput approver1PosInput = PositionInput.builder()
         .withName("Test Approver 1 Position").withOrganization(getOrganizationInput(advisorOrg))
@@ -595,12 +602,12 @@ public class ReportResourceTest extends AbstractResourceTest {
     // Verify these users
     final PersonInput approver1ActivateInput = getPersonInput(approver1);
     approver1ActivateInput.setPendingVerification(false);
-    nrUpdated = withCredentials(approver1.getDomainUsername(),
+    nrUpdated = withCredentials(getDomainUsername(approver1),
         t -> mutationExecutor.updateMe("", approver1ActivateInput));
     assertThat(nrUpdated).isEqualTo(1);
     final PersonInput approver2ActivateInput = getPersonInput(approver2);
     approver2ActivateInput.setPendingVerification(false);
-    nrUpdated = withCredentials(approver2.getDomainUsername(),
+    nrUpdated = withCredentials(getDomainUsername(approver2),
         t -> mutationExecutor.updateMe("", approver2ActivateInput));
     assertThat(nrUpdated).isEqualTo(1);
 
@@ -694,7 +701,7 @@ public class ReportResourceTest extends AbstractResourceTest {
             .withNextSteps("This is the next steps on a report")
             .withKeyOutcomes("These are the key outcomes of this engagement")
             .withClassification(getFirstClassification()).build();
-    final Report created = withCredentials(author.getDomainUsername(),
+    final Report created = withCredentials(getDomainUsername(author),
         t -> mutationExecutor.createReport(FIELDS, rInput));
     assertThat(created).isNotNull();
     assertThat(created.getUuid()).isNotNull();
@@ -709,7 +716,7 @@ public class ReportResourceTest extends AbstractResourceTest {
 
     // Have another regular user try to submit the report
     try {
-      withCredentials(getRegularUser().getDomainUsername(),
+      withCredentials(getDomainUsername(getRegularUser()),
           t -> mutationExecutor.submitReport("", created.getUuid()));
       fail("Expected an Exception");
     } catch (Exception expectedException) {
@@ -718,7 +725,7 @@ public class ReportResourceTest extends AbstractResourceTest {
 
     // Have a superuser of another AO try to submit the report
     try {
-      withCredentials(getSuperuser().getDomainUsername(),
+      withCredentials(getDomainUsername(getSuperuser()),
           t -> mutationExecutor.submitReport("", created.getUuid()));
       fail("Expected an Exception");
     } catch (Exception expectedException) {
@@ -726,32 +733,32 @@ public class ReportResourceTest extends AbstractResourceTest {
     }
 
     // Have the author submit the report
-    int numRows = withCredentials(author.getDomainUsername(),
+    int numRows = withCredentials(getDomainUsername(author),
         t -> mutationExecutor.submitReport("", created.getUuid()));
     assertThat(numRows).isOne();
 
-    final Report returned1 = withCredentials(author.getDomainUsername(),
+    final Report returned1 = withCredentials(getDomainUsername(author),
         t -> queryExecutor.report(FIELDS, created.getUuid()));
     assertThat(returned1.getState()).isEqualTo(ReportState.PENDING_APPROVAL);
 
     // Verify that author can still edit the report
     returned1.setAtmosphereDetails("Everybody was super nice! Again!");
-    final Report r2 = withCredentials(author.getDomainUsername(),
+    final Report r2 = withCredentials(getDomainUsername(author),
         t -> mutationExecutor.updateReport(FIELDS, getReportInput(returned1), true));
     assertThat(r2.getAtmosphereDetails()).isEqualTo(returned1.getAtmosphereDetails());
 
     // Have the author submit the report, again
-    numRows = withCredentials(author.getDomainUsername(),
+    numRows = withCredentials(getDomainUsername(author),
         t -> mutationExecutor.submitReport("", created.getUuid()));
     assertThat(numRows).isOne();
 
-    final Report returned2 = withCredentials(author.getDomainUsername(),
+    final Report returned2 = withCredentials(getDomainUsername(author),
         t -> queryExecutor.report(FIELDS, created.getUuid()));
     assertThat(returned2.getState()).isEqualTo(ReportState.PENDING_APPROVAL);
 
     // The author should not be able to submit the report now
     try {
-      withCredentials(author.getDomainUsername(),
+      withCredentials(getDomainUsername(author),
           t -> mutationExecutor.submitReport("", returned2.getUuid()));
       fail("Expected an Exception");
     } catch (Exception expectedException) {
@@ -777,7 +784,7 @@ public class ReportResourceTest extends AbstractResourceTest {
     // Verify this shows up on the approver's list of pending documents
     final ReportSearchQueryInput pendingQuery =
         ReportSearchQueryInput.builder().withPendingApprovalOf(approver1.getUuid()).build();
-    AnetBeanList_Report pending = withCredentials(approver1.getDomainUsername(),
+    AnetBeanList_Report pending = withCredentials(getDomainUsername(approver1),
         t -> queryExecutor.reportList(getListFields(FIELDS), pendingQuery));
     assertThat(pending.getList().stream().map(Report::getUuid).collect(Collectors.toSet()))
         .contains(returned2.getUuid());
@@ -793,37 +800,37 @@ public class ReportResourceTest extends AbstractResourceTest {
     assertThat(reportAction.getStep().getUuid()).isEqualTo(releaseApprovalStep.getUuid());
 
     // Reject the report
-    numRows = withCredentials(approver1.getDomainUsername(), t -> mutationExecutor.rejectReport("",
+    numRows = withCredentials(getDomainUsername(approver1), t -> mutationExecutor.rejectReport("",
         TestData.createCommentInput("a test rejection"), created.getUuid()));
     assertThat(numRows).isOne();
 
     // Check on report status to verify it was rejected
-    final Report returned3 = withCredentials(author.getDomainUsername(),
+    final Report returned3 = withCredentials(getDomainUsername(author),
         t -> queryExecutor.report(FIELDS, created.getUuid()));
     assertThat(returned3.getState()).isEqualTo(ReportState.REJECTED);
     assertThat(returned3.getApprovalStep()).isNull();
 
     // Author needs to re-submit
-    numRows = withCredentials(author.getDomainUsername(),
+    numRows = withCredentials(getDomainUsername(author),
         t -> mutationExecutor.submitReport("", created.getUuid()));
     assertThat(numRows).isOne();
 
     // TODO: Approver modify the report *specifically change the attendees!*
 
     // Approve the report
-    numRows = withCredentials(approver1.getDomainUsername(),
+    numRows = withCredentials(getDomainUsername(approver1),
         t -> mutationExecutor.approveReport("", null, created.getUuid()));
     assertThat(numRows).isOne();
 
     // Check on Report status to verify it got moved forward
-    final Report returned4 = withCredentials(author.getDomainUsername(),
+    final Report returned4 = withCredentials(getDomainUsername(author),
         t -> queryExecutor.report(FIELDS, created.getUuid()));
     assertThat(returned4.getState()).isEqualTo(ReportState.PENDING_APPROVAL);
     assertThat(returned4.getApprovalStep().getUuid()).isEqualTo(releaseApprovalStep.getUuid());
 
     // Verify that the wrong person cannot approve this report.
     try {
-      withCredentials(approver1.getDomainUsername(),
+      withCredentials(getDomainUsername(approver1),
           t -> mutationExecutor.approveReport("", null, created.getUuid()));
       fail("Expected an Exception");
     } catch (Exception expectedException) {
@@ -831,19 +838,19 @@ public class ReportResourceTest extends AbstractResourceTest {
     }
 
     // Approve the report
-    numRows = withCredentials(approver2.getDomainUsername(),
+    numRows = withCredentials(getDomainUsername(approver2),
         t -> mutationExecutor.approveReport("", null, created.getUuid()));
     assertThat(numRows).isOne();
 
     // Check on Report status to verify it got moved forward
-    final Report returned5 = withCredentials(author.getDomainUsername(),
+    final Report returned5 = withCredentials(getDomainUsername(author),
         t -> queryExecutor.report(FIELDS, created.getUuid()));
     assertThat(returned5.getState()).isEqualTo(ReportState.APPROVED);
     assertThat(returned5.getApprovalStep()).isNull();
 
     // The author should not be able to submit the report now
     try {
-      withCredentials(author.getDomainUsername(),
+      withCredentials(getDomainUsername(author),
           t -> mutationExecutor.submitReport("", returned5.getUuid()));
       fail("Expected an Exception");
     } catch (Exception expectedException) {
@@ -868,17 +875,17 @@ public class ReportResourceTest extends AbstractResourceTest {
 
     // Post a comment on the report because it's awesome
     final Comment commentOne =
-        withCredentials(author.getDomainUsername(), t -> mutationExecutor.addComment(COMMENT_FIELDS,
+        withCredentials(getDomainUsername(author), t -> mutationExecutor.addComment(COMMENT_FIELDS,
             TestData.createCommentInput("This is a test comment one"), created.getUuid()));
     assertThat(commentOne.getUuid()).isNotNull();
     assertThat(commentOne.getAuthor().getUuid()).isEqualTo(author.getUuid());
 
-    final Comment commentTwo = withCredentials(approver1.getDomainUsername(),
+    final Comment commentTwo = withCredentials(getDomainUsername(approver1),
         t -> mutationExecutor.addComment(COMMENT_FIELDS,
             TestData.createCommentInput("This is a test comment two"), created.getUuid()));
     assertThat(commentTwo.getUuid()).isNotNull();
 
-    final Report returned6 = withCredentials(approver1.getDomainUsername(),
+    final Report returned6 = withCredentials(getDomainUsername(approver1),
         t -> queryExecutor.report(FIELDS, created.getUuid()));
     final List<Comment> commentsReturned = returned6.getComments();
     assertThat(commentsReturned).hasSize(3); // the rejection comment will be there as well.
@@ -902,7 +909,7 @@ public class ReportResourceTest extends AbstractResourceTest {
     final PersonSearchQueryInput queryPeople =
         PersonSearchQueryInput.builder().withStatus(Status.ACTIVE).withInMyReports(true)
             .withSortBy(PersonSearchSortBy.RECENT).withSortOrder(SortOrder.DESC).build();
-    final AnetBeanList_Person recentPeople = withCredentials(author.getDomainUsername(),
+    final AnetBeanList_Person recentPeople = withCredentials(getDomainUsername(author),
         t -> queryExecutor.personList(getListFields(PERSON_FIELDS), queryPeople));
     assertThat(recentPeople.getList().stream().map(Person::getUuid).collect(Collectors.toSet()))
         .contains(reportAttendeePerson.getUuid());
@@ -910,7 +917,7 @@ public class ReportResourceTest extends AbstractResourceTest {
     final TaskSearchQueryInput queryTasks =
         TaskSearchQueryInput.builder().withStatus(Status.ACTIVE).withInMyReports(true)
             .withSortBy(TaskSearchSortBy.RECENT).withSortOrder(SortOrder.DESC).build();
-    final AnetBeanList_Task recentTasks = withCredentials(author.getDomainUsername(),
+    final AnetBeanList_Task recentTasks = withCredentials(getDomainUsername(author),
         t -> queryExecutor.taskList(getListFields(TASK_FIELDS), queryTasks));
     assertThat(recentTasks.getList().stream().map(Task::getUuid).collect(Collectors.toSet()))
         .contains(action.getUuid());
@@ -918,7 +925,7 @@ public class ReportResourceTest extends AbstractResourceTest {
     final LocationSearchQueryInput queryLocations =
         LocationSearchQueryInput.builder().withStatus(Status.ACTIVE).withInMyReports(true)
             .withSortBy(LocationSearchSortBy.RECENT).withSortOrder(SortOrder.DESC).build();
-    final AnetBeanList_Location recentLocations = withCredentials(author.getDomainUsername(),
+    final AnetBeanList_Location recentLocations = withCredentials(getDomainUsername(author),
         t -> queryExecutor.locationList(getListFields(LOCATION_FIELDS), queryLocations));
     assertThat(
         recentLocations.getList().stream().map(Location::getUuid).collect(Collectors.toSet()))
@@ -947,9 +954,10 @@ public class ReportResourceTest extends AbstractResourceTest {
     final EmailAddressInput emailAddressInput =
         EmailAddressInput.builder().withNetwork(Utils.getEmailNetworkForNotifications())
             .withAddress("newguy@example.com").build();
+    final UserInput userInput = UserInput.builder().withDomainUsername("newguy").build();
     final PersonInput authorInput =
         PersonInput.builder().withName("A New Guy").withUser(true).withStatus(Status.ACTIVE)
-            .withDomainUsername("newguy").withEmailAddresses(List.of(emailAddressInput)).build();
+            .withUsers(List.of(userInput)).withEmailAddresses(List.of(emailAddressInput)).build();
     final Person author =
         withCredentials(adminUser, t -> mutationExecutor.createPerson(PERSON_FIELDS, authorInput));
     assertThat(author).isNotNull();
@@ -1032,13 +1040,13 @@ public class ReportResourceTest extends AbstractResourceTest {
         List.of(personToPrimaryReportPerson(roger, true), personToReportPerson(jack, false),
             personToPrimaryReportPerson(bob, false), personToReportAuthor(author)));
 
-    final Report updated = withCredentials(author.getDomainUsername(),
+    final Report updated = withCredentials(getDomainUsername(author),
         t -> mutationExecutor.updateReport(FIELDS, getReportInput(returned), true));
     assertThat(updated).isNotNull();
     assertThat(updated.getAdvisorOrg().getUuid()).isNotEqualTo(returned.getAdvisorOrg().getUuid());
 
     // Re-submit the reported
-    numRows = withCredentials(author.getDomainUsername(),
+    numRows = withCredentials(getDomainUsername(author),
         t -> mutationExecutor.submitReport("", r.getUuid()));
     assertThat(numRows).isOne();
 
@@ -1052,13 +1060,13 @@ public class ReportResourceTest extends AbstractResourceTest {
         List.of(personToPrimaryReportPerson(roger, true), personToReportPerson(jack, false),
             personToPrimaryReportPerson(ben, false), personToReportAuthor(author)));
 
-    final Report updated2 = withCredentials(author.getDomainUsername(),
+    final Report updated2 = withCredentials(getDomainUsername(author),
         t -> mutationExecutor.updateReport(FIELDS, getReportInput(updated), true));
     assertThat(updated2).isNotNull();
     assertThat(updated2.getAdvisorOrg().getUuid()).isNotEqualTo(updated.getAdvisorOrg().getUuid());
 
     // Re-submit the report
-    numRows = withCredentials(author.getDomainUsername(),
+    numRows = withCredentials(getDomainUsername(author),
         t -> mutationExecutor.submitReport("", r.getUuid()));
     assertThat(numRows).isOne();
 
@@ -1102,7 +1110,7 @@ public class ReportResourceTest extends AbstractResourceTest {
     // Fetch some objects from the DB that we'll use later.
     final LocationSearchQueryInput queryLocs =
         LocationSearchQueryInput.builder().withText("Police").build();
-    final AnetBeanList_Location locSearchResults = withCredentials(elizabeth.getDomainUsername(),
+    final AnetBeanList_Location locSearchResults = withCredentials(getDomainUsername(elizabeth),
         t -> queryExecutor.locationList(getListFields(LOCATION_FIELDS), queryLocs));
     assertThat(locSearchResults).isNotNull();
     assertThat(locSearchResults.getList()).isNotEmpty();
@@ -1110,7 +1118,7 @@ public class ReportResourceTest extends AbstractResourceTest {
 
     final TaskSearchQueryInput queryTasks =
         TaskSearchQueryInput.builder().withText("Budgeting").build();
-    final AnetBeanList_Task taskSearchResults = withCredentials(elizabeth.getDomainUsername(),
+    final AnetBeanList_Task taskSearchResults = withCredentials(getDomainUsername(elizabeth),
         t -> queryExecutor.taskList(getListFields(TASK_FIELDS), queryTasks));
     assertThat(taskSearchResults.getTotalCount()).isGreaterThan(2);
 
@@ -1123,7 +1131,7 @@ public class ReportResourceTest extends AbstractResourceTest {
         .withReportPeople(getReportPeopleInput(
             List.of(personToPrimaryReportPerson(roger, true), personToReportAuthor(elizabeth))))
         .withTasks(List.of(getTaskInput(taskSearchResults.getList().get(0)))).build();
-    Report returned = withCredentials(elizabeth.getDomainUsername(),
+    Report returned = withCredentials(getDomainUsername(elizabeth),
         t -> mutationExecutor.createReport(FIELDS, rInput));
     assertThat(returned).isNotNull();
     assertThat(returned.getUuid()).isNotNull();
@@ -1137,12 +1145,12 @@ public class ReportResourceTest extends AbstractResourceTest {
     returned.setReportPeople(List.of(personToPrimaryReportPerson(roger, true),
         personToReportPerson(nick, false), personToPrimaryReportAuthor(elizabeth)));
     returned.setTasks(List.of());
-    Report updated = withCredentials(elizabeth.getDomainUsername(),
+    Report updated = withCredentials(getDomainUsername(elizabeth),
         t -> mutationExecutor.updateReport(FIELDS, getReportInput(returned), true));
     assertThat(updated).isNotNull();
 
     // Verify the report changed
-    Report returned2 = withCredentials(elizabeth.getDomainUsername(),
+    Report returned2 = withCredentials(getDomainUsername(elizabeth),
         t -> queryExecutor.report(FIELDS, returned.getUuid()));
     assertThat(returned2.getIntent()).isEqualTo(rInput.getIntent());
     assertThat(returned2.getLocation().getUuid()).isEqualTo(loc.getUuid());
@@ -1159,10 +1167,10 @@ public class ReportResourceTest extends AbstractResourceTest {
         .isEqualTo(UtilsTest.getCombinedJsonTestCase().getOutput());
 
     // Elizabeth submits the report
-    int numRows = withCredentials(elizabeth.getDomainUsername(),
+    int numRows = withCredentials(getDomainUsername(elizabeth),
         t -> mutationExecutor.submitReport("", returned.getUuid()));
     assertThat(numRows).isOne();
-    Report returned3 = withCredentials(elizabeth.getDomainUsername(),
+    Report returned3 = withCredentials(getDomainUsername(elizabeth),
         t -> queryExecutor.report(FIELDS, returned.getUuid()));
     assertThat(returned3.getState()).isEqualTo(ReportState.PENDING_APPROVAL);
 
@@ -1184,7 +1192,7 @@ public class ReportResourceTest extends AbstractResourceTest {
         t -> mutationExecutor.updateReport(FIELDS, getReportInput(returned3), true));
     assertThat(updated).isNotNull();
 
-    Report returned4 = withCredentials(elizabeth.getDomainUsername(),
+    Report returned4 = withCredentials(getDomainUsername(elizabeth),
         t -> queryExecutor.report(FIELDS, returned.getUuid()));
     assertThat(returned4.getReportText()).endsWith("Bob!!");
     final List<ReportPerson> returned4Attendees = returned4.getAttendees();
@@ -1595,23 +1603,23 @@ public class ReportResourceTest extends AbstractResourceTest {
     assertThat(results.getList()).hasSize(1);
     Instant actualReportDate = results.getList().get(0).getUpdatedAt();
 
-    // Greater than startDate and equal to endDate
+    // Greater than startDate and equal to endDate plus 1 ms (to avoid rounding errors)
     query.setUpdatedAtStart(startDate);
-    query.setUpdatedAtEnd(actualReportDate);
+    query.setUpdatedAtEnd(actualReportDate.plus(1, ChronoUnit.MILLIS));
     results =
         withCredentials(adminUser, t -> queryExecutor.reportList(getListFields(FIELDS), query));
     assertThat(results.getList()).hasSize(1);
 
-    // Equal to startDate and smaller than endDate
+    // Equal to startDate and smaller than endDate plus 1 ms (to avoid rounding errors)
     query.setUpdatedAtStart(actualReportDate);
-    query.setUpdatedAtEnd(endDate);
+    query.setUpdatedAtEnd(endDate.plus(1, ChronoUnit.MILLIS));
     results =
         withCredentials(adminUser, t -> queryExecutor.reportList(getListFields(FIELDS), query));
     assertThat(results.getList()).hasSize(1);
 
-    // Equal to startDate and equal to endDate
+    // Equal to startDate and equal to endDate plus 1 ms (to avoid rounding errors)
     query.setUpdatedAtStart(actualReportDate);
-    query.setUpdatedAtEnd(actualReportDate);
+    query.setUpdatedAtEnd(actualReportDate.plus(1, ChronoUnit.MILLIS));
     results =
         withCredentials(adminUser, t -> queryExecutor.reportList(getListFields(FIELDS), query));
     assertThat(results.getList()).hasSize(1);
@@ -1667,7 +1675,7 @@ public class ReportResourceTest extends AbstractResourceTest {
         .withReportText("I'm writing a report that I intend to delete very soon.")
         .withKeyOutcomes("Summary for the key outcomes").withNextSteps("Summary for the next steps")
         .withEngagementDate(Instant.now()).withDuration(15).build();
-    final Report r = withCredentials(elizabeth.getDomainUsername(),
+    final Report r = withCredentials(getDomainUsername(elizabeth),
         t -> mutationExecutor.createReport(FIELDS, rInput));
     assertThat(r).isNotNull();
     assertThat(r.getUuid()).isNotNull();
@@ -1685,7 +1693,7 @@ public class ReportResourceTest extends AbstractResourceTest {
         AttachmentInput.builder().withFileName("testDeleteAttachment.jpg").withMimeType(mimeType)
             .withDescription("a test attachment created by testDeleteAttachment")
             .withAttachmentRelatedObjects(Collections.singletonList(testAroInput)).build();
-    final String createdAttachmentUuid = withCredentials(elizabeth.getDomainUsername(),
+    final String createdAttachmentUuid = withCredentials(getDomainUsername(elizabeth),
         t -> mutationExecutor.createAttachment("", testAttachmentInput));
     assertThat(createdAttachmentUuid).isNotNull();
 
@@ -1705,7 +1713,7 @@ public class ReportResourceTest extends AbstractResourceTest {
     }
 
     // Now have the author delete this report.
-    final Integer nrDeleted = withCredentials(elizabeth.getDomainUsername(),
+    final Integer nrDeleted = withCredentials(getDomainUsername(elizabeth),
         t -> mutationExecutor.deleteReport("", r.getUuid()));
     assertThat(nrDeleted).isEqualTo(1);
 
@@ -1742,15 +1750,15 @@ public class ReportResourceTest extends AbstractResourceTest {
                 personToPrimaryReportPerson(steve, true))))
             .withCancelledReason(ReportCancelledReason.CANCELLED_BY_INTERLOCUTOR).build();
 
-    final Report saved = withCredentials(elizabeth.getDomainUsername(),
+    final Report saved = withCredentials(getDomainUsername(elizabeth),
         t -> mutationExecutor.createReport(FIELDS, rInput));
     assertThat(saved).isNotNull();
     assertThat(saved.getUuid()).isNotNull();
 
-    int numRows = withCredentials(elizabeth.getDomainUsername(),
+    int numRows = withCredentials(getDomainUsername(elizabeth),
         t -> mutationExecutor.submitReport("", saved.getUuid()));
     assertThat(numRows).isOne();
-    final Report returned = withCredentials(elizabeth.getDomainUsername(),
+    final Report returned = withCredentials(getDomainUsername(elizabeth),
         t -> queryExecutor.report(FIELDS, saved.getUuid()));
     assertThat(returned.getState()).isEqualTo(ReportState.PENDING_APPROVAL);
     assertThat(returned.getCancelledReason())
@@ -1770,13 +1778,13 @@ public class ReportResourceTest extends AbstractResourceTest {
     assertThat(numRows).isOne();
 
     // Ensure it went to cancelled status.
-    final Report returned2 = withCredentials(elizabeth.getDomainUsername(),
+    final Report returned2 = withCredentials(getDomainUsername(elizabeth),
         t -> queryExecutor.report(FIELDS, saved.getUuid()));
     assertThat(returned2.getState()).isEqualTo(ReportState.CANCELLED);
 
     // The author should not be able to submit the report now
     try {
-      withCredentials(elizabeth.getDomainUsername(),
+      withCredentials(getDomainUsername(elizabeth),
           t -> mutationExecutor.submitReport("", returned2.getUuid()));
       fail("Expected an Exception");
     } catch (Exception expectedException) {
@@ -1873,7 +1881,7 @@ public class ReportResourceTest extends AbstractResourceTest {
         .withKeyOutcomes("Foobar the bazbiz").withReportPeople(getReportPeopleInput(List
             .of(personToPrimaryReportAuthor(elizabeth), personToPrimaryReportPerson(steve, true))))
         .build();
-    final Report r1 = withCredentials(elizabeth.getDomainUsername(),
+    final Report r1 = withCredentials(getDomainUsername(elizabeth),
         t -> mutationExecutor.createReport(FIELDS, rInput));
     assertThat(r1).isNotNull();
     assertThat(r1.getUuid()).isNotNull();
@@ -1888,7 +1896,7 @@ public class ReportResourceTest extends AbstractResourceTest {
 
     // Submit the report
     try {
-      withCredentials(elizabeth.getDomainUsername(),
+      withCredentials(getDomainUsername(elizabeth),
           t -> mutationExecutor.submitReport("", r1.getUuid()));
       fail("Expected an Exception");
     } catch (Exception expectedException) {
@@ -1898,12 +1906,12 @@ public class ReportResourceTest extends AbstractResourceTest {
     // Oops set the engagementDate.
     r1.setEngagementDate(Instant.now());
     r1.setDuration(115);
-    final Report updated = withCredentials(elizabeth.getDomainUsername(),
+    final Report updated = withCredentials(getDomainUsername(elizabeth),
         t -> mutationExecutor.updateReport(FIELDS, getReportInput(r1), true));
     assertThat(updated).isNotNull();
 
     // Re-submit the report, it should work.
-    int numRows = withCredentials(elizabeth.getDomainUsername(),
+    int numRows = withCredentials(getDomainUsername(elizabeth),
         t -> mutationExecutor.submitReport("", r1.getUuid()));
     assertThat(numRows).isOne();
 
@@ -1912,7 +1920,7 @@ public class ReportResourceTest extends AbstractResourceTest {
     assertThat(numRows).isOne();
 
     // Verify report is in APPROVED state.
-    final Report r2 = withCredentials(elizabeth.getDomainUsername(),
+    final Report r2 = withCredentials(getDomainUsername(elizabeth),
         t -> queryExecutor.report(FIELDS, r1.getUuid()));
     assertThat(r2.getState()).isEqualTo(ReportState.APPROVED);
 
@@ -1921,7 +1929,7 @@ public class ReportResourceTest extends AbstractResourceTest {
     assertThat(numRows).isOne();
 
     // Verify report is in PUBLISHED state.
-    final Report r3 = withCredentials(elizabeth.getDomainUsername(),
+    final Report r3 = withCredentials(getDomainUsername(elizabeth),
         t -> queryExecutor.report(FIELDS, r1.getUuid()));
     assertThat(r3.getState()).isEqualTo(ReportState.PUBLISHED);
 
@@ -1957,7 +1965,7 @@ public class ReportResourceTest extends AbstractResourceTest {
         .withReportText(
             "This reportTest was generated by ReportsResourceTest#testSensitiveInformation")
         .withReportSensitiveInformation(rsiInput).build();
-    final Report returned = withCredentials(elizabeth.getDomainUsername(),
+    final Report returned = withCredentials(getDomainUsername(elizabeth),
         t -> mutationExecutor.createReport(FIELDS, rInput));
     assertThat(returned).isNotNull();
     assertThat(returned.getUuid()).isNotNull();
@@ -1967,7 +1975,7 @@ public class ReportResourceTest extends AbstractResourceTest {
     assertThat(returned.getReportSensitiveInformation().getText())
         .isEqualTo(UtilsTest.getCombinedHtmlTestCase().getOutput());
 
-    final Report returned2 = withCredentials(elizabeth.getDomainUsername(),
+    final Report returned2 = withCredentials(getDomainUsername(elizabeth),
         t -> queryExecutor.report(FIELDS, returned.getUuid()));
     // elizabeth should be allowed to see it
     assertThat(returned2.getReportSensitiveInformation()).isNotNull();
@@ -1977,7 +1985,7 @@ public class ReportResourceTest extends AbstractResourceTest {
     // update HTML of report sensitive information
     returned2.getReportSensitiveInformation()
         .setText(UtilsTest.getCombinedHtmlTestCase().getInput());
-    final Report updated = withCredentials(elizabeth.getDomainUsername(),
+    final Report updated = withCredentials(getDomainUsername(elizabeth),
         t -> mutationExecutor.updateReport(FIELDS, getReportInput(returned2), true));
     assertThat(updated).isNotNull();
     assertThat(updated.getReportSensitiveInformation()).isNotNull();
@@ -2135,7 +2143,7 @@ public class ReportResourceTest extends AbstractResourceTest {
     try {
       createTestReport();
       final List<AdvisorReportsEntry> advisorReports =
-          withCredentials(user.getDomainUsername(),
+          withCredentials(getDomainUsername(user),
               t -> queryExecutor.advisorReportInsights(
                   "{ uuid name stats { week nrReportsSubmitted nrEngagementsAttended } }", "-1",
                   3));
@@ -2169,7 +2177,7 @@ public class ReportResourceTest extends AbstractResourceTest {
   private Location getLocation(Person user, String name) {
     final LocationSearchQueryInput query =
         LocationSearchQueryInput.builder().withText(name).build();
-    final AnetBeanList_Location results = withCredentials(user.getDomainUsername(),
+    final AnetBeanList_Location results = withCredentials(getDomainUsername(user),
         t -> queryExecutor.locationList(getListFields(LOCATION_FIELDS), query));
     assertThat(results).isNotNull();
     assertThat(results.getList()).isNotEmpty();
@@ -2197,7 +2205,7 @@ public class ReportResourceTest extends AbstractResourceTest {
 
     // Reference task 1.1.A
     final TaskSearchQueryInput query = TaskSearchQueryInput.builder().withText("1.1.A").build();
-    final AnetBeanList_Task searchObjects = withCredentials(author.getDomainUsername(),
+    final AnetBeanList_Task searchObjects = withCredentials(getDomainUsername(author),
         t -> queryExecutor.taskList(getListFields(TASK_FIELDS), query));
     assertThat(searchObjects).isNotNull();
     assertThat(searchObjects.getList()).isNotEmpty();
@@ -2208,17 +2216,17 @@ public class ReportResourceTest extends AbstractResourceTest {
     rInput.setTasks(List.of(getTaskInput(t11a)));
 
     // Create the report
-    final Report created = withCredentials(author.getDomainUsername(),
+    final Report created = withCredentials(getDomainUsername(author),
         t -> mutationExecutor.createReport(FIELDS, rInput));
     assertThat(created).isNotNull();
     assertThat(created.getUuid()).isNotNull();
     assertThat(created.getState()).isEqualTo(ReportState.DRAFT);
 
     // Submit the report
-    int numRows = withCredentials(author.getDomainUsername(),
+    int numRows = withCredentials(getDomainUsername(author),
         t -> mutationExecutor.submitReport("", created.getUuid()));
     assertThat(numRows).isOne();
-    final Report submitted = withCredentials(author.getDomainUsername(),
+    final Report submitted = withCredentials(getDomainUsername(author),
         t -> queryExecutor.report(FIELDS, created.getUuid()));
     assertThat(submitted).isNotNull();
     assertThat(submitted.getState()).isEqualTo(ReportState.PENDING_APPROVAL);
@@ -2257,7 +2265,7 @@ public class ReportResourceTest extends AbstractResourceTest {
     numRows =
         withCredentials("bob", t -> mutationExecutor.approveReport("", null, submitted.getUuid()));
     assertThat(numRows).isOne();
-    final Report approvedStep1 = withCredentials(author.getDomainUsername(),
+    final Report approvedStep1 = withCredentials(getDomainUsername(author),
         t -> queryExecutor.report(FIELDS, created.getUuid()));
     assertThat(approvedStep1).isNotNull();
     assertThat(approvedStep1.getState()).isEqualTo(ReportState.PENDING_APPROVAL);
@@ -2268,10 +2276,10 @@ public class ReportResourceTest extends AbstractResourceTest {
     assertThat(step2.getRelatedObjectUuid()).isEqualTo(t11a.getUuid());
 
     // Have the report approved by the 1.1.A approver
-    numRows = withCredentials(andrew.getDomainUsername(),
+    numRows = withCredentials(getDomainUsername(andrew),
         t -> mutationExecutor.approveReport("", null, submitted.getUuid()));
     assertThat(numRows).isOne();
-    final Report approvedStep2 = withCredentials(author.getDomainUsername(),
+    final Report approvedStep2 = withCredentials(getDomainUsername(author),
         t -> queryExecutor.report(FIELDS, created.getUuid()));
     assertThat(approvedStep2).isNotNull();
     assertThat(approvedStep1.getState()).isEqualTo(ReportState.PENDING_APPROVAL);
@@ -2285,7 +2293,7 @@ public class ReportResourceTest extends AbstractResourceTest {
     numRows = withCredentials(adminUser,
         t -> mutationExecutor.approveReport("", null, submitted.getUuid()));
     assertThat(numRows).isOne();
-    final Report approvedStep3 = withCredentials(author.getDomainUsername(),
+    final Report approvedStep3 = withCredentials(getDomainUsername(author),
         t -> queryExecutor.report(FIELDS, created.getUuid()));
     assertThat(approvedStep3).isNotNull();
     assertThat(approvedStep3.getState()).isEqualTo(ReportState.APPROVED);
@@ -2298,7 +2306,7 @@ public class ReportResourceTest extends AbstractResourceTest {
         .withReportPeople(getReportPeopleInput(List.of(personToReportAuthor(author))))
         .withState(ReportState.DRAFT).withAtmosphere(Atmosphere.POSITIVE)
         .withIntent("Testing report authors").withEngagementDate(Instant.now()).build();
-    final Report reportFirstAuthor = withCredentials(author.getDomainUsername(),
+    final Report reportFirstAuthor = withCredentials(getDomainUsername(author),
         t -> mutationExecutor.createReport(FIELDS, rInput));
     assertThat(reportFirstAuthor).isNotNull();
     assertThat(reportFirstAuthor.getUuid()).isNotNull();
@@ -2309,7 +2317,7 @@ public class ReportResourceTest extends AbstractResourceTest {
     // Try to remove the author, should fail
     reportFirstAuthor.setReportPeople(null);
     try {
-      withCredentials(author.getDomainUsername(),
+      withCredentials(getDomainUsername(author),
           t -> mutationExecutor.updateReport(FIELDS, getReportInput(reportFirstAuthor), true));
       fail("Expected an Exception");
     } catch (Exception expectedException) {
@@ -2320,7 +2328,7 @@ public class ReportResourceTest extends AbstractResourceTest {
     final Person liz = getElizabethElizawell();
     reportFirstAuthor
         .setReportPeople(List.of(personToReportAuthor(author), personToReportAuthor(liz)));
-    final Report reportTwoAuthors = withCredentials(author.getDomainUsername(),
+    final Report reportTwoAuthors = withCredentials(getDomainUsername(author),
         t -> mutationExecutor.updateReport(FIELDS, getReportInput(reportFirstAuthor), true));
     assertThat(reportTwoAuthors.getReportPeople())
         .anyMatch(rp -> Objects.equals(rp.getUuid(), author.getUuid()) && rp.getAuthor());
@@ -2329,7 +2337,7 @@ public class ReportResourceTest extends AbstractResourceTest {
 
     // Remove the first author
     reportTwoAuthors.setReportPeople(List.of(personToReportAuthor(liz)));
-    final Report reportSecondAuthor = withCredentials(author.getDomainUsername(),
+    final Report reportSecondAuthor = withCredentials(getDomainUsername(author),
         t -> mutationExecutor.updateReport(FIELDS, getReportInput(reportTwoAuthors), true));
     assertThat(reportSecondAuthor.getReportPeople())
         .noneMatch(rp -> Objects.equals(rp.getUuid(), author.getUuid()) && rp.getAuthor());
@@ -2339,7 +2347,7 @@ public class ReportResourceTest extends AbstractResourceTest {
     // Try to edit the report as the first author, should fail
     reportSecondAuthor.setIntent("Testing report authors again");
     try {
-      withCredentials(author.getDomainUsername(),
+      withCredentials(getDomainUsername(author),
           t -> mutationExecutor.updateReport(FIELDS, getReportInput(reportSecondAuthor), true));
       fail("Expected an Exception");
     } catch (Exception expectedException) {
@@ -2350,7 +2358,7 @@ public class ReportResourceTest extends AbstractResourceTest {
     reportSecondAuthor
         .setReportPeople(List.of(personToReportAuthor(author), personToReportAuthor(liz)));
     try {
-      withCredentials(author.getDomainUsername(),
+      withCredentials(getDomainUsername(author),
           t -> mutationExecutor.updateReport(FIELDS, getReportInput(reportSecondAuthor), true));
       fail("Expected an Exception");
     } catch (Exception expectedException) {
@@ -2359,7 +2367,7 @@ public class ReportResourceTest extends AbstractResourceTest {
 
     // Try to delete the report as the first author, should fail
     try {
-      withCredentials(author.getDomainUsername(),
+      withCredentials(getDomainUsername(author),
           t -> mutationExecutor.deleteReport("", reportSecondAuthor.getUuid()));
       fail("Expected an Exception");
     } catch (Exception expectedException) {
@@ -2383,8 +2391,7 @@ public class ReportResourceTest extends AbstractResourceTest {
   }
 
   private void testUnpublishReport(boolean isFuture) {
-    final Person author =
-        findOrPutPersonInDb(Person.builder().withDomainUsername("selena").build());
+    final Person author = findOrPutPersonInDb("selena", Person.builder().build());
     final Location loc = getLocation(author, "Cabot Tower");
     final Instant engagementDate = Instant.now().atZone(DaoUtils.getServerNativeZoneId())
         .minusWeeks(isFuture ? -2 : 2).toInstant();
@@ -2400,7 +2407,7 @@ public class ReportResourceTest extends AbstractResourceTest {
 
     // Reference task EF7
     final TaskSearchQueryInput query = TaskSearchQueryInput.builder().withText("EF7").build();
-    final AnetBeanList_Task searchObjects = withCredentials(author.getDomainUsername(),
+    final AnetBeanList_Task searchObjects = withCredentials(getDomainUsername(author),
         t -> queryExecutor.taskList(getListFields(TASK_FIELDS), query));
     assertThat(searchObjects).isNotNull();
     assertThat(searchObjects.getList()).isNotEmpty();
@@ -2411,17 +2418,17 @@ public class ReportResourceTest extends AbstractResourceTest {
     rInput.setTasks(List.of(getTaskInput(t11a)));
 
     // Create the report
-    final Report created = withCredentials(author.getDomainUsername(),
+    final Report created = withCredentials(getDomainUsername(author),
         t -> mutationExecutor.createReport(FIELDS, rInput));
     assertThat(created).isNotNull();
     assertThat(created.getUuid()).isNotNull();
     assertThat(created.getState()).isEqualTo(ReportState.DRAFT);
 
     // Submit the report
-    int numRows = withCredentials(author.getDomainUsername(),
+    int numRows = withCredentials(getDomainUsername(author),
         t -> mutationExecutor.submitReport("", created.getUuid()));
     assertThat(numRows).isOne();
-    final Report submitted = withCredentials(author.getDomainUsername(),
+    final Report submitted = withCredentials(getDomainUsername(author),
         t -> queryExecutor.report(FIELDS, created.getUuid()));
     assertThat(submitted).isNotNull();
     if (!isFuture) {
@@ -2431,7 +2438,7 @@ public class ReportResourceTest extends AbstractResourceTest {
           t -> mutationExecutor.approveReport("", null, created.getUuid()));
       assertThat(numRows).isOne();
     }
-    final Report approved = withCredentials(author.getDomainUsername(),
+    final Report approved = withCredentials(getDomainUsername(author),
         t -> queryExecutor.report(FIELDS, created.getUuid()));
     assertThat(approved).isNotNull();
     assertThat(approved.getState()).isEqualTo(ReportState.APPROVED);
@@ -2448,14 +2455,14 @@ public class ReportResourceTest extends AbstractResourceTest {
     numRows =
         withCredentials(adminUser, t -> mutationExecutor.publishReport("", approved.getUuid()));
     assertThat(numRows).isOne();
-    final Report published = withCredentials(author.getDomainUsername(),
+    final Report published = withCredentials(getDomainUsername(author),
         t -> queryExecutor.report(FIELDS, created.getUuid()));
     assertThat(published).isNotNull();
     assertThat(published.getState()).isEqualTo(ReportState.PUBLISHED);
 
     // Try to unpublish published report by regular user
     try {
-      withCredentials(author.getDomainUsername(),
+      withCredentials(getDomainUsername(author),
           t -> mutationExecutor.unpublishReport("", published.getUuid()));
       fail("Expected an Exception");
     } catch (Exception expectedException) {
@@ -2473,14 +2480,14 @@ public class ReportResourceTest extends AbstractResourceTest {
         withCredentials(adminUser, t -> mutationExecutor.unpublishReport("", published.getUuid()));
     assertThat(nrUnpublished).isEqualTo(1);
     // Check that workflow has been extended
-    final Report unpublished = withCredentials(author.getDomainUsername(),
+    final Report unpublished = withCredentials(getDomainUsername(author),
         t -> queryExecutor.report(FIELDS, published.getUuid()));
     assertThat(unpublished).isNotNull();
     assertThat(unpublished.getState()).isEqualTo(ReportState.DRAFT);
     assertThat(unpublished.getWorkflow()).hasSize(published.getWorkflow().size() + 1);
 
     // Clean up
-    final Integer nrDeleted = withCredentials(author.getDomainUsername(),
+    final Integer nrDeleted = withCredentials(getDomainUsername(author),
         t -> mutationExecutor.deleteReport("", unpublished.getUuid()));
     assertThat(nrDeleted).isEqualTo(1);
   }

--- a/src/test/java/mil/dds/anet/test/resources/RestrictedFieldsTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/RestrictedFieldsTest.java
@@ -32,7 +32,7 @@ class RestrictedFieldsTest extends AbstractResourceTest {
   private static final String EMAIL_ADDRESSES_FIELDS =
       "emailAddresses(network: ?" + EMAIL_NETWORK_PARAMETER + ") { network address }";
   private static final String PERSON_FIELDS =
-      "{ uuid name domainUsername phoneNumber " + EMAIL_ADDRESSES_FIELDS + " }";
+      "{ uuid name users { uuid domainUsername } phoneNumber " + EMAIL_ADDRESSES_FIELDS + " }";
   private static final String ORGANIZATION_FIELDS =
       "{ uuid shortName longName identificationCode " + EMAIL_ADDRESSES_FIELDS + " }";
   private static final String POSITION_FIELDS =

--- a/src/test/java/mil/dds/anet/test/resources/TaskResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/TaskResourceTest.java
@@ -369,7 +369,7 @@ class TaskResourceTest extends AbstractResourceTest {
 
     // interlocutor organization
     final OrganizationSearchQueryInput query = OrganizationSearchQueryInput.builder().build();
-    final AnetBeanList_Organization interlocutorOrgs = withCredentials(user.getDomainUsername(),
+    final AnetBeanList_Organization interlocutorOrgs = withCredentials(getDomainUsername(user),
         t -> queryExecutor.organizationList(getListFields(orgFields), query));
     assertThat(interlocutorOrgs).isNotNull();
     assertThat(interlocutorOrgs.getList()).isNotEmpty();
@@ -380,7 +380,7 @@ class TaskResourceTest extends AbstractResourceTest {
     taskInterlocutorInput
         .setTaskedOrganizations(Collections.singletonList(getOrganizationInput(interlocutorOrg)));
     try {
-      final Task createdTask = withCredentials(user.getDomainUsername(),
+      final Task createdTask = withCredentials(getDomainUsername(user),
           t -> mutationExecutor.createTask(FIELDS, taskInterlocutorInput));
       if (isAdmin) {
         assertThat(createdTask).isNotNull();
@@ -400,7 +400,7 @@ class TaskResourceTest extends AbstractResourceTest {
     taskInterlocutorInput
         .setTaskedOrganizations(Collections.singletonList(getOrganizationInput(organization)));
     try {
-      final Task createdTask = withCredentials(user.getDomainUsername(),
+      final Task createdTask = withCredentials(getDomainUsername(user),
           t -> mutationExecutor.createTask(FIELDS, taskOwnInput));
       if (isAdmin) {
         assertThat(createdTask).isNotNull();
@@ -416,7 +416,7 @@ class TaskResourceTest extends AbstractResourceTest {
 
     // other advisor organization
     final OrganizationSearchQueryInput query2 = OrganizationSearchQueryInput.builder().build();
-    final AnetBeanList_Organization advisorOrgs = withCredentials(user.getDomainUsername(),
+    final AnetBeanList_Organization advisorOrgs = withCredentials(getDomainUsername(user),
         t -> queryExecutor.organizationList(getListFields(orgFields), query2));
     assertThat(advisorOrgs).isNotNull();
     assertThat(advisorOrgs.getList()).isNotEmpty();
@@ -429,7 +429,7 @@ class TaskResourceTest extends AbstractResourceTest {
     taskOtherInput
         .setTaskedOrganizations(Collections.singletonList(getOrganizationInput(advisorOrg)));
     try {
-      final Task createdTask = withCredentials(user.getDomainUsername(),
+      final Task createdTask = withCredentials(getDomainUsername(user),
           t -> mutationExecutor.createTask(FIELDS, taskOtherInput));
       if (isAdmin) {
         assertThat(createdTask).isNotNull();

--- a/src/test/resources/anet.graphql
+++ b/src/test/resources/anet.graphql
@@ -930,7 +930,6 @@ type Person {
   createdAt: Instant
   customFields: String
   customSensitiveInformation: [CustomSensitiveInformation]
-  domainUsername: String
   emailAddresses(network: String): [EmailAddress]
   endOfTourDate: Instant
   entityAvatar: EntityAvatar
@@ -947,6 +946,7 @@ type Person {
   status: Status
   updatedAt: Instant
   user: Boolean
+  users: [User]
   uuid: String
 }
 
@@ -958,7 +958,6 @@ input PersonInput {
   createdAt: Instant
   customFields: String
   customSensitiveInformation: [CustomSensitiveInformationInput]
-  domainUsername: String
   emailAddresses: [EmailAddressInput]
   endOfTourDate: Instant
   entityAvatar: EntityAvatarInput
@@ -973,6 +972,7 @@ input PersonInput {
   status: Status
   updatedAt: Instant
   user: Boolean
+  users: [UserInput]
   uuid: String
 }
 
@@ -1310,7 +1310,6 @@ type ReportPerson {
   createdAt: Instant
   customFields: String
   customSensitiveInformation: [CustomSensitiveInformation]
-  domainUsername: String
   emailAddresses(network: String): [EmailAddress]
   endOfTourDate: Instant
   entityAvatar: EntityAvatar
@@ -1329,6 +1328,7 @@ type ReportPerson {
   status: Status
   updatedAt: Instant
   user: Boolean
+  users: [User]
   uuid: String
 }
 
@@ -1342,7 +1342,6 @@ input ReportPersonInput {
   createdAt: Instant
   customFields: String
   customSensitiveInformation: [CustomSensitiveInformationInput]
-  domainUsername: String
   emailAddresses: [EmailAddressInput]
   endOfTourDate: Instant
   entityAvatar: EntityAvatarInput
@@ -1359,6 +1358,7 @@ input ReportPersonInput {
   status: Status
   updatedAt: Instant
   user: Boolean
+  users: [UserInput]
   uuid: String
 }
 
@@ -1673,6 +1673,12 @@ enum TokenScope {
 }
 
 """"""
+type User {
+  domainUsername: String
+  uuid: String
+}
+
+""""""
 type UserActivity {
   count: Long!
   organization: Organization
@@ -1702,4 +1708,10 @@ input UserActivitySearchQueryInput {
 enum UserActivitySearchSortBy {
   COUNT
   NONE
+}
+
+""""""
+input UserInput {
+  domainUsername: String
+  uuid: String
 }

--- a/src/test/resources/graphQLTests/person.gql
+++ b/src/test/resources/graphQLTests/person.gql
@@ -19,7 +19,11 @@ person(uuid:"${personUuid}") {
     address
   }
   phoneNumber
-  domainUsername
+  user
+  users {
+    uuid
+    domainUsername
+  }
   biography
   obsoleteCountry
   country {

--- a/testDictionaries/no-custom-fields.yml
+++ b/testDictionaries/no-custom-fields.yml
@@ -498,8 +498,8 @@ fields:
       placeholder: Last name
     user:
       label: ANET user
-    domainUsername:
-      label: Domain username
+    users:
+      label: User accounts
     position:
       label: Current Position
       placeholder: Fill in the person's current position
@@ -890,7 +890,7 @@ fields:
         - position
         - prevPositions
         - user
-        - domainUsername
+        - users
         - authorizationGroups
         - emailAddresses
         - phoneNumber


### PR DESCRIPTION
Users can now have multiple domain usernames.

Closes [AB#1257](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1257)

#### User changes
- If a user has multiple domain usernames with access to ANET, they can use any of those, and they will be the same person in ANET.

#### Superuser changes
- None

#### Admin changes
- Admins can assign multiple domain usernames to a person.

#### System admin changes
- [x] application.yml or anet-dictionary.yml needs change:
  Change:
  ```yaml
  fields:
    person:
      […]
      domainUsername:
        label: Domain username
      […]
  ```
  To:
  ```yaml
  fields:
    person:
      […]
      users:
        label: User accounts
      […]
  ```
  and if you have `domainUsername` as part of the `showPageOrderedFields` list, change that to `users` as well.
- [x] db needs migration
- [ ] documentation has changed
- [x] graphql schema has changed

### Checklist
- [x] described the user behavior in PR body
- [x] referenced/updated all related issues
- [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
- [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
- [x] added and/or updated unit tests
- [x] added and/or updated e2e tests
- [x] added and/or updated data migrations
- [ ] updated documentation
- [x] resolved all build errors and warnings
- [ ] opened debt issues for anything not resolved here