### PR TITLE
Show instant assessment labels in report views

### DIFF
--- a/client/src/components/CustomFields.tsx
+++ b/client/src/components/CustomFields.tsx
@@ -941,7 +941,7 @@ const CompactLikertScale = ({
   values,
   levels
 }: CompactLikertScaleProps) => {
-  const fieldValue = Number(Object.get(values, name) || 0).toFixed(0)
+  const fieldValue = Number(Object.get(values, name) || 0).toFixed(1)
   const sortedLevels = levels.sort((a, b) => a.endValue - b.endValue)
   const levelLabel =
     sortedLevels.find(level => fieldValue <= level.endValue)?.label || null

--- a/client/src/components/CustomFields.tsx
+++ b/client/src/components/CustomFields.tsx
@@ -1351,7 +1351,12 @@ export const ReadonlyCustomFields = ({
         }
         const ReadonlyFieldComponent = READONLY_FIELD_COMPONENTS[type]
         const value = Object.get(values, fieldName) || null
-        if (hideIfEmpty && _isEmpty(value)) {
+        if (
+          hideIfEmpty &&
+          (value == null ||
+            value === "" ||
+            (value instanceof Object && _isEmpty(value)))
+        ) {
           return null
         }
         return ReadonlyFieldComponent ? (

--- a/client/src/components/assessments/instant/InstantAssessmentsContainerField.tsx
+++ b/client/src/components/assessments/instant/InstantAssessmentsContainerField.tsx
@@ -70,39 +70,46 @@ const InstantAssessmentRow = ({
   }
 
   return (
-    <tr>
-      <td>
-        {!_isEmpty(entityInstantAssessmentConfig?.questions) &&
-          (readOnlyAccess ? (
-            <ReadonlyCustomFields
-              parentFieldName={parentFieldName}
-              fieldsConfig={entityInstantAssessmentConfig.questions}
-              values={values}
-              isCompact={isCompact}
-              hideIfEmpty={isCompact}
-            />
-          ) : (
-            <CustomFieldsContainer
-              parentFieldName={parentFieldName}
-              fieldsConfig={entityInstantAssessmentConfig.questions}
+    <>
+      {assessmentConfig?.label && (
+        <tr>
+          <td className="fw-bold text-secondary">{assessmentConfig.label}</td>
+        </tr>
+      )}
+      <tr>
+        <td>
+          {!_isEmpty(entityInstantAssessmentConfig?.questions) &&
+            (readOnlyAccess ? (
+              <ReadonlyCustomFields
+                parentFieldName={parentFieldName}
+                fieldsConfig={entityInstantAssessmentConfig.questions}
+                values={values}
+                isCompact={isCompact}
+                hideIfEmpty={isCompact}
+              />
+            ) : (
+              <CustomFieldsContainer
+                parentFieldName={parentFieldName}
+                fieldsConfig={entityInstantAssessmentConfig.questions}
+                formikProps={formikProps}
+                isCompact={isCompact}
+                hideIfEmpty={isCompact}
+              />
+            ))}
+          {!_isEmpty(entityInstantAssessmentConfig?.questionSets) && (
+            <QuestionSet
+              entity={entity}
+              relatedObject={relatedObject}
+              questionSets={entityInstantAssessmentConfig.questionSets}
+              parentFieldName={`${parentFieldName}.questionSets`}
               formikProps={formikProps}
               isCompact={isCompact}
-              hideIfEmpty={isCompact}
+              readonly={readOnlyAccess}
             />
-          ))}
-        {!_isEmpty(entityInstantAssessmentConfig?.questionSets) && (
-          <QuestionSet
-            entity={entity}
-            relatedObject={relatedObject}
-            questionSets={entityInstantAssessmentConfig.questionSets}
-            parentFieldName={`${parentFieldName}.questionSets`}
-            formikProps={formikProps}
-            isCompact={isCompact}
-            readonly={readOnlyAccess}
-          />
-        )}
-      </td>
-    </tr>
+          )}
+        </td>
+      </tr>
+    </>
   )
 }
 
@@ -165,7 +172,7 @@ const InstantAssessmentsContainerField = ({
           return (
             <React.Fragment key={`assessment-${values.uuid}-${entity.uuid}`}>
               <tr>
-                <td>
+                <th>
                   {modelType === Task.resourceName ? (
                     <BreadcrumbTrail
                       modelType={modelType}
@@ -180,7 +187,7 @@ const InstantAssessmentsContainerField = ({
                       showAvatar={!isCompact}
                     />
                   )}
-                </td>
+                </th>
               </tr>
               {entityInstantAssessments.map(([ak, ac]) => (
                 <InstantAssessmentRow

--- a/client/src/components/assessments/instant/InstantAssessmentsContainerField.tsx
+++ b/client/src/components/assessments/instant/InstantAssessmentsContainerField.tsx
@@ -122,7 +122,6 @@ interface InstantAssessmentsContainerFieldProps {
   canRead?: boolean
   canWrite?: boolean
   readonly?: boolean
-  showEntitiesWithoutAssessments?: boolean
 }
 
 const InstantAssessmentsContainerField = ({
@@ -135,8 +134,7 @@ const InstantAssessmentsContainerField = ({
   isCompact,
   canRead = false,
   canWrite = false,
-  readonly = false,
-  showEntitiesWithoutAssessments
+  readonly = false
 }: InstantAssessmentsContainerFieldProps) => {
   const { values } = formikProps
 
@@ -151,25 +149,12 @@ const InstantAssessmentsContainerField = ({
       !_isEmpty(filteredAssessment?.questionSets)
     )
   }
-  // Sort entities to display the ones without any assessment at the beginning,
-  // then the ones with assessments. Keep the original sort order within each section.
-  function sortEntries(e1, e2) {
-    const e1hasAssessments = e1
-      .getInstantAssessments()
-      .some(([, ac]) => hasFilteredAssessments(ac, e1))
-    const e2hasAssessments = e2
-      .getInstantAssessments()
-      .some(([, ac]) => hasFilteredAssessments(ac, e2))
-    return Number(e1hasAssessments) - Number(e2hasAssessments)
-  }
   function getEntitiesWithAssessments(entity) {
     return entity
       .getInstantAssessments()
       .some(([, ac]) => hasFilteredAssessments(ac, entity))
   }
-  const filteredEntities = showEntitiesWithoutAssessments
-    ? entities.sort(sortEntries)
-    : entities.filter(getEntitiesWithAssessments)
+  const filteredEntities = entities.filter(getEntitiesWithAssessments)
   return (
     <Table id={id}>
       <tbody>

--- a/client/src/pages/reports/Compact.tsx
+++ b/client/src/pages/reports/Compact.tsx
@@ -597,7 +597,6 @@ const CompactReportView = ({ pageDispatchers }: CompactReportViewProps) => {
         isCompact
         canRead={canReadAssessments}
         readonly
-        showEntitiesWithoutAssessments
       />
     ) : (
       attendees.map(attendee => (

--- a/client/tests/webdriver/baseSpecs/printReport.spec.js
+++ b/client/tests/webdriver/baseSpecs/printReport.spec.js
@@ -8,10 +8,13 @@ const INTERLOCUTORS = [
   "CIV KYLESON, Kyle",
   "CIV SHARTON, Shardul"
 ]
+const INTERLOCUTORS_WITH_ASSESSMENTS = INTERLOCUTORS
 
 const ADVISORS = ["CIV DMIN, Arthur", "CIV GUIST, Lin"]
+const ADVISORS_WITH_ASSESSMENTS = ["CIV GUIST, Lin"]
 
 const TASKS = ["EF 1 » EF 1.2 » 1.2.A", "EF 1 » EF 1.2 » 1.2.B"]
+const TASKS_WITH_ASSESSMENTS = TASKS
 
 const DEFAULT_REPORT_CLASSIFICATION = "DEMO USE ONLY"
 
@@ -97,15 +100,51 @@ describe("Show print report page", () => {
         "interlocutors-assessments",
         true
       )
-      for (const interlocutor of INTERLOCUTORS) {
+      for (const interlocutor of INTERLOCUTORS_WITH_ASSESSMENTS) {
         expect(displayedInterlocutors).to.contain(interlocutor)
+
+        const attendeeAssessmentLabel =
+          await ShowReport.getAttendeeAssessmentLabel(
+            "interlocutors-assessments",
+            interlocutor,
+            1
+          )
+        // eslint-disable-next-line no-unused-expressions
+        expect(await attendeeAssessmentLabel.isExisting()).to.be.true
+        expect(await attendeeAssessmentLabel.getText()).to.equal(
+          "Engagement assessment of interlocutor"
+        )
       }
       const displayedAdvisors = await ShowReport.getCompactViewElements(
         "advisors-assessments",
         true
       )
-      for (const advisor of ADVISORS) {
+      for (const advisor of ADVISORS_WITH_ASSESSMENTS) {
         expect(displayedAdvisors).to.contain(advisor)
+
+        const attendeeAssessment1Label =
+          await ShowReport.getAttendeeAssessmentLabel(
+            "advisors-assessments",
+            advisor,
+            1
+          )
+        // eslint-disable-next-line no-unused-expressions
+        expect(await attendeeAssessment1Label.isExisting()).to.be.true
+        expect(await attendeeAssessment1Label.getText()).to.equal(
+          "Engagement assessment of linguist"
+        )
+
+        const attendeeAssessment2Label =
+          await ShowReport.getAttendeeAssessmentLabel(
+            "advisors-assessments",
+            advisor,
+            3
+          )
+        // eslint-disable-next-line no-unused-expressions
+        expect(await attendeeAssessment2Label.isExisting()).to.be.true
+        expect(await attendeeAssessment2Label.getText()).to.equal(
+          "Engagement assessment of linguist Guist, Lin"
+        )
       }
     })
     it("Should display all tasks", async() => {
@@ -120,8 +159,33 @@ describe("Show print report page", () => {
         "tasks-assessments",
         true
       )
-      for (const task of TASKS) {
+      for (const task of TASKS_WITH_ASSESSMENTS) {
         expect(displayedTasks).to.contain(task)
+
+        const taskShortName = task.split(" » ")?.pop()
+        const taskAssessment1Label =
+          await ShowReport.getTaskEngagementAssessmentLabel(
+            "tasks-assessments",
+            taskShortName,
+            1
+          )
+        // eslint-disable-next-line no-unused-expressions
+        expect(await taskAssessment1Label.isExisting()).to.be.true
+        expect(await taskAssessment1Label.getText()).to.equal(
+          "Restricted engagement assessment of objective"
+        )
+
+        const taskAssessment2Label =
+          await ShowReport.getTaskEngagementAssessmentLabel(
+            "tasks-assessments",
+            taskShortName,
+            3
+          )
+        // eslint-disable-next-line no-unused-expressions
+        expect(await taskAssessment2Label.isExisting()).to.be.true
+        expect(await taskAssessment2Label.getText()).to.equal(
+          "Engagement assessment of objective"
+        )
       }
     })
   })

--- a/client/tests/webdriver/baseSpecs/showReport.spec.js
+++ b/client/tests/webdriver/baseSpecs/showReport.spec.js
@@ -13,20 +13,90 @@ describe("Show report page", () => {
   describe("When on the show page of a report with assessments", () => {
     it("We should see a table of tasks instant assessments related to the current report", async() => {
       await (
-        await ShowReport.getTasksEngagementAssessments()
+        await ShowReport.getTasksEngagementAssessments(
+          "tasks-engagement-assessments"
+        )
       ).waitForDisplayed()
+      /* eslint-disable no-unused-expressions */
+      // Should show the assessment labels
+      const TASK1 = "1.2.A"
+      expect(
+        await (
+          await ShowReport.getTaskEngagementAssessment(
+            "tasks-engagement-assessments",
+            TASK1
+          )
+        ).isExisting()
+      ).to.be.true
+      const task1Assessment1Label =
+        await ShowReport.getTaskEngagementAssessmentLabel(
+          "tasks-engagement-assessments",
+          TASK1,
+          1
+        )
+      expect(await task1Assessment1Label.isExisting()).to.be.true
+      expect(await task1Assessment1Label.getText()).to.equal(
+        "Restricted engagement assessment of objective"
+      )
+      const task1Assessment2Label =
+        await ShowReport.getTaskEngagementAssessmentLabel(
+          "tasks-engagement-assessments",
+          TASK1,
+          3
+        )
+      expect(await task1Assessment2Label.isExisting()).to.be.true
+      expect(await task1Assessment2Label.getText()).to.equal(
+        "Engagement assessment of objective"
+      )
+      const TASK2 = "1.2.B"
+      expect(
+        await (
+          await ShowReport.getTaskEngagementAssessment(
+            "tasks-engagement-assessments",
+            TASK2
+          )
+        ).isExisting()
+      ).to.be.true
+      const task2Assessment1Label =
+        await ShowReport.getTaskEngagementAssessmentLabel(
+          "tasks-engagement-assessments",
+          TASK2,
+          1
+        )
+      expect(await task2Assessment1Label.isExisting()).to.be.true
+      expect(await task2Assessment1Label.getText()).to.equal(
+        "Restricted engagement assessment of objective"
+      )
+      const task2Assessment2Label =
+        await ShowReport.getTaskEngagementAssessmentLabel(
+          "tasks-engagement-assessments",
+          TASK2,
+          3
+        )
+      expect(await task2Assessment2Label.isExisting()).to.be.true
+      expect(await task2Assessment2Label.getText()).to.equal(
+        "Engagement assessment of objective"
+      )
+      /* eslint-enable no-unused-expressions */
+
       // The tasks on the page have an svg type of assessment (LikertScale widgets)
       // and two other questions
       const svgAssessments = await (
-        await ShowReport.getTasksEngagementAssessments()
+        await ShowReport.getTasksEngagementAssessments(
+          "tasks-engagement-assessments"
+        )
       ).$$("svg")
       expect(svgAssessments).to.have.length(4)
       const question2Assessments = await (
-        await ShowReport.getTasksEngagementAssessments()
+        await ShowReport.getTasksEngagementAssessments(
+          "tasks-engagement-assessments"
+        )
       ).$$("[name*=question2]")
       expect(question2Assessments).to.have.length(4)
       const question3Assessments = await (
-        await ShowReport.getTasksEngagementAssessments()
+        await ShowReport.getTasksEngagementAssessments(
+          "tasks-engagement-assessments"
+        )
       ).$$("[name*=question3]")
       expect(question3Assessments).to.have.length(4)
     })

--- a/client/tests/webdriver/customFieldsSpecs/createFutureReport.spec.js
+++ b/client/tests/webdriver/customFieldsSpecs/createFutureReport.spec.js
@@ -144,6 +144,15 @@ describe("Create report form page", () => {
           await CreateFutureReport.getAttendeeAssessment(INTERLOCUTOR_VALUE)
         ).isExisting()
       ).to.be.true
+      const attendeeAssessmentLabel =
+        await CreateFutureReport.getAttendeeAssessmentLabel(
+          INTERLOCUTOR_VALUE,
+          1
+        )
+      expect(await attendeeAssessmentLabel.isExisting()).to.be.true
+      expect(await attendeeAssessmentLabel.getText()).to.equal(
+        "Engagement assessment of interlocutor"
+      )
       // Task assessments should be shown in the form
       expect(
         await (await CreateFutureReport.getTasksAssessments()).isExisting()
@@ -151,6 +160,18 @@ describe("Create report form page", () => {
       expect(
         await (await CreateFutureReport.getTaskAssessment(TASK)).isExisting()
       ).to.be.true
+      const taskAssessment1Label =
+        await CreateFutureReport.getTaskAssessmentLabel(TASK, 1)
+      expect(await taskAssessment1Label.isExisting()).to.be.true
+      expect(await taskAssessment1Label.getText()).to.equal(
+        "Restricted engagement assessment of objective"
+      )
+      const taskAssessment2Label =
+        await CreateFutureReport.getTaskAssessmentLabel(TASK, 3)
+      expect(await taskAssessment2Label.isExisting()).to.be.true
+      expect(await taskAssessment2Label.getText()).to.equal(
+        "Engagement assessment of objective"
+      )
       /* eslint-enable no-unused-expressions */
 
       // Save report

--- a/client/tests/webdriver/customFieldsSpecs/pendingAssessments.spec.js
+++ b/client/tests/webdriver/customFieldsSpecs/pendingAssessments.spec.js
@@ -266,11 +266,17 @@ describe("In new report page", () => {
       await browser.pause(SHORT_WAIT_MS) // wait for assessment questions to be updated
       await (await CreateReport.getTasksAssessments()).scrollIntoView()
       const taskAssessmentRows = await CreateReport.getTaskAssessmentRows()
-      expect(taskAssessmentRows).to.have.length(3) // a heading and two assessments
-      for (let i = 0; i < 2; i += 2) {
-        const task = taskAssessmentRows[i]
+      expect(taskAssessmentRows).to.have.length(5) // a heading and two assessments
+      const task = taskAssessmentRows[0]
+      for (let i = 1; i < 5; i += 2) {
+        const label = taskAssessmentRows[i]
         const assessment = taskAssessmentRows[i + 1]
         const questions = await assessment.$$("td > div")
+        expect(await label.getText()).to.equal(
+          i === 1
+            ? "Restricted engagement assessment of objective"
+            : "Engagement assessment of objective"
+        )
         switch (await task.getText()) {
           case "EF 1 » EF 1.2 » 1.2.A":
             expect(questions).to.have.length(3)
@@ -303,10 +309,14 @@ describe("In new report page", () => {
       await (await CreateReport.getAttendeesAssessments()).scrollIntoView()
       const attendeeAssessmentRows =
         await CreateReport.getAttendeeAssessmentRows()
-      expect(attendeeAssessmentRows).to.have.length(6)
-      for (let i = 0; i < 6; i += 2) {
+      expect(attendeeAssessmentRows).to.have.length(9)
+      for (let i = 0; i < 9; i += 3) {
         const attendee = attendeeAssessmentRows[i]
-        const assessment = attendeeAssessmentRows[i + 1]
+        const label = attendeeAssessmentRows[i + 1]
+        const assessment = attendeeAssessmentRows[i + 2]
+        expect(await label.getText()).to.equal(
+          "Engagement assessment of interlocutor"
+        )
         const questions = await assessment.$$("td > div")
         switch (await attendee.getText()) {
           case "OF-3 ROGWELL, Roger":
@@ -337,10 +347,14 @@ describe("In new report page", () => {
       await (await CreateReport.getAttendeesAssessments()).scrollIntoView()
       const attendeeAssessmentRows =
         await CreateReport.getAttendeeAssessmentRows()
-      expect(attendeeAssessmentRows).to.have.length(6)
-      for (let i = 0; i < 6; i += 2) {
+      expect(attendeeAssessmentRows).to.have.length(9)
+      for (let i = 0; i < 9; i += 3) {
         const attendee = attendeeAssessmentRows[i]
-        const assessment = attendeeAssessmentRows[i + 1]
+        const label = attendeeAssessmentRows[i + 1]
+        const assessment = attendeeAssessmentRows[i + 2]
+        expect(await label.getText()).to.equal(
+          "Engagement assessment of interlocutor"
+        )
         const questions = await assessment.$$("td > div")
         switch (await attendee.getText()) {
           case "OF-3 ROGWELL, Roger":

--- a/client/tests/webdriver/pages/createReport.page.js
+++ b/client/tests/webdriver/pages/createReport.page.js
@@ -253,7 +253,13 @@ export class CreateReport extends Page {
 
   async getAttendeeAssessment(name) {
     return (await this.getAttendeesAssessments()).$(
-      `.//td//a[text()="${name}"]`
+      `.//th//a[text()="${name}"]`
+    )
+  }
+
+  async getAttendeeAssessmentLabel(name, i) {
+    return (await this.getAttendeeAssessment(name)).$(
+      `../../../following-sibling::tr[${i}]/td`
     )
   }
 
@@ -267,7 +273,13 @@ export class CreateReport extends Page {
 
   async getTaskAssessment(shortName) {
     return (await this.getTasksAssessments()).$(
-      `.//td//a[text()="${shortName}"]`
+      `.//th//a[text()="${shortName}"]`
+    )
+  }
+
+  async getTaskAssessmentLabel(shortName, i) {
+    return (await this.getTaskAssessment(shortName)).$(
+      `../../../../following-sibling::tr[${i}]/td`
     )
   }
 

--- a/client/tests/webdriver/pages/report/showReport.page.js
+++ b/client/tests/webdriver/pages/report/showReport.page.js
@@ -18,8 +18,36 @@ class ShowReport extends Page {
     return browser.$("//a[text()='Edit']")
   }
 
-  async getTasksEngagementAssessments() {
-    return browser.$("#tasks-engagement-assessments")
+  async getAttendeesAssessments(id) {
+    return browser.$(`#${id}`)
+  }
+
+  async getAttendeeAssessment(id, name) {
+    return (await this.getAttendeesAssessments(id)).$(
+      `.//th//a[text()="${name}"]`
+    )
+  }
+
+  async getAttendeeAssessmentLabel(id, name, i) {
+    return (await this.getAttendeeAssessment(id, name)).$(
+      `../../../following-sibling::tr[${i}]/td`
+    )
+  }
+
+  async getTasksEngagementAssessments(id) {
+    return browser.$(`#${id}`)
+  }
+
+  async getTaskEngagementAssessment(id, shortName) {
+    return (await this.getTasksEngagementAssessments(id)).$(
+      `.//th//a[text()="${shortName}"]`
+    )
+  }
+
+  async getTaskEngagementAssessmentLabel(id, shortName, i) {
+    return (await this.getTaskEngagementAssessment(id, shortName)).$(
+      `../../../../following-sibling::tr[${i}]/td`
+    )
   }
 
   async getTask12BUrl() {
@@ -206,7 +234,7 @@ class ShowReport extends Page {
 
   async getCompactViewElements(type, withAssessments) {
     const elements = await (withAssessments
-      ? browser.$$(`#${type} > tbody > tr > td > span`)
+      ? browser.$$(`#${type} > tbody > tr > th > span`)
       : browser.$$(`#${type} > td > span`))
     return await elements.map(async element => (await element).getText())
   }


### PR DESCRIPTION
When there were multiple instant assessment definitions for a report attendee or task, it was difficult to distinguish them, as no label for them was shown. Change this by showing the (optional) label from the dictionary before the corresponding instant assessment.

Closes [AB#1375](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1375)

#### User changes
- Instant assessments on reports now show a label indicating which assessment it is.

#### Superuser changes
- None

#### Admin changes
- None

#### System admin changes
- [ ] application.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
- [x] described the user behavior in PR body
- [x] referenced/updated all related issues
- [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
- [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
- [ ] added and/or updated unit tests
- [x] added and/or updated e2e tests
- [ ] added and/or updated data migrations
- [ ] updated documentation
- [ ] resolved all build errors and warnings
- [x] opened debt issues for anything not resolved here: [AB#1388](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1388)