### PR TITLE
Add advanced people search filter to find ANET users

### DIFF
--- a/client/src/components/SearchFilters.tsx
+++ b/client/src/components/SearchFilters.tsx
@@ -440,6 +440,16 @@ export const searchFilters = function (includeAdminFilters) {
           labels: ["Yes", "No"]
         }
       },
+      [`Is ${Settings.fields.person.user?.label}?`]: {
+        component: RadioButtonFilter,
+        deserializer: deserializeRadioButtonFilter,
+        labelClass: "pt-0",
+        props: {
+          queryKey: "isUser",
+          options: [true, false],
+          labels: ["Yes", "No"]
+        }
+      },
       "Holding Position As": {
         component: SelectFilter,
         deserializer: deserializeSelectFilter,

--- a/src/main/java/mil/dds/anet/beans/search/PersonSearchQuery.java
+++ b/src/main/java/mil/dds/anet/beans/search/PersonSearchQuery.java
@@ -60,6 +60,11 @@ public class PersonSearchQuery extends SubscribableObjectSearchQuery<PersonSearc
   @GraphQLInputField
   List<PositionType> positionType;
 
+  // Find people who are ANET users
+  @GraphQLQuery
+  @GraphQLInputField
+  private Boolean isUser;
+
   public PersonSearchQuery() {
     super(PersonSearchSortBy.NAME);
     this.setPageSize(100);
@@ -170,6 +175,14 @@ public class PersonSearchQuery extends SubscribableObjectSearchQuery<PersonSearc
     this.assessment = assessment;
   }
 
+  public Boolean getIsUser() {
+    return isUser;
+  }
+
+  public void setIsUser(Boolean isUser) {
+    this.isUser = isUser;
+  }
+
   @Override
   public PersonSearchQuery clone() throws CloneNotSupportedException {
     final PersonSearchQuery clone = (PersonSearchQuery) super.clone();
@@ -188,5 +201,4 @@ public class PersonSearchQuery extends SubscribableObjectSearchQuery<PersonSearc
     }
     return clone;
   }
-
 }

--- a/src/main/java/mil/dds/anet/search/AbstractPersonSearcher.java
+++ b/src/main/java/mil/dds/anet/search/AbstractPersonSearcher.java
@@ -108,6 +108,14 @@ public abstract class AbstractPersonSearcher extends AbstractSearcher<Person, Pe
       addAssessmentQuery(query.getAssessment(), PersonDao.TABLE_NAME, "regular.person");
     }
 
+    if (query.getIsUser() != null) {
+      if (query.getIsUser()) {
+        qb.addWhereClause("people.user IS TRUE");
+      } else {
+        qb.addWhereClause("people.user IS NOT TRUE");
+      }
+    }
+
     if (Boolean.TRUE.equals(query.isInMyReports())) {
       qb.addSelectClause("\"inMyReports\".max AS \"inMyReports_max\"");
       qb.addFromClause("JOIN ("

--- a/src/test/resources/anet.graphql
+++ b/src/test/resources/anet.graphql
@@ -1044,6 +1044,7 @@ input PersonSearchQueryInput {
   endOfTourDateStart: Instant
   hasBiography: Boolean
   inMyReports: Boolean
+  isUser: Boolean
   locationRecurseStrategy: RecurseStrategy
   locationUuid: [String]
   matchPositionName: Boolean


### PR DESCRIPTION
There's a new advanced search filter for people, that allows to find people who are (or who are not) ANET users.

Closes [AB#1449](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1449)

#### User changes
- Users can search for ANET users

#### Superuser changes
- None

#### Admin changes
- None

#### System admin changes
- [ ] application.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [x] graphql schema has changed

### Checklist
- [x] described the user behavior in PR body
- [x] referenced/updated all related issues
- [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
- [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
- [ ] added and/or updated unit tests
- [ ] added and/or updated e2e tests
- [ ] added and/or updated data migrations
- [ ] updated documentation
- [x] resolved all build errors and warnings
- [ ] opened debt issues for anything not resolved here
