### PR TITLE
Improve MGRS coordinate validation

### DIFF
--- a/client/src/components/CustomFields.tsx
+++ b/client/src/components/CustomFields.tsx
@@ -377,12 +377,13 @@ const GeoLocationField = ({
   function updateCoordinateFields(latLng) {
     const parsedLat = parseCoordinate(latLng.lat)
     const parsedLng = parseCoordinate(latLng.lng)
+    const parsedMgrs = convertLatLngToMGRS(parsedLat, parsedLng)
+    formikProps.setFieldTouched(`${name}.lat`, false, false)
+    formikProps.setFieldTouched(`${name}.lng`, false, false)
+    formikProps.setFieldTouched(`${name}.displayedCoordinate`, false, false)
     formikProps.setFieldValue(`${name}.lat`, parsedLat)
     formikProps.setFieldValue(`${name}.lng`, parsedLng)
-    formikProps.setFieldValue(
-      `${name}.displayedCoordinate`,
-      convertLatLngToMGRS(parsedLat, parsedLng)
-    )
+    formikProps.setFieldValue(`${name}.displayedCoordinate`, parsedMgrs)
   }
 }
 

--- a/client/src/models/Location.ts
+++ b/client/src/models/Location.ts
@@ -26,6 +26,9 @@ export default class Location extends Model {
     Settings.fields.location.customFields
   )
 
+  static LATITUDE_ERROR = "Latitude must be a number between -90 and +90"
+  static LONGITUDE_ERROR = "Longitude must be a number between -180 and +180"
+
   static LOCATION_FORMATS = {
     LAT_LON: "LAT_LON",
     MGRS: "MGRS"
@@ -74,8 +77,9 @@ export default class Location extends Model {
       lat: yup
         .number()
         .nullable()
-        .min(-90, "Latitude must be a number between -90 and +90")
-        .max(90, "Latitude must be a number between -90 and +90")
+        .typeError(Location.LATITUDE_ERROR)
+        .min(-90, Location.LATITUDE_ERROR)
+        .max(90, Location.LATITUDE_ERROR)
         .test("lat", "Please enter latitude", function(lat) {
           const { lng } = this.parent
           if (utils.isNumeric(lng)) {
@@ -87,8 +91,9 @@ export default class Location extends Model {
       lng: yup
         .number()
         .nullable()
-        .min(-180, "Longitude must be a number between -180 and +180")
-        .max(180, "Longitude must be a number between -180 and +180")
+        .typeError(Location.LONGITUDE_ERROR)
+        .min(-180, Location.LONGITUDE_ERROR)
+        .max(180, Location.LONGITUDE_ERROR)
         .test("lng", "Please enter longitude", function(lng) {
           const { lat } = this.parent
           if (utils.isNumeric(lat)) {
@@ -101,24 +106,19 @@ export default class Location extends Model {
       displayedCoordinate: yup
         .string()
         .nullable()
-        .test({
-          name: "displayedCoordinate",
-          test: function(displayedCoordinate) {
+        .test(
+          "displayedCoordinate",
+          "Please enter a valid MGRS coordinate",
+          function(displayedCoordinate) {
             if (_isEmpty(displayedCoordinate)) {
               return true
             }
-            if (Location.locationFormat === Location.LOCATION_FORMATS.MGRS) {
-              const latLngValue = convertMGRSToLatLng(displayedCoordinate)
-              return !latLngValue[0] || !latLngValue[1]
-                ? this.createError({
-                  message: "Please enter a valid MGRS coordinate",
-                  path: "displayedCoordinate"
-                })
-                : true
-            }
-            return true
+            const latLngValue = convertMGRSToLatLng(displayedCoordinate)
+            return (
+              utils.isNumeric(latLngValue[0]) && utils.isNumeric(latLngValue[1])
+            )
           }
-        })
+        )
         .default(null),
       parentLocations: yup.array().nullable().default([]),
       childrenLocations: yup.array().nullable().default([]),

--- a/client/src/pages/locations/Form.tsx
+++ b/client/src/pages/locations/Form.tsx
@@ -492,12 +492,13 @@ const LocationForm = ({
         function updateCoordinateFields(latLng) {
           const parsedLat = parseCoordinate(latLng.lat)
           const parsedLng = parseCoordinate(latLng.lng)
+          const parsedMgrs = convertLatLngToMGRS(parsedLat, parsedLng)
+          setFieldTouched("lat", false, false)
+          setFieldTouched("lng", false, false)
+          setFieldTouched("displayedCoordinate", false, false)
           setFieldValue("lat", parsedLat)
           setFieldValue("lng", parsedLng)
-          setFieldValue(
-            "displayedCoordinate",
-            convertLatLngToMGRS(parsedLat, parsedLng)
-          )
+          setFieldValue("displayedCoordinate", parsedMgrs)
         }
       }}
     </Formik>


### PR DESCRIPTION
When switching from Lat/Lng to MGRS, invalid MGRS coordinates were not validated properly. Also, custom fields of type geo_location (e.g. in a report) had no validation of coordinates at all. This is now improved.

Closes [AB#1376](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1376)

#### User changes
- Users get a warning for invalid coordinates when editing custom geo_location fields in reports.

#### Superuser changes
- Superusers get a warning for invalid coordinates when editing locations.

#### Admin changes
- None.

#### System admin changes
- [ ] application.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
- [x] described the user behavior in PR body
- [x] referenced/updated all related issues
- [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
- [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
- [ ] added and/or updated unit tests
- [ ] added and/or updated e2e tests
- [ ] added and/or updated data migrations
- [ ] updated documentation
- [x] resolved all build errors and warnings
- [ ] opened debt issues for anything not resolved here
