### PR TITLE
Show which user was approved or deleted

### DIFF
--- a/client/src/index.css
+++ b/client/src/index.css
@@ -509,7 +509,7 @@ li#search-nav .nav > li a {
 }
 
 .onboarding-new {
-  width: 40%;
+  width: fit-content;
   margin-left: auto;
   margin-right: auto;
 }

--- a/client/src/pages/admin/UsersPendingVerification.tsx
+++ b/client/src/pages/admin/UsersPendingVerification.tsx
@@ -102,19 +102,23 @@ const UsersPendingVerification = ({
               {list.map(person => (
                 <tr key={person.uuid}>
                   <td>
-                    <LinkTo modelType="Person" model={person} />
+                    <LinkTo
+                      modelType="Person"
+                      model={person}
+                      showAvatar={false}
+                    />
                   </td>
                   <td>
                     <Button
                       variant="primary"
-                      onClick={() => updateAccess(person.uuid, true)}
+                      onClick={() => updateAccess(person, true)}
                     >
                       Allow Access
                     </Button>
                     <Button
                       variant="outline-danger"
                       className="ms-2"
-                      onClick={() => updateAccess(person.uuid, false)}
+                      onClick={() => updateAccess(person, false)}
                     >
                       Deny Access
                     </Button>
@@ -128,14 +132,25 @@ const UsersPendingVerification = ({
     </Fieldset>
   )
 
-  function updateAccess(uuid, isApproved) {
+  function updateAccess(person, isApproved) {
     return API.mutation(isApproved ? GQL_APPROVE_USER : GQL_DELETE_USER, {
-      uuid
+      uuid: person.uuid
     })
       .then(data => {
-        setStateSuccess(
-          `Pending user was successfully ${isApproved ? "approved" : "deleted"}`
+        const msg = (
+          <>
+            Pending user{" "}
+            <LinkTo
+              modelType="Person"
+              model={person}
+              showAvatar={false}
+              isLink={isApproved}
+              showPreview={isApproved}
+            />{" "}
+            was successfully {isApproved ? "approved" : "deleted"}.
+          </>
         )
+        setStateSuccess(msg)
         setStateError(null)
         refetch()
       })


### PR DESCRIPTION
When a user was approved, show a link to the user in the confirmation message, so the admin can easily navigate to that user.
When a user was deleted, show the name of the user in the confirmation message.

Closes [AB#1074](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1074) 

#### User changes
- None

#### Superuser changes
- None

#### Admin changes
- When automatic approval of new users is disabled, admins have a better view of which users they manually approved or deleted.

#### System admin changes
- [ ] application.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
- [x] described the user behavior in PR body
- [x] referenced/updated all related issues
- [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
- [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
- [ ] added and/or updated unit tests
- [ ] added and/or updated e2e tests
- [ ] added and/or updated data migrations
- [ ] updated documentation
- [x] resolved all build errors and warnings
- [ ] opened debt issues for anything not resolved here