### PR TITLE
Automatically refresh the ANET banner message

### DIFF
--- a/client/src/components/TopBar.tsx
+++ b/client/src/components/TopBar.tsx
@@ -1,6 +1,4 @@
-import { gql } from "@apollo/client"
 import { resetPages } from "actions"
-import API from "api"
 import AppContext from "components/AppContext"
 import GeneralBanner, {
   GENERAL_BANNER_LEVEL,
@@ -12,19 +10,8 @@ import GeneralBanner, {
 import Header from "components/Header"
 import NoPositionBanner from "components/NoPositionBanner"
 import SecurityBanner from "components/SecurityBanner"
-import React, { useContext, useEffect, useMemo, useRef, useState } from "react"
+import React, { useContext, useEffect, useRef, useState } from "react"
 import { connect } from "react-redux"
-
-const POLLING_INTERVAL = 60_000 // milliseconds
-
-const GQL_GET_ADMIN_SETTINGS = gql`
-  query TopBarAdminSettings {
-    adminSettings {
-      key
-      value
-    }
-  }
-`
 
 interface TopBarProps {
   handleTopbarHeight: (...args: unknown[]) => unknown
@@ -46,47 +33,13 @@ const TopBar = ({
   const [height, setHeight] = useState(0)
   const topbarDiv = useRef()
 
-  const {
-    data: adminData,
-    startPolling,
-    stopPolling
-  } = API.useApiQuery(GQL_GET_ADMIN_SETTINGS)
-
-  useEffect(() => {
-    startPolling?.(POLLING_INTERVAL)
-    return () => stopPolling?.()
-  }, [startPolling, stopPolling])
-
-  const polledSettings = useMemo(() => {
-    const list = adminData?.adminSettings || []
-    if (!list.length) {
-      return undefined
-    }
-    const output = {}
-    for (const setting of list) {
-      output[setting.key] = setting.value
-    }
-    return output
-  }, [adminData])
-
-  const effectiveSettings = polledSettings || appSettings
-  const visibilitySetting = parseInt(
-    effectiveSettings[GENERAL_BANNER_VISIBILITY],
-    10
-  )
-  const bannerOptions = useMemo(
-    () => ({
-      level: effectiveSettings[GENERAL_BANNER_LEVEL],
-      message: effectiveSettings[GENERAL_BANNER_TEXT],
-      title: GENERAL_BANNER_TITLE,
-      visible: bannerVisibility
-    }),
-    [
-      effectiveSettings[GENERAL_BANNER_LEVEL],
-      effectiveSettings[GENERAL_BANNER_TEXT],
-      bannerVisibility
-    ]
-  )
+  const visibilitySetting = parseInt(appSettings[GENERAL_BANNER_VISIBILITY], 10)
+  const bannerOptions = {
+    level: appSettings[GENERAL_BANNER_LEVEL],
+    message: appSettings[GENERAL_BANNER_TEXT],
+    title: GENERAL_BANNER_TITLE,
+    visible: bannerVisibility
+  }
 
   useEffect(() => {
     function updateTopbarHeight() {

--- a/client/src/pages/App.tsx
+++ b/client/src/pages/App.tsx
@@ -10,13 +10,13 @@ import {
 } from "components/Page"
 import "components/previews/RegisterPreviewComponents"
 import ResponsiveLayout from "components/ResponsiveLayout"
-import { useConnectionInfo } from "connectionUtils"
 import { Organization, Person } from "models"
 import {
   getNotifications,
   GRAPHQL_NOTIFICATIONS_ASSESSMENT_FIELDS
 } from "notificationsUtils"
 import Routing from "pages/Routing"
+import { usePollingRequest } from "pollingUtils"
 import React from "react"
 import { connect } from "react-redux"
 import { Navigate, useLocation, useNavigate } from "react-router-dom"
@@ -172,11 +172,6 @@ const GQL_GET_APP_DATA = gql`
       }
     }
 
-    adminSettings {
-      key
-      value
-    }
-
     topLevelOrgs: organizationList(
       query: {
         pageSize: 0
@@ -206,7 +201,7 @@ const App = ({ pageDispatchers, pageProps }: AppProps) => {
   const routerLocation = useLocation()
 
   const { loading, error, data, refetch } = API.useApiQuery(GQL_GET_APP_DATA)
-  const connectionInfo = useConnectionInfo()
+  const { adminSettings, ...connectionInfo } = usePollingRequest()
   const { done, result } = useBoilerplate({
     loading,
     error,
@@ -233,7 +228,7 @@ const App = ({ pageDispatchers, pageProps }: AppProps) => {
   return (
     <AppContext.Provider
       value={{
-        appSettings: appState.settings,
+        appSettings: adminSettings,
         currentUser: appState.currentUser,
         loadAppData: refetch,
         notifications: appState.notifications,
@@ -268,16 +263,10 @@ const App = ({ pageDispatchers, pageProps }: AppProps) => {
     }
 
     const allOrganizations = getSortedOrganizationsFromData(data.topLevelOrgs)
-    const settings = {}
-    data.adminSettings.forEach(
-      setting => (settings[setting.key] = setting.value)
-    )
-
     const currentUser = new Person(data.me)
     const notifications = getNotifications(currentUser.position)
     return {
       currentUser,
-      settings,
       allOrganizations,
       notifications
     }


### PR DESCRIPTION
Closes [AB#1447](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1447)

#### User changes
- Will be able to see new ANET status messages without refreshing the page

#### Superuser changes
- None

#### Admin changes
- Should be able to edit ANET status messages and make it visible to all users almost immediately

#### System admin changes
- [ ] application.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
- [x] described the user behavior in PR body
- [x] referenced/updated all related issues
- [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
- [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
- [ ] added and/or updated unit tests
- [ ] added and/or updated e2e tests
- [ ] added and/or updated data migrations
- [ ] updated documentation
- [x] resolved all build errors and warnings
- [ ] opened debt issues for anything not resolved here
