### PR TITLE
 Make sure the filtered person is shown in the audit trail person filter input

### DIFF
--- a/client/src/pages/admin/auditTrail/Index.tsx
+++ b/client/src/pages/admin/auditTrail/Index.tsx
@@ -146,7 +146,7 @@ const AuditTrailTable = ({ pageDispatchers }: AuditTrailTableProps) => {
               filterDefs={peopleFilters}
               onChange={handleSelectedPersonChange}
               objectType={Person}
-              valueKey="name"
+              valueFunc={Person.fullName}
               fields={Person.autocompleteQuery}
               addon={PEOPLE_ICON}
             />


### PR DESCRIPTION
Closes [AB#1603](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1603)

#### User changes
- None

#### Superuser changes
- None

#### Admin changes
- When filtering on a person in the Audit trail, the filtered person is now correctly shown in the filter input.

#### System admin changes
- [ ] application.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
- [x] described the user behavior in PR body
- [x] referenced/updated all related issues
- [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
- [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
- [ ] added and/or updated unit tests
- [ ] added and/or updated e2e tests
- [ ] added and/or updated data migrations
- [ ] updated documentation
- [x] resolved all build errors and warnings
- [ ] opened debt issues for anything not resolved here