### PR TITLE
Remove background color from print view

### DIFF
--- a/client/src/components/Compact.tsx
+++ b/client/src/components/Compact.tsx
@@ -66,8 +66,6 @@ export const CompactView = ({
   )
 }
 
-// color-adjust forces browsers to keep color values of the node
-// supported in most major browsers' new versions, but not in IE or some older versions
 // TODO: Find a way to calculate background text width after 45deg rotation currently it is hardcoded as 130
 const CompactViewS = styled.div`
   position: relative;
@@ -83,16 +81,12 @@ const CompactViewS = styled.div`
     left: ${props => getBackgroundIndent(props.pageSize.width, 130)};
     font-size: 150px;
     color: rgba(161, 158, 158, 0.3) !important;
-    -webkit-print-color-adjust: exact;
-    color-adjust: exact !important;
     transform: rotateZ(-45deg);
   }
   @media print {
     outline: none;
     .banner {
       display: inline-block !important;
-      -webkit-print-color-adjust: exact;
-      color-adjust: exact !important;
     }
     table {
       page-break-inside: auto;
@@ -221,8 +215,6 @@ const HF_COMMON_STYLE = `
   justify-content: space-between;
   align-items: center;
   padding: 1rem;
-  -webkit-print-color-adjust: exact !important;
-  color-adjust: exact !important;
   @media print {
     position: fixed;
     max-height: 80px;

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -21,6 +21,9 @@ body {
   overflow: hidden;
   margin: 0;
   box-sizing: border-box;
+  @media print {
+    background: #ffffff !important;
+  }
 }
 
 .anet {

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -23,6 +23,8 @@ body {
   box-sizing: border-box;
   @media print {
     background: #ffffff !important;
+    -webkit-print-color-adjust: exact;
+    print-color-adjust: exact;
   }
 }
 


### PR DESCRIPTION
The background is now white when printing in ANET. This means that clicking "Background graphics" in the print menu won't have any visual difference.

Closes [AB#1392](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1392)

#### User changes
-  The print previews now have a completely white background.

#### Superuser changes
- None

#### Admin changes
- None

#### System admin changes
- [ ] application.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
- [x] described the user behavior in PR body
- [x] referenced/updated all related issues
- [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
- [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
- [ ] added and/or updated unit tests
- [ ] added and/or updated e2e tests
- [ ] added and/or updated data migrations
- [ ] updated documentation
- [x] resolved all build errors and warnings
- [ ] opened debt issues for anything not resolved here
