### PR TITLE
Update subscriptions and subscriptionUpdates when merging

### DIFF
--- a/src/main/java/mil/dds/anet/database/AnetSubscribableObjectDao.java
+++ b/src/main/java/mil/dds/anet/database/AnetSubscribableObjectDao.java
@@ -8,7 +8,6 @@ import java.util.List;
 import java.util.Map;
 import mil.dds.anet.beans.SubscribableObject;
 import mil.dds.anet.beans.search.AbstractSearchQuery;
-import mil.dds.anet.utils.DaoUtils;
 import mil.dds.anet.views.AbstractSubscribableAnetBean;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -24,36 +23,10 @@ public abstract class AnetSubscribableObjectDao<T extends AbstractSubscribableAn
   public abstract SubscriptionUpdateGroup getSubscriptionUpdate(T obj);
 
   @Transactional
-  @Override
-  public int update(T obj) {
-    DaoUtils.setUpdateFields(obj);
-    final int numRows = updateInternal(obj);
-    if (numRows > 0) {
-      final SubscriptionUpdateGroup subscriptionUpdate = getSubscriptionUpdate(obj);
-      final SubscriptionDao subscriptionDao = engine().getSubscriptionDao();
-      subscriptionDao.updateSubscriptions(subscriptionUpdate);
-    }
-    return numRows;
-  }
-
-  @Transactional
-  @Override
-  public int delete(String uuid) {
-    final T obj = getObjectForSubscriptionDelete(uuid);
-    final int numRows = deleteInternal(uuid);
-    if (numRows > 0 && obj != null) {
-      obj.setUuid(uuid);
-      DaoUtils.setUpdateFields(obj);
-      final SubscriptionUpdateGroup subscriptionUpdate = getSubscriptionUpdate(obj);
-      final SubscriptionDao subscriptionDao = engine().getSubscriptionDao();
-      subscriptionDao.updateSubscriptions(subscriptionUpdate);
-    }
-    return numRows;
-  }
-
-  /* override this method if you want to update subscriptions on delete */
-  protected T getObjectForSubscriptionDelete(String uuid) {
-    return null;
+  public void updateSubscriptions(T obj) {
+    final SubscriptionUpdateGroup subscriptionUpdate = getSubscriptionUpdate(obj);
+    final SubscriptionDao subscriptionDao = engine().getSubscriptionDao();
+    subscriptionDao.updateSubscriptions(subscriptionUpdate);
   }
 
   protected SubscriptionUpdateGroup getCommonSubscriptionUpdate(AbstractSubscribableAnetBean obj,

--- a/src/main/java/mil/dds/anet/database/LocationDao.java
+++ b/src/main/java/mil/dds/anet/database/LocationDao.java
@@ -175,6 +175,13 @@ public class LocationDao extends AnetSubscribableObjectDao<Location, LocationSea
     // Delete customSensitiveInformation for loser
     deleteForMerge("customSensitiveInformation", "relatedObjectUuid", loserLocationUuid);
 
+    // Update subscriptions
+    updateM2mForMerge("subscriptions", "subscriberUuid", "subscribedObjectUuid", winnerLocationUuid,
+        loserLocationUuid);
+    // Update subscriptionUpdates
+    updateForMerge("subscriptionUpdates", "updatedObjectUuid", winnerLocationUuid,
+        loserLocationUuid);
+
     // Finally, delete the location
     final int nrDeleted = deleteForMerge(LocationDao.TABLE_NAME, "uuid", loserLocationUuid);
     if (nrDeleted > 0) {

--- a/src/main/java/mil/dds/anet/database/OrganizationDao.java
+++ b/src/main/java/mil/dds/anet/database/OrganizationDao.java
@@ -408,6 +408,13 @@ public class OrganizationDao
       // Delete customSensitiveInformation for loser
       deleteForMerge("customSensitiveInformation", "relatedObjectUuid", loserOrganizationUuid);
 
+      // Update subscriptions
+      updateM2mForMerge("subscriptions", "subscriberUuid", "subscribedObjectUuid",
+          winnerOrganizationUuid, loserOrganizationUuid);
+      // Update subscriptionUpdates
+      updateForMerge("subscriptionUpdates", "updatedObjectUuid", winnerOrganizationUuid,
+          loserOrganizationUuid);
+
       // Finally, delete loser
       final int nrDeleted =
           deleteForMerge(OrganizationDao.TABLE_NAME, "uuid", loserOrganizationUuid);

--- a/src/main/java/mil/dds/anet/database/PersonDao.java
+++ b/src/main/java/mil/dds/anet/database/PersonDao.java
@@ -549,6 +549,12 @@ public class PersonDao extends AnetSubscribableObjectDao<Person, PersonSearchQue
       // Delete customSensitiveInformation for loser
       deleteForMerge("customSensitiveInformation", "relatedObjectUuid", loserUuid);
 
+      // Update subscriptions
+      updateM2mForMerge("subscriptions", "subscriberUuid", "subscribedObjectUuid", winnerUuid,
+          loserUuid);
+      // Update subscriptionUpdates
+      updateForMerge("subscriptionUpdates", "updatedObjectUuid", winnerUuid, loserUuid);
+
       // Finally, delete loser
       final int nrDeleted = deleteForMerge(PersonDao.TABLE_NAME, "uuid", loserUuid);
       if (nrDeleted > 0) {

--- a/src/main/java/mil/dds/anet/database/PositionDao.java
+++ b/src/main/java/mil/dds/anet/database/PositionDao.java
@@ -486,11 +486,6 @@ public class PositionDao extends AnetSubscribableObjectDao<Position, PositionSea
   }
 
   @Override
-  protected Position getObjectForSubscriptionDelete(String uuid) {
-    return new Position();
-  }
-
-  @Override
   public int deleteInternal(String positionUuid) {
     final Handle handle = getDbHandle();
     try {

--- a/src/main/java/mil/dds/anet/database/PositionDao.java
+++ b/src/main/java/mil/dds/anet/database/PositionDao.java
@@ -666,6 +666,12 @@ public class PositionDao extends AnetSubscribableObjectDao<Position, PositionSea
       // Delete customSensitiveInformation for loser
       deleteForMerge("customSensitiveInformation", "relatedObjectUuid", loserUuid);
 
+      // Update subscriptions
+      updateM2mForMerge("subscriptions", "subscriberUuid", "subscribedObjectUuid", winnerUuid,
+          loserUuid);
+      // Update subscriptionUpdates
+      updateForMerge("subscriptionUpdates", "updatedObjectUuid", winnerUuid, loserUuid);
+
       // Finally, delete loser
       final int nrDeleted = deleteForMerge(PositionDao.TABLE_NAME, "uuid", loserUuid);
       if (nrDeleted > 0) {

--- a/src/main/java/mil/dds/anet/database/ReportDao.java
+++ b/src/main/java/mil/dds/anet/database/ReportDao.java
@@ -237,17 +237,7 @@ public class ReportDao extends AnetSubscribableObjectDao<Report, ReportSearchQue
   @Transactional
   public int update(Report r, Person user) {
     DaoUtils.setUpdateFields(r);
-    return updateWithSubscriptions(r, user);
-  }
-
-  private int updateWithSubscriptions(Report r, Person user) {
-    final int numRows = updateInternal(r, user);
-    if (numRows > 0) {
-      final SubscriptionUpdateGroup subscriptionUpdate = getSubscriptionUpdate(r);
-      final SubscriptionDao subscriptionDao = engine().getSubscriptionDao();
-      subscriptionDao.updateSubscriptions(subscriptionUpdate);
-    }
-    return numRows;
+    return updateInternal(r, user);
   }
 
   @Override
@@ -470,14 +460,6 @@ public class ReportDao extends AnetSubscribableObjectDao<Report, ReportSearchQue
   public CompletableFuture<AnetBeanList<Report>> search(GraphQLContext context,
       Set<String> subFields, ReportSearchQuery query) {
     return new PostgresqlReportSearcher(databaseHandler).runSearch(context, subFields, query);
-  }
-
-  @Override
-  protected Report getObjectForSubscriptionDelete(String uuid) {
-    final Report obj = new Report();
-    final Report tmp = getByUuid(uuid);
-    obj.setState(tmp.getState());
-    return obj;
   }
 
   /*

--- a/src/main/java/mil/dds/anet/database/TaskDao.java
+++ b/src/main/java/mil/dds/anet/database/TaskDao.java
@@ -338,6 +338,12 @@ public class TaskDao extends AnetSubscribableObjectDao<Task, TaskSearchQuery> {
       // Delete customSensitiveInformation for loser
       deleteForMerge("customSensitiveInformation", "relatedObjectUuid", loserTaskUuid);
 
+      // Update subscriptions
+      updateM2mForMerge("subscriptions", "subscriberUuid", "subscribedObjectUuid", winnerTaskUuid,
+          loserTaskUuid);
+      // Update subscriptionUpdates
+      updateForMerge("subscriptionUpdates", "updatedObjectUuid", winnerTaskUuid, loserTaskUuid);
+
       // Finally, delete loser
       final int nrDeleted = deleteForMerge(TaskDao.TABLE_NAME, "uuid", loserTaskUuid);
       if (nrDeleted > 0) {

--- a/src/main/java/mil/dds/anet/resources/AuthorizationGroupResource.java
+++ b/src/main/java/mil/dds/anet/resources/AuthorizationGroupResource.java
@@ -100,6 +100,9 @@ public class AuthorizationGroupResource {
               List.of(DaoUtils.getUuid(oldPosition))));
     }
 
+    // Update any subscriptions
+    dao.updateSubscriptions(a);
+
     AnetAuditLogger.log("AuthorizationGroup {} updated by {}", a, user);
     // GraphQL mutations *have* to return something, so we return the number of updated rows
     return numRows;

--- a/src/main/java/mil/dds/anet/resources/EventSeriesResource.java
+++ b/src/main/java/mil/dds/anet/resources/EventSeriesResource.java
@@ -98,6 +98,9 @@ public class EventSeriesResource {
           "Couldn't process event series update");
     }
 
+    // Update any subscriptions
+    dao.updateSubscriptions(eventSeries);
+
     AnetAuditLogger.log("EventSeries {} updated by {}", eventSeries, user);
     // GraphQL mutations *have* to return something, so we return the number of updated rows
     return numRows;

--- a/src/main/java/mil/dds/anet/resources/LocationResource.java
+++ b/src/main/java/mil/dds/anet/resources/LocationResource.java
@@ -163,6 +163,9 @@ public class LocationResource {
     DaoUtils.saveCustomSensitiveInformation(user, LocationDao.TABLE_NAME, l.getUuid(),
         l.customSensitiveInformationKey(), l.getCustomSensitiveInformation());
 
+    // Update any subscriptions
+    dao.updateSubscriptions(l);
+
     AnetAuditLogger.log("Location {} updated by {}", l, user);
     // GraphQL mutations *have* to return something, so we return the number of updated rows
     return numRows;
@@ -201,6 +204,10 @@ public class LocationResource {
       throw new ResponseStatusException(HttpStatus.NOT_FOUND,
           "Couldn't process merge operation, error occurred while updating merged location relation information.");
     }
+
+    // Update any subscriptions
+    dao.updateSubscriptions(winnerLocation);
+
     AnetAuditLogger.log("Location {} merged into {} by {}", loserLocation, winnerLocation, user);
     return numRows;
   }

--- a/src/main/java/mil/dds/anet/resources/OrganizationResource.java
+++ b/src/main/java/mil/dds/anet/resources/OrganizationResource.java
@@ -228,6 +228,9 @@ public class OrganizationResource {
     engine.getEmailAddressDao().updateEmailAddresses(OrganizationDao.TABLE_NAME, org.getUuid(),
         org.getEmailAddresses());
 
+    // Update any subscriptions
+    dao.updateSubscriptions(org);
+
     return numRows;
   }
 
@@ -255,6 +258,10 @@ public class OrganizationResource {
       throw new ResponseStatusException(HttpStatus.NOT_FOUND,
           "Couldn't process merge operation, error occurred while updating merged organization relation information.");
     }
+
+    // Update any subscriptions
+    dao.updateSubscriptions(winnerOrganization);
+
     AnetAuditLogger.log("Organization {} merged into {} by {}", loserOrganization,
         winnerOrganization, user);
     return numberOfAffectedRows;

--- a/src/main/java/mil/dds/anet/resources/PersonResource.java
+++ b/src/main/java/mil/dds/anet/resources/PersonResource.java
@@ -224,6 +224,9 @@ public class PersonResource {
     DaoUtils.saveCustomSensitiveInformation(user, PersonDao.TABLE_NAME, p.getUuid(),
         p.customSensitiveInformationKey(), p.getCustomSensitiveInformation());
 
+    // Update any subscriptions
+    dao.updateSubscriptions(p);
+
     AnetAuditLogger.log("Person {} updated by {}", p, user);
     // GraphQL mutations *have* to return something, so we return the number of updated rows
     return numRows;
@@ -295,6 +298,9 @@ public class PersonResource {
       throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR,
           "Couldn't " + (isApproved ? "approve" : "delete") + " person");
     }
+
+    // Update any subscriptions
+    dao.updateSubscriptions(person);
 
     AnetAuditLogger.log("Person {} " + (isApproved ? "approved" : "deleted") + " by {}", person,
         user);
@@ -388,8 +394,11 @@ public class PersonResource {
       throw new ResponseStatusException(HttpStatus.NOT_FOUND,
           "Couldn't process merge operation, error occurred while updating merged person relation information.");
     }
-    AnetAuditLogger.log("Person {} merged into {} by {}", loser, winner, user);
 
+    // Update any subscriptions
+    dao.updateSubscriptions(winner);
+
+    AnetAuditLogger.log("Person {} merged into {} by {}", loser, winner, user);
     // GraphQL mutations *have* to return something, so we return the number of updated rows
     return numRows;
   }

--- a/src/main/java/mil/dds/anet/resources/TaskResource.java
+++ b/src/main/java/mil/dds/anet/resources/TaskResource.java
@@ -230,8 +230,10 @@ public class TaskResource {
       DaoUtils.saveCustomSensitiveInformation(user, TaskDao.TABLE_NAME, t.getUuid(),
           t.customSensitiveInformationKey(), t.getCustomSensitiveInformation());
 
-      AnetAuditLogger.log("Task {} updated by {}", t, user);
+      // Update any subscriptions
+      dao.updateSubscriptions(t);
 
+      AnetAuditLogger.log("Task {} updated by {}", t, user);
       // GraphQL mutations *have* to return something, so we return the number of updated rows
       return numRows;
     } catch (UnableToExecuteStatementException e) {
@@ -273,6 +275,10 @@ public class TaskResource {
       throw new ResponseStatusException(HttpStatus.NOT_FOUND,
           "Couldn't process merge operation, error occurred while updating merged task relation information.");
     }
+
+    // Update any subscriptions
+    dao.updateSubscriptions(winnerTask);
+
     AnetAuditLogger.log("Task {} merged into {} by {}", loserTask, winnerTask, user);
     return numberOfAffectedRows;
   }

--- a/src/test/java/mil/dds/anet/test/resources/merge/OrganizationMergeTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/merge/OrganizationMergeTest.java
@@ -6,10 +6,13 @@ import static mil.dds.anet.test.resources.OrganizationResourceTest.FIELDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import mil.dds.anet.database.OrganizationDao;
 import mil.dds.anet.test.client.Organization;
 import mil.dds.anet.test.client.OrganizationInput;
 import mil.dds.anet.test.resources.AbstractResourceTest;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class OrganizationMergeTest extends AbstractResourceTest {
   @Test
@@ -23,27 +26,48 @@ class OrganizationMergeTest extends AbstractResourceTest {
         parentOrg.getUuid(), getOrganizationInput(childOrg)))).isInstanceOf(Exception.class);
   }
 
-  @Test
-  void shouldMerge() {
+  @ParameterizedTest
+  @MethodSource("provideMergeTestParameters")
+  void testMerge(boolean subscribeToLoser, boolean subscribeToWinner) {
+    final String objectType = OrganizationDao.TABLE_NAME;
+
     final var loserInput = OrganizationInput.builder().withShortName("LM1")
         .withLongName("Loser for Merge").withStatus(INACTIVE).build();
     final var loser =
         withCredentials(adminUser, t -> mutationExecutor.createOrganization(FIELDS, loserInput));
     assertThat(loser).isNotNull().extracting(Organization::getUuid).isNotNull();
 
+    // Subscribe to the organization
+    final String loserSubscriptionUuid = addSubscription(subscribeToLoser, objectType,
+        loser.getUuid(), t -> mutationExecutor.updateOrganization("", getOrganizationInput(loser)));
+
     final var winnerInput = OrganizationInput.builder().withShortName("WM1")
         .withLongName("Winner for Merge").withStatus(ACTIVE).build();
     final var winner =
         withCredentials(adminUser, t -> mutationExecutor.createOrganization(FIELDS, winnerInput));
 
+    // Subscribe to the organization
+    final String winnerSubscriptionUuid =
+        addSubscription(subscribeToWinner, objectType, winner.getUuid(),
+            t -> mutationExecutor.updateOrganization("", getOrganizationInput(winner)));
+
+    // Merge the two organizations
     final var mergeInput = getOrganizationInput(winner);
     mergeInput.setStatus(loser.getStatus());
     final var updated = withCredentials(adminUser,
         t -> mutationExecutor.mergeOrganizations("", loser.getUuid(), mergeInput));
     assertThat(updated).isOne();
 
+    // Assert that loser is gone.
     assertThatThrownBy(
         () -> withCredentials(adminUser, t -> queryExecutor.organization(FIELDS, loser.getUuid())))
         .isInstanceOf(Exception.class);
+
+    // Check the subscriptions and updates
+    checkSubscriptionsAndUpdatesAfterMerge(subscribeToLoser || subscribeToWinner, objectType,
+        loser.getUuid(), winner.getUuid());
+    // And unsubscribe
+    deleteSubscription(subscribeToWinner, loserSubscriptionUuid);
+    deleteSubscription(false, winnerSubscriptionUuid);
   }
 }

--- a/src/test/java/mil/dds/anet/test/resources/merge/TaskMergeTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/merge/TaskMergeTest.java
@@ -6,10 +6,14 @@ import static mil.dds.anet.test.resources.TaskResourceTest.FIELDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.util.UUID;
+import mil.dds.anet.database.TaskDao;
 import mil.dds.anet.test.client.Task;
 import mil.dds.anet.test.client.TaskInput;
 import mil.dds.anet.test.resources.AbstractResourceTest;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class TaskMergeTest extends AbstractResourceTest {
   @Test
@@ -24,27 +28,47 @@ class TaskMergeTest extends AbstractResourceTest {
         .isInstanceOf(Exception.class);
   }
 
-  @Test
-  void shouldMerge() {
-    final var loserInput = TaskInput.builder().withShortName("LM1").withLongName("Loser for Merge")
-        .withStatus(INACTIVE).build();
+  @ParameterizedTest
+  @MethodSource("provideMergeTestParameters")
+  void testMerge(boolean subscribeToLoser, boolean subscribeToWinner) {
+    final String objectType = TaskDao.TABLE_NAME;
+
+    final var loserInput = TaskInput.builder().withShortName("LM1-" + UUID.randomUUID())
+        .withLongName("Loser for Merge").withStatus(INACTIVE).build();
     final var loser =
         withCredentials(adminUser, t -> mutationExecutor.createTask(FIELDS, loserInput));
     assertThat(loser).isNotNull().extracting(Task::getUuid).isNotNull();
 
-    final var winnerInput = TaskInput.builder().withShortName("WM1")
+    // Subscribe to the task
+    final String loserSubscriptionUuid = addSubscription(subscribeToLoser, objectType,
+        loser.getUuid(), t -> mutationExecutor.updateTask("", getTaskInput(loser)));
+
+    final var winnerInput = TaskInput.builder().withShortName("WM1-" + UUID.randomUUID())
         .withLongName("Winner for Merge").withStatus(ACTIVE).build();
     final var winner =
         withCredentials(adminUser, t -> mutationExecutor.createTask(FIELDS, winnerInput));
 
+    // Subscribe to the task
+    final String winnerSubscriptionUuid = addSubscription(subscribeToWinner, objectType,
+        winner.getUuid(), t -> mutationExecutor.updateTask("", getTaskInput(winner)));
+
+    // Merge the two tasks
     final var mergeInput = getTaskInput(winner);
     mergeInput.setStatus(loser.getStatus());
     final var updated = withCredentials(adminUser,
         t -> mutationExecutor.mergeTasks("", loser.getUuid(), mergeInput));
     assertThat(updated).isOne();
 
+    // Assert that loser is gone.
     assertThatThrownBy(
         () -> withCredentials(adminUser, t -> queryExecutor.task(FIELDS, loser.getUuid())))
         .isInstanceOf(Exception.class);
+
+    // Check the subscriptions and updates
+    checkSubscriptionsAndUpdatesAfterMerge(subscribeToLoser || subscribeToWinner, objectType,
+        loser.getUuid(), winner.getUuid());
+    // And unsubscribe
+    deleteSubscription(subscribeToWinner, loserSubscriptionUuid);
+    deleteSubscription(false, winnerSubscriptionUuid);
   }
 }


### PR DESCRIPTION
When merging (locations, organizations, people, positions, or tasks), subscriptions to the 'loser' of the merge were not correctly updated.
Subscription updates could also be not 100% consistent with the final state of the updated object, this has now been corrected as well.

Closes [AB#1456](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1456)

#### User changes
- None

#### Superuser changes
- None

#### Admin changes
- When merging (locations, organizations, people, positions, or tasks), subscriptions to the 'loser' of the merge are now correctly updated.

#### System admin changes
- [ ] application.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
- [x] described the user behavior in PR body
- [x] referenced/updated all related issues
- [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
- [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
- [x] added and/or updated unit tests
- [ ] added and/or updated e2e tests
- [ ] added and/or updated data migrations
- [ ] updated documentation
- [x] resolved all build errors and warnings
- [ ] opened debt issues for anything not resolved here