### PR TITLE
Improve display of custom fields on merge pages

### DIFF
--- a/client/src/components/CustomFields.tsx
+++ b/client/src/components/CustomFields.tsx
@@ -97,13 +97,14 @@ const ReadonlySpecialField = ({
   isCompact,
   ...otherFieldProps
 }: ReadonlySpecialFieldProps) => {
+  const value = Object.get(values, name) || null
+  const field = { name, value }
   if (widget === SPECIAL_WIDGET_TYPES.RICH_TEXT_EDITOR) {
     const fieldValue = Object.get(values, name) || "" // name might be a path for a nested prop
     return (
-      <FastField
-        name={name}
+      <FieldHelper.ReadonlyField
+        field={field}
         isCompact={isCompact}
-        component={FieldHelper.ReadonlyField}
         humanValue={<RichTextEditor readOnly value={fieldValue} />}
         {...Object.without(otherFieldProps, "style")}
       />
@@ -111,10 +112,9 @@ const ReadonlySpecialField = ({
   }
   if (widget === SPECIAL_WIDGET_TYPES.LIKERT_SCALE && isCompact) {
     return (
-      <FastField
-        name={name}
+      <FieldHelper.ReadonlyField
+        field={field}
         isCompact={isCompact}
-        component={FieldHelper.ReadonlyField}
         humanValue={
           <CompactLikertScale
             name={name}
@@ -128,10 +128,9 @@ const ReadonlySpecialField = ({
   }
   const WidgetComponent = SPECIAL_WIDGET_COMPONENTS[widget]
   return (
-    <FastField
-      name={name}
+    <FieldHelper.SpecialField
+      field={field}
       isCompact={isCompact}
-      component={FieldHelper.SpecialField}
       widget={<WidgetComponent />}
       readonly
       {...otherFieldProps}
@@ -167,21 +166,23 @@ const ReadonlyTextField = fieldProps => {
   const {
     name,
     label,
+    values,
     vertical,
     isCompact,
     extraColElem,
     labelColumnWidth,
     className
   } = fieldProps
+  const value = Object.get(values, name) || null
+  const field = { name, value }
   return (
-    <FastField
-      name={name}
+    <FieldHelper.ReadonlyField
+      field={field}
       label={label}
       vertical={vertical}
       isCompact={isCompact}
       extraColElem={extraColElem}
       labelColumnWidth={labelColumnWidth}
-      component={FieldHelper.ReadonlyField}
       className={className}
     />
   )
@@ -205,6 +206,7 @@ const ReadonlyDateField = fieldProps => {
   const {
     name,
     label,
+    values,
     vertical,
     isCompact,
     withTime,
@@ -212,15 +214,16 @@ const ReadonlyDateField = fieldProps => {
     labelColumnWidth,
     className
   } = fieldProps
+  const value = Object.get(values, name) || null
+  const field = { name, value }
   return (
-    <FastField
-      name={name}
+    <FieldHelper.ReadonlyField
+      field={field}
       label={label}
       vertical={vertical}
       isCompact={isCompact}
       extraColElem={extraColElem}
       labelColumnWidth={labelColumnWidth}
-      component={FieldHelper.ReadonlyField}
       humanValue={fieldVal =>
         fieldVal &&
         moment(fieldVal).format(
@@ -286,11 +289,11 @@ const ReadonlyJsonField = ({
   className
 }: ReadonlyJsonFieldProps) => {
   const value = Object.get(values, name) || {}
+  const field = { name, value }
   return (
-    <FastField
-      name={name}
+    <FieldHelper.ReadonlyField
+      field={field}
       label={label}
-      component={FieldHelper.ReadonlyField}
       humanValue={JSON.stringify(value)}
       extraColElem={extraColElem}
       labelColumnWidth={labelColumnWidth}
@@ -476,14 +479,14 @@ const ReadonlyEnumField = fieldProps => {
     labelColumnWidth,
     className
   } = fieldProps
+  const value = Object.get(values, name) || null
+  const field = { name, value }
   return (
-    <FastField
-      name={name}
+    <FieldHelper.ReadonlyField
+      field={field}
       label={label}
       vertical={vertical}
-      values={values}
       isCompact={isCompact}
-      component={FieldHelper.ReadonlyField}
       humanValue={fieldVal => enumHumanValue(choices, fieldVal)}
       extraColElem={extraColElem}
       labelColumnWidth={labelColumnWidth}
@@ -637,13 +640,7 @@ const ReadonlyArrayOfObjectsField = fieldProps => {
 
   return (
     <Fieldset title={fieldsetTitle} isCompact={isCompact}>
-      <FieldArray
-        name={name}
-        /* div cannot be parent or child in print table, tbody, tr */
-        render={arrayHelpers =>
-          isCompact ? <>{arrayOfObjects}</> : <div>{arrayOfObjects}</div>
-        }
-      />
+      {arrayOfObjects}
     </Fieldset>
   )
 }
@@ -768,11 +765,11 @@ const ReadonlyAnetObjectField = ({
   className
 }: ReadonlyAnetObjectFieldProps) => {
   const { type, uuid } = Object.get(values, name) || {}
+  const field = { name }
   return (
-    <FastField
-      name={name}
+    <FieldHelper.ReadonlyField
+      field={field}
       label={label}
-      component={FieldHelper.ReadonlyField}
       isCompact={isCompact}
       humanValue={
         type &&
@@ -902,11 +899,12 @@ const ReadonlyArrayOfAnetObjectsField = ({
   className
 }: ReadonlyArrayOfAnetObjectsFieldProps) => {
   const fieldValue = Object.get(values, name) || []
+  const value = Object.get(values, name) || null
+  const field = { name, value }
   return (
-    <FastField
-      name={name}
+    <FieldHelper.ReadonlyField
+      field={field}
       label={label}
-      component={FieldHelper.ReadonlyField}
       isCompact={isCompact}
       humanValue={
         !_isEmpty(fieldValue) && (
@@ -1355,6 +1353,7 @@ export const ReadonlyCustomFields = ({
         }
         const ReadonlyFieldComponent = READONLY_FIELD_COMPONENTS[type]
         const value = Object.get(values, fieldName) || null
+        const field = { name: fieldName, value }
         if (
           hideIfEmpty &&
           (value == null ||
@@ -1375,10 +1374,9 @@ export const ReadonlyCustomFields = ({
             {...extraProps}
           />
         ) : (
-          <FastField
-            name={fieldName}
+          <FieldHelper.ReadonlyField
+            field={field}
             isCompact={isCompact}
-            component={FieldHelper.ReadonlyField}
             humanValue={<i>Missing ReadonlyFieldComponent for {type}</i>}
             extraColElem={extraColElem}
             labelColumnWidth={labelColumnWidth}
@@ -1386,17 +1384,7 @@ export const ReadonlyCustomFields = ({
           />
         )
 
-        return (
-          <React.Fragment key={key}>
-            {isCompact ? (
-              <table>
-                <tbody>{content}</tbody>
-              </table>
-            ) : (
-              content
-            )}
-          </React.Fragment>
-        )
+        return <React.Fragment key={key}>{content}</React.Fragment>
       })}
     </>
   )
@@ -1439,6 +1427,8 @@ export const mapReadonlyCustomFieldsToComps = ({
       }
     }
     const ReadonlyFieldComponent = READONLY_FIELD_COMPONENTS[type]
+    const value = Object.get(values, fieldName) || null
+    const field = { name: fieldName, value }
     accum[key] = ReadonlyFieldComponent ? (
       <ReadonlyFieldComponent
         key={key}
@@ -1452,10 +1442,9 @@ export const mapReadonlyCustomFieldsToComps = ({
         {...extraProps}
       />
     ) : (
-      <FastField
+      <FieldHelper.ReadonlyField
         key={key}
-        name={fieldName}
-        component={FieldHelper.ReadonlyField}
+        field={field}
         humanValue={<i>Missing ReadonlyFieldComponent for {type}</i>}
         extraColElem={extraColElem}
         labelColumnWidth={labelColumnWidth}

--- a/client/src/components/CustomFields.tsx
+++ b/client/src/components/CustomFields.tsx
@@ -639,7 +639,11 @@ const ReadonlyArrayOfObjectsField = fieldProps => {
   ))
 
   return (
-    <Fieldset title={fieldsetTitle} isCompact={isCompact}>
+    <Fieldset
+      title={fieldsetTitle}
+      isCompact={isCompact}
+      className="custom-array-field"
+    >
       {arrayOfObjects}
     </Fieldset>
   )
@@ -1398,7 +1402,9 @@ export function mapReadonlyCustomFieldToComp({
   values,
   vertical,
   labelColumnWidth,
-  isCompact
+  isCompact,
+  hideLabel,
+  hideTooltip
 }: {
   key: string
   fieldConfig: object
@@ -1407,11 +1413,16 @@ export function mapReadonlyCustomFieldToComp({
   vertical?: boolean
   labelColumnWidth?: number
   isCompact?: boolean
+  hideLabel?: boolean
+  hideTooltip?: boolean
 }) {
   const fieldName = `${parentFieldName}.${key}`
   const fieldProps = getFieldPropsFromFieldConfig(fieldConfig)
+  if (hideLabel) {
+    fieldProps.label = null
+  }
   let extraColElem = null
-  if (fieldConfig.authorizationGroupUuids) {
+  if (fieldConfig.authorizationGroupUuids && !hideTooltip) {
     fieldProps.className = "sensitive-information"
     extraColElem = (
       <div>
@@ -1429,7 +1440,9 @@ export function mapReadonlyCustomFieldToComp({
   let extraProps = {}
   if (type === CUSTOM_FIELD_TYPE.ARRAY_OF_OBJECTS) {
     extraProps = {
-      fieldConfig
+      fieldConfig: hideLabel
+        ? Object.without(fieldConfig, "label")
+        : fieldConfig
     }
   }
   const ReadonlyFieldComponent = READONLY_FIELD_COMPONENTS[type]

--- a/client/src/components/FieldHelper.tsx
+++ b/client/src/components/FieldHelper.tsx
@@ -288,8 +288,8 @@ interface ReadonlyFieldProps {
 }
 
 export const ReadonlyField = ({
-  field, // { name, value, onChange, onBlur }
-  form, // also values, setXXXX, handleXXXX, dirty, isValid, status, etc.
+  field = {}, // { name, value, onChange, onBlur }
+  form = {}, // also values, setXXXX, handleXXXX, dirty, isValid, status, etc.
   label,
   asA,
   children,
@@ -342,8 +342,8 @@ interface SpecialFieldProps {
 }
 
 export const SpecialField = ({
-  field, // { name, value, onChange, onBlur }
-  form, // also values, setXXXX, handleXXXX, dirty, isValid, status, etc.
+  field = {}, // { name, value, onChange, onBlur }
+  form = {}, // also values, setXXXX, handleXXXX, dirty, isValid, status, etc.
   label,
   children,
   extraColElem,

--- a/client/src/components/Fieldset.tsx
+++ b/client/src/components/Fieldset.tsx
@@ -41,7 +41,7 @@ const Fieldset = ({
     <Element
       id={id}
       name={id}
-      className="scroll-anchor-container"
+      className="scroll-anchor-container w-100"
       style={style}
     >
       {(title || action) && (

--- a/client/src/components/graphs/LikertScale.tsx
+++ b/client/src/components/graphs/LikertScale.tsx
@@ -232,7 +232,7 @@ const LikertScale = ({
       )}
       <g ref={axisRef} transform={`translate(0 ${scaleYPosition})`} />
 
-      {onChange && (editable || (value && value >= scale.domain()[0])) && (
+      {((onChange && editable) || (value && value >= scale.domain()[0])) && (
         <g ref={cursorRef}>
           <polygon
             points="0,0 13,13 13,30 -13,30 -13,13"

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -64,6 +64,11 @@ fieldset {
   width: 100%;
 }
 
+fieldset.custom-array-field {
+  background: unset;
+  box-shadow: unset;
+}
+
 .modal-body fieldset {
   box-shadow: none;
   padding-bottom: 0;

--- a/client/src/pages/admin/merge/MergeLocations.tsx
+++ b/client/src/pages/admin/merge/MergeLocations.tsx
@@ -7,7 +7,10 @@ import { LocationOverlayRow } from "components/advancedSelectWidget/AdvancedSele
 import AdvancedSingleSelect from "components/advancedSelectWidget/AdvancedSingleSelect"
 import ApprovalSteps from "components/approvals/ApprovalSteps"
 import EntityAvatarDisplay from "components/avatar/EntityAvatarDisplay"
-import { customFieldsJSONString } from "components/CustomFields"
+import {
+  customFieldsJSONString,
+  mapReadonlyCustomFieldToComp
+} from "components/CustomFields"
 import DictionaryField from "components/DictionaryField"
 import BaseGeoLocation from "components/GeoLocation"
 import LocationTable from "components/LocationTable"
@@ -314,23 +317,23 @@ const MergeLocations = ({ pageDispatchers }: MergeLocationsProps) => {
               />
               {Settings.fields.location.customFields &&
                 Object.entries(Settings.fields.location.customFields).map(
-                  ([fieldName, fieldConfig]) => {
-                    const fieldValue =
-                      mergedLocation?.[DEFAULT_CUSTOM_FIELDS_PARENT]?.[
-                        fieldName
-                      ]
-                    return (
-                      <MergeField
-                        key={fieldName}
-                        label={fieldConfig.label || fieldName}
-                        value={JSON.stringify(fieldValue)}
-                        align={ALIGN_OPTIONS.CENTER}
-                        fieldName={`${DEFAULT_CUSTOM_FIELDS_PARENT}.${fieldName}`}
-                        mergeState={mergeState}
-                        dispatchMergeActions={dispatchMergeActions}
-                      />
-                    )
-                  }
+                  ([fieldName, fieldConfig]: [string, object]) => (
+                    <MergeField
+                      key={fieldName}
+                      label={fieldConfig.label || fieldName}
+                      value={mapReadonlyCustomFieldToComp({
+                        fieldConfig,
+                        parentFieldName: DEFAULT_CUSTOM_FIELDS_PARENT,
+                        key: fieldName,
+                        values: mergedLocation,
+                        hideLabel: true
+                      })}
+                      align={ALIGN_OPTIONS.CENTER}
+                      fieldName={`${DEFAULT_CUSTOM_FIELDS_PARENT}.${fieldName}`}
+                      mergeState={mergeState}
+                      dispatchMergeActions={dispatchMergeActions}
+                    />
+                  )
                 )}
             </fieldset>
           )}
@@ -686,32 +689,33 @@ const LocationColumn = ({
           />
           {Settings.fields.location.customFields &&
             Object.entries(Settings.fields.location.customFields).map(
-              ([fieldName, fieldConfig]) => {
-                const fieldValue =
-                  location?.[DEFAULT_CUSTOM_FIELDS_PARENT]?.[fieldName]
-                return (
-                  <MergeField
-                    key={fieldName}
-                    fieldName={`${DEFAULT_CUSTOM_FIELDS_PARENT}.${fieldName}`}
-                    label={fieldConfig.label || fieldName}
-                    // To be able to see arrays and objects
-                    value={JSON.stringify(fieldValue)}
-                    align={align}
-                    action={() =>
-                      dispatchMergeActions(
-                        setAMergedField(
-                          `${DEFAULT_CUSTOM_FIELDS_PARENT}.${fieldName}`,
-                          fieldValue,
-                          align
-                        )
+              ([fieldName, fieldConfig]: [string, object]) => (
+                <MergeField
+                  key={fieldName}
+                  fieldName={`${DEFAULT_CUSTOM_FIELDS_PARENT}.${fieldName}`}
+                  label={fieldConfig.label || fieldName}
+                  value={mapReadonlyCustomFieldToComp({
+                    fieldConfig,
+                    parentFieldName: DEFAULT_CUSTOM_FIELDS_PARENT,
+                    key: fieldName,
+                    values: location,
+                    hideLabel: true
+                  })}
+                  align={align}
+                  action={() =>
+                    dispatchMergeActions(
+                      setAMergedField(
+                        `${DEFAULT_CUSTOM_FIELDS_PARENT}.${fieldName}`,
+                        location?.[DEFAULT_CUSTOM_FIELDS_PARENT]?.[fieldName],
+                        align
                       )
-                    }
-                    mergeState={mergeState}
-                    autoMerge
-                    dispatchMergeActions={dispatchMergeActions}
-                  />
-                )
-              }
+                    )
+                  }
+                  mergeState={mergeState}
+                  autoMerge
+                  dispatchMergeActions={dispatchMergeActions}
+                />
+              )
             )}
         </fieldset>
       )}

--- a/client/src/pages/admin/merge/MergeOrganizations.tsx
+++ b/client/src/pages/admin/merge/MergeOrganizations.tsx
@@ -9,7 +9,10 @@ import { fieldsList as app6fieldsList } from "components/App6Symbol"
 import App6SymbolPreview from "components/App6SymbolPreview"
 import ApprovalSteps from "components/approvals/ApprovalSteps"
 import EntityAvatarDisplay from "components/avatar/EntityAvatarDisplay"
-import { customFieldsJSONString } from "components/CustomFields"
+import {
+  customFieldsJSONString,
+  mapReadonlyCustomFieldToComp
+} from "components/CustomFields"
 import DictionaryField from "components/DictionaryField"
 import EmailAddressTable from "components/EmailAddressTable"
 import LinkTo from "components/LinkTo"
@@ -465,23 +468,23 @@ const MergeOrganizations = ({ pageDispatchers }: MergeOrganizationsProps) => {
               />
               {Settings.fields.organization.customFields &&
                 Object.entries(Settings.fields.organization.customFields).map(
-                  ([fieldName, fieldConfig]) => {
-                    const fieldValue =
-                      mergedOrganization?.[DEFAULT_CUSTOM_FIELDS_PARENT]?.[
-                        fieldName
-                      ]
-                    return (
-                      <MergeField
-                        key={fieldName}
-                        label={fieldConfig.label || fieldName}
-                        value={JSON.stringify(fieldValue)}
-                        align={ALIGN_OPTIONS.CENTER}
-                        fieldName={`${DEFAULT_CUSTOM_FIELDS_PARENT}.${fieldName}`}
-                        mergeState={mergeState}
-                        dispatchMergeActions={dispatchMergeActions}
-                      />
-                    )
-                  }
+                  ([fieldName, fieldConfig]: [string, object]) => (
+                    <MergeField
+                      key={fieldName}
+                      label={fieldConfig.label || fieldName}
+                      value={mapReadonlyCustomFieldToComp({
+                        fieldConfig,
+                        parentFieldName: DEFAULT_CUSTOM_FIELDS_PARENT,
+                        key: fieldName,
+                        values: mergedOrganization,
+                        hideLabel: true
+                      })}
+                      align={ALIGN_OPTIONS.CENTER}
+                      fieldName={`${DEFAULT_CUSTOM_FIELDS_PARENT}.${fieldName}`}
+                      mergeState={mergeState}
+                      dispatchMergeActions={dispatchMergeActions}
+                    />
+                  )
                 )}
             </fieldset>
           )}
@@ -896,32 +899,35 @@ const OrganizationColumn = ({
           />
           {Settings.fields.organization.customFields &&
             Object.entries(Settings.fields.organization.customFields).map(
-              ([fieldName, fieldConfig]) => {
-                const fieldValue =
-                  organization?.[DEFAULT_CUSTOM_FIELDS_PARENT]?.[fieldName]
-                return (
-                  <MergeField
-                    key={fieldName}
-                    fieldName={`${DEFAULT_CUSTOM_FIELDS_PARENT}.${fieldName}`}
-                    label={fieldConfig.label || fieldName}
-                    // To be able to see arrays and objects
-                    value={JSON.stringify(fieldValue)}
-                    align={align}
-                    action={() =>
-                      dispatchMergeActions(
-                        setAMergedField(
-                          `${DEFAULT_CUSTOM_FIELDS_PARENT}.${fieldName}`,
-                          fieldValue,
-                          align
-                        )
+              ([fieldName, fieldConfig]: [string, object]) => (
+                <MergeField
+                  key={fieldName}
+                  fieldName={`${DEFAULT_CUSTOM_FIELDS_PARENT}.${fieldName}`}
+                  label={fieldConfig.label || fieldName}
+                  value={mapReadonlyCustomFieldToComp({
+                    fieldConfig,
+                    parentFieldName: DEFAULT_CUSTOM_FIELDS_PARENT,
+                    key: fieldName,
+                    values: organization,
+                    hideLabel: true
+                  })}
+                  align={align}
+                  action={() =>
+                    dispatchMergeActions(
+                      setAMergedField(
+                        `${DEFAULT_CUSTOM_FIELDS_PARENT}.${fieldName}`,
+                        organization?.[DEFAULT_CUSTOM_FIELDS_PARENT]?.[
+                          fieldName
+                        ],
+                        align
                       )
-                    }
-                    mergeState={mergeState}
-                    autoMerge
-                    dispatchMergeActions={dispatchMergeActions}
-                  />
-                )
-              }
+                    )
+                  }
+                  mergeState={mergeState}
+                  autoMerge
+                  dispatchMergeActions={dispatchMergeActions}
+                />
+              )
             )}
         </fieldset>
       )}

--- a/client/src/pages/admin/merge/MergePeople.tsx
+++ b/client/src/pages/admin/merge/MergePeople.tsx
@@ -337,9 +337,12 @@ const MergePeople = ({ pageDispatchers }: MergePeopleProps) => {
               <DictionaryField
                 wrappedComponent={MergeField}
                 dictProps={Settings.fields.person.endOfTourDate}
-                value={moment(mergedPerson.endOfTourDate).format(
-                  Settings.dateFormats.forms.displayShort.date
-                )}
+                value={
+                  mergedPerson.endOfTourDate &&
+                  moment(mergedPerson.endOfTourDate).format(
+                    Settings.dateFormats.forms.displayShort.date
+                  )
+                }
                 align={ALIGN_OPTIONS.CENTER}
                 fieldName="endOfTourDate"
                 mergeState={mergeState}
@@ -755,9 +758,12 @@ const PersonColumn = ({
             wrappedComponent={MergeField}
             dictProps={Settings.fields.person.endOfTourDate}
             fieldName="endOfTourDate"
-            value={moment(person.endOfTourDate).format(
-              Settings.dateFormats.forms.displayShort.date
-            )}
+            value={
+              person.endOfTourDate &&
+              moment(person.endOfTourDate).format(
+                Settings.dateFormats.forms.displayShort.date
+              )
+            }
             align={align}
             action={() => {
               dispatchMergeActions(

--- a/client/src/pages/admin/merge/MergePeople.tsx
+++ b/client/src/pages/admin/merge/MergePeople.tsx
@@ -8,7 +8,10 @@ import { PersonSimpleOverlayRow } from "components/advancedSelectWidget/Advanced
 import AdvancedSingleSelect from "components/advancedSelectWidget/AdvancedSingleSelect"
 import EntityAvatarDisplay from "components/avatar/EntityAvatarDisplay"
 import CountryDisplay from "components/CountryDisplay"
-import { customFieldsJSONString } from "components/CustomFields"
+import {
+  customFieldsJSONString,
+  mapReadonlyCustomFieldToComp
+} from "components/CustomFields"
 import DictionaryField from "components/DictionaryField"
 import EditHistory from "components/EditHistory"
 import EmailAddressTable from "components/EmailAddressTable"
@@ -355,57 +358,48 @@ const MergePeople = ({ pageDispatchers }: MergePeopleProps) => {
               />
               {Settings.fields.person.customFields &&
                 Object.entries(Settings.fields.person.customFields).map(
-                  ([fieldName, fieldConfig]) => {
-                    const fieldValue =
-                      mergedPerson?.[DEFAULT_CUSTOM_FIELDS_PARENT]?.[fieldName]
-                    return (
-                      <MergeField
-                        key={fieldName}
-                        label={fieldConfig.label || fieldName}
-                        value={JSON.stringify(fieldValue)}
-                        align={ALIGN_OPTIONS.CENTER}
-                        fieldName={`${DEFAULT_CUSTOM_FIELDS_PARENT}.${fieldName}`}
-                        mergeState={mergeState}
-                        dispatchMergeActions={dispatchMergeActions}
-                      />
-                    )
-                  }
-                )}
-              {Settings.fields.person.customSensitiveInformation &&
-                Object.entries(
-                  Settings.fields.person.customSensitiveInformation
-                ).map(([fieldName, fieldConfig]) => {
-                  const fieldValue =
-                    mergedPerson?.[SENSITIVE_CUSTOM_FIELDS_PARENT]?.[fieldName]
-                  return (
+                  ([fieldName, fieldConfig]: [string, object]) => (
                     <MergeField
                       key={fieldName}
                       label={fieldConfig.label || fieldName}
-                      value={
-                        <>
-                          {JSON.stringify(fieldValue)}
-                          {mergeState.selectedMap?.[
-                            `${SENSITIVE_CUSTOM_FIELDS_PARENT}.${fieldName}`
-                          ] && (
-                            <Tooltip
-                              content={fieldConfig.tooltipText}
-                              intent={Intent.WARNING}
-                            >
-                              <Icon
-                                icon={IconNames.INFO_SIGN}
-                                intent={Intent.PRIMARY}
-                              />
-                            </Tooltip>
-                          )}
-                        </>
-                      }
+                      value={mapReadonlyCustomFieldToComp({
+                        fieldConfig,
+                        parentFieldName: DEFAULT_CUSTOM_FIELDS_PARENT,
+                        key: fieldName,
+                        values: mergedPerson,
+                        hideLabel: true
+                      })}
                       align={ALIGN_OPTIONS.CENTER}
-                      fieldName={`${SENSITIVE_CUSTOM_FIELDS_PARENT}.${fieldName}`}
+                      fieldName={`${DEFAULT_CUSTOM_FIELDS_PARENT}.${fieldName}`}
                       mergeState={mergeState}
                       dispatchMergeActions={dispatchMergeActions}
                     />
                   )
-                })}
+                )}
+              {Settings.fields.person.customSensitiveInformation &&
+                Object.entries(
+                  Settings.fields.person.customSensitiveInformation
+                ).map(([fieldName, fieldConfig]: [string, object]) => (
+                  <MergeField
+                    key={fieldName}
+                    label={fieldConfig.label || fieldName}
+                    value={mapReadonlyCustomFieldToComp({
+                      fieldConfig,
+                      parentFieldName: SENSITIVE_CUSTOM_FIELDS_PARENT,
+                      key: fieldName,
+                      values: mergedPerson,
+                      hideLabel: true,
+                      hideTooltip:
+                        !mergeState.selectedMap?.[
+                          `${SENSITIVE_CUSTOM_FIELDS_PARENT}.${fieldName}`
+                        ]
+                    })}
+                    align={ALIGN_OPTIONS.CENTER}
+                    fieldName={`${SENSITIVE_CUSTOM_FIELDS_PARENT}.${fieldName}`}
+                    mergeState={mergeState}
+                    dispatchMergeActions={dispatchMergeActions}
+                  />
+                ))}
             </fieldset>
           )}
         </Col>
@@ -791,64 +785,24 @@ const PersonColumn = ({
           />
           {Settings.fields.person.customFields &&
             Object.entries(Settings.fields.person.customFields).map(
-              ([fieldName, fieldConfig]) => {
-                const fieldValue =
-                  person?.[DEFAULT_CUSTOM_FIELDS_PARENT]?.[fieldName]
-                return (
-                  <MergeField
-                    key={fieldName}
-                    fieldName={`${DEFAULT_CUSTOM_FIELDS_PARENT}.${fieldName}`}
-                    label={fieldConfig.label || fieldName}
-                    // To be able to see arrays and objects
-                    value={JSON.stringify(fieldValue)}
-                    align={align}
-                    action={() =>
-                      dispatchMergeActions(
-                        setAMergedField(
-                          `${DEFAULT_CUSTOM_FIELDS_PARENT}.${fieldName}`,
-                          fieldValue,
-                          align
-                        )
-                      )
-                    }
-                    mergeState={mergeState}
-                    autoMerge
-                    dispatchMergeActions={dispatchMergeActions}
-                  />
-                )
-              }
-            )}
-          {Settings.fields.person.customSensitiveInformation &&
-            Object.entries(
-              Settings.fields.person.customSensitiveInformation
-            ).map(([fieldName, fieldConfig]) => {
-              const fieldValue =
-                person?.[SENSITIVE_CUSTOM_FIELDS_PARENT]?.[fieldName]
-              return (
+              ([fieldName, fieldConfig]: [string, object]) => (
                 <MergeField
                   key={fieldName}
-                  fieldName={`${SENSITIVE_CUSTOM_FIELDS_PARENT}.${fieldName}`}
+                  fieldName={`${DEFAULT_CUSTOM_FIELDS_PARENT}.${fieldName}`}
                   label={fieldConfig.label || fieldName}
-                  value={
-                    <>
-                      {JSON.stringify(fieldValue)}
-                      <Tooltip
-                        content={fieldConfig.tooltipText}
-                        intent={Intent.WARNING}
-                      >
-                        <Icon
-                          icon={IconNames.INFO_SIGN}
-                          intent={Intent.PRIMARY}
-                        />
-                      </Tooltip>
-                    </>
-                  }
+                  value={mapReadonlyCustomFieldToComp({
+                    fieldConfig,
+                    parentFieldName: DEFAULT_CUSTOM_FIELDS_PARENT,
+                    key: fieldName,
+                    values: person,
+                    hideLabel: true
+                  })}
                   align={align}
                   action={() =>
                     dispatchMergeActions(
                       setAMergedField(
-                        `${SENSITIVE_CUSTOM_FIELDS_PARENT}.${fieldName}`,
-                        fieldValue,
+                        `${DEFAULT_CUSTOM_FIELDS_PARENT}.${fieldName}`,
+                        person?.[DEFAULT_CUSTOM_FIELDS_PARENT]?.[fieldName],
                         align
                       )
                     )
@@ -858,7 +812,37 @@ const PersonColumn = ({
                   dispatchMergeActions={dispatchMergeActions}
                 />
               )
-            })}
+            )}
+          {Settings.fields.person.customSensitiveInformation &&
+            Object.entries(
+              Settings.fields.person.customSensitiveInformation
+            ).map(([fieldName, fieldConfig]: [string, object]) => (
+              <MergeField
+                key={fieldName}
+                fieldName={`${SENSITIVE_CUSTOM_FIELDS_PARENT}.${fieldName}`}
+                label={fieldConfig.label || fieldName}
+                value={mapReadonlyCustomFieldToComp({
+                  fieldConfig,
+                  parentFieldName: SENSITIVE_CUSTOM_FIELDS_PARENT,
+                  key: fieldName,
+                  values: person,
+                  hideLabel: true
+                })}
+                align={align}
+                action={() =>
+                  dispatchMergeActions(
+                    setAMergedField(
+                      `${SENSITIVE_CUSTOM_FIELDS_PARENT}.${fieldName}`,
+                      person?.[SENSITIVE_CUSTOM_FIELDS_PARENT]?.[fieldName],
+                      align
+                    )
+                  )
+                }
+                mergeState={mergeState}
+                autoMerge
+                dispatchMergeActions={dispatchMergeActions}
+              />
+            ))}
         </fieldset>
       )}
     </PersonCol>

--- a/client/src/pages/admin/merge/MergePositions.tsx
+++ b/client/src/pages/admin/merge/MergePositions.tsx
@@ -7,7 +7,10 @@ import { PositionOverlayRow } from "components/advancedSelectWidget/AdvancedSele
 import AdvancedSingleSelect from "components/advancedSelectWidget/AdvancedSingleSelect"
 import AssociatedPositions from "components/AssociatedPositions"
 import EntityAvatarDisplay from "components/avatar/EntityAvatarDisplay"
-import { customFieldsJSONString } from "components/CustomFields"
+import {
+  customFieldsJSONString,
+  mapReadonlyCustomFieldToComp
+} from "components/CustomFields"
 import DictionaryField from "components/DictionaryField"
 import EditAssociatedPositions from "components/EditAssociatedPositions"
 import EditHistory from "components/EditHistory"
@@ -354,23 +357,23 @@ const MergePositions = ({ pageDispatchers }: MergePositionsProps) => {
               )}
               {Settings.fields.position.customFields &&
                 Object.entries(Settings.fields.position.customFields).map(
-                  ([fieldName, fieldConfig]) => {
-                    const fieldValue =
-                      mergedPosition?.[DEFAULT_CUSTOM_FIELDS_PARENT]?.[
-                        fieldName
-                      ]
-                    return (
-                      <MergeField
-                        key={fieldName}
-                        label={fieldConfig.label || fieldName}
-                        value={JSON.stringify(fieldValue)}
-                        align={ALIGN_OPTIONS.CENTER}
-                        fieldName={`${DEFAULT_CUSTOM_FIELDS_PARENT}.${fieldName}`}
-                        mergeState={mergeState}
-                        dispatchMergeActions={dispatchMergeActions}
-                      />
-                    )
-                  }
+                  ([fieldName, fieldConfig]: [string, object]) => (
+                    <MergeField
+                      key={fieldName}
+                      label={fieldConfig.label || fieldName}
+                      value={mapReadonlyCustomFieldToComp({
+                        fieldConfig,
+                        parentFieldName: DEFAULT_CUSTOM_FIELDS_PARENT,
+                        key: fieldName,
+                        values: mergedPosition,
+                        hideLabel: true
+                      })}
+                      align={ALIGN_OPTIONS.CENTER}
+                      fieldName={`${DEFAULT_CUSTOM_FIELDS_PARENT}.${fieldName}`}
+                      mergeState={mergeState}
+                      dispatchMergeActions={dispatchMergeActions}
+                    />
+                  )
                 )}
               <DictionaryField
                 wrappedComponent={MergeField}
@@ -759,33 +762,33 @@ const PositionColumn = ({
           )}
           {Settings.fields.position.customFields &&
             Object.entries(Settings.fields.position.customFields).map(
-              ([fieldName, fieldConfig]) => {
-                const fieldValue =
-                  position?.[DEFAULT_CUSTOM_FIELDS_PARENT]?.[fieldName]
-
-                return (
-                  <MergeField
-                    key={fieldName}
-                    fieldName={`${DEFAULT_CUSTOM_FIELDS_PARENT}.${fieldName}`}
-                    label={fieldConfig.label || fieldName}
-                    // To be able to see arrays and objects
-                    value={JSON.stringify(fieldValue)}
-                    align={align}
-                    action={() =>
-                      dispatchMergeActions(
-                        setAMergedField(
-                          `${DEFAULT_CUSTOM_FIELDS_PARENT}.${fieldName}`,
-                          fieldValue,
-                          align
-                        )
+              ([fieldName, fieldConfig]: [string, object]) => (
+                <MergeField
+                  key={fieldName}
+                  fieldName={`${DEFAULT_CUSTOM_FIELDS_PARENT}.${fieldName}`}
+                  label={fieldConfig.label || fieldName}
+                  value={mapReadonlyCustomFieldToComp({
+                    fieldConfig,
+                    parentFieldName: DEFAULT_CUSTOM_FIELDS_PARENT,
+                    key: fieldName,
+                    values: position,
+                    hideLabel: true
+                  })}
+                  align={align}
+                  action={() =>
+                    dispatchMergeActions(
+                      setAMergedField(
+                        `${DEFAULT_CUSTOM_FIELDS_PARENT}.${fieldName}`,
+                        position?.[DEFAULT_CUSTOM_FIELDS_PARENT]?.[fieldName],
+                        align
                       )
-                    }
-                    mergeState={mergeState}
-                    autoMerge
-                    dispatchMergeActions={dispatchMergeActions}
-                  />
-                )
-              }
+                    )
+                  }
+                  mergeState={mergeState}
+                  autoMerge
+                  dispatchMergeActions={dispatchMergeActions}
+                />
+              )
             )}
           <DictionaryField
             wrappedComponent={MergeField}

--- a/client/tests/webdriver/baseSpecs/mergePeople.spec.js
+++ b/client/tests/webdriver/baseSpecs/mergePeople.spec.js
@@ -28,10 +28,10 @@ const EXAMPLE_PEOPLE = {
     notes: ["Merge one person note", "A really nice person to work with"],
     perUuid: "3cb2076c-5317-47fe-86ad-76f298993917",
     posUuid: "885dd6bf-4647-4ef7-9bc4-4dd2826064bb",
-    colourOptions: '"RED"',
-    numberFieldName: '"5"',
-    birthday: '"2003-01-31T23:00:00.000Z"',
-    politicalPosition: '"MIDDLE"'
+    colourOptions: "Red",
+    numberField: "5",
+    birthday: `${moment("2003-01-31T23:00:00.000Z").format("D MMMM YYYY")}`,
+    politicalPosition: "Middle"
   },
   validRight: {
     search: "loser",
@@ -55,10 +55,10 @@ const EXAMPLE_PEOPLE = {
     notes: ["Merge two person note"],
     perUuid: "c725aef3-cdd1-4baf-ac72-f28219b234e9",
     posUuid: "4dc40a27-19ae-4e03-a4f3-55b2c768725f",
-    colourOptions: '"RED"',
-    numberFieldName: '"6"',
-    birthday: '"2010-11-11T23:00:00.000Z"',
-    politicalPosition: '"MIDDLE"'
+    colourOptions: "Red",
+    numberField: "6",
+    birthday: `${moment("2010-11-11T23:00:00.000Z").format("D MMMM YYYY")}`,
+    politicalPosition: "Middle"
   },
   userRight: {
     search: "andrew",
@@ -80,8 +80,8 @@ const EXAMPLE_PEOPLE = {
     ],
     biography: "Andrew is the EF 1 Manager",
     notes: ["A really nice person to work with"],
-    colourOptions: '""',
-    numberFieldName: "null",
+    colourOptions: "",
+    numberField: "",
     birthday: "",
     politicalPosition: ""
   }
@@ -368,7 +368,7 @@ describe("Merge people who are both non-users", () => {
         await (
           await MergePeople.getColumnContent("mid", "Number field")
         ).getText()
-      ).to.eq(EXAMPLE_PEOPLE.validLeft.numberFieldName)
+      ).to.eq(EXAMPLE_PEOPLE.validLeft.numberField)
     }
     expect(
       await (
@@ -428,7 +428,7 @@ describe("Merge people who are both non-users", () => {
         await (
           await MergePeople.getColumnContent("mid", "Number field")
         ).getText()
-      ).to.eq(EXAMPLE_PEOPLE.validRight.numberFieldName)
+      ).to.eq(EXAMPLE_PEOPLE.validRight.numberField)
     }
     expect(
       await (
@@ -536,7 +536,7 @@ describe("Merge people who are both non-users", () => {
     if (hasCustomFields) {
       await (await MergePeople.getSelectButton("left", "Number field")).click()
       await MergePeople.waitForColumnToChange(
-        EXAMPLE_PEOPLE.validLeft.numberFieldName,
+        EXAMPLE_PEOPLE.validLeft.numberField,
         "mid",
         "Number field"
       )
@@ -544,7 +544,7 @@ describe("Merge people who are both non-users", () => {
         await (
           await MergePeople.getColumnContent("mid", "Number field")
         ).getText()
-      ).to.equal(EXAMPLE_PEOPLE.validLeft.numberFieldName)
+      ).to.equal(EXAMPLE_PEOPLE.validLeft.numberField)
     }
 
     await (await MergePeople.getSelectButton("left", "Date of birth")).click()
@@ -711,7 +711,7 @@ describe("Merge user with non-user", () => {
         await (
           await MergePeople.getColumnContent("mid", "Number field")
         ).getText()
-      ).to.eq(EXAMPLE_PEOPLE.validLeft.numberFieldName)
+      ).to.eq(EXAMPLE_PEOPLE.validLeft.numberField)
     }
     expect(
       await (
@@ -783,7 +783,7 @@ describe("Merge user with non-user", () => {
         await (
           await MergePeople.getColumnContent("mid", "Number field")
         ).getText()
-      ).to.eq(EXAMPLE_PEOPLE.userRight.numberFieldName)
+      ).to.eq(EXAMPLE_PEOPLE.userRight.numberField)
     }
     expect(
       await (


### PR DESCRIPTION
Custom (sensitive) fields on the merge pages were shown in a way that wasn't always very readable. These changes improve that.

Closes [AB#1166](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1166)

#### User changes
- None

#### Superuser changes
- None

#### Admin changes
- On the merge pages, custom (sensitive) fields are displayed in a much more readable way.

#### System admin changes
- [ ] application.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
- [x] described the user behavior in PR body
- [x] referenced/updated all related issues
- [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
- [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
- [ ] added and/or updated unit tests
- [x] added and/or updated e2e tests
- [ ] added and/or updated data migrations
- [ ] updated documentation
- [x] resolved all build errors and warnings
- [ ] opened debt issues for anything not resolved here
