### PR TITLE
Improve error handling in MART dictionary export

### DIFF
--- a/client/src/pages/admin/martImporter/Show.tsx
+++ b/client/src/pages/admin/martImporter/Show.tsx
@@ -3,6 +3,7 @@ import MartImportedReportTable from "pages/admin/martImporter/MartImportedReport
 import ReportHistoryModal from "pages/admin/martImporter/ReportHistoryModal"
 import React, { useState } from "react"
 import { Button } from "react-bootstrap"
+import { toast } from "react-toastify"
 
 const MartImporterShow = () => {
   usePageTitle("MART reports imported")
@@ -11,17 +12,8 @@ const MartImporterShow = () => {
   const [showHistoryModal, setShowHistoryModal] = useState(false)
   return (
     <>
-      <Button variant="primary">
-        <a
-          href="/api/admin/dictionary/mart"
-          style={{
-            color: "white",
-            padding: "6px 12px",
-            textDecoration: "none"
-          }}
-        >
-          Export Dictionary for MART
-        </a>
+      <Button variant="primary" onClick={handleExport}>
+        Export Dictionary for MART
       </Button>
       <MartImportedReportTable onSelectReport={renderHistoryModal} />
       {showHistoryModal && (
@@ -38,6 +30,35 @@ const MartImporterShow = () => {
   function renderHistoryModal(martImportedReport: any) {
     setSelectedMartImportedReport(martImportedReport)
     setShowHistoryModal(true)
+  }
+  async function handleExport() {
+    try {
+      const response = await fetch("/api/admin/dictionary/mart", {
+        method: "GET",
+        headers: {
+          Accept: "application/x-yaml"
+        }
+      })
+      if (!response.ok) {
+        // Error happened in back-end producing dictionary, notify and end
+        const errorJson = await response.json()
+        toast.error(errorJson?.errors[0]?.message)
+        return
+      }
+      // All good, proceed
+      const blob = await response.blob()
+      const url = window.URL.createObjectURL(blob)
+
+      const link = document.createElement("a")
+      link.href = url
+      link.download = "anet-dictionary.yml"
+      document.body.appendChild(link)
+      link.click()
+      link.remove()
+      window.URL.revokeObjectURL(url)
+    } catch (err) {
+      toast.error(`Unexpected error during MART dictionary export "${err}"`)
+    }
   }
 }
 

--- a/client/src/pages/admin/martImporter/Show.tsx
+++ b/client/src/pages/admin/martImporter/Show.tsx
@@ -42,7 +42,7 @@ const MartImporterShow = () => {
       if (!response.ok) {
         // Error happened in back-end producing dictionary, notify and end
         const errorJson = await response.json()
-        toast.error(errorJson?.errors[0]?.message)
+        toast.error(errorJson?.errors?.[0]?.message)
         return
       }
       // All good, proceed

--- a/src/main/java/mil/dds/anet/resources/AdminResource.java
+++ b/src/main/java/mil/dds/anet/resources/AdminResource.java
@@ -8,7 +8,6 @@ import io.leangen.graphql.annotations.GraphQLRootContext;
 import io.leangen.graphql.spqr.spring.annotations.GraphQLApi;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
-import java.io.StringWriter;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 import java.security.Principal;
@@ -122,22 +121,18 @@ public class AdminResource {
     options.setIndentWithIndicator(true);
 
     final Yaml yaml = new Yaml(options);
-    final StringWriter stringWriter = new StringWriter();
-    yaml.dump(dictionaryForMart, stringWriter);
-    final String yamlContent = stringWriter.toString();
-
-    StreamingResponseBody responseBody = outputStream -> {
-      try (Writer writer = new OutputStreamWriter(outputStream, StandardCharsets.UTF_8)) {
-        writer.write(yamlContent);
+    final StreamingResponseBody responseBody = outputStream -> {
+      try (final Writer writer = new OutputStreamWriter(outputStream, StandardCharsets.UTF_8)) {
+        yaml.dump(dictionaryForMart, writer);
       }
     };
 
-    HttpHeaders headers = new HttpHeaders();
+    final HttpHeaders headers = new HttpHeaders();
     headers.setContentDisposition(
         ContentDisposition.attachment().filename("anet-dictionary.yml").build());
 
-    return ResponseEntity.ok().contentType(MediaType.parseMediaType("application/x-yaml"))
-        .headers(headers).body(responseBody);
+    return ResponseEntity.ok().contentType(MediaType.APPLICATION_YAML).headers(headers)
+        .body(responseBody);
   }
 
   /**


### PR DESCRIPTION
Make ANET handle misconfiguration of MART dictionary export more gracefully.

Closes [AB#1434](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1434)

#### User changes
- None

#### Superuser changes
- None

#### Admin changes
- If the martDictionaryExport properties are wrong or any error occurs during the generation of the MART dictionary the admin will see an error as opposed to receving an empty file.

#### System admin changes
- [ ] application.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
- [x] described the user behavior in PR body
- [x] referenced/updated all related issues
- [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
- [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
- [ ] added and/or updated unit tests
- [ ] added and/or updated e2e tests
- [ ] added and/or updated data migrations
- [ ] updated documentation
- [x] resolved all build errors and warnings
- [ ] opened debt issues for anything not resolved here
