### PR TITLE
Show a clearer error message when edits to an event or eventSeries are not permitted

### DIFF
--- a/client/tests/webdriver/baseSpecs/createNewEvent.spec.js
+++ b/client/tests/webdriver/baseSpecs/createNewEvent.spec.js
@@ -5,7 +5,7 @@ const ORG = "ANET Admin"
 const ORG_COMPLETE = "ANET Administrators"
 
 describe("Create event page", () => {
-  describe("When creating an event", () => {
+  describe("When creating an event as admin", () => {
     it("Should show required data warnings when submitting empty form", async() => {
       await CreateEvent.openAsAdminUser()
       await (await CreateEvent.getForm()).waitForExist()
@@ -71,6 +71,49 @@ describe("Create event page", () => {
 
       await CreateEvent.submitForm()
       await CreateEvent.waitForAlertSuccessToLoad()
+
+      await CreateEvent.logout()
+    })
+  })
+
+  describe("When creating an event as superuser", () => {
+    it("Should warn when adminOrg is not correctly filled in", async() => {
+      await CreateEvent.open()
+      await (await CreateEvent.getForm()).waitForExist()
+      await (await CreateEvent.getForm()).waitForDisplayed()
+
+      await (await CreateEvent.getNameInput()).waitForDisplayed()
+      await (await CreateEvent.getNameInput()).setValue("Test Event Series")
+
+      await (
+        await CreateEvent.getTypeInput()
+      ).selectByAttribute("value", "CONFERENCE")
+
+      await (await CreateEvent.getStartDateInput()).waitForDisplayed()
+      await (await CreateEvent.getStartDateInput()).setValue("01-01-2025 00:00")
+
+      await (await CreateEvent.getEndDateInput()).waitForDisplayed()
+      await (await CreateEvent.getEndDateInput()).setValue("02-01-2025 23:59")
+
+      await CreateEvent.submitForm()
+      expect(await (await CreateEvent.getAlertDanger()).getText()).to.eq(
+        "You must fill in the Admin Organization"
+      )
+
+      const adminOrg = "EF 2.2"
+
+      await (await CreateEvent.getAdminOrganizationInput()).click()
+      await (await CreateEvent.getAdminOrganizationInput()).setValue(adminOrg)
+      await CreateEvent.waitForAdminOrgAdvancedSelectToChange(adminOrg)
+      expect(
+        await (await CreateEvent.getAdminOrgAdvancedSelectFirstItem()).getText()
+      ).to.include(adminOrg)
+      await (await CreateEvent.getAdminOrgAdvancedSelectFirstItem()).click()
+
+      await CreateEvent.submitForm()
+      await CreateEvent.waitForAlertSuccessToLoad()
+
+      await CreateEvent.logout()
     })
   })
 })

--- a/client/tests/webdriver/baseSpecs/createNewEventSeries.spec.js
+++ b/client/tests/webdriver/baseSpecs/createNewEventSeries.spec.js
@@ -5,7 +5,7 @@ const ORG = "ANET Admin"
 const ORG_COMPLETE = "ANET Administrators"
 
 describe("Create event series page", () => {
-  describe("When creating an event series", () => {
+  describe("When creating an event series as admin", () => {
     it("Should show required data warnings when submitting empty form", async() => {
       await CreateEventSeries.openAsAdminUser()
       await (await CreateEventSeries.getForm()).waitForExist()
@@ -75,6 +75,49 @@ describe("Create event series page", () => {
 
       await CreateEventSeries.submitForm()
       await CreateEventSeries.waitForAlertSuccessToLoad()
+
+      await CreateEventSeries.logout()
+    })
+  })
+
+  describe("When creating an event series as superuser", () => {
+    it("Should warn when adminOrg is not correctly filled in", async() => {
+      await CreateEventSeries.open()
+      await (await CreateEventSeries.getForm()).waitForExist()
+      await (await CreateEventSeries.getForm()).waitForDisplayed()
+
+      await (await CreateEventSeries.getNameInput()).waitForDisplayed()
+      await (
+        await CreateEventSeries.getNameInput()
+      ).setValue("Test Event Series")
+
+      await CreateEventSeries.submitForm()
+      expect(await (await CreateEventSeries.getAlertDanger()).getText()).to.eq(
+        "You must fill in the Admin Organization"
+      )
+
+      const adminOrg = "EF 2.2"
+      await (
+        await CreateEventSeries.getAdminOrganizationInput()
+      ).waitForDisplayed()
+      await (await CreateEventSeries.getAdminOrganizationInput()).click()
+      await (
+        await CreateEventSeries.getAdminOrganizationInput()
+      ).setValue(adminOrg)
+      await CreateEventSeries.waitForAdminOrgAdvancedSelectToChange(adminOrg)
+      expect(
+        await (
+          await CreateEventSeries.getAdminOrgAdvancedSelectFirstItem()
+        ).getText()
+      ).to.include(adminOrg)
+      await (
+        await CreateEventSeries.getAdminOrgAdvancedSelectFirstItem()
+      ).click()
+
+      await CreateEventSeries.submitForm()
+      await CreateEventSeries.waitForAlertSuccessToLoad()
+
+      await CreateEventSeries.logout()
     })
   })
 })

--- a/src/main/java/mil/dds/anet/resources/EntityAvatarResource.java
+++ b/src/main/java/mil/dds/anet/resources/EntityAvatarResource.java
@@ -84,7 +84,7 @@ public class EntityAvatarResource {
     return numRows;
   }
 
-  public static void assertPermission(final Person user, final String relatedObjectType,
+  public void assertPermission(final Person user, final String relatedObjectType,
       final String relatedObjectUuid) {
     if (!hasPermission(user, relatedObjectType, relatedObjectUuid)) {
       throw new ResponseStatusException(HttpStatus.FORBIDDEN, AuthUtils.UNAUTH_MESSAGE);

--- a/src/main/java/mil/dds/anet/resources/EventResource.java
+++ b/src/main/java/mil/dds/anet/resources/EventResource.java
@@ -40,7 +40,7 @@ public class EventResource {
     return AuthUtils.isAdmin(user) || AuthUtils.canAdministrateOrg(user, orgUuid);
   }
 
-  public static void assertPermission(final Person user, final String orgUuid) {
+  public void assertPermission(final Person user, final String orgUuid) {
     if (!hasPermission(user, orgUuid)) {
       throw new ResponseStatusException(HttpStatus.FORBIDDEN, AuthUtils.UNAUTH_MESSAGE);
     }

--- a/src/main/java/mil/dds/anet/resources/EventResource.java
+++ b/src/main/java/mil/dds/anet/resources/EventResource.java
@@ -14,6 +14,7 @@ import mil.dds.anet.beans.Person;
 import mil.dds.anet.beans.Task;
 import mil.dds.anet.beans.lists.AnetBeanList;
 import mil.dds.anet.beans.search.EventSearchQuery;
+import mil.dds.anet.config.AnetDictionary;
 import mil.dds.anet.database.EventDao;
 import mil.dds.anet.graphql.AllowUnverifiedUsers;
 import mil.dds.anet.utils.AnetAuditLogger;
@@ -28,10 +29,12 @@ import org.springframework.web.server.ResponseStatusException;
 @GraphQLApi
 public class EventResource {
 
+  private final AnetDictionary dict;
   private final AnetObjectEngine engine;
   private final EventDao dao;
 
-  public EventResource(AnetObjectEngine engine) {
+  public EventResource(AnetDictionary dict, AnetObjectEngine engine) {
+    this.dict = dict;
     this.engine = engine;
     this.dao = engine.getEventDao();
   }
@@ -42,7 +45,10 @@ public class EventResource {
 
   public void assertPermission(final Person user, final String orgUuid) {
     if (!hasPermission(user, orgUuid)) {
-      throw new ResponseStatusException(HttpStatus.FORBIDDEN, AuthUtils.UNAUTH_MESSAGE);
+      throw new ResponseStatusException(HttpStatus.FORBIDDEN,
+          String.format(
+              orgUuid == null ? AuthUtils.MISSING_ORG_MESSAGE : AuthUtils.UNAUTH_ORG_MESSAGE,
+              dict.getDictionaryEntry("fields.event.adminOrg.label")));
     }
   }
 

--- a/src/main/java/mil/dds/anet/resources/EventSeriesResource.java
+++ b/src/main/java/mil/dds/anet/resources/EventSeriesResource.java
@@ -11,6 +11,7 @@ import mil.dds.anet.beans.EventSeries;
 import mil.dds.anet.beans.Person;
 import mil.dds.anet.beans.lists.AnetBeanList;
 import mil.dds.anet.beans.search.EventSeriesSearchQuery;
+import mil.dds.anet.config.AnetDictionary;
 import mil.dds.anet.database.EventSeriesDao;
 import mil.dds.anet.graphql.AllowUnverifiedUsers;
 import mil.dds.anet.utils.AnetAuditLogger;
@@ -25,9 +26,11 @@ import org.springframework.web.server.ResponseStatusException;
 @GraphQLApi
 public class EventSeriesResource {
 
+  private final AnetDictionary dict;
   private final EventSeriesDao dao;
 
-  public EventSeriesResource(AnetObjectEngine engine) {
+  public EventSeriesResource(AnetDictionary dict, AnetObjectEngine engine) {
+    this.dict = dict;
     this.dao = engine.getEventSeriesDao();
   }
 
@@ -37,7 +40,10 @@ public class EventSeriesResource {
 
   public void assertPermission(final Person user, final String orgUuid) {
     if (!hasPermission(user, orgUuid)) {
-      throw new ResponseStatusException(HttpStatus.FORBIDDEN, AuthUtils.UNAUTH_MESSAGE);
+      throw new ResponseStatusException(HttpStatus.FORBIDDEN,
+          String.format(
+              orgUuid == null ? AuthUtils.MISSING_ORG_MESSAGE : AuthUtils.UNAUTH_ORG_MESSAGE,
+              dict.getDictionaryEntry("fields.eventSeries.adminOrg.label")));
     }
   }
 

--- a/src/main/java/mil/dds/anet/resources/EventSeriesResource.java
+++ b/src/main/java/mil/dds/anet/resources/EventSeriesResource.java
@@ -35,7 +35,7 @@ public class EventSeriesResource {
     return AuthUtils.isAdmin(user) || AuthUtils.canAdministrateOrg(user, orgUuid);
   }
 
-  public static void assertPermission(final Person user, final String orgUuid) {
+  public void assertPermission(final Person user, final String orgUuid) {
     if (!hasPermission(user, orgUuid)) {
       throw new ResponseStatusException(HttpStatus.FORBIDDEN, AuthUtils.UNAUTH_MESSAGE);
     }

--- a/src/main/java/mil/dds/anet/resources/LocationResource.java
+++ b/src/main/java/mil/dds/anet/resources/LocationResource.java
@@ -45,7 +45,7 @@ public class LocationResource {
     return AuthUtils.isSuperuser(user);
   }
 
-  public static void assertPermission(final Person user, final String locationUuid) {
+  public void assertPermission(final Person user, final String locationUuid) {
     if (!hasPermission(user, locationUuid)) {
       throw new ResponseStatusException(HttpStatus.FORBIDDEN, AuthUtils.UNAUTH_MESSAGE);
     }

--- a/src/main/java/mil/dds/anet/resources/OrganizationResource.java
+++ b/src/main/java/mil/dds/anet/resources/OrganizationResource.java
@@ -54,7 +54,7 @@ public class OrganizationResource {
     return hasPermission(user, organization.getUuid());
   }
 
-  public static void assertPermission(final Person user, final String organizationUuid) {
+  public void assertPermission(final Person user, final String organizationUuid) {
     if (!hasPermission(user, organizationUuid)) {
       throw new ResponseStatusException(HttpStatus.FORBIDDEN, AuthUtils.UNAUTH_MESSAGE);
     }

--- a/src/main/java/mil/dds/anet/resources/PositionResource.java
+++ b/src/main/java/mil/dds/anet/resources/PositionResource.java
@@ -49,7 +49,7 @@ public class PositionResource {
     return AuthUtils.canAdministrateOrg(user, position.getOrganizationUuid());
   }
 
-  public static void assertPermission(final Person user, final Position position) {
+  public void assertPermission(final Person user, final Position position) {
     if (!hasPermission(user, position)) {
       throw new ResponseStatusException(HttpStatus.FORBIDDEN, AuthUtils.UNAUTH_MESSAGE);
     }

--- a/src/main/java/mil/dds/anet/utils/AuthUtils.java
+++ b/src/main/java/mil/dds/anet/utils/AuthUtils.java
@@ -20,6 +20,8 @@ public class AuthUtils {
       LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
   public static final String UNAUTH_MESSAGE = "You do not have permissions to do this";
+  public static final String UNAUTH_ORG_MESSAGE = "You must be a superuser of the %s";
+  public static final String MISSING_ORG_MESSAGE = "You must fill in the %s";
 
   private AuthUtils() {}
 


### PR DESCRIPTION
When a superuser edits an event or eventSeries without filling in an Admin Organization (or filling in one that is not permitted), they got a standard error message that permission was denied. We now show a clearer error message in that case.

Closes [AB#1389](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1389)

#### User changes
- None

#### Superuser changes
- A clearer message "You must be a superuser of the Admin Organization" is shown when edits to an event or eventSeries are not permitted.

#### Admin changes
- None.

#### System admin changes
- [ ] application.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
- [x] described the user behavior in PR body
- [x] referenced/updated all related issues
- [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
- [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
- [ ] added and/or updated unit tests
- [x] added and/or updated e2e tests
- [ ] added and/or updated data migrations
- [ ] updated documentation
- [x] resolved all build errors and warnings
- [ ] opened debt issues for anything not resolved here