### PR TITLE
Address invalid HTML in compact report

### DIFF
--- a/client/src/components/CustomFields.tsx
+++ b/client/src/components/CustomFields.tsx
@@ -1384,7 +1384,7 @@ export const ReadonlyCustomFields = ({
         )
 
         return (
-          <div key={key}>
+          <React.Fragment key={key}>
             {isCompact ? (
               <table>
                 <tbody>{content}</tbody>
@@ -1392,7 +1392,7 @@ export const ReadonlyCustomFields = ({
             ) : (
               content
             )}
-          </div>
+          </React.Fragment>
         )
       })}
     </>

--- a/client/src/components/CustomFields.tsx
+++ b/client/src/components/CustomFields.tsx
@@ -1360,9 +1360,8 @@ export const ReadonlyCustomFields = ({
         ) {
           return null
         }
-        return ReadonlyFieldComponent ? (
+        const content = ReadonlyFieldComponent ? (
           <ReadonlyFieldComponent
-            key={key}
             name={fieldName}
             values={values}
             vertical={vertical}
@@ -1374,7 +1373,6 @@ export const ReadonlyCustomFields = ({
           />
         ) : (
           <FastField
-            key={key}
             name={fieldName}
             isCompact={isCompact}
             component={FieldHelper.ReadonlyField}
@@ -1383,6 +1381,18 @@ export const ReadonlyCustomFields = ({
             labelColumnWidth={labelColumnWidth}
             {...fieldProps}
           />
+        )
+
+        return (
+          <div key={key}>
+            {isCompact ? (
+              <table>
+                <tbody>{content}</tbody>
+              </table>
+            ) : (
+              content
+            )}
+          </div>
         )
       })}
     </>

--- a/client/src/pages/reports/Compact.tsx
+++ b/client/src/pages/reports/Compact.tsx
@@ -450,8 +450,9 @@ const CompactReportView = ({ pageDispatchers }: CompactReportViewProps) => {
                   />
                 )}
                 {Settings.fields.report.customFields && (
-                  <tr>
-                    <td>
+                  <CompactRow
+                    id="customFields"
+                    content={
                       <ReadonlyCustomFields
                         fieldsConfig={Settings.fields.report.customFields}
                         values={report}
@@ -459,8 +460,10 @@ const CompactReportView = ({ pageDispatchers }: CompactReportViewProps) => {
                         isCompact
                         hideIfEmpty
                       />
-                    </td>
-                  </tr>
+                    }
+                    className="reportField"
+                    hideIfEmpty
+                  />
                 )}
               </FullColumn>
             </CompactTable>

--- a/client/src/pages/reports/Compact.tsx
+++ b/client/src/pages/reports/Compact.tsx
@@ -428,19 +428,26 @@ const CompactReportView = ({ pageDispatchers }: CompactReportViewProps) => {
                   />
                 )}
                 {optionalFields.assessments.active && (
-                  <CompactReportViewS>
-                    {getAttendeesAndAssessments(
-                      true,
-                      true,
-                      "interlocutors-assessments"
-                    )}
-                    {getAttendeesAndAssessments(
-                      false,
-                      true,
-                      "advisors-assessments"
-                    )}
-                    {getTasksAndAssessments(true, "tasks-assessments")}
-                  </CompactReportViewS>
+                  <CompactRow
+                    id="assessments"
+                    content={
+                      <CompactReportViewS>
+                        {getAttendeesAndAssessments(
+                          true,
+                          true,
+                          "interlocutors-assessments"
+                        )}
+                        {getAttendeesAndAssessments(
+                          false,
+                          true,
+                          "advisors-assessments"
+                        )}
+                        {getTasksAndAssessments(true, "tasks-assessments")}
+                      </CompactReportViewS>
+                    }
+                    className="reportField"
+                    hideIfEmpty
+                  />
                 )}
                 {Settings.fields.report.customFields && (
                   <ReadonlyCustomFields
@@ -611,7 +618,7 @@ const CompactReportView = ({ pageDispatchers }: CompactReportViewProps) => {
   }
 }
 
-const CompactReportViewS = styled.table`
+const CompactReportViewS = styled.div`
   .table {
     & span.badge {
       background-color: unset !important;

--- a/client/src/pages/reports/Compact.tsx
+++ b/client/src/pages/reports/Compact.tsx
@@ -450,13 +450,17 @@ const CompactReportView = ({ pageDispatchers }: CompactReportViewProps) => {
                   />
                 )}
                 {Settings.fields.report.customFields && (
-                  <ReadonlyCustomFields
-                    fieldsConfig={Settings.fields.report.customFields}
-                    values={report}
-                    vertical
-                    isCompact
-                    hideIfEmpty
-                  />
+                  <tr>
+                    <td>
+                      <ReadonlyCustomFields
+                        fieldsConfig={Settings.fields.report.customFields}
+                        values={report}
+                        vertical
+                        isCompact
+                        hideIfEmpty
+                      />
+                    </td>
+                  </tr>
                 )}
               </FullColumn>
             </CompactTable>


### PR DESCRIPTION
There was a small (not visible to users) issue with invalid HTML when showing assessments in the compact report view; this is now corrected.

Closes [AB#1388](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1388)

#### User changes
- None

#### Superuser changes
- None

#### Admin changes
- None

#### System admin changes
- [ ] application.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
- [x] described the user behavior in PR body
- [x] referenced/updated all related issues
- [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
- [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
- [ ] added and/or updated unit tests
- [ ] added and/or updated e2e tests
- [ ] added and/or updated data migrations
- [ ] updated documentation
- [x] resolved all build errors and warnings
- [ ] opened debt issues for anything not resolved here
