### PR TITLE
Make email worker frequency configurable

### DIFF
--- a/application.yml
+++ b/application.yml
@@ -60,6 +60,8 @@ anet:
   # The email address that all automated emails should come from.
   # ex: "ANET <anet@example.com>"
   email-from-addr: "Anet Testing <anet+testing@example.com>"
+  # How frequently the AnetEmailWorker will kick in
+  email-fixed-rate-in-seconds: 300
 
   # The URL that should be used for links in emails
   # ex:  "http://anet.yourdomain"

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -118,6 +118,8 @@ ANET is configured primarily through the `application.yml` file. This is a Sprin
 
     - **email-from-addr**: This is the email address that emails from ANET will be sent from.
 
+    - **email-fixed-rate-in-seconds**: The frequency in seconds in which the AnetEmailWorker will work
+
     - **server-url**: The URL that should be used for links in emails, e.g. `"https://anet.example.com"`; should not include an ending slash!
 
     - **keycloak-configuration**:

--- a/src/main/java/mil/dds/anet/threads/AnetEmailWorker.java
+++ b/src/main/java/mil/dds/anet/threads/AnetEmailWorker.java
@@ -69,7 +69,8 @@ public class AnetEmailWorker extends AbstractWorker {
     AnetEmailWorker.instance = instance;
   }
 
-  @Scheduled(initialDelay = 10, fixedRate = 300, timeUnit = TimeUnit.SECONDS)
+  @Scheduled(initialDelay = 10, fixedRateString = "${anet.email-fixed-rate-in-seconds:300}",
+      timeUnit = TimeUnit.SECONDS)
   @Override
   public void run() {
     super.run();


### PR DESCRIPTION
Make email worker frequency configurable with a new property in `application.yml`.

Closes [AB#1587](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1587)

#### User changes
- None

#### Superuser changes
- None

#### Admin changes
- None

#### System admin changes
- [x] application.yml or anet-dictionary.yml needs change
  This property needs to be added to `application.yml`:
  ```yaml
  email-fixed-rate-in-seconds: 300
  ```
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
- [x] described the user behavior in PR body
- [x] referenced/updated all related issues
- [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
- [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
- [ ] added and/or updated unit tests
- [ ] added and/or updated e2e tests
- [ ] added and/or updated data migrations
- [ ] updated documentation
- [x] resolved all build errors and warnings
- [ ] opened debt issues for anything not resolved here
