### PR TITLE
Set explicit minimal GitHub Actions permissions for all workflows

### DIFF
--- a/.github/workflows/build-gradle.yml
+++ b/.github/workflows/build-gradle.yml
@@ -10,6 +10,9 @@ on:
     branches:
     - main
 
+permissions:
+  contents: read
+
 env:
   NODE_OPTIONS: '--max-old-space-size=8192'
   DB_DRIVER: postgresql

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -9,8 +9,13 @@ on:
   schedule:
     - cron: '0 3 * * 3'
 
+permissions:
+  contents: read
+
 jobs:
   analyse:
+    permissions:
+      security-events: write
     name: Analyse
     runs-on: ubuntu-latest
 

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -9,8 +9,13 @@ on:
       tags:
         description: 'Update release notes'
 
+permissions:
+  contents: read
+
 jobs:
   update_release_draft:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       # Drafts next Release notes as Pull Requests are merged into the default branch;


### PR DESCRIPTION
Closes code scanning alerts about missing workflow permissions.