### PR TITLE
Don't show planning conflicts for cancelled reports

### DIFF
--- a/client/src/components/PlanningConflictForReport.tsx
+++ b/client/src/components/PlanningConflictForReport.tsx
@@ -21,6 +21,7 @@ const GET_REPORT_WITH_ATTENDED_REPORTS = gql`
             uuid
             engagementDate
             duration
+            state
           }
         }
       }


### PR DESCRIPTION
Reports could show planning conflicts with engagements that were cancelled. But obviously, cancelled engagements should not results in planning conflicts.

Closes AB#1455

#### User changes
- Reports no longer show planning conflicts against cancelled engagements.

#### Superuser changes
- None

#### Admin changes
- None

#### System admin changes
- [ ] application.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
- [x] described the user behavior in PR body
- [x] referenced/updated all related issues
- [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
- [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
- [ ] added and/or updated unit tests
- [x] added and/or updated e2e tests
- [ ] added and/or updated data migrations
- [ ] updated documentation
- [ ] resolved all build errors and warnings
- [ ] opened debt issues for anything not resolved here