### PR TITLE
Run all client-side tests in incognito mode

### DIFF
--- a/client/config/browserstack.config.js
+++ b/client/config/browserstack.config.js
@@ -38,8 +38,9 @@ const capabilities = {
   browserName: "Chrome",
   browserVersion: "latest",
   "goog:chromeOptions": {
+    // Run in incognito mode
     // Maximize the window so we can see what's going on
-    args: ["--start-maximized"]
+    args: ["--incognito", "--start-maximized"]
   },
   "bstack:options": bstackOptions
 }

--- a/client/config/wdio.config.js
+++ b/client/config/wdio.config.js
@@ -68,11 +68,11 @@ const config = {
       acceptInsecureCerts: true,
       "goog:chromeOptions": {
         // run in incognito mode
-        // args: ['--incognito'],
         // Note: it is important to have a big window height as otherwise
         // while scrolling some form fields might go under the header and
         // therefore we would get failing tests related to these fields.
         args: [
+          "--incognito",
           "--headless=old",
           "--disable-gpu",
           "--disable-search-engine-choice-screen",

--- a/client/tests/util/test.js
+++ b/client/tests/util/test.js
@@ -93,6 +93,7 @@ test.beforeEach(t => {
     const options = new chrome.Options(capabilities)
       .setBrowserVersion("131") // or "stable"
       .addArguments([
+        "--incognito",
         "--headless=old",
         "--disable-gpu",
         "--disable-search-engine-choice-screen",


### PR DESCRIPTION
This prevents the tests from failing e.g. on BrowserStack because of Chrome's "Change your password" pop-up.