### PR TITLE
Don't return outdated reportSensitiveInformation when updating a report

### DIFF
--- a/src/main/java/mil/dds/anet/database/ReportDao.java
+++ b/src/main/java/mil/dds/anet/database/ReportDao.java
@@ -142,12 +142,13 @@ public class ReportDao extends AnetSubscribableObjectDao<Report, ReportSearchQue
           .bind("cancelledReason", DaoUtils.getEnumId(r.getCancelledReason())).execute();
 
       // Write sensitive information (if allowed)
-      ReportSensitiveInformation rsi = r.getReportSensitiveInformation();
+      final ReportSensitiveInformation rsi = r.getReportSensitiveInformation();
       if (rsi != null) {
         rsi.setText(Utils.sanitizeHtml(rsi.getText()));
       }
-      rsi = engine().getReportSensitiveInformationDao().insert(rsi, user, r);
-      r.setReportSensitiveInformation(rsi);
+      final ReportSensitiveInformation newRsi =
+          engine().getReportSensitiveInformationDao().insert(rsi, user, r);
+      r.setReportSensitiveInformation(newRsi);
 
       final ReportBatch rb = handle.attach(ReportBatch.class);
       if (r.getReportPeople() != null) {
@@ -238,11 +239,16 @@ public class ReportDao extends AnetSubscribableObjectDao<Report, ReportSearchQue
     final Handle handle = getDbHandle();
     try {
       // Write sensitive information (if allowed)
-      ReportSensitiveInformation rsi = r.getReportSensitiveInformation();
+      final ReportSensitiveInformation rsi = r.getReportSensitiveInformation();
       if (rsi != null) {
         rsi.setText(Utils.sanitizeHtml(rsi.getText()));
       }
-      engine().getReportSensitiveInformationDao().insertOrUpdate(rsi, user, r);
+      final Object o = engine().getReportSensitiveInformationDao().insertOrUpdate(rsi, user, r);
+      if (o instanceof ReportSensitiveInformation newRsi) {
+        r.setReportSensitiveInformation(newRsi);
+      } else {
+        r.setReportSensitiveInformation(rsi);
+      }
 
       DaoUtils.setUpdateFields(r);
 

--- a/src/main/java/mil/dds/anet/resources/ReportResource.java
+++ b/src/main/java/mil/dds/anet/resources/ReportResource.java
@@ -350,11 +350,6 @@ public class ReportResource {
     DaoUtils.saveCustomSensitiveInformation(editor, ReportDao.TABLE_NAME, r.getUuid(),
         r.getCustomSensitiveInformation());
 
-    // Clear and re-load sensitive information; needed in case of autoSave by the client form, or
-    // when sensitive info is 'empty' HTML
-    r.setReportSensitiveInformation(null);
-    r.loadReportSensitiveInformation(engine.getContext()).join();
-
     // Return the report in the response; used in autoSave by the client form
     return existing;
   }

--- a/src/test/java/mil/dds/anet/test/resources/ReportResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/ReportResourceTest.java
@@ -1965,14 +1965,14 @@ public class ReportResourceTest extends AbstractResourceTest {
 
     // update HTML of report sensitive information
     returned2.getReportSensitiveInformation()
-        .setText(UtilsTest.getCombinedHtmlTestCase().getInput());
+        .setText(UtilsTest.getCombinedHtmlTestCase().getInput() + "<p>test</p>");
     final Report updated = withCredentials(elizabeth.getDomainUsername(),
         t -> mutationExecutor.updateReport(FIELDS, getReportInput(returned2), true));
     assertThat(updated).isNotNull();
     assertThat(updated.getReportSensitiveInformation()).isNotNull();
     // check that HTML of report sensitive information is sanitized after update
     assertThat(updated.getReportSensitiveInformation().getText())
-        .isEqualTo(UtilsTest.getCombinedHtmlTestCase().getOutput());
+        .isEqualTo(UtilsTest.getCombinedHtmlTestCase().getOutput() + "<p>test</p>");
 
     final Report returned3 =
         withCredentials(jackUser, t -> queryExecutor.report(FIELDS, returned.getUuid()));


### PR DESCRIPTION
Due to nested transactions, we could be returning old/stale reportSensitiveInformation when a report was updated; if that happened through a report autoSave, changes might get lost.

Relates to the changes for [AB#1159](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1159)

#### User changes
- Changes to reportSensitiveInformation don't get lost.

#### Superuser changes
- None

#### Admin changes
- None

#### System admin changes
- [ ] application.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
- [x] described the user behavior in PR body
- [x] referenced/updated all related issues
- [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
- [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
- [x] added and/or updated unit tests
- [ ] added and/or updated e2e tests
- [ ] added and/or updated data migrations
- [ ] updated documentation
- [x] resolved all build errors and warnings
- [ ] opened debt issues for anything not resolved here