### PR TITLE
Remove biography from the onboarding page

### DIFF
--- a/client/src/pages/onboarding/Edit.tsx
+++ b/client/src/pages/onboarding/Edit.tsx
@@ -23,7 +23,6 @@ const GQL_GET_SELF = gql`
       status
       phoneNumber
       pendingVerification
-      biography
       obsoleteCountry
       country {
         uuid

--- a/client/src/pages/onboarding/Show.tsx
+++ b/client/src/pages/onboarding/Show.tsx
@@ -34,7 +34,6 @@ const GQL_GET_SELF = gql`
       status
       phoneNumber
       pendingVerification
-      biography
       obsoleteCountry
       country {
         uuid
@@ -171,13 +170,8 @@ const OnboardingShow = ({ pageDispatchers }: OnboardingShowProps) => {
   }
 
   function mapNonCustomFields() {
-    const classNameExceptions = {
-      biography: "biography"
-    }
-
     // map fields that have specific human value
     const humanValuesExceptions = {
-      biography: <RichTextEditor readOnly value={person.biography} />,
       emailAddresses: (
         <EmailAddressTable
           label={Settings.fields.person.emailAddresses.label}
@@ -206,7 +200,6 @@ const OnboardingShow = ({ pageDispatchers }: OnboardingShowProps) => {
           name={key}
           component={FieldHelper.ReadonlyField}
           humanValue={humanValuesExceptions[key]}
-          className={classNameExceptions[key]}
         />
       )
 

--- a/client/src/pages/people/Form.tsx
+++ b/client/src/pages/people/Form.tsx
@@ -696,31 +696,33 @@ const PersonForm = ({
                     </Alert>
                   )}
                 </DictionaryField>
-                <DictionaryField
-                  wrappedComponent={FastField}
-                  dictProps={Settings.fields.person.biography}
-                  name="biography"
-                  component={FieldHelper.SpecialField}
-                  value={values.biography}
-                  onChange={value => {
-                    // prevent initial unnecessary render of RichTextEditor
-                    if (!_isEqual(value, values.biography)) {
-                      setFieldValue("biography", value)
-                    }
-                  }}
-                  onHandleBlur={() => {
-                    // validation will be done by setFieldValue
-                    setFieldTouched("biography", true, false)
-                  }}
-                  widget={
-                    <RichTextEditor
-                      className="biography"
-                      placeholder={
-                        Settings.fields.person.biography?.placeholder
+                {!forOnboarding && (
+                  <DictionaryField
+                    wrappedComponent={FastField}
+                    dictProps={Settings.fields.person.biography}
+                    name="biography"
+                    component={FieldHelper.SpecialField}
+                    value={values.biography}
+                    onChange={value => {
+                      // prevent initial unnecessary render of RichTextEditor
+                      if (!_isEqual(value, values.biography)) {
+                        setFieldValue("biography", value)
                       }
-                    />
-                  }
-                />
+                    }}
+                    onHandleBlur={() => {
+                      // validation will be done by setFieldValue
+                      setFieldTouched("biography", true, false)
+                    }}
+                    widget={
+                      <RichTextEditor
+                        className="biography"
+                        placeholder={
+                          Settings.fields.person.biography?.placeholder
+                        }
+                      />
+                    }
+                  />
+                )}
 
                 {edit && attachmentEditEnabled && (
                   <Field

--- a/client/tests/webdriver/baseSpecs/onboardNewUser.spec.js
+++ b/client/tests/webdriver/baseSpecs/onboardNewUser.spec.js
@@ -49,6 +49,9 @@ describe("Onboard new user login", () => {
         await (await OnboardPage.getEmailAddress(index)).getValue()
       ).to.equal(address)
     }
+
+    // Check that biography does not exist
+    await (await OnboardPage.getBiography()).waitForExist({ reverse: true })
   })
 
   it("Should not save if endOfTourDate is not in the future", async() => {

--- a/client/tests/webdriver/pages/onboard.page.js
+++ b/client/tests/webdriver/pages/onboard.page.js
@@ -21,6 +21,10 @@ class Onboard extends CreatePerson {
       { timeout: 5000, timeoutMsg: "Expected different welcome text after 5s" }
     )
   }
+
+  async getBiography() {
+    return browser.$("#biography")
+  }
 }
 
 export default new Onboard()


### PR DESCRIPTION
The biography on the onboarding page was not very useful, as the user has no access to link any ANET objects by that point.

Closes [AB#1391](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1391)

#### New user changes
- New users will no longer be able to fill in any biography on the onboarding page

#### User changes
- None

#### Superuser changes
- None

#### Admin changes
- None

#### System admin changes
- [ ] application.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
- [x] described the user behavior in PR body
- [x] referenced/updated all related issues
- [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
- [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
- [ ] added and/or updated unit tests
- [x] added and/or updated e2e tests
- [ ] added and/or updated data migrations
- [ ] updated documentation
- [x] resolved all build errors and warnings
- [ ] opened debt issues for anything not resolved here
