### PR TITLE
Add support for DateRangeFilter options "Next … days"

### DIFF
--- a/client/src/components/advancedSearch/DateRangeFilter.tsx
+++ b/client/src/components/advancedSearch/DateRangeFilter.tsx
@@ -12,6 +12,10 @@ import {
   LAST_MONTH,
   LAST_WEEK,
   LAST_X_DAYS,
+  NEXT_DAY,
+  NEXT_MONTH,
+  NEXT_WEEK,
+  NEXT_X_DAYS,
   ON,
   RANGE_TYPE_LABELS
 } from "dateUtils"
@@ -90,6 +94,18 @@ const DateRangeFilter = ({
       </option>,
       <option key="last_x_days" value={LAST_X_DAYS}>
         {RANGE_TYPE_LABELS[LAST_X_DAYS]}
+      </option>,
+      <option key="next_day" value={NEXT_DAY}>
+        {RANGE_TYPE_LABELS[NEXT_DAY]}
+      </option>,
+      <option key="next_week" value={NEXT_WEEK}>
+        {RANGE_TYPE_LABELS[NEXT_WEEK]}
+      </option>,
+      <option key="next_month" value={NEXT_MONTH}>
+        {RANGE_TYPE_LABELS[NEXT_MONTH]}
+      </option>,
+      <option key="next_x_days" value={NEXT_X_DAYS}>
+        {RANGE_TYPE_LABELS[NEXT_X_DAYS]}
       </option>
     ]
     const options = onlyBetween
@@ -128,6 +144,9 @@ const DateRangeFilter = ({
   if (value.relative === LAST_X_DAYS) {
     dateRangeDisplay = `Last ${value.days ?? "?"} ${pluralize("day", value.days)}`
   }
+  if (value.relative === NEXT_X_DAYS) {
+    dateRangeDisplay = `Next ${value.days ?? "?"} ${pluralize("day", value.days)}`
+  }
   const dateStart = value.start && moment(value.start).toDate()
   const dateEnd = value.end && moment(value.end).toDate()
   return !asFormField ? (
@@ -165,7 +184,7 @@ const DateRangeFilter = ({
             onChange={handleChangeEnd}
           />
         )}
-        {value.relative === LAST_X_DAYS && (
+        {[NEXT_X_DAYS, LAST_X_DAYS].includes(value.relative) && (
           <IntegerInput
             min={1}
             max={999}
@@ -224,10 +243,19 @@ export const deserialize = ({ queryKey }, query, key) => {
   }
 
   if (Object.hasOwn(query, endKey)) {
-    filterValue.end = moment(query[endKey]).format(DATE_FORMAT)
-    toQueryValue[endKey] = query[endKey]
-    if (!Object.hasOwn(query, startKey)) {
-      filterValue.relative = BEFORE
+    const endVal = query[endKey]
+    toQueryValue[endKey] = endVal
+    const nextValues = [NEXT_DAY, NEXT_WEEK, NEXT_MONTH]
+    if (nextValues.indexOf(+endVal) !== -1) {
+      filterValue.relative = endVal
+    } else if (utils.isNumeric(endVal)) {
+      filterValue.relative = NEXT_X_DAYS
+      filterValue.days = parseInt(endVal) / NEXT_DAY
+    } else {
+      filterValue.end = moment(endVal).format(DATE_FORMAT)
+      if (!Object.hasOwn(query, startKey)) {
+        filterValue.relative = BEFORE
+      }
     }
   }
 

--- a/client/src/dateUtils.ts
+++ b/client/src/dateUtils.ts
@@ -9,6 +9,10 @@ export const LAST_X_DAYS = "4"
 export const LAST_DAY = -1 * 1000 * 60 * 60 * 24
 export const LAST_WEEK = LAST_DAY * 7
 export const LAST_MONTH = LAST_DAY * 30
+export const NEXT_X_DAYS = "5"
+export const NEXT_DAY = -LAST_DAY
+export const NEXT_WEEK = -LAST_WEEK
+export const NEXT_MONTH = -LAST_MONTH
 
 export const RANGE_TYPE_LABELS = {
   [BETWEEN]: "Between",
@@ -18,7 +22,11 @@ export const RANGE_TYPE_LABELS = {
   [LAST_X_DAYS]: "Last … days",
   [LAST_DAY]: "Last 24 hours",
   [LAST_WEEK]: "Last 7 days",
-  [LAST_MONTH]: "Last 30 days"
+  [LAST_MONTH]: "Last 30 days",
+  [NEXT_X_DAYS]: "Next … days",
+  [NEXT_DAY]: "Next 24 hours",
+  [NEXT_WEEK]: "Next 7 days",
+  [NEXT_MONTH]: "Next 30 days"
 }
 
 export function dateRangeStartKey(queryKey) {
@@ -68,10 +76,25 @@ export function dateToQuery(queryKey, value) {
     } else {
       return {}
     }
-  } else {
+  } else if (value.relative === NEXT_X_DAYS) {
+    const days = value.days
+    if (utils.isNumeric(days)) {
+      const milliseconds = days * NEXT_DAY
+      return {
+        [endKey]: milliseconds
+      }
+    } else {
+      return {}
+    }
+  } else if (value.relative < 0) {
     // LAST_DAY, LAST_WEEK, LAST_MONTH => Time relative to now, up till now
     return {
       [startKey]: parseInt(value.relative)
+    }
+  } else {
+    // NEXT_DAY, NEXT_WEEK, NEXT_MONTH => Time relative to now, from now
+    return {
+      [endKey]: parseInt(value.relative)
     }
   }
 }

--- a/src/main/java/mil/dds/anet/search/AbstractSearchQueryBuilder.java
+++ b/src/main/java/mil/dds/anet/search/AbstractSearchQueryBuilder.java
@@ -155,6 +155,10 @@ public abstract class AbstractSearchQueryBuilder<B, T extends AbstractSearchQuer
       whereClauses
           .add(String.format("%s %s :%s", startFieldName, startComp.getOperator(), startParamName));
       DaoUtils.addInstantAsLocalDateTime(sqlArgs, startParamName, startFieldValue);
+    } else if (DaoUtils.isRelativeDate(endFieldValue) && endComp == Comparison.BEFORE) {
+      whereClauses.add(String.format("%s %s :%s", startFieldName, Comparison.AFTER.getOperator(),
+          startParamName));
+      DaoUtils.addInstantAsLocalDateTime(sqlArgs, startParamName, Instant.now());
     }
     if (endFieldValue != null) {
       whereClauses

--- a/src/main/java/mil/dds/anet/utils/DaoUtils.java
+++ b/src/main/java/mil/dds/anet/utils/DaoUtils.java
@@ -195,16 +195,18 @@ public class DaoUtils {
     return instant == null ? null : LocalDateTime.ofInstant(instant, getServerNativeZoneId());
   }
 
+  private static final long MAX_RELATIVE_TIME = 999L * 24L * 60L * 60L * 1000L; // 999 days
+
   /*
    * For all search interfaces we accept either specific dates as number of milliseconds since the
-   * Unix Epoch, OR a number of milliseconds before today's date, where these relative times should
-   * be negative, i.e. before Epoch.
+   * Unix Epoch, OR a number of milliseconds before or after today's date, where these relative
+   * times should be at most 999 days before or after Epoch.
    */
   public static boolean isRelativeDate(Instant input) {
     if (input == null) {
       return false;
     }
-    return input.toEpochMilli() < 0;
+    return Math.abs(input.toEpochMilli()) <= MAX_RELATIVE_TIME;
   }
 
   private static Instant handleRelativeDate(Instant input) {


### PR DESCRIPTION
In addition to be able to filter searches on "Last … days", users can now also filter on "Next … days".

Closes [AB#1380](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1380)

#### User changes
- Users can now also filter searches for dates on "Next … days".

#### Superuser changes
- None.

#### Admin changes
- None.

#### System admin changes
- [ ] application.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
- [x] described the user behavior in PR body
- [x] referenced/updated all related issues
- [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
- [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
- [ ] added and/or updated unit tests
- [ ] added and/or updated e2e tests
- [ ] added and/or updated data migrations
- [ ] updated documentation
- [x] resolved all build errors and warnings
- [ ] opened debt issues for anything not resolved here