### PR TITLE
Create MART web service in ANET for dictionary export

### DIFF
--- a/client/src/pages/admin/accessTokens/Index.tsx
+++ b/client/src/pages/admin/accessTokens/Index.tsx
@@ -93,6 +93,11 @@ const tokenScopeButtons = [
     id: "graphql",
     value: "GRAPHQL",
     label: "GraphQL"
+  },
+  {
+    id: "mart",
+    value: "MART",
+    label: "MART"
   }
 ]
 

--- a/client/src/pages/admin/martImporter/Show.tsx
+++ b/client/src/pages/admin/martImporter/Show.tsx
@@ -33,7 +33,7 @@ const MartImporterShow = () => {
   }
   async function handleExport() {
     try {
-      const response = await fetch("/api/admin/dictionary/mart", {
+      const response = await fetch("/api/admin/martDictionary", {
         method: "GET",
         headers: {
           Accept: "application/x-yaml"

--- a/insertBaseData-psql.sql
+++ b/insertBaseData-psql.sql
@@ -1592,6 +1592,8 @@ INSERT INTO "accessTokens" (uuid, name, "pointOfContact", description, "tokenHas
   ('2e45aef0-b9de-4818-be95-b0cc2aececfc', 'Sample Web Service Access Token for NVG', 'Arthur Dmin <arthur@example.ns>', 'A sample web service access token for the NVG Web Service', 'AaEge0eLJTP25aRAA5jIZxyzvejJBxPk+kAJDpv+5nc=', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP + INTERVAL '10 years', 0),
   -- GRAPHQL token value is W+Cs0C6uagyXhcfKOkO8TOGSHRY6ZNXf
   ('e23d6c6e-9206-4dcc-99f4-7ce64620e35e', 'Sample Web Service Access Token for GRAPHQL', 'Rebecca Beccabon, +2-456-7324', 'A sample web service access token for the GRAPHQL Web Service', 'pNrklOyrjwx9913Tsx5zqT0GOppKQJnnqX5zzM7X0L0=', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP + INTERVAL '10 years', 1),
+  -- MART token value is BwiEPXAx2Oc+kvhAGBwyMvN8iOXxOEVo
+  ('9f117107-1483-4d8e-9ecc-de433be1f5f5', 'Sample Web Service Access Token for MART', 'Rebecca Beccabon, +2-456-7324', 'A sample web service access token for the MART Web Service', 'dL4nKQ4agoM9lkSR5vn6aoNclTlSAMAU059L4sQzrn8=', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP + INTERVAL '10 years', 2),
   -- GRAPHQL expired token value is 8ESgHLxLxh7VStAAgn9hpEIDo0CYOiGn
   ('64070f3b-ce5a-428b-ac76-77bd25989a09', 'An expired Web Service Access Token for GRAPHQL', NULL, 'An expired web service access token for the GRAPHQL Web Service', 'ZdV6x+/szanYoIipY+IaJYIoBXd600d3ME07vzIfgTA==', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP - INTERVAL '10 years', 1);
 

--- a/src/main/java/mil/dds/anet/beans/AccessToken.java
+++ b/src/main/java/mil/dds/anet/beans/AccessToken.java
@@ -20,7 +20,7 @@ public class AccessToken extends AbstractAnetBean implements RelatableObject {
   private static final Base64.Encoder BASE64_ENCODER = Base64.getEncoder();
 
   public enum TokenScope {
-    NVG, GRAPHQL
+    NVG, GRAPHQL, MART
   }
 
   @GraphQLQuery

--- a/src/main/java/mil/dds/anet/config/SecurityConfig.java
+++ b/src/main/java/mil/dds/anet/config/SecurityConfig.java
@@ -17,6 +17,7 @@ import mil.dds.anet.resources.HomeResource;
 import mil.dds.anet.utils.ResponseUtils;
 import mil.dds.anet.views.UserActivityFilter;
 import mil.dds.anet.ws.GraphQLWebService;
+import mil.dds.anet.ws.MartWebService;
 import mil.dds.anet.ws.security.BearerTokenAuthFilter;
 import mil.dds.anet.ws.security.BearerTokenService;
 import org.springframework.beans.factory.annotation.Value;
@@ -121,6 +122,23 @@ public class SecurityConfig {
         .addFilterBefore(bearerTokenAuthFilter, BasicAuthenticationFilter.class)
         .authorizeHttpRequests(authorize ->
         // Allow all GraphQL web service requests; service itself checks access
+        authorize.anyRequest().permitAll());
+
+    setCommonWebServiceSecurity(http);
+
+    return http.build();
+  }
+
+  @Bean
+  @Order(30)
+  public SecurityFilterChain martWebServiceFilterChain(HttpSecurity http) throws Exception {
+    http
+        // Only applies to MART Web Service endpoint
+        .securityMatcher(MartWebService.MART_WEB_SERVICE)
+        // Insert bearer token authentication filter into the chain
+        .addFilterBefore(bearerTokenAuthFilter, BasicAuthenticationFilter.class)
+        .authorizeHttpRequests(authorize ->
+        // Allow all MART web service requests; service itself checks access
         authorize.anyRequest().permitAll());
 
     setCommonWebServiceSecurity(http);

--- a/src/main/java/mil/dds/anet/resources/AdminResource.java
+++ b/src/main/java/mil/dds/anet/resources/AdminResource.java
@@ -57,7 +57,7 @@ public class AdminResource {
 
   public static final String ADMIN_RESOURCE_PATH = "/api/admin";
   public static final String DICTIONARY_PATH = "/dictionary";
-  public static final String DICTIONARY_MART_PATH = "/mart";
+  public static final String DICTIONARY_MART_PATH = "/martDictionary";
   public static final String ADMIN_DICTIONARY_RESOURCE_PATH = ADMIN_RESOURCE_PATH + DICTIONARY_PATH;
 
   private final AnetConfig config;
@@ -108,7 +108,7 @@ public class AdminResource {
     return dict.getDictionary();
   }
 
-  @GetMapping(path = DICTIONARY_PATH + DICTIONARY_MART_PATH)
+  @GetMapping(path = DICTIONARY_MART_PATH)
   public ResponseEntity<StreamingResponseBody> getMartDictionary(Principal principal) {
     if (Boolean.FALSE.equals(dict.getDictionaryEntry("featureMartGuiEnabled"))) {
       throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "MART Feature is not enabled");
@@ -116,29 +116,12 @@ public class AdminResource {
     final Person user = SecurityUtils.getPersonFromPrincipal(principal);
     AuthUtils.assertAdministrator(user);
 
-    // Create MART dictionary
-    final Map<String, Object> dictionaryForMart = martDictionaryService.createDictionaryForMart();
-
-    // Dump to Yaml and return
-    final DumperOptions options = new DumperOptions();
-    options.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
-    options.setIndent(2);
-    options.setIndicatorIndent(2);
-    options.setIndentWithIndicator(true);
-
-    final Yaml yaml = new Yaml(options);
-    final StreamingResponseBody responseBody = outputStream -> {
-      try (final Writer writer = new OutputStreamWriter(outputStream, StandardCharsets.UTF_8)) {
-        yaml.dump(dictionaryForMart, writer);
-      }
-    };
-
     final HttpHeaders headers = new HttpHeaders();
     headers.setContentDisposition(
         ContentDisposition.attachment().filename("anet-dictionary.yml").build());
 
     return ResponseEntity.ok().contentType(MediaType.APPLICATION_YAML).headers(headers)
-        .body(responseBody);
+        .body(Utils.toYamlStream(martDictionaryService.createDictionaryForMart()));
   }
 
   /**

--- a/src/main/java/mil/dds/anet/utils/Utils.java
+++ b/src/main/java/mil/dds/anet/utils/Utils.java
@@ -7,6 +7,8 @@ import freemarker.template.Configuration;
 import freemarker.template.DefaultObjectWrapperBuilder;
 import io.leangen.graphql.execution.ResolutionEnvironment;
 import jakarta.annotation.Nullable;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
 import java.lang.invoke.MethodHandles;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
@@ -65,6 +67,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.server.ResponseStatusException;
+import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
+import org.yaml.snakeyaml.DumperOptions;
+import org.yaml.snakeyaml.Yaml;
 import tools.jackson.core.JacksonException;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
@@ -1058,6 +1063,22 @@ public class Utils {
       icon = "\uD83D\uDD22"; // 🯄 🔢
     }
     return icon;
+  }
+
+  public static StreamingResponseBody toYamlStream(Map<String, Object> data) {
+    final DumperOptions options = new DumperOptions();
+    options.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
+    options.setIndent(2);
+    options.setIndicatorIndent(2);
+    options.setIndentWithIndicator(true);
+
+    final Yaml yaml = new Yaml(options);
+
+    return outputStream -> {
+      try (Writer writer = new OutputStreamWriter(outputStream, StandardCharsets.UTF_8)) {
+        yaml.dump(data, writer);
+      }
+    };
   }
 
 }

--- a/src/main/java/mil/dds/anet/ws/MartWebService.java
+++ b/src/main/java/mil/dds/anet/ws/MartWebService.java
@@ -34,7 +34,8 @@ public class MartWebService {
   @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
   public ResponseEntity<StreamingResponseBody> getMartDictionary() {
     if (Boolean.FALSE.equals(dict.getDictionaryEntry("featureMartGuiEnabled"))) {
-      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "MART Feature is not enabled");
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+          "featureMartGuiEnabled is not enabled");
     }
 
     final HttpHeaders headers = new HttpHeaders();

--- a/src/main/java/mil/dds/anet/ws/MartWebService.java
+++ b/src/main/java/mil/dds/anet/ws/MartWebService.java
@@ -1,0 +1,47 @@
+package mil.dds.anet.ws;
+
+import mil.dds.anet.config.AnetDictionary;
+import mil.dds.anet.services.IMartDictionaryService;
+import mil.dds.anet.utils.Utils;
+import org.springframework.http.ContentDisposition;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
+
+@RestController
+@RequestMapping(MartWebService.MART_WEB_SERVICE)
+@EnableMethodSecurity
+public class MartWebService {
+  public static final String MART_WEB_SERVICE = "/martWebService";
+
+  private final AnetDictionary dict;
+  private final IMartDictionaryService martDictionaryService;
+
+  public MartWebService(AnetDictionary dict, IMartDictionaryService martDictionaryService) {
+    this.martDictionaryService = martDictionaryService;
+    this.dict = dict;
+  }
+
+  @PreAuthorize("hasAuthority('SCOPE_MART')")
+  @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
+  public ResponseEntity<StreamingResponseBody> getMartDictionary() {
+    if (Boolean.FALSE.equals(dict.getDictionaryEntry("featureMartGuiEnabled"))) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "MART Feature is not enabled");
+    }
+
+    final HttpHeaders headers = new HttpHeaders();
+    headers.setContentDisposition(
+        ContentDisposition.attachment().filename("anet-dictionary.yml").build());
+
+    return ResponseEntity.ok().contentType(MediaType.APPLICATION_YAML).headers(headers)
+        .body(Utils.toYamlStream(martDictionaryService.createDictionaryForMart()));
+  }
+}

--- a/src/main/java/mil/dds/anet/ws/security/AccessTokenPrincipal.java
+++ b/src/main/java/mil/dds/anet/ws/security/AccessTokenPrincipal.java
@@ -14,6 +14,7 @@ public record AccessTokenPrincipal(AccessToken accessToken,
     return switch (scope) {
       case GRAPHQL -> WebServiceGrantedAuthority.GRAPHQL;
       case NVG -> WebServiceGrantedAuthority.NVG;
+      case MART -> WebServiceGrantedAuthority.MART;
     };
   }
 

--- a/src/main/java/mil/dds/anet/ws/security/WebServiceGrantedAuthority.java
+++ b/src/main/java/mil/dds/anet/ws/security/WebServiceGrantedAuthority.java
@@ -6,9 +6,11 @@ public class WebServiceGrantedAuthority {
 
   public static final String SCOPE_GRAPHQL = "SCOPE_GRAPHQL";
   public static final String SCOPE_NVG = "SCOPE_NVG";
+  public static final String SCOPE_MART = "SCOPE_MART";
 
   public static final SimpleGrantedAuthority GRAPHQL = new SimpleGrantedAuthority(SCOPE_GRAPHQL);
   public static final SimpleGrantedAuthority NVG = new SimpleGrantedAuthority(SCOPE_NVG);
+  public static final SimpleGrantedAuthority MART = new SimpleGrantedAuthority(SCOPE_MART);
 
   private WebServiceGrantedAuthority() {}
 }

--- a/src/test/java/mil/dds/anet/test/resources/AbstractResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/AbstractResourceTest.java
@@ -66,6 +66,8 @@ import mil.dds.anet.test.client.util.QueryExecutor;
 import mil.dds.anet.threads.MaterializedViewForLinksRefreshWorker;
 import mil.dds.anet.threads.MaterializedViewRefreshWorker;
 import mil.dds.anet.utils.Utils;
+import mil.dds.anet.ws.security.AccessTokenAuthentication;
+import mil.dds.anet.ws.security.BearerTokenService;
 import org.apache.commons.lang3.ArrayUtils;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.params.provider.Arguments;
@@ -73,6 +75,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.BeanUtils;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.context.SecurityContextHolder;
 import tools.jackson.core.JacksonException;
 import tools.jackson.databind.DeserializationFeature;
 import tools.jackson.databind.ObjectMapper;
@@ -96,6 +99,9 @@ public abstract class AbstractResourceTest extends AnetApplicationTest {
 
   @Autowired
   protected AdminDao adminDao;
+
+  @Autowired
+  private BearerTokenService bearerTokenService;
 
   protected static final Logger logger =
       LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
@@ -650,4 +656,16 @@ public abstract class AbstractResourceTest extends AnetApplicationTest {
       }
     }
   }
+
+  protected void setAuthentication(String bearerToken) {
+    var accessTokenAuthentication = createAccessTokenAuthentication(bearerToken);
+    SecurityContextHolder.getContext().setAuthentication(accessTokenAuthentication);
+  }
+
+  private AccessTokenAuthentication createAccessTokenAuthentication(String bearerToken) {
+    var accessToken = bearerTokenService.getAccessPrincipalFromAuthHeader(bearerToken);
+    assertThat(accessToken.isEmpty()).isFalse();
+    return new AccessTokenAuthentication(accessToken.get());
+  }
+
 }

--- a/src/test/java/mil/dds/anet/test/ws/GraphQLWebServiceTest.java
+++ b/src/test/java/mil/dds/anet/test/ws/GraphQLWebServiceTest.java
@@ -42,17 +42,10 @@ class GraphQLWebServiceTest extends AbstractResourceTest {
   @Autowired
   private GraphQLWebService graphQLWebService;
 
-  @Autowired
-  private BearerTokenService bearerTokenService;
 
   @AfterEach
   void clearSecurity() {
     SecurityContextHolder.clearContext();
-  }
-
-  private void setAuthentication(String bearerToken) {
-    var accessTokenAuthentication = createAccessTokenAuthentication(bearerToken);
-    SecurityContextHolder.getContext().setAuthentication(accessTokenAuthentication);
   }
 
   @Test
@@ -102,12 +95,6 @@ class GraphQLWebServiceTest extends AbstractResourceTest {
     assertThat(assessments).filteredOn(
         a -> "fields.regular.person.assessments.interlocutorMonthly".equals(a.get("assessmentKey")))
         .isEmpty();
-  }
-
-  private AccessTokenAuthentication createAccessTokenAuthentication(String bearerToken) {
-    var accessToken = bearerTokenService.getAccessPrincipalFromAuthHeader(bearerToken);
-    assertThat(accessToken.isEmpty()).isFalse();
-    return new AccessTokenAuthentication(accessToken.get());
   }
 
   @Test

--- a/src/test/java/mil/dds/anet/test/ws/MARTWebServiceTest.java
+++ b/src/test/java/mil/dds/anet/test/ws/MARTWebServiceTest.java
@@ -1,0 +1,49 @@
+package mil.dds.anet.test.ws;
+
+import static mil.dds.anet.test.ws.security.BearerToken.VALID_MART_TOKEN;
+import static mil.dds.anet.test.ws.security.BearerToken.VALID_NVG_TOKEN;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import mil.dds.anet.test.resources.AbstractResourceTest;
+import mil.dds.anet.ws.MartWebService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
+
+class MARTWebServiceTest extends AbstractResourceTest {
+
+  @Autowired
+  private MartWebService martWebService;
+
+  @AfterEach
+  void clearSecurity() {
+    SecurityContextHolder.clearContext();
+  }
+
+  @Test
+  void testWithValidToken() {
+    setAuthentication(VALID_MART_TOKEN);
+    ResponseEntity<StreamingResponseBody> response = martWebService.getMartDictionary();
+    // Assert status and headers
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(response.getHeaders()).isNotNull();
+    assertThat(response.getHeaders().getContentType()).isEqualTo(MediaType.APPLICATION_YAML);
+    assertThat(response.getHeaders().getContentDisposition().getFilename())
+        .contains("anet-dictionary.yml");
+  }
+
+  @Test
+  void testWithWrongToken() {
+    try {
+      setAuthentication(VALID_NVG_TOKEN);
+      martWebService.getMartDictionary();
+    } catch (Exception expectedException) {
+      assertThat(expectedException).hasMessage("Access Denied");
+    }
+  }
+}

--- a/src/test/java/mil/dds/anet/test/ws/security/BearerToken.java
+++ b/src/test/java/mil/dds/anet/test/ws/security/BearerToken.java
@@ -5,6 +5,7 @@ public class BearerToken {
   public static final String UNKNOWN_TOKEN = "Bearer WFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhY";
   public static final String VALID_NVG_TOKEN = "Bearer XfayXIGGC4vKu5j9UEgAAbZYj50v88Zv";
   public static final String VALID_GRAPHQL_TOKEN = "Bearer W+Cs0C6uagyXhcfKOkO8TOGSHRY6ZNXf";
+  public static final String VALID_MART_TOKEN = "Bearer BwiEPXAx2Oc+kvhAGBwyMvN8iOXxOEVo";
   public static final String CORRUPT_TOKEN1 = "Bearer bogus";
   public static final String CORRUPT_TOKEN2 = "bogus";
   public static final String EXPIRED_TOKEN = "Bearer 8ESgHLxLxh7VStAAgn9hpEIDo0CYOiGn";

--- a/src/test/resources/anet.graphql
+++ b/src/test/resources/anet.graphql
@@ -1907,6 +1907,7 @@ enum TaskSearchSortBy {
 """"""
 enum TokenScope {
   GRAPHQL
+  MART
   NVG
 }
 


### PR DESCRIPTION
Creates a web service that allows the export of the MART dictionary with a web service access token

Closes [AB#1582](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1582)

#### User changes
- None

#### Superuser changes
- None

#### Admin changes
- They will be able to call a web service to obtain a dictionary for MART in the same fashion as the exiting GraphQL web service.

#### System admin changes
- [ ] application.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [x] graphql schema has changed

### Checklist
- [x] described the user behavior in PR body
- [x] referenced/updated all related issues
- [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
- [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
- [x] added and/or updated unit tests
- [ ] added and/or updated e2e tests
- [ ] added and/or updated data migrations
- [ ] updated documentation
- [x] resolved all build errors and warnings
- [ ] opened debt issues for anything not resolved here
