### PR TITLE
Add search option to exclude reports with specific tasks

### DIFF
--- a/client/src/components/SearchFilters.tsx
+++ b/client/src/components/SearchFilters.tsx
@@ -378,6 +378,13 @@ export const searchFilters = function (includeAdminFilters) {
       props: {
         queryKey: "taskUuid"
       }
+    },
+    [`Not Within ${Settings.fields.task.shortLabel}`]: {
+      component: TaskFilter,
+      deserializer: deserializeTaskFilter,
+      props: {
+        queryKey: "notTaskUuid"
+      }
     }
   }
 

--- a/src/main/java/mil/dds/anet/beans/search/RecursiveFkBatchParams.java
+++ b/src/main/java/mil/dds/anet/beans/search/RecursiveFkBatchParams.java
@@ -25,7 +25,7 @@ public class RecursiveFkBatchParams<B extends AbstractAnetBean, T extends Abstra
       AbstractSearchQueryBuilder<B, T> qb) {
     qb.addRecursiveBatchClause(outerQb, getTableName(), new String[] {getForeignKey()},
         "batch_parents", recursiveTableName, "uuid", recursiveForeignKey, "batchUuids",
-        getBatchUuids(), recurseStrategy);
+        getBatchUuids(), recurseStrategy, null);
   }
 
   public String getRecursiveTableName() {

--- a/src/main/java/mil/dds/anet/beans/search/RecursiveM2mBatchParams.java
+++ b/src/main/java/mil/dds/anet/beans/search/RecursiveM2mBatchParams.java
@@ -25,7 +25,7 @@ public class RecursiveM2mBatchParams<B extends AbstractAnetBean, T extends Abstr
       AbstractSearchQueryBuilder<B, T> qb) {
     qb.addRecursiveBatchClause(outerQb, getTableName(), new String[] {getForeignKey()},
         "batch_parents", recursiveTableName, getM2mLeftKey(), recursiveForeignKey, "batchUuids",
-        getBatchUuids(), recurseStrategy);
+        getBatchUuids(), recurseStrategy, null);
   }
 
   public String getRecursiveTableName() {

--- a/src/main/java/mil/dds/anet/beans/search/ReportSearchQuery.java
+++ b/src/main/java/mil/dds/anet/beans/search/ReportSearchQuery.java
@@ -70,6 +70,9 @@ public class ReportSearchQuery extends SubscribableObjectSearchQuery<ReportSearc
   List<String> taskUuid;
   @GraphQLQuery
   @GraphQLInputField
+  private List<String> notTaskUuid;
+  @GraphQLQuery
+  @GraphQLInputField
   String pendingApprovalOf;
   @GraphQLQuery
   @GraphQLInputField
@@ -254,6 +257,14 @@ public class ReportSearchQuery extends SubscribableObjectSearchQuery<ReportSearc
     this.taskUuid = taskUuid;
   }
 
+  public List<String> getNotTaskUuid() {
+    return notTaskUuid;
+  }
+
+  public void setNotTaskUuid(List<String> notTaskUuid) {
+    this.notTaskUuid = notTaskUuid;
+  }
+
   public String getPendingApprovalOf() {
     return pendingApprovalOf;
   }
@@ -385,6 +396,7 @@ public class ReportSearchQuery extends SubscribableObjectSearchQuery<ReportSearc
         && Objects.equals(getLocationUuid(), other.getLocationUuid())
         && Objects.equals(getLocationRecurseStrategy(), other.getLocationRecurseStrategy())
         && Objects.equals(getTaskUuid(), other.getTaskUuid())
+        && Objects.equals(getNotTaskUuid(), other.getNotTaskUuid())
         && Objects.equals(getPendingApprovalOf(), other.getPendingApprovalOf())
         && Objects.equals(getState(), other.getState())
         && Objects.equals(getIncludeAllDrafts(), other.getIncludeAllDrafts())
@@ -420,7 +432,9 @@ public class ReportSearchQuery extends SubscribableObjectSearchQuery<ReportSearc
     if (taskUuid != null) {
       clone.setTaskUuid(new ArrayList<>(taskUuid));
     }
+    if (notTaskUuid != null) {
+      clone.setTaskUuid(new ArrayList<>(notTaskUuid));
+    }
     return clone;
   }
-
 }

--- a/src/main/java/mil/dds/anet/search/AbstractEventSearcher.java
+++ b/src/main/java/mil/dds/anet/search/AbstractEventSearcher.java
@@ -87,7 +87,7 @@ public abstract class AbstractEventSearcher extends AbstractSearcher<Event, Even
     } else {
       qb.addRecursiveClause(null, "events", new String[] {"\"locationUuid\""}, "parent_locations",
           "\"locationRelationships\"", "\"childLocationUuid\"", "\"parentLocationUuid\"",
-          "locationUuid", query.getLocationUuid(), true, true);
+          "locationUuid", query.getLocationUuid(), true, true, null);
     }
   }
 
@@ -98,7 +98,7 @@ public abstract class AbstractEventSearcher extends AbstractSearcher<Event, Even
     } else {
       qb.addRecursiveClause(null, "events", new String[] {"\"ownerOrgUuid\""}, "parent_owner_orgs",
           "organizations", "uuid", "\"parentOrgUuid\"", "ownerOrgUuid", query.getOwnerOrgUuid(),
-          true, true);
+          true, true, null);
     }
   }
 
@@ -109,7 +109,7 @@ public abstract class AbstractEventSearcher extends AbstractSearcher<Event, Even
     } else {
       qb.addRecursiveClause(null, "events", new String[] {"\"hostOrgUuid\""}, "parent_host_orgs",
           "organizations", "uuid", "\"parentOrgUuid\"", "hostOrgUuid", query.getHostOrgUuid(), true,
-          true);
+          true, null);
     }
   }
 
@@ -120,7 +120,7 @@ public abstract class AbstractEventSearcher extends AbstractSearcher<Event, Even
     } else {
       qb.addRecursiveClause(null, "events", new String[] {"\"adminOrgUuid\""}, "parent_admin_orgs",
           "organizations", "uuid", "\"parentOrgUuid\"", "adminOrgUuid", query.getAdminOrgUuid(),
-          true, true);
+          true, true, null);
     }
   }
 
@@ -131,7 +131,7 @@ public abstract class AbstractEventSearcher extends AbstractSearcher<Event, Even
       qb.addWhereClause("et.\"taskUuid\" IS NULL");
     } else {
       qb.addRecursiveClause(null, "et", "\"taskUuid\"", "parent_tasks", "tasks",
-          "\"parentTaskUuid\"", "parentTaskUuid", query.getTaskUuid(), true);
+          "\"parentTaskUuid\"", "parentTaskUuid", query.getTaskUuid(), true, null);
     }
   }
 

--- a/src/main/java/mil/dds/anet/search/AbstractEventSeriesSearcher.java
+++ b/src/main/java/mil/dds/anet/search/AbstractEventSeriesSearcher.java
@@ -70,7 +70,7 @@ public abstract class AbstractEventSeriesSearcher
     } else {
       qb.addRecursiveClause(null, "\"eventSeries\"", new String[] {"\"ownerOrgUuid\""},
           "parent_owner_orgs", "organizations", "uuid", "\"parentOrgUuid\"", "ownerOrgUuid",
-          query.getOwnerOrgUuid(), true, true);
+          query.getOwnerOrgUuid(), true, true, null);
     }
   }
 
@@ -81,7 +81,7 @@ public abstract class AbstractEventSeriesSearcher
     } else {
       qb.addRecursiveClause(null, "\"eventSeries\"", new String[] {"\"hostOrgUuid\""},
           "parent_host_orgs", "organizations", "uuid", "\"parentOrgUuid\"", "hostOrgUuid",
-          query.getHostOrgUuid(), true, true);
+          query.getHostOrgUuid(), true, true, null);
     }
   }
 
@@ -92,7 +92,7 @@ public abstract class AbstractEventSeriesSearcher
     } else {
       qb.addRecursiveClause(null, "\"eventSeries\"", new String[] {"\"adminOrgUuid\""},
           "parent_admin_orgs", "organizations", "uuid", "\"parentOrgUuid\"", "adminOrgUuid",
-          query.getAdminOrgUuid(), true, true);
+          query.getAdminOrgUuid(), true, true, null);
     }
   }
 

--- a/src/main/java/mil/dds/anet/search/AbstractLocationSearcher.java
+++ b/src/main/java/mil/dds/anet/search/AbstractLocationSearcher.java
@@ -108,7 +108,8 @@ public abstract class AbstractLocationSearcher
       qb.addRecursiveClause(null, "locations", new String[] {"uuid"}, "parent_locations",
           "\"locationRelationships\"", "\"childLocationUuid\"", "\"parentLocationUuid\"",
           "locationUuid", query.getLocationUuid(),
-          ISearchQuery.RecurseStrategy.CHILDREN.equals(query.getLocationRecurseStrategy()), true);
+          ISearchQuery.RecurseStrategy.CHILDREN.equals(query.getLocationRecurseStrategy()), true,
+          null);
     } else {
       qb.addInListClause("locationUuid", "locations.uuid", query.getLocationUuid());
     }

--- a/src/main/java/mil/dds/anet/search/AbstractOrganizationSearcher.java
+++ b/src/main/java/mil/dds/anet/search/AbstractOrganizationSearcher.java
@@ -104,7 +104,7 @@ public abstract class AbstractOrganizationSearcher extends
         || RecurseStrategy.PARENTS.equals(query.getOrgRecurseStrategy())) {
       qb.addRecursiveClause(null, "organizations", "\"uuid\"", "parent_orgs", "organizations",
           "\"parentOrgUuid\"", "parentOrgUuid", query.getParentOrgUuid(),
-          RecurseStrategy.CHILDREN.equals(query.getOrgRecurseStrategy()));
+          RecurseStrategy.CHILDREN.equals(query.getOrgRecurseStrategy()), null);
     } else {
       qb.addInListClause("parentOrgUuid", "organizations.\"parentOrgUuid\"",
           query.getParentOrgUuid());
@@ -117,7 +117,8 @@ public abstract class AbstractOrganizationSearcher extends
       qb.addRecursiveClause(null, "organizations", new String[] {"\"locationUuid\""},
           "parent_locations", "\"locationRelationships\"", "\"childLocationUuid\"",
           "\"parentLocationUuid\"", "locationUuid", query.getLocationUuid(),
-          ISearchQuery.RecurseStrategy.CHILDREN.equals(query.getLocationRecurseStrategy()), true);
+          ISearchQuery.RecurseStrategy.CHILDREN.equals(query.getLocationRecurseStrategy()), true,
+          null);
     } else {
       qb.addInListClause("locationUuid", "organizations.\"locationUuid\"", query.getLocationUuid());
     }

--- a/src/main/java/mil/dds/anet/search/AbstractPersonSearcher.java
+++ b/src/main/java/mil/dds/anet/search/AbstractPersonSearcher.java
@@ -84,7 +84,7 @@ public abstract class AbstractPersonSearcher extends AbstractSearcher<Person, Pe
           || RecurseStrategy.PARENTS.equals(query.getOrgRecurseStrategy())) {
         qb.addRecursiveClause(null, "positions", "\"organizationUuid\"", "parent_orgs",
             "organizations", "\"parentOrgUuid\"", "orgUuid", query.getOrgUuid(),
-            RecurseStrategy.CHILDREN.equals(query.getOrgRecurseStrategy()));
+            RecurseStrategy.CHILDREN.equals(query.getOrgRecurseStrategy()), null);
       } else {
         qb.addInListClause("orgUuid", "positions.\"organizationUuid\"", query.getOrgUuid());
       }
@@ -140,7 +140,8 @@ public abstract class AbstractPersonSearcher extends AbstractSearcher<Person, Pe
       qb.addRecursiveClause(null, "positions", new String[] {"\"locationUuid\""},
           "parent_locations", "\"locationRelationships\"", "\"childLocationUuid\"",
           "\"parentLocationUuid\"", "locationUuid", query.getLocationUuid(),
-          ISearchQuery.RecurseStrategy.CHILDREN.equals(query.getLocationRecurseStrategy()), true);
+          ISearchQuery.RecurseStrategy.CHILDREN.equals(query.getLocationRecurseStrategy()), true,
+          null);
     } else {
       qb.addInListClause("locationUuid", "positions.\"locationUuid\"", query.getLocationUuid());
     }

--- a/src/main/java/mil/dds/anet/search/AbstractPositionSearcher.java
+++ b/src/main/java/mil/dds/anet/search/AbstractPositionSearcher.java
@@ -97,7 +97,7 @@ public abstract class AbstractPositionSearcher
           || RecurseStrategy.PARENTS.equals(query.getOrgRecurseStrategy())) {
         qb.addRecursiveClause(null, "positions", "\"organizationUuid\"", "parent_orgs",
             "organizations", "\"parentOrgUuid\"", "orgUuid", query.getOrganizationUuid(),
-            RecurseStrategy.CHILDREN.equals(query.getOrgRecurseStrategy()));
+            RecurseStrategy.CHILDREN.equals(query.getOrgRecurseStrategy()), null);
       } else {
         qb.addInListClause("orgUuid", "positions.\"organizationUuid\"",
             query.getOrganizationUuid());
@@ -154,7 +154,8 @@ public abstract class AbstractPositionSearcher
       qb.addRecursiveClause(null, "positions", new String[] {"\"locationUuid\""},
           "parent_locations", "\"locationRelationships\"", "\"childLocationUuid\"",
           "\"parentLocationUuid\"", "locationUuid", query.getLocationUuid(),
-          ISearchQuery.RecurseStrategy.CHILDREN.equals(query.getLocationRecurseStrategy()), true);
+          ISearchQuery.RecurseStrategy.CHILDREN.equals(query.getLocationRecurseStrategy()), true,
+          null);
     } else {
       qb.addInListClause("locationUuid", "positions.\"locationUuid\"", query.getLocationUuid());
     }

--- a/src/main/java/mil/dds/anet/search/AbstractReportSearcher.java
+++ b/src/main/java/mil/dds/anet/search/AbstractReportSearcher.java
@@ -351,7 +351,7 @@ public abstract class AbstractReportSearcher extends AbstractSearcher<Report, Re
       qb.addWhereClause("rt.\"taskUuid\" IS NULL");
     } else {
       qb.addRecursiveClause(outerQb, "rt", "\"taskUuid\"", "parent_tasks", "tasks",
-          "\"parentTaskUuid\"", "parentTaskUuid", query.getTaskUuid(), true);
+          "\"parentTaskUuid\"", "parentTaskUuid", query.getTaskUuid(), true, null);
     }
   }
 
@@ -364,8 +364,8 @@ public abstract class AbstractReportSearcher extends AbstractSearcher<Report, Re
       qb.addRecursiveClause(outerQb, "reports",
           new String[] {"\"advisorOrganizationUuid\"", "\"interlocutorOrganizationUuid\""},
           "parent_orgs", "organizations", "uuid", "\"parentOrgUuid\"", "orgUuid",
-          query.getOrgUuid(), RecurseStrategy.CHILDREN.equals(query.getOrgRecurseStrategy()),
-          false);
+          query.getOrgUuid(), RecurseStrategy.CHILDREN.equals(query.getOrgRecurseStrategy()), false,
+          null);
     } else {
       qb.addWhereClause("(reports.\"advisorOrganizationUuid\" IN ( <orgUuid> )"
           + " OR reports.\"interlocutorOrganizationUuid\" IN ( <orgUuid> ))");
@@ -385,7 +385,8 @@ public abstract class AbstractReportSearcher extends AbstractSearcher<Report, Re
       qb.addRecursiveClause(outerQb, "reports", new String[] {"\"locationUuid\""},
           "parent_locations", "\"locationRelationships\"", "\"childLocationUuid\"",
           "\"parentLocationUuid\"", "locationUuid", query.getLocationUuid(),
-          ISearchQuery.RecurseStrategy.CHILDREN.equals(query.getLocationRecurseStrategy()), true);
+          ISearchQuery.RecurseStrategy.CHILDREN.equals(query.getLocationRecurseStrategy()), true,
+          null);
     } else {
       qb.addInListClause("locationUuid", "reports.\"locationUuid\"", query.getLocationUuid());
     }

--- a/src/main/java/mil/dds/anet/search/AbstractReportSearcher.java
+++ b/src/main/java/mil/dds/anet/search/AbstractReportSearcher.java
@@ -179,6 +179,10 @@ public abstract class AbstractReportSearcher extends AbstractSearcher<Report, Re
       addTaskUuidQuery(query);
     }
 
+    if (!Utils.isEmptyOrNull(query.getNotTaskUuid())) {
+      addNotTaskUuidQuery(query);
+    }
+
     if (!Utils.isEmptyOrNull(query.getOrgUuid())) {
       addOrgUuidQuery(query);
     }
@@ -353,6 +357,16 @@ public abstract class AbstractReportSearcher extends AbstractSearcher<Report, Re
       qb.addRecursiveClause(outerQb, "rt", "\"taskUuid\"", "parent_tasks", "tasks",
           "\"parentTaskUuid\"", "parentTaskUuid", query.getTaskUuid(), true, null);
     }
+  }
+
+  protected abstract void addNotTaskUuidQuery(ReportSearchQuery query);
+
+  protected void addNotTaskUuidQuery(AbstractSearchQueryBuilder<Report, ReportSearchQuery> outerQb,
+      ReportSearchQuery query) {
+    final String notInClause =
+        "reports.uuid NOT IN (SELECT rt_not.\"reportUuid\" FROM \"reportTasks\" rt_not, parent_tasks_not WHERE (%1$s))";
+    qb.addRecursiveClause(outerQb, "rt_not", "\"taskUuid\"", "parent_tasks_not", "tasks",
+        "\"parentTaskUuid\"", "parentTaskNotUuid", query.getNotTaskUuid(), true, notInClause);
   }
 
   protected abstract void addOrgUuidQuery(ReportSearchQuery query);

--- a/src/main/java/mil/dds/anet/search/AbstractTaskSearcher.java
+++ b/src/main/java/mil/dds/anet/search/AbstractTaskSearcher.java
@@ -132,7 +132,7 @@ public abstract class AbstractTaskSearcher extends AbstractSearcher<Task, TaskSe
         || RecurseStrategy.PARENTS.equals(query.getOrgRecurseStrategy())) {
       qb.addRecursiveClause(null, "\"taskTaskedOrganizations\"", "\"organizationUuid\"",
           "parent_orgs", "organizations", "\"parentOrgUuid\"", "orgUuid", query.getTaskedOrgUuid(),
-          RecurseStrategy.CHILDREN.equals(query.getOrgRecurseStrategy()));
+          RecurseStrategy.CHILDREN.equals(query.getOrgRecurseStrategy()), null);
     } else {
       qb.addInListClause("orgUuid", "\"taskTaskedOrganizations\".\"organizationUuid\"",
           query.getTaskedOrgUuid());
@@ -144,7 +144,7 @@ public abstract class AbstractTaskSearcher extends AbstractSearcher<Task, TaskSe
         || RecurseStrategy.PARENTS.equals(query.getParentTaskRecurseStrategy())) {
       qb.addRecursiveClause(null, "tasks", "\"uuid\"", "parent_tasks", "tasks",
           "\"parentTaskUuid\"", "parentTaskUuid", query.getParentTaskUuid(),
-          RecurseStrategy.CHILDREN.equals(query.getParentTaskRecurseStrategy()));
+          RecurseStrategy.CHILDREN.equals(query.getParentTaskRecurseStrategy()), null);
     } else if (query.getParentTaskUuid().size() == 1
         && Task.DUMMY_TASK_UUID.equals(query.getParentTaskUuid().get(0))) {
       qb.addIsNullOrEmptyClause("tasks.\"parentTaskUuid\"");

--- a/src/main/java/mil/dds/anet/search/pg/PostgresqlReportSearcher.java
+++ b/src/main/java/mil/dds/anet/search/pg/PostgresqlReportSearcher.java
@@ -76,6 +76,11 @@ public class PostgresqlReportSearcher extends AbstractReportSearcher {
   }
 
   @Override
+  protected void addNotTaskUuidQuery(ReportSearchQuery query) {
+    addNotTaskUuidQuery(qb, query);
+  }
+
+  @Override
   protected void addOrgUuidQuery(ReportSearchQuery query) {
     addOrgUuidQuery(qb, query);
   }

--- a/src/main/java/mil/dds/anet/ws/Nvg20WebService.java
+++ b/src/main/java/mil/dds/anet/ws/Nvg20WebService.java
@@ -663,43 +663,38 @@ public class Nvg20WebService implements NVGPortType2012 {
       final NvgConfig nvgConfig = new NvgConfig();
       for (final Object object : nvgQueryList) {
         if (object instanceof SelectResponseType selectResponse) {
-          if (APP6_VERSION_ID.equals(selectResponse.getRefid())) {
-            nvgConfig.setApp6Version(
+          switch (selectResponse.getRefid()) {
+            case APP6_VERSION_ID -> nvgConfig.setApp6Version(
                 Utils.isEmptyOrNull(selectResponse.getSelected()) ? DEFAULT_APP6_VERSION
                     : selectResponse.getSelected().get(0));
-          } else if (EXCLUDE_TASKS.equals(selectResponse.getRefid())) {
-            nvgConfig.setExcludeTaskUuids(selectResponse.getSelected());
-          } else {
-            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR,
+            case EXCLUDE_TASKS -> nvgConfig.setExcludeTaskUuids(selectResponse.getSelected());
+            default -> throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR,
                 "Unrecognized select_response: " + selectResponse.getRefid());
           }
         } else if (object instanceof InputResponseType inputResponse) {
-          if (ACCESS_TOKEN_ID.equals(inputResponse.getRefid())) {
-            nvgConfig.setAccessToken(inputResponse.getValue());
-          } else if (APP6_VERSION_ID.equals(inputResponse.getRefid())) {
-            // Note: this is actually not correct, it should be a SelectResponseType (see above),
-            // however we keep it here for backwards compatibility…
-            nvgConfig.setApp6Version(inputResponse.getValue());
-          } else if (PAST_PERIOD_IN_DAYS_ID.equals(inputResponse.getRefid())) {
-            nvgConfig.setPastDays(Integer.parseInt(inputResponse.getValue()));
-          } else if (FUTURE_PERIOD_IN_DAYS_ID.equals(inputResponse.getRefid())) {
-            nvgConfig.setFutureDays(Integer.parseInt(inputResponse.getValue()));
-          } else if (INCLUDE_DOCUMENT_CONFIDENTIALITY_LABEL.equals(inputResponse.getRefid())) {
-            nvgConfig.setIncludeDocumentConfidentialityLabel(
-                Boolean.parseBoolean(inputResponse.getValue()));
-          } else if (ADD_DOCUMENT_CONFIDENTIALITY_LABEL_AS_METADATA
-              .equals(inputResponse.getRefid())) {
-            nvgConfig.setAddDocumentConfidentialityLabelAsMetadata(
-                Boolean.parseBoolean(inputResponse.getValue()));
-          } else if (INCLUDE_ELEMENT_CONFIDENTIALITY_LABELS.equals(inputResponse.getRefid())) {
-            nvgConfig.setIncludeElementConfidentialityLabels(
-                Boolean.parseBoolean(inputResponse.getValue()));
-          } else if (ADD_ELEMENT_CONFIDENTIALITY_LABELS_AS_METADATA
-              .equals(inputResponse.getRefid())) {
-            nvgConfig.setAddElementConfidentialityLabelsAsMetadata(
-                Boolean.parseBoolean(inputResponse.getValue()));
-          } else {
-            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR,
+          switch (inputResponse.getRefid()) {
+            case ACCESS_TOKEN_ID -> nvgConfig.setAccessToken(inputResponse.getValue());
+            case APP6_VERSION_ID ->
+              // Note: this is actually not correct, it should be a SelectResponseType (see above),
+              // however we keep it here for backwards compatibility…
+              nvgConfig.setApp6Version(inputResponse.getValue());
+            case PAST_PERIOD_IN_DAYS_ID ->
+              nvgConfig.setPastDays(Integer.parseInt(inputResponse.getValue()));
+            case FUTURE_PERIOD_IN_DAYS_ID ->
+              nvgConfig.setFutureDays(Integer.parseInt(inputResponse.getValue()));
+            case INCLUDE_DOCUMENT_CONFIDENTIALITY_LABEL ->
+              nvgConfig.setIncludeDocumentConfidentialityLabel(
+                  Boolean.parseBoolean(inputResponse.getValue()));
+            case ADD_DOCUMENT_CONFIDENTIALITY_LABEL_AS_METADATA ->
+              nvgConfig.setAddDocumentConfidentialityLabelAsMetadata(
+                  Boolean.parseBoolean(inputResponse.getValue()));
+            case INCLUDE_ELEMENT_CONFIDENTIALITY_LABELS ->
+              nvgConfig.setIncludeElementConfidentialityLabels(
+                  Boolean.parseBoolean(inputResponse.getValue()));
+            case ADD_ELEMENT_CONFIDENTIALITY_LABELS_AS_METADATA ->
+              nvgConfig.setAddElementConfidentialityLabelsAsMetadata(
+                  Boolean.parseBoolean(inputResponse.getValue()));
+            default -> throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR,
                 "Unrecognized input_response: " + inputResponse.getRefid());
           }
         } else {

--- a/src/test/java/mil/dds/anet/test/resources/ReportResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/ReportResourceTest.java
@@ -1668,6 +1668,75 @@ public class ReportResourceTest extends AbstractResourceTest {
   }
 
   @Test
+  void searchTaskUuids() {
+    // Reports with any task
+    final ReportSearchQueryInput anyTaskQuery = ReportSearchQueryInput.builder().build();
+    // Reports without a non-existing task
+    final ReportSearchQueryInput nonExistingTaskQuery =
+        ReportSearchQueryInput.builder().withNotTaskUuid(List.of("nonexisting")).build();
+
+    final AnetBeanList_Report anyTaskResults = withCredentials(adminUser,
+        t -> queryExecutor.reportList(getListFields(FIELDS), anyTaskQuery));
+    assertThat(anyTaskResults).isNotNull();
+    assertThat(anyTaskResults.getTotalCount()).isPositive();
+    final AnetBeanList_Report nonExistingTaskResults = withCredentials(adminUser,
+        t -> queryExecutor.reportList(getListFields(FIELDS), nonExistingTaskQuery));
+    assertThat(nonExistingTaskResults).isNotNull();
+    assertThat(nonExistingTaskResults.getTotalCount()).isPositive();
+
+    assertThat(anyTaskResults.getTotalCount()).isEqualTo(nonExistingTaskResults.getTotalCount());
+
+    // Reports with and without the same specific tasks
+    final String TASK_EF1_UUID = "1145e584-4485-4ce0-89c4-2fa2e1fe846a";
+    final ReportSearchQueryInput withAndWithoutQuery = ReportSearchQueryInput.builder()
+        .withTaskUuid(List.of(TASK_EF1_UUID)).withNotTaskUuid(List.of(TASK_EF1_UUID)).build();
+    final AnetBeanList_Report withAndWithoutResults = withCredentials(adminUser,
+        t -> queryExecutor.reportList(getListFields(FIELDS), withAndWithoutQuery));
+    assertThat(withAndWithoutResults).isNotNull();
+    assertThat(withAndWithoutResults.getTotalCount()).isZero();
+
+    // Reports with specific tasks
+    final String TASK_1_1_UUID = "fdf107e7-a88a-4dc4-b744-748e9aaffabc";
+    final String TASK_1_1_A_UUID = "7b2ad5c3-018b-48f5-b679-61fbbda21693";
+    final ReportSearchQueryInput query1 =
+        ReportSearchQueryInput.builder().withTaskUuid(List.of(TASK_EF1_UUID)).build();
+    final ReportSearchQueryInput query2 =
+        ReportSearchQueryInput.builder().withTaskUuid(List.of(TASK_1_1_UUID)).build();
+    final ReportSearchQueryInput query3 =
+        ReportSearchQueryInput.builder().withTaskUuid(List.of(TASK_1_1_A_UUID)).build();
+    final ReportSearchQueryInput query4 = ReportSearchQueryInput.builder()
+        .withTaskUuid(List.of(TASK_EF1_UUID)).withNotTaskUuid(List.of(TASK_1_1_UUID)).build();
+    final ReportSearchQueryInput query5 = ReportSearchQueryInput.builder()
+        .withTaskUuid(List.of(TASK_1_1_UUID)).withNotTaskUuid(List.of(TASK_1_1_A_UUID)).build();
+
+    final AnetBeanList_Report results1 =
+        withCredentials(adminUser, t -> queryExecutor.reportList(getListFields(FIELDS), query1));
+    assertThat(results1).isNotNull();
+    assertThat(results1.getTotalCount()).isPositive();
+    final AnetBeanList_Report results2 =
+        withCredentials(adminUser, t -> queryExecutor.reportList(getListFields(FIELDS), query2));
+    assertThat(results2).isNotNull();
+    assertThat(results2.getTotalCount()).isPositive();
+    final AnetBeanList_Report results3 =
+        withCredentials(adminUser, t -> queryExecutor.reportList(getListFields(FIELDS), query3));
+    assertThat(results3).isNotNull();
+    assertThat(results3.getTotalCount()).isPositive();
+    final AnetBeanList_Report results4 =
+        withCredentials(adminUser, t -> queryExecutor.reportList(getListFields(FIELDS), query4));
+    assertThat(results4).isNotNull();
+    assertThat(results4.getTotalCount()).isPositive();
+    final AnetBeanList_Report results5 =
+        withCredentials(adminUser, t -> queryExecutor.reportList(getListFields(FIELDS), query5));
+    assertThat(results5).isNotNull();
+    assertThat(results5.getTotalCount()).isPositive();
+
+    assertThat(results1.getTotalCount() - results2.getTotalCount())
+        .isEqualTo(results4.getTotalCount());
+    assertThat(results2.getTotalCount() - results3.getTotalCount())
+        .isEqualTo(results5.getTotalCount());
+  }
+
+  @Test
   void reportDeleteTest() {
     final Map<String, Object> attachmentSettings = AttachmentResource.getAttachmentSettings();
     final Person elizabeth = getElizabethElizawell();

--- a/src/test/resources/anet.graphql
+++ b/src/test/resources/anet.graphql
@@ -1424,6 +1424,7 @@ input ReportSearchQueryInput {
   includeEngagementDayOfWeek: Boolean
   locationRecurseStrategy: RecurseStrategy
   locationUuid: [String]
+  notTaskUuid: [String]
   orgRecurseStrategy: RecurseStrategy
   orgUuid: [String]
   pageNum: Int


### PR DESCRIPTION
An new search filter has been added to the search for engagement reports: exclude engagement reports linked to specific tasks. This option is also available in the NVG SOAP service.

Closes [AB#1450](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1450)

#### User changes
- Users can search for engagement reports that are _not_ linked to specific tasks (i.e. exclude engagement reports linked to these tasks).
- The option to exclude engagement reports linked to specific tasks has also been added to the NVG SOAP service.
- The NVG SOAP reponse now includes the list of tasks linked to an engagement report (as a semicolon-separated list).

#### Superuser changes
- None

#### Admin changes
- None

#### System admin changes
- [ ] application.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [x] graphql schema has changed

### Checklist
- [x] described the user behavior in PR body
- [x] referenced/updated all related issues
- [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
- [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
- [x] added and/or updated unit tests
- [ ] added and/or updated e2e tests
- [ ] added and/or updated data migrations
- [ ] updated documentation
- [x] resolved all build errors and warnings
- [ ] opened debt issues for anything not resolved here