### PR TITLE
Prevent saving duplicate searches

### DIFF
--- a/client/src/pages/searches/Search.tsx
+++ b/client/src/pages/searches/Search.tsx
@@ -861,6 +861,13 @@ const Search = ({
       toast.success("Search saved")
       setError(null)
       setShowSaveSearch(false)
+      setSearches([
+        ...searches,
+        {
+          objectType: searchQuery.objectType || null,
+          query: JSON.stringify(canonicalize(getSearchQuery(searchQuery)))
+        }
+      ])
     }
   }
 


### PR DESCRIPTION
Users should not be allowed to saved searches equal to their existing ones

Closes AB#1396

#### User changes
- Users won't be able to create a duplicate search, regardless of order filter

#### Superuser changes
- None

#### Admin changes
- None

#### System admin changes
- [ ] application.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
- [x] described the user behavior in PR body
- [x] referenced/updated all related issues
- [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
- [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
- [ ] added and/or updated unit tests
- [ ] added and/or updated e2e tests
- [ ] added and/or updated data migrations
- [ ] updated documentation
- [x] resolved all build errors and warnings
- [ ] opened debt issues for anything not resolved here
