### PR TITLE
Saved searches without name

### DIFF
--- a/client/src/pages/searches/MySavedSearches.tsx
+++ b/client/src/pages/searches/MySavedSearches.tsx
@@ -114,23 +114,14 @@ const MySavedSearches = ({
           <Table striped responsive className="mt-3 mb-3">
             <thead>
               <tr>
-                <th style={{ width: "20%" }}>Search Name</th>
                 <th style={{ width: "70%" }}>Description</th>
+                <th style={{ width: "20%" }}>Search Name</th>
                 <th style={{ width: "10%" }}>Action</th>
               </tr>
             </thead>
             <tbody>
               {paginatedSearches.map(savedSearch => (
                 <tr key={savedSearch.uuid} className="align-middle">
-                  <td style={{ paddingRight: 0 }}>
-                    <Button
-                      className="text-start text-decoration-none"
-                      variant="link"
-                      onClick={() => showSearch(savedSearch)}
-                    >
-                      {savedSearch.name}
-                    </Button>
-                  </td>
                   <td style={{ paddingLeft: 0 }}>
                     <Button
                       className="text-start text-decoration-none"
@@ -143,6 +134,15 @@ const MySavedSearches = ({
                           style={{ pointerEvents: "none" }}
                         />
                       )}
+                    </Button>
+                  </td>
+                  <td style={{ paddingRight: 0 }}>
+                    <Button
+                      className="text-start text-decoration-none"
+                      variant="link"
+                      onClick={() => showSearch(savedSearch)}
+                    >
+                      {savedSearch.name}
                     </Button>
                   </td>
                   <td>

--- a/client/src/pages/searches/Search.tsx
+++ b/client/src/pages/searches/Search.tsx
@@ -1857,7 +1857,7 @@ const Search = ({
                 <Field
                   name="name"
                   component={FieldHelper.InputField}
-                  placeholder="Give this saved search a name"
+                  placeholder="Give this saved search a name (optional)"
                   vertical
                 />
                 <div className="submit-buttons">

--- a/src/main/java/mil/dds/anet/resources/SavedSearchResource.java
+++ b/src/main/java/mil/dds/anet/resources/SavedSearchResource.java
@@ -39,7 +39,7 @@ public class SavedSearchResource {
       AnetAuditLogger.log("SavedSearch {} created by {}", created, user);
       return created;
     } catch (UnableToExecuteStatementException e) {
-      throw ResponseUtils.handleSqlException(e, "Duplicate name for saved search");
+      throw ResponseUtils.handleSqlException(e, "Unable to create saved search");
     }
   }
 

--- a/src/main/java/mil/dds/anet/resources/SavedSearchResource.java
+++ b/src/main/java/mil/dds/anet/resources/SavedSearchResource.java
@@ -34,13 +34,9 @@ public class SavedSearchResource {
       @GraphQLArgument(name = "savedSearch") SavedSearch savedSearch) {
     Person user = DaoUtils.getUserFromContext(context);
     savedSearch.setOwnerUuid(user.getUuid());
-    try {
-      final SavedSearch created = dao.insert(savedSearch);
-      AnetAuditLogger.log("SavedSearch {} created by {}", created, user);
-      return created;
-    } catch (UnableToExecuteStatementException e) {
-      throw ResponseUtils.handleSqlException(e, "Unable to create saved search");
-    }
+    final SavedSearch created = dao.insert(savedSearch);
+    AnetAuditLogger.log("SavedSearch {} created by {}", created, user);
+    return created;
   }
 
   @GraphQLQuery(name = "mySearches")

--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -6451,6 +6451,10 @@
 		</sql>
 	</changeSet>
 
+	<changeSet id="drop-UQ_OwnerUuidName" author="jlnat">
+		<dropUniqueConstraint tableName="savedSearches" constraintName="UQ_OwnerUuidName" />
+	</changeSet>
+
 	<!-- Keep this change set as the last one in the change log;
 	     it will be re-run whenever it changes. -->
 	<changeSet id="set-up-full-text-search" runOnChange="true" author="gjvoosten">


### PR DESCRIPTION
Saved searches no longer need a name to be told apart on the saved searches page, as the description on the table should be enough. We are now be able to save as many searches as we want without a name or with the same name.

Closes [AB#1382](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1382)

#### User changes
- Will be able to save a search with any, or no name

#### Superuser changes
- None

#### Admin changes
- None

#### System admin changes
- [ ] application.yml or anet-dictionary.yml needs change
- [x] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
- [x] described the user behavior in PR body
- [x] referenced/updated all related issues
- [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
- [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
- [ ] added and/or updated unit tests
- [ ] added and/or updated e2e tests
- [x] added and/or updated data migrations
- [ ] updated documentation
- [x] resolved all build errors and warnings
- [ ] opened debt issues for anything not resolved here
