### PR TITLE
Update APP-6 symbology for NVG

### DIFF
--- a/src/main/java/mil/dds/anet/ws/Nvg20WebService.java
+++ b/src/main/java/mil/dds/anet/ws/Nvg20WebService.java
@@ -175,8 +175,8 @@ public class Nvg20WebService implements NVGPortType2012 {
             STATUS_PRESENT, ACTIVITY_STATUS_PRESENT_APP6D, // -
             STATUS_PLANNED, ACTIVITY_STATUS_PLANNED_APP6D));
 
-    // Not the correct interpretation of the standard, but currently used by external tools
-    static final String DEFAULT_APP6_VERSION = SYMBOLOGY_VERSION_APP6D_UNOFFICIAL;
+    // Use the current standard by default
+    static final String DEFAULT_APP6_VERSION = SYMBOLOGY_VERSION_APP6D;
     static final Set<String> VALID_APP6_VERSIONS = Set.of(SYMBOLOGY_VERSION_APP6B,
         SYMBOLOGY_VERSION_APP6D_UNOFFICIAL, SYMBOLOGY_VERSION_APP6D);
 

--- a/src/main/java/mil/dds/anet/ws/Nvg20WebService.java
+++ b/src/main/java/mil/dds/anet/ws/Nvg20WebService.java
@@ -123,7 +123,7 @@ public class Nvg20WebService implements NVGPortType2012 {
     // - %1$s = status: P for Present, A for Anticipated/Planned
     // - U = function id: Unit
     // - ------- = more defaults
-    private static final String ACTIVITY_MEETING_APP6B = "SFG%1$sU-------";
+    private static final String ACTIVITY_MEETING_APP6B = "SFG%1$sU----------";
     private static final String ACTIVITY_STATUS_PRESENT_APP6B = "P";
     private static final String ACTIVITY_STATUS_PLANNED_APP6B = "A";
 


### PR DESCRIPTION
- Correctly encode APP-6B symbols as 15 characters.
- Switch the default app6Version to the current APP-6D standard.

Closes [AB#1457](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1457)