### PR TITLE
No need to loadAppData() after changing events or eventSeries

### DIFF
--- a/client/src/pages/eventSeries/Form.tsx
+++ b/client/src/pages/eventSeries/Form.tsx
@@ -51,7 +51,7 @@ const EventSeriesForm = ({
   initialValues,
   notesComponent
 }: EventSeriesFormProps) => {
-  const { loadAppData, currentUser } = useContext(AppContext)
+  const { currentUser } = useContext(AppContext)
   const navigate = useNavigate()
   const [error, setError] = useState(null)
   const [attachmentList, setAttachmentList] = useState(
@@ -352,7 +352,6 @@ const EventSeriesForm = ({
     // reset the form to latest values
     // to avoid unsaved changes prompt if it somehow becomes dirty
     form.resetForm({ values, isSubmitting: true })
-    loadAppData()
     if (!edit) {
       navigate(EventSeries.pathForEdit(eventSeries), { replace: true })
     }

--- a/client/src/pages/events/Form.tsx
+++ b/client/src/pages/events/Form.tsx
@@ -90,7 +90,7 @@ const EventForm = ({
   initialValues,
   notesComponent
 }: EventFormProps) => {
-  const { loadAppData, currentUser } = useContext(AppContext)
+  const { currentUser } = useContext(AppContext)
   const navigate = useNavigate()
   const [saveError, setSaveError] = useState(null)
   const tasksLabel = pluralize(Settings.fields.task.shortLabel)
@@ -712,7 +712,6 @@ const EventForm = ({
     // reset the form to latest values
     // to avoid unsaved changes prompt if it somehow becomes dirty
     form.resetForm({ values, isSubmitting: true })
-    loadAppData()
     if (!edit) {
       navigate(Event.pathForEdit(event), { replace: true })
     }


### PR DESCRIPTION
There's nothing in the app data that is influenced by this, so no need to reload it.