### PR TITLE
Improve display of (empty) GeoLocation fields in Compact views

### DIFF
--- a/client/src/components/CustomFields.tsx
+++ b/client/src/components/CustomFields.tsx
@@ -970,7 +970,10 @@ interface CompactGeoLocationProps {
 }
 
 const CompactGeoLocation = ({ coordinates }: CompactGeoLocationProps) => {
-  const coords = `${coordinates.lat}, ${coordinates.lng} - ${coordinates.displayedCoordinate}`
+  const coords =
+    `${utils.isNumeric(coordinates.lat) ? coordinates.lat : "?"}, ` +
+    `${utils.isNumeric(coordinates.lng) ? coordinates.lng : "?"} - ` +
+    `${coordinates.displayedCoordinate || "?"}`
   return <>{coords}</>
 }
 


### PR DESCRIPTION
Empty GeoLocation fields were shown in Compact views as `null, null - `; this improves it to show `?, ? - ?` instead (conform other read-only views).

Closes AB#1400

#### User changes
- The display of (empty) GeoLocation fields in Compact views is improved.

#### Superuser changes
- None

#### Admin changes
- None

#### System admin changes
- [ ] application.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
- [x] described the user behavior in PR body
- [x] referenced/updated all related issues
- [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
- [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
- [ ] added and/or updated unit tests
- [ ] added and/or updated e2e tests
- [ ] added and/or updated data migrations
- [ ] updated documentation
- [ ] resolved all build errors and warnings
- [ ] opened debt issues for anything not resolved here
