### PR TITLE
Add map view to location search results

### DIFF
--- a/client/src/components/LocationCollection.tsx
+++ b/client/src/components/LocationCollection.tsx
@@ -51,24 +51,22 @@ const LocationCollection = ({
         {showHeader && (
           <header>
             {viewFormats.length > 1 && (
-              <>
-                <ButtonToggleGroup
-                  value={viewFormat}
-                  onChange={setViewFormat}
-                  className="d-print-none"
-                >
-                  {viewFormats.includes(FORMAT_TABLE) && (
-                    <Button value={FORMAT_TABLE} variant="outline-secondary">
-                      Table
-                    </Button>
-                  )}
-                  {viewFormats.includes(FORMAT_MAP) && (
-                    <Button value={FORMAT_MAP} variant="outline-secondary">
-                      Map
-                    </Button>
-                  )}
-                </ButtonToggleGroup>
-              </>
+              <ButtonToggleGroup
+                value={viewFormat}
+                onChange={setViewFormat}
+                className="d-print-none"
+              >
+                {viewFormats.includes(FORMAT_TABLE) && (
+                  <Button value={FORMAT_TABLE} variant="outline-secondary">
+                    Table
+                  </Button>
+                )}
+                {viewFormats.includes(FORMAT_MAP) && (
+                  <Button value={FORMAT_MAP} variant="outline-secondary">
+                    Map
+                  </Button>
+                )}
+              </ButtonToggleGroup>
             )}
             {locationsFilter && (
               <div className="locations-filter">Filter: {locationsFilter}</div>

--- a/client/src/components/LocationCollection.tsx
+++ b/client/src/components/LocationCollection.tsx
@@ -1,0 +1,120 @@
+import { setPagination } from "actions"
+import ButtonToggleGroup from "components/ButtonToggleGroup"
+import LocationMap from "components/LocationMap"
+import LocationTable from "components/LocationTable"
+import {
+  mapPageDispatchersToProps,
+  PageDispatchersPropType
+} from "components/Page"
+import React, { useState } from "react"
+import { Button } from "react-bootstrap"
+import { connect } from "react-redux"
+
+export const FORMAT_TABLE = "table"
+export const FORMAT_MAP = "map"
+
+interface LocationCollectionProps {
+  pageDispatchers?: PageDispatchersPropType
+  paginationKey?: string
+  pagination?: any
+  setPagination?: (...args: unknown[]) => unknown
+  viewFormats?: string[]
+  locationsFilter?: React.ReactNode
+  queryParams?: any
+  setTotalCount?: (...args: unknown[]) => unknown
+  mapId?: string
+  width?: number | string
+  height?: number | string
+  marginBottom?: number | string
+}
+
+const LocationCollection = ({
+  pageDispatchers,
+  paginationKey,
+  pagination,
+  setPagination,
+  viewFormats = [FORMAT_TABLE, FORMAT_MAP],
+  locationsFilter,
+  queryParams,
+  setTotalCount,
+  mapId,
+  width,
+  height,
+  marginBottom
+}: LocationCollectionProps) => {
+  const [viewFormat, setViewFormat] = useState(viewFormats[0])
+  const showHeader = viewFormats.length > 1 || locationsFilter
+
+  return (
+    <div className="location-collection">
+      <div>
+        {showHeader && (
+          <header>
+            {viewFormats.length > 1 && (
+              <>
+                <ButtonToggleGroup
+                  value={viewFormat}
+                  onChange={setViewFormat}
+                  className="d-print-none"
+                >
+                  {viewFormats.includes(FORMAT_TABLE) && (
+                    <Button value={FORMAT_TABLE} variant="outline-secondary">
+                      Table
+                    </Button>
+                  )}
+                  {viewFormats.includes(FORMAT_MAP) && (
+                    <Button value={FORMAT_MAP} variant="outline-secondary">
+                      Map
+                    </Button>
+                  )}
+                </ButtonToggleGroup>
+              </>
+            )}
+            {locationsFilter && (
+              <div className="locations-filter">Filter: {locationsFilter}</div>
+            )}
+          </header>
+        )}
+
+        <div>
+          {viewFormat === FORMAT_TABLE && (
+            <LocationTable
+              pageDispatchers={pageDispatchers}
+              paginationKey={paginationKey || null}
+              pagination={paginationKey ? pagination : null}
+              setPagination={paginationKey ? setPagination : null}
+              queryParams={queryParams}
+              setTotalCount={setTotalCount}
+            />
+          )}
+          {viewFormat === FORMAT_MAP && (
+            <LocationMap
+              pageDispatchers={pageDispatchers}
+              queryParams={queryParams}
+              setTotalCount={setTotalCount}
+              mapId={mapId || "locations"}
+              width={width}
+              height={height}
+              marginBottom={marginBottom}
+            />
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+const mapDispatchToProps = (dispatch, ownProps) => {
+  const pageDispatchers = mapPageDispatchersToProps(dispatch, ownProps)
+  return {
+    setPagination: (pageKey: string, pageNum: number) =>
+      dispatch(setPagination(pageKey, pageNum)),
+    ...pageDispatchers
+  }
+}
+
+const mapStateToProps = state => ({
+  pagination: state.pagination
+})
+
+export default connect(mapStateToProps, mapDispatchToProps)(LocationCollection)

--- a/client/src/components/LocationMap.tsx
+++ b/client/src/components/LocationMap.tsx
@@ -1,3 +1,7 @@
+import {
+  gqlEntityFieldsMap,
+  gqlPaginationFields
+} from "constants/GraphQLDefinitions"
 import { gql } from "@apollo/client"
 import API from "api"
 import LocationsMapWidget from "components/aggregations/LocationsMapWidget"
@@ -12,14 +16,12 @@ import { connect } from "react-redux"
 const GQL_GET_LOCATION_LIST = gql`
   query ($locationQuery: LocationSearchQueryInput) {
     locationList(query: $locationQuery) {
-      pageNum
-      pageSize
-      totalCount
+      ${gqlPaginationFields}
       list {
-        uuid
-        name
+        ${gqlEntityFieldsMap.Location}
         lat
         lng
+        type
       }
     }
   }

--- a/client/src/components/LocationMap.tsx
+++ b/client/src/components/LocationMap.tsx
@@ -1,0 +1,79 @@
+import { gql } from "@apollo/client"
+import API from "api"
+import LocationsMapWidget from "components/aggregations/LocationsMapWidget"
+import {
+  mapPageDispatchersToProps,
+  PageDispatchersPropType,
+  useBoilerplate
+} from "components/Page"
+import React, { useEffect } from "react"
+import { connect } from "react-redux"
+
+const GQL_GET_LOCATION_LIST = gql`
+  query ($locationQuery: LocationSearchQueryInput) {
+    locationList(query: $locationQuery) {
+      pageNum
+      pageSize
+      totalCount
+      list {
+        uuid
+        name
+        lat
+        lng
+      }
+    }
+  }
+`
+
+interface LocationMapProps {
+  pageDispatchers?: PageDispatchersPropType
+  queryParams?: any
+  setTotalCount?: (...args: unknown[]) => unknown
+  mapId: string
+  width?: number | string
+  height?: number | string
+  marginBottom?: number | string
+}
+
+const LocationMap = ({
+  pageDispatchers,
+  queryParams,
+  setTotalCount,
+  mapId = "locations",
+  width,
+  height,
+  marginBottom
+}: LocationMapProps) => {
+  const locationQuery = Object.assign({}, queryParams, { pageSize: 0 })
+  const { loading, error, data } = API.useApiQuery(GQL_GET_LOCATION_LIST, {
+    locationQuery
+  })
+  const { done, result } = useBoilerplate({
+    loading,
+    error,
+    pageDispatchers
+  })
+  const totalCount = done ? null : data?.locationList?.totalCount
+  useEffect(
+    () => setTotalCount && setTotalCount(totalCount),
+    [setTotalCount, totalCount]
+  )
+
+  if (done) {
+    return result
+  }
+
+  const locations = data ? data.locationList.list : []
+  return (
+    <LocationsMapWidget
+      values={locations}
+      widgetId={mapId}
+      width={width}
+      height={height}
+      marginBottom={marginBottom}
+      whenUnspecified={<em>No locations found</em>}
+    />
+  )
+}
+
+export default connect(null, mapPageDispatchersToProps)(LocationMap)

--- a/client/src/components/LocationMap.tsx
+++ b/client/src/components/LocationMap.tsx
@@ -46,7 +46,7 @@ const LocationMap = ({
   height,
   marginBottom
 }: LocationMapProps) => {
-  const locationQuery = Object.assign({}, queryParams, { pageSize: 0 })
+  const locationQuery = { ...queryParams, pageSize: 0 }
   const { loading, error, data } = API.useApiQuery(GQL_GET_LOCATION_LIST, {
     locationQuery
   })
@@ -55,11 +55,11 @@ const LocationMap = ({
     error,
     pageDispatchers
   })
+
   const totalCount = done ? null : data?.locationList?.totalCount
-  useEffect(
-    () => setTotalCount && setTotalCount(totalCount),
-    [setTotalCount, totalCount]
-  )
+  useEffect(() => {
+    setTotalCount?.(totalCount)
+  }, [setTotalCount, totalCount])
 
   if (done) {
     return result

--- a/client/src/components/LocationTable.tsx
+++ b/client/src/components/LocationTable.tsx
@@ -69,23 +69,24 @@ const LocationTableWithQuery = ({
   const latestQueryParams = useRef(queryParams)
   const queryParamsUnchanged = _isEqual(latestQueryParams.current, queryParams)
   const [pageNum, setPageNum] = useState(
-    (queryParamsUnchanged && pagination?.[paginationKey!]?.pageNum) ?? 0
+    (queryParamsUnchanged && pagination?.[paginationKey]?.pageNum) ?? 0
   )
 
   useEffect(() => {
     if (!queryParamsUnchanged) {
       latestQueryParams.current = queryParams
-      if (setPagination && paginationKey) {
-        setPagination(paginationKey, 0)
+      if (paginationKey) {
+        setPagination?.(paginationKey, 0)
       }
       setPageNum(0)
     }
   }, [queryParams, setPagination, paginationKey, queryParamsUnchanged])
 
-  const locationQuery = Object.assign({}, queryParams, {
+  const locationQuery = {
+    ...queryParams,
     pageNum: queryParamsUnchanged ? pageNum : 0,
     pageSize: queryParams.pageSize || DEFAULT_PAGESIZE
-  })
+  }
 
   const { loading, error, data } = API.useApiQuery(GQL_GET_LOCATION_LIST, {
     locationQuery
@@ -98,9 +99,7 @@ const LocationTableWithQuery = ({
 
   const totalCount = done ? null : data?.locationList?.totalCount
   useEffect(() => {
-    if (setTotalCount) {
-      setTotalCount(totalCount)
-    }
+    setTotalCount?.(totalCount)
   }, [setTotalCount, totalCount])
 
   if (done) {

--- a/client/src/components/LocationTable.tsx
+++ b/client/src/components/LocationTable.tsx
@@ -13,8 +13,9 @@ import {
 import RemoveButton from "components/RemoveButton"
 import UltimatePaginationTopDown from "components/UltimatePaginationTopDown"
 import _get from "lodash/get"
+import _isEqual from "lodash/isEqual"
 import { Location } from "models"
-import React, { useState } from "react"
+import React, { useEffect, useRef, useState } from "react"
 import { Table } from "react-bootstrap"
 import { connect } from "react-redux"
 
@@ -32,30 +33,60 @@ const GQL_GET_LOCATION_LIST = gql`
   }
 `
 
+const DEFAULT_PAGESIZE = 10
+
 interface LocationTableProps {
-  // query variables for locations, when query & pagination wanted:
+  pageDispatchers?: PageDispatchersPropType
   queryParams?: any
+  setTotalCount?: (...args: unknown[]) => unknown
+  paginationKey?: string
+  pagination?: any
+  setPagination?: (...args: unknown[]) => unknown
+  id?: string
+  showDelete?: boolean
+  onDelete?: (...args: unknown[]) => unknown
 }
 
 const LocationTable = (props: LocationTableProps) => {
-  if (props.queryParams) {
-    return <PaginatedLocations {...props} />
+  const { queryParams } = props
+  if (queryParams) {
+    return <LocationTableWithQuery {...props} />
   }
   return <BaseLocationTable {...props} />
 }
 
-interface PaginatedLocationsProps {
-  pageDispatchers?: PageDispatchersPropType
-  queryParams?: any
-}
-
-const PaginatedLocations = ({
-  queryParams,
+const LocationTableWithQuery = ({
   pageDispatchers,
-  ...otherProps
-}: PaginatedLocationsProps) => {
-  const [pageNum, setPageNum] = useState(0)
-  const locationQuery = Object.assign({}, queryParams, { pageNum })
+  queryParams,
+  setTotalCount,
+  paginationKey,
+  pagination,
+  setPagination,
+  id,
+  showDelete,
+  onDelete
+}: LocationTableProps) => {
+  const latestQueryParams = useRef(queryParams)
+  const queryParamsUnchanged = _isEqual(latestQueryParams.current, queryParams)
+  const [pageNum, setPageNum] = useState(
+    (queryParamsUnchanged && pagination?.[paginationKey!]?.pageNum) ?? 0
+  )
+
+  useEffect(() => {
+    if (!queryParamsUnchanged) {
+      latestQueryParams.current = queryParams
+      if (setPagination && paginationKey) {
+        setPagination(paginationKey, 0)
+      }
+      setPageNum(0)
+    }
+  }, [queryParams, setPagination, paginationKey, queryParamsUnchanged])
+
+  const locationQuery = Object.assign({}, queryParams, {
+    pageNum: queryParamsUnchanged ? pageNum : 0,
+    pageSize: queryParams.pageSize || DEFAULT_PAGESIZE
+  })
+
   const { loading, error, data } = API.useApiQuery(GQL_GET_LOCATION_LIST, {
     locationQuery
   })
@@ -64,25 +95,41 @@ const PaginatedLocations = ({
     error,
     pageDispatchers
   })
+
+  const totalCount = done ? null : data?.locationList?.totalCount
+  useEffect(() => {
+    if (setTotalCount) {
+      setTotalCount(totalCount)
+    }
+  }, [setTotalCount, totalCount])
+
   if (done) {
     return result
   }
 
-  const {
-    pageSize,
-    pageNum: curPage,
-    totalCount,
-    list: locations
-  } = data.locationList
+  const paginatedLocations = data ? data.locationList : []
+  const { pageSize, pageNum: curPage, list: locations } = paginatedLocations
+  if (_get(locations, "length", 0) === 0) {
+    return <em>No locations found</em>
+  }
+
+  function setPage(newPageNum: number) {
+    if (setPagination && paginationKey) {
+      setPagination(paginationKey, newPageNum)
+    }
+    setPageNum(newPageNum)
+  }
 
   return (
     <BaseLocationTable
+      id={id}
+      showDelete={showDelete}
+      onDelete={onDelete}
       locations={locations}
-      pageSize={pageSize}
-      pageNum={curPage}
-      totalCount={totalCount}
-      goToPage={setPageNum}
-      {...otherProps}
+      pageSize={setPagination && pageSize}
+      pageNum={setPagination && curPage}
+      totalCount={setPagination && totalCount}
+      goToPage={setPagination && setPage}
     />
   )
 }

--- a/client/src/components/aggregations/LocationsMapWidget.tsx
+++ b/client/src/components/aggregations/LocationsMapWidget.tsx
@@ -25,7 +25,7 @@ const LocationsMapWidget = ({
       return []
     }
     const markerArray = []
-    values.forEach(location => {
+    for (const location of values) {
       if (Location.hasCoordinates(location)) {
         markerArray.push({
           id: location.uuid,
@@ -35,7 +35,7 @@ const LocationsMapWidget = ({
           contents: location
         })
       }
-    })
+    }
     return markerArray
   }, [values])
 

--- a/client/src/components/aggregations/LocationsMapWidget.tsx
+++ b/client/src/components/aggregations/LocationsMapWidget.tsx
@@ -1,0 +1,76 @@
+import { AggregationWidgetPropType } from "components/aggregations/utils"
+import Leaflet, { ICON_TYPES, MarkerPopupProps } from "components/Leaflet"
+import LinkTo from "components/LinkTo"
+import _isEmpty from "lodash/isEmpty"
+import { Location } from "models"
+import React, { useMemo, useState } from "react"
+import { createPortal } from "react-dom"
+
+interface LocationsMapWidgetProps extends AggregationWidgetPropType {
+  width?: number | string
+  height?: number | string
+}
+
+const LocationsMapWidget = ({
+  values = [],
+  widgetId,
+  width,
+  height,
+  whenUnspecified = null,
+  ...otherWidgetProps // eslint-disable-line @typescript-eslint/no-unused-vars
+}: LocationsMapWidgetProps) => {
+  const [markerPopup, setMarkerPopup] = useState<MarkerPopupProps>({})
+  const markers = useMemo(() => {
+    if (!values.length) {
+      return []
+    }
+    const markerArray = []
+    values.forEach(location => {
+      if (Location.hasCoordinates(location)) {
+        markerArray.push({
+          id: location.uuid,
+          icon: ICON_TYPES.GREEN,
+          lat: location.lat,
+          lng: location.lng,
+          contents: location
+        })
+      }
+    })
+    return markerArray
+  }, [values])
+
+  if (_isEmpty(markers)) {
+    return whenUnspecified
+  }
+
+  return (
+    <div className="non-scrollable">
+      <Leaflet
+        markers={markers}
+        setMarkerPopup={setMarkerPopup}
+        width={width}
+        height={height}
+        mapId={widgetId}
+        marginBottom={0}
+      />
+      {markerPopup.container &&
+        createPortal(
+          renderMarkerPopupContents(markerPopup.contents),
+          markerPopup.container
+        )}
+    </div>
+  )
+
+  function renderMarkerPopupContents(location) {
+    if (!location) {
+      return null
+    }
+    return (
+      <>
+        <b>Location:</b> <LinkTo modelType="Location" model={location} />
+      </>
+    )
+  }
+}
+
+export default LocationsMapWidget

--- a/client/src/pages/searches/Search.tsx
+++ b/client/src/pages/searches/Search.tsx
@@ -16,6 +16,7 @@ import API from "api"
 import AppContext from "components/AppContext"
 import * as FieldHelper from "components/FieldHelper"
 import Fieldset from "components/Fieldset"
+import LocationCollection from "components/LocationCollection"
 import Messages from "components/Messages"
 import { AnchorNavItem } from "components/Nav"
 import {
@@ -32,7 +33,6 @@ import AttachmentSearchResults from "components/search/AttachmentSearchResults"
 import AuthorizationGroupSearchResults from "components/search/AuthorizationGroupSearchResults"
 import EventSearchResults from "components/search/EventSearchResults"
 import EventSeriesSearchResults from "components/search/EventSeriesSearchResults"
-import LocationSearchResults from "components/search/LocationSearchResults"
 import OrganizationSearchResults from "components/search/OrganizationSearchResults"
 import PeopleSearchResults from "components/search/PeopleSearchResults"
 import PositionSearchResults from "components/search/PositionSearchResults"
@@ -128,7 +128,7 @@ const SEARCH_ITEMS = {
   [SEARCH_OBJECT_TYPES.LOCATIONS]: {
     navTo: "locations",
     iconImg: LOCATIONS_ICON,
-    searchResultsComponent: LocationSearchResults
+    searchResultsComponent: LocationCollection
   },
   [SEARCH_OBJECT_TYPES.REPORTS]: {
     navTo: "reports",

--- a/client/tests/e2e/permissions.js
+++ b/client/tests/e2e/permissions.js
@@ -587,9 +587,10 @@ async function getFromSearchResults(
   const $searchBarSubmit = await $("#searchBarSubmit")
   await $searchBarSubmit.click()
 
-  const $searchResultLinks = await $$(
-    "#" + searchResultsType + "-search-results td a"
-  )
+  const searchResultsIdentifier = ["locations"].includes(searchResultsType)
+    ? `.${searchResultsType.slice(0, -1)}-collection`
+    : `#${searchResultsType}-search-results`
+  const $searchResultLinks = await $$(`${searchResultsIdentifier} td a`)
 
   async function findLinkWithText(text) {
     for (const $link of $searchResultLinks) {

--- a/client/tests/webdriver/pages/search.page.js
+++ b/client/tests/webdriver/pages/search.page.js
@@ -34,7 +34,7 @@ class Search extends Page {
   }
 
   async getFoundLocationTable() {
-    return browser.$("div#locations #locations-search-results")
+    return browser.$("div#locations .location-collection")
   }
 
   async getFoundAuthorizationGroupTable() {


### PR DESCRIPTION
Along side with the table view for the locations when searching, this adds a map view of those same locations (only the ones that have coordinates).

Closes [AB#1503](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1503)

#### User changes
- Users can view the location search results also on a map

#### Superuser changes
- None

#### Admin changes
- Noone

#### System admin changes
- [ ] application.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
- [x] described the user behavior in PR body
- [x] referenced/updated all related issues
- [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
- [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
- [ ] added and/or updated unit tests
- [x] added and/or updated e2e tests
- [ ] added and/or updated data migrations
- [ ] updated documentation
- [x] resolved all build errors and warnings
- [ ] opened debt issues for anything not resolved here
