### PR TITLE
Link to existing attachments

### DIFF
--- a/client/src/components/Attachment/Attachment.css
+++ b/client/src/components/Attachment/Attachment.css
@@ -157,5 +157,5 @@
 
 .attachment-link-count {
   font-size: 12px;
-  color: #667085;
+  color: #445566;
 }

--- a/client/src/components/Attachment/Attachment.css
+++ b/client/src/components/Attachment/Attachment.css
@@ -131,3 +131,31 @@
     margin-top: 10px;
   }
 }
+
+.attachment-link-container {
+  margin: 0 0 15px 0;
+  padding: 12px 14px;
+  border-radius: 6px;
+  border: 1px solid #e0e0e0;
+  background-color: #fafafa;
+}
+
+.attachment-link-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 600;
+  margin-bottom: 8px;
+}
+
+.attachment-link-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-top: 8px;
+}
+
+.attachment-link-count {
+  font-size: 12px;
+  color: #667085;
+}

--- a/client/src/components/Attachment/AttachmentCard.tsx
+++ b/client/src/components/Attachment/AttachmentCard.tsx
@@ -105,7 +105,7 @@ const AttachmentCard = ({
                   onClick={() => onUnlink(attachment)}
                   disabled={unlinkDisabled}
                 >
-                  <Icon icon={IconNames.LINK} />
+                  <Icon icon={IconNames.UNLINK} />
                 </Button>
               )}
               <ConfirmDestructive

--- a/client/src/components/Attachment/AttachmentCard.tsx
+++ b/client/src/components/Attachment/AttachmentCard.tsx
@@ -5,7 +5,7 @@ import API from "api"
 import ConfirmDestructive from "components/ConfirmDestructive"
 import LinkTo from "components/LinkTo"
 import React from "react"
-import { Card } from "react-bootstrap"
+import { Button, Card } from "react-bootstrap"
 import { toast } from "react-toastify"
 import utils from "utils"
 import "./Attachment.css"
@@ -24,6 +24,9 @@ interface AttachmentCardProps {
   setError?: (...args: unknown[]) => unknown
   uploadedList?: any[]
   setUploadedList?: (...args: unknown[]) => unknown
+  onUnlink?: (...args: unknown[]) => unknown
+  unlinkTitle?: string
+  unlinkDisabled?: boolean
 }
 
 const AttachmentCard = ({
@@ -33,7 +36,10 @@ const AttachmentCard = ({
   edit,
   setError,
   uploadedList,
-  setUploadedList
+  setUploadedList,
+  onUnlink,
+  unlinkTitle,
+  unlinkDisabled
 }: AttachmentCardProps) => {
   const computedCaptionStyle = captionStyle ?? {
     maxWidth: edit ? "201px" : "176px"
@@ -92,6 +98,16 @@ const AttachmentCard = ({
                   <Icon icon={IconNames.EDIT} className="icon edit" />
                 </LinkTo>
               </div>
+              {onUnlink && (
+                <Button
+                  variant="outline-secondary"
+                  title={unlinkTitle || "Unlink attachment"}
+                  onClick={() => onUnlink(attachment)}
+                  disabled={unlinkDisabled}
+                >
+                  <Icon icon={IconNames.LINK} />
+                </Button>
+              )}
               <ConfirmDestructive
                 onConfirm={() => deleteAttachment(attachment)}
                 objectType="attachment"

--- a/client/src/components/Attachment/UploadAttachment.tsx
+++ b/client/src/components/Attachment/UploadAttachment.tsx
@@ -303,6 +303,56 @@ const UploadAttachment = ({
     }
   }
 
+  const unlinkAttachment = async attachmentToUnlink => {
+    const currentObjectUuid = objectUuid
+
+    try {
+      const data = await API.query(GQL_GET_ATTACHMENT_FOR_LINKING, {
+        uuid: attachmentToUnlink.uuid
+      })
+      const attachment = data?.attachment
+      if (!attachment) {
+        return
+      }
+      const relatedObjects = attachment.attachmentRelatedObjects || []
+      const nextRelatedObjects = relatedObjects
+        .filter(
+          object =>
+            !(
+              object.relatedObjectType === relatedObjectType &&
+              object.relatedObjectUuid === currentObjectUuid
+            )
+        )
+        .map(({ relatedObjectType, relatedObjectUuid }) => ({
+          relatedObjectType,
+          relatedObjectUuid
+        }))
+
+      if (nextRelatedObjects.length === relatedObjects.length) {
+        return
+      }
+
+      const attachmentInput = Attachment.filterClientSideFields(attachment)
+      attachmentInput.attachmentRelatedObjects = nextRelatedObjects
+
+      await API.mutation(GQL_UPDATE_ATTACHMENT, {
+        attachment: attachmentInput
+      })
+
+      updateAttachments(
+        attachments.filter(a => a.uuid !== attachmentToUnlink.uuid)
+      )
+
+      const attachmentLabel =
+        attachmentToUnlink.caption ||
+        attachmentToUnlink.fileName ||
+        attachmentToUnlink.uuid
+      toast.success(`Unlinked ${attachmentLabel}`)
+    } catch (unlinkError) {
+      setError(unlinkError)
+    }
+  }
+
   return (
     <div>
       <Messages error={error} />
@@ -369,6 +419,8 @@ const UploadAttachment = ({
             setError={setError}
             uploadedList={attachments}
             setUploadedList={updateAttachments}
+            onUnlink={unlinkAttachment}
+            unlinkTitle={`Unlink from this ${RELATED_OBJECT_TYPE_TO_ENTITY_TYPE[relatedObjectType]}`}
           />
         ))}
       </div>

--- a/client/src/components/Attachment/UploadAttachment.tsx
+++ b/client/src/components/Attachment/UploadAttachment.tsx
@@ -1,5 +1,5 @@
 import { gql } from "@apollo/client"
-import { Icon } from "@blueprintjs/core"
+import { Icon, Tooltip } from "@blueprintjs/core"
 import { IconNames } from "@blueprintjs/icons"
 import API from "api"
 import axios from "axios"
@@ -143,6 +143,17 @@ const UploadAttachment = ({
   const mimeTypes = Settings.fields.attachment.fileTypes?.map(
     fileType => fileType.mimeType
   )
+  const selectedNames = linkSelection.map(
+    attachment => attachment.caption || attachment.fileName || attachment.uuid
+  )
+  const maxSelectedNames = 5
+  const selectedSummary =
+    selectedNames.length > maxSelectedNames
+      ? selectedNames.slice(0, maxSelectedNames).join(", ") +
+        " +" +
+        (selectedNames.length - maxSelectedNames) +
+        " more"
+      : selectedNames.join(", ")
 
   const handleFileEvent = async e => {
     // Must keep a copy of this state here, as it is not updated while this function runs
@@ -339,9 +350,11 @@ const UploadAttachment = ({
             {isLinking ? "Linking..." : "Link selected"}
           </Button>
           {linkSelection.length > 0 && (
-            <span className="attachment-link-count">
-              Will link: {linkSelection.length} attachment(s)
-            </span>
+            <Tooltip content={selectedSummary} position="top">
+              <span className="attachment-link-count">
+                Will link: {linkSelection.length} attachment(s)
+              </span>
+            </Tooltip>
           )}
         </div>
       </section>

--- a/client/src/components/Attachment/UploadAttachment.tsx
+++ b/client/src/components/Attachment/UploadAttachment.tsx
@@ -421,6 +421,7 @@ const UploadAttachment = ({
           disabledValue={attachments}
           onConfirm={value => setLinkSelection(value)}
           className="attachment-link-select"
+          hideAttachedHereFilter
         />
         <div className="attachment-link-actions">
           <Button

--- a/client/src/components/Attachment/UploadAttachment.tsx
+++ b/client/src/components/Attachment/UploadAttachment.tsx
@@ -1,12 +1,12 @@
+import {
+  gqlAllAttachmentFields,
+  gqlAttachmentRelatedObjectsFields
+} from "constants/GraphQLDefinitions"
 import { gql } from "@apollo/client"
 import { Icon, Tooltip } from "@blueprintjs/core"
 import { IconNames } from "@blueprintjs/icons"
 import API from "api"
 import axios from "axios"
-import {
-  gqlAllAttachmentFields,
-  gqlAttachmentRelatedObjectsFields
-} from "constants/GraphQLDefinitions"
 import MultiTypeAdvancedSelectComponent, {
   ENTITY_TYPES
 } from "components/advancedSelectWidget/MultiTypeAdvancedSelectComponent"
@@ -215,6 +215,11 @@ const UploadAttachment = ({
   }
 
   const handleLinkAttachments = async () => {
+    if (linkSelection.length === 0) {
+      toast.info("Select one or more attachments to link")
+      return
+    }
+
     setIsLinking(true)
     let currentObjectUuid = objectUuid
     try {
@@ -231,6 +236,13 @@ const UploadAttachment = ({
         attachment => !existingAttachmentUuids.has(attachment.uuid)
       )
 
+      if (toLink.length === 0) {
+        toast.info(
+          `${linkSelection.length} attachment(s) were already linked to this object`
+        )
+        setLinkSelection([])
+        return
+      }
 
       const results = await Promise.all(
         toLink.map(async selected => {
@@ -265,7 +277,8 @@ const UploadAttachment = ({
               }
             ]
 
-            const attachmentInput = Attachment.filterClientSideFields(attachment)
+            const attachmentInput =
+              Attachment.filterClientSideFields(attachment)
             attachmentInput.attachmentRelatedObjects = nextRelatedObjects
 
             await API.mutation(GQL_UPDATE_ATTACHMENT, {
@@ -279,9 +292,7 @@ const UploadAttachment = ({
         })
       )
 
-      const newlyLinked = results
-        .filter(r => r?.linked)
-        .map(r => r.attachment)
+      const newlyLinked = results.filter(r => r?.linked).map(r => r.attachment)
 
       if (newlyLinked.length > 0) {
         const merged = [...attachments]
@@ -294,10 +305,26 @@ const UploadAttachment = ({
         toast.success(`${newlyLinked.length} attachment(s) linked successfully`)
       }
 
+      const skippedCount = results.filter(r => r?.skipped).length
+      if (skippedCount > 0) {
+        toast.info(
+          `${skippedCount} attachment(s) were already linked to this object`
+        )
+      }
+
+      const errorCount = results.filter(r => r?.error).length
+      if (errorCount > 0) {
+        toast.error(
+          `${errorCount} attachment(s) could not be linked due to an error`
+        )
+      }
 
       setLinkSelection([])
     } catch (linkError) {
       setError(linkError)
+      toast.error(
+        `Linking attachments failed: ${linkError?.message || "Unknown error"}`
+      )
     } finally {
       setIsLinking(false)
     }
@@ -312,6 +339,7 @@ const UploadAttachment = ({
       })
       const attachment = data?.attachment
       if (!attachment) {
+        toast.error("Unlinking attachment failed; could not load attachment")
         return
       }
       const relatedObjects = attachment.attachmentRelatedObjects || []
@@ -350,6 +378,9 @@ const UploadAttachment = ({
       toast.success(`Unlinked ${attachmentLabel}`)
     } catch (unlinkError) {
       setError(unlinkError)
+      toast.error(
+        `Unlinking attachment failed: ${unlinkError?.message || "Unknown error"}`
+      )
     }
   }
 

--- a/client/src/components/Attachment/UploadAttachment.tsx
+++ b/client/src/components/Attachment/UploadAttachment.tsx
@@ -387,6 +387,7 @@ const UploadAttachment = ({
           objectType={ENTITY_TYPES.ATTACHMENTS}
           isMultiSelect
           value={linkSelection}
+          disabledValue={attachments}
           onConfirm={value => setLinkSelection(value)}
           className="attachment-link-select"
         />

--- a/client/src/components/Attachment/UploadAttachment.tsx
+++ b/client/src/components/Attachment/UploadAttachment.tsx
@@ -3,9 +3,17 @@ import { Icon } from "@blueprintjs/core"
 import { IconNames } from "@blueprintjs/icons"
 import API from "api"
 import axios from "axios"
+import {
+  gqlAllAttachmentFields,
+  gqlAttachmentRelatedObjectsFields
+} from "constants/GraphQLDefinitions"
+import MultiTypeAdvancedSelectComponent, {
+  ENTITY_TYPES
+} from "components/advancedSelectWidget/MultiTypeAdvancedSelectComponent"
 import Messages from "components/Messages"
 import { Attachment } from "models"
 import React, { useState } from "react"
+import { Button } from "react-bootstrap"
 import { toast } from "react-toastify"
 import Settings from "settings"
 import utils from "utils"
@@ -16,6 +24,21 @@ import AttachmentCard from "./AttachmentCard"
 const GQL_CREATE_ATTACHMENT = gql`
   mutation ($attachment: AttachmentInput!) {
     createAttachment(attachment: $attachment)
+  }
+`
+
+const GQL_GET_ATTACHMENT_FOR_LINKING = gql`
+  query ($uuid: String!) {
+    attachment(uuid: $uuid) {
+      ${gqlAllAttachmentFields}
+      ${gqlAttachmentRelatedObjectsFields}
+    }
+  }
+`
+
+const GQL_UPDATE_ATTACHMENT = gql`
+  mutation ($attachment: AttachmentInput!, $force: Boolean) {
+    updateAttachment(attachment: $attachment, force: $force)
   }
 `
 
@@ -115,6 +138,8 @@ const UploadAttachment = ({
 }: UploadAttachmentProps) => {
   const [error, setError] = useState(null)
   const [objectUuid, setObjectUuid] = useState(relatedObjectUuid)
+  const [linkSelection, setLinkSelection] = useState<any[]>([])
+  const [isLinking, setIsLinking] = useState(false)
   const mimeTypes = Settings.fields.attachment.fileTypes?.map(
     fileType => fileType.mimeType
   )
@@ -178,6 +203,95 @@ const UploadAttachment = ({
     }
   }
 
+  const handleLinkAttachments = async () => {
+    setIsLinking(true)
+    let currentObjectUuid = objectUuid
+    try {
+      if (!currentObjectUuid) {
+        const response = await saveRelatedObject()
+        currentObjectUuid = response.uuid
+        setObjectUuid(currentObjectUuid)
+      }
+
+      const existingAttachmentUuids = new Set(
+        attachments.map(attachment => attachment.uuid)
+      )
+      const toLink = linkSelection.filter(
+        attachment => !existingAttachmentUuids.has(attachment.uuid)
+      )
+
+
+      const results = await Promise.all(
+        toLink.map(async selected => {
+          try {
+            const data = await API.query(GQL_GET_ATTACHMENT_FOR_LINKING, {
+              uuid: selected.uuid
+            })
+            const attachment = data?.attachment
+            if (!attachment) {
+              return { error: true, attachment: selected }
+            }
+            const relatedObjects = attachment.attachmentRelatedObjects || []
+            const alreadyLinked = relatedObjects.some(
+              object =>
+                object.relatedObjectType === relatedObjectType &&
+                object.relatedObjectUuid === currentObjectUuid
+            )
+            if (alreadyLinked) {
+              return { skipped: true, attachment }
+            }
+
+            const nextRelatedObjects = [
+              ...relatedObjects.map(
+                ({ relatedObjectType, relatedObjectUuid }) => ({
+                  relatedObjectType,
+                  relatedObjectUuid
+                })
+              ),
+              {
+                relatedObjectType,
+                relatedObjectUuid: currentObjectUuid
+              }
+            ]
+
+            const attachmentInput = Attachment.filterClientSideFields(attachment)
+            attachmentInput.attachmentRelatedObjects = nextRelatedObjects
+
+            await API.mutation(GQL_UPDATE_ATTACHMENT, {
+              attachment: attachmentInput
+            })
+
+            return { linked: true, attachment }
+          } catch (linkError) {
+            return { error: true, attachment: selected, linkError }
+          }
+        })
+      )
+
+      const newlyLinked = results
+        .filter(r => r?.linked)
+        .map(r => r.attachment)
+
+      if (newlyLinked.length > 0) {
+        const merged = [...attachments]
+        newlyLinked.forEach(att => {
+          if (!merged.some(existing => existing.uuid === att.uuid)) {
+            merged.push(att)
+          }
+        })
+        updateAttachments(merged)
+        toast.success(`${newlyLinked.length} attachment(s) linked successfully`)
+      }
+
+
+      setLinkSelection([])
+    } catch (linkError) {
+      setError(linkError)
+    } finally {
+      setIsLinking(false)
+    }
+  }
+
   return (
     <div>
       <Messages error={error} />
@@ -199,6 +313,37 @@ const UploadAttachment = ({
           accept={mimeTypes}
           onChange={handleFileEvent}
         />
+      </section>
+
+      <section className="attachment-link-container">
+        <div className="attachment-link-header">
+          <Icon className="icon" size={20} icon={IconNames.LINK} />
+          <span>Link existing attachments</span>
+        </div>
+        <MultiTypeAdvancedSelectComponent
+          fieldName="linkExistingAttachments"
+          entityTypes={[ENTITY_TYPES.ATTACHMENTS]}
+          objectType={ENTITY_TYPES.ATTACHMENTS}
+          isMultiSelect
+          value={linkSelection}
+          onConfirm={value => setLinkSelection(value)}
+          className="attachment-link-select"
+        />
+        <div className="attachment-link-actions">
+          <Button
+            variant="outline-primary"
+            size="sm"
+            onClick={handleLinkAttachments}
+            disabled={isLinking || linkSelection.length === 0}
+          >
+            {isLinking ? "Linking..." : "Link selected"}
+          </Button>
+          {linkSelection.length > 0 && (
+            <span className="attachment-link-count">
+              Will link: {linkSelection.length} attachment(s)
+            </span>
+          )}
+        </div>
       </section>
 
       {/** **** Show uploaded files in here **** **/}

--- a/client/src/components/Attachment/UploadAttachment.tsx
+++ b/client/src/components/Attachment/UploadAttachment.tsx
@@ -430,7 +430,7 @@ const UploadAttachment = ({
             onClick={handleLinkAttachments}
             disabled={isLinking || linkSelection.length === 0}
           >
-            {isLinking ? "Linking..." : "Link selected"}
+            {isLinking ? "Linking..." : "Link selected attachments"}
           </Button>
           {linkSelection.length > 0 && (
             <Tooltip content={selectedSummary} position="top">

--- a/client/src/components/advancedSelectWidget/AdvancedSelect.css
+++ b/client/src/components/advancedSelectWidget/AdvancedSelect.css
@@ -45,3 +45,11 @@
 .advanced-select-popover > .bp6-overlay > .bp6-transition-container {
   width: 100%;
 }
+
+.advanced-select-row-disabled {
+  opacity: 0.5;
+}
+
+.advanced-select-row-disabled td {
+  cursor: not-allowed;
+}

--- a/client/src/components/advancedSelectWidget/AdvancedSelectOverlayTable.tsx
+++ b/client/src/components/advancedSelectWidget/AdvancedSelectOverlayTable.tsx
@@ -82,6 +82,9 @@ const AdvancedSelectOverlayTable = ({
               })
           return (
             <tr
+              className={
+                isDisabled ? "advanced-select-row-disabled" : undefined
+              }
               key={`${item.uuid}-${pageNum}-${i}`}
               onClick={handleClick}
               style={style}

--- a/client/src/components/advancedSelectWidget/MultiTypeAdvancedSelectComponent.tsx
+++ b/client/src/components/advancedSelectWidget/MultiTypeAdvancedSelectComponent.tsx
@@ -232,6 +232,7 @@ interface MultiTypeAdvancedSelectComponentProps {
   entityTypes: string[]
   value?: any | any[]
   valueKey?: string
+  disabledValue?: any | any[]
   isMultiSelect: boolean
   filters?: any[]
   className?: string
@@ -244,6 +245,7 @@ const MultiTypeAdvancedSelectComponent = ({
   entityTypes = COMMON_ENTITY_TYPES,
   value,
   valueKey,
+  disabledValue,
   isMultiSelect = false,
   filters = [],
   className
@@ -314,6 +316,7 @@ const MultiTypeAdvancedSelectComponent = ({
         placeholder={searchPlaceholder}
         value={value}
         valueKey={valueKey}
+        disabledValue={disabledValue}
         showEmbedded
         keepSearchText
         overlayColumns={advancedSelectProps.overlayColumns}

--- a/client/src/components/advancedSelectWidget/MultiTypeAdvancedSelectComponent.tsx
+++ b/client/src/components/advancedSelectWidget/MultiTypeAdvancedSelectComponent.tsx
@@ -129,11 +129,16 @@ const widgetPropsAuthorizationGroup = {
   addon: COMMUNITIES_ICON
 }
 
-const generateAttachmentFilters = (_, currentUser, mainObject) => {
+const generateAttachmentFilters = (
+  _,
+  currentUser,
+  mainObject,
+  options = {}
+) => {
   const filters = {}
-  if (mainObject?.uuid) {
+  if (mainObject?.uuid && !options.hideAttachedHereFilter) {
     filters.objectAttachments = {
-      label: "Attached here",
+      label: "Attached here",
       queryVars: {
         relatedObjectUuid: mainObject.uuid
       }
@@ -142,13 +147,13 @@ const generateAttachmentFilters = (_, currentUser, mainObject) => {
   return {
     ...filters,
     myAttachments: {
-      label: "My attachments",
+      label: "My attachments",
       queryVars: {
         authorUuid: currentUser?.uuid
       }
     },
     allAttachments: {
-      label: "All attachments"
+      label: "All attachments"
     }
   }
 }
@@ -236,6 +241,7 @@ interface MultiTypeAdvancedSelectComponentProps {
   isMultiSelect: boolean
   filters?: any[]
   className?: string
+  hideAttachedHereFilter?: boolean
 }
 
 const MultiTypeAdvancedSelectComponent = ({
@@ -248,7 +254,8 @@ const MultiTypeAdvancedSelectComponent = ({
   disabledValue,
   isMultiSelect = false,
   filters = [],
-  className
+  className,
+  hideAttachedHereFilter
 }: MultiTypeAdvancedSelectComponentProps) => {
   const { currentUser } = useContext(AppContext)
   const mainObject = useContext(AttachmentContext)
@@ -278,7 +285,9 @@ const MultiTypeAdvancedSelectComponent = ({
   const filterElement = filters?.find(f => f?.[entityType])?.[entityType] ?? {}
   const filterDefs =
     typeof advancedSelectProps.filterDefs === "function"
-      ? advancedSelectProps.filterDefs(filterElement, currentUser, mainObject)
+      ? advancedSelectProps.filterDefs(filterElement, currentUser, mainObject, {
+          hideAttachedHereFilter
+        })
       : { ...advancedSelectProps.filterDefs, ...filterElement }
 
   return (

--- a/client/tests/webdriver/baseSpecs/linkingAttachments.spec.js
+++ b/client/tests/webdriver/baseSpecs/linkingAttachments.spec.js
@@ -1,0 +1,55 @@
+import { expect } from "chai"
+import Home from "../pages/home.page"
+import ShowPerson from "../pages/showPerson.page"
+
+const ADMIN_PERSON_UUID = "b5d495af-44d5-4c35-851a-1039352a8307"
+const ADMIN_LINK_ATTACHMENT_UUID = "13318e42-a0a3-438f-8ed5-dc16b1ef17bc"
+const ADMIN_LINK_ATTACHMENT_CAPTION = "Erin"
+
+const REGULAR_PERSON_UUID = "a9d65d96-d107-45c3-bbaa-1133a354335b"
+const REGULAR_LINK_ATTACHMENT_UUID = "3187ad8a-6130-4ec0-bffc-9ebfad4dee39"
+const REGULAR_USER_CREDENTIALS = "elizabeth"
+const REGULAR_LINK_ATTACHMENT_CAPTION = "Michael"
+
+describe("Linking attachments", () => {
+  it("Admin can link and unlink an attachment", async () => {
+    await ShowPerson.openAsAdminUser(ADMIN_PERSON_UUID)
+    await ShowPerson.openAttachmentsEdit()
+    await ShowPerson.ensureAttachmentUnlinked(ADMIN_LINK_ATTACHMENT_UUID)
+
+    await ShowPerson.selectAttachmentToLink(ADMIN_LINK_ATTACHMENT_CAPTION)
+    await ShowPerson.linkSelectedAttachments()
+    await ShowPerson.waitForLinkToComplete()
+
+    await ShowPerson.unlinkAttachmentByUuid(ADMIN_LINK_ATTACHMENT_UUID)
+    await ShowPerson.waitForAttachmentToDisappear(ADMIN_LINK_ATTACHMENT_UUID)
+
+    await ShowPerson.logout()
+  })
+
+  it("Regular user can link/unlink but cannot delete unowned attachment", async () => {
+    await Home.open("/", REGULAR_USER_CREDENTIALS)
+    await ShowPerson.open(REGULAR_PERSON_UUID)
+    await ShowPerson.openAttachmentsEdit()
+    await ShowPerson.ensureAttachmentUnlinked(REGULAR_LINK_ATTACHMENT_UUID)
+
+    await ShowPerson.selectAttachmentToLink(REGULAR_LINK_ATTACHMENT_CAPTION)
+    await ShowPerson.linkSelectedAttachments()
+    await ShowPerson.waitForLinkToComplete()
+
+    await ShowPerson.attemptDeleteAttachmentByUuid(REGULAR_LINK_ATTACHMENT_UUID)
+
+    await browser.waitUntil(async () => {
+      return ShowPerson.attachmentCardExistsByUuid(REGULAR_LINK_ATTACHMENT_UUID)
+    })
+
+    await ShowPerson.unlinkAttachmentByUuid(REGULAR_LINK_ATTACHMENT_UUID)
+    await ShowPerson.waitForAttachmentToDisappear(REGULAR_LINK_ATTACHMENT_UUID)
+
+    expect(
+      await ShowPerson.attachmentCardExistsByUuid(REGULAR_LINK_ATTACHMENT_UUID)
+    ).to.equal(false)
+
+    await ShowPerson.logout()
+  })
+})

--- a/client/tests/webdriver/pages/showPerson.page.js
+++ b/client/tests/webdriver/pages/showPerson.page.js
@@ -55,6 +55,106 @@ class ShowPerson extends Page {
     return await browser.$("#edit-attachments")
   }
 
+  async openAttachmentsEdit() {
+    const edit = await this.getEditAttachmentsButton()
+    await edit.waitForDisplayed()
+    await edit.click()
+    await (await this.getAttachments()).waitForExist()
+  }
+
+  async selectAttachmentToLink(caption) {
+    const input = await browser.$('input[name="linkExistingAttachments"]')
+    await input.waitForDisplayed()
+    await input.click()
+    const popover = await browser.$("#linkExistingAttachments-popover")
+    await popover.waitForExist()
+    const allAttachmentsFilter = await browser.$(
+      '//div[@id="linkExistingAttachments-popover"]//button[text()="All attachments"]'
+    )
+    if (await allAttachmentsFilter.isExisting()) {
+      await allAttachmentsFilter.click()
+    } else {
+      const filterSelect = await browser.$(
+        "#linkExistingAttachments-popover select"
+      )
+      if (await filterSelect.isExisting()) {
+        await filterSelect.selectByVisibleText("All attachments")
+      }
+    }
+    await input.setValue(caption)
+    const row = await browser.$(
+      `//div[@id="linkExistingAttachments-popover"]//tbody//tr[.//td[contains(normalize-space(.), "${caption}")]]`
+    )
+    await row.waitForExist()
+    await row.click()
+  }
+
+  async linkSelectedAttachments() {
+    const button = await browser.$('//button[text()="Link selected"]')
+    await button.waitForEnabled()
+    await button.click()
+  }
+
+  async waitForLinkToComplete() {
+    const button = await browser.$('//button[text()="Link selected"]')
+    await browser.waitUntil(
+      async () => {
+        const text = await button.getText()
+        const countExists = await browser
+          .$(".attachment-link-count")
+          .isExisting()
+        return text === "Link selected" && !countExists
+      },
+      { timeout: 15000, timeoutMsg: "Expected link action to complete" }
+    )
+  }
+
+  async getAttachmentCardByUuid(uuid) {
+    const selector = `//div[contains(@class,"attachment-card")]//a[contains(@href,"/attachments/${uuid}/edit")]/ancestor::div[contains(@class,"attachment-card")]`
+    const card = await browser.$(selector)
+    await card.waitForExist({ timeout: 10000 })
+    return card
+  }
+
+  async attachmentCardExistsByUuid(uuid) {
+    const selector = `//div[contains(@class,"attachment-card")]//a[contains(@href,"/attachments/${uuid}/edit")]/ancestor::div[contains(@class,"attachment-card")]`
+    return (await browser.$(selector)).isExisting()
+  }
+
+  async unlinkAttachmentByUuid(uuid) {
+    const card = await this.getAttachmentCardByUuid(uuid)
+    const unlinkButton = await card.$('button[title^="Unlink from this"]')
+    await unlinkButton.waitForClickable()
+    await unlinkButton.click()
+  }
+
+  async waitForAttachmentToDisappear(uuid) {
+    await browser.waitUntil(
+      async () => !(await this.attachmentCardExistsByUuid(uuid)),
+      {
+        timeout: 15000,
+        timeoutMsg: `Expected attachment ${uuid} to be unlinked`
+      }
+    )
+  }
+
+  async ensureAttachmentUnlinked(uuid) {
+    if (await this.attachmentCardExistsByUuid(uuid)) {
+      await this.unlinkAttachmentByUuid(uuid)
+      await this.waitForAttachmentToDisappear(uuid)
+    }
+  }
+
+  async attemptDeleteAttachmentByUuid(uuid) {
+    const card = await this.getAttachmentCardByUuid(uuid)
+    const deleteButton = await card.$("button.btn-outline-danger")
+    await deleteButton.waitForDisplayed()
+    await deleteButton.click()
+    const confirm = await this.getDeleteConfirmButton()
+    await confirm.waitForDisplayed()
+    await confirm.click()
+  }
+
   async getDefaultPreset() {
     return browser.$('//a[text()="Default"]')
   }

--- a/client/tests/webdriver/pages/showPerson.page.js
+++ b/client/tests/webdriver/pages/showPerson.page.js
@@ -90,20 +90,24 @@ class ShowPerson extends Page {
   }
 
   async linkSelectedAttachments() {
-    const button = await browser.$('//button[text()="Link selected"]')
+    const button = await browser.$(
+      '//button[text()="Link selected attachments"]'
+    )
     await button.waitForEnabled()
     await button.click()
   }
 
   async waitForLinkToComplete() {
-    const button = await browser.$('//button[text()="Link selected"]')
+    const button = await browser.$(
+      '//button[text()="Link selected attachments"]'
+    )
     await browser.waitUntil(
       async () => {
         const text = await button.getText()
         const countExists = await browser
           .$(".attachment-link-count")
           .isExisting()
-        return text === "Link selected" && !countExists
+        return text === "Link selected attachments" && !countExists
       },
       { timeout: 15000, timeoutMsg: "Expected link action to complete" }
     )

--- a/src/main/java/mil/dds/anet/resources/AttachmentResource.java
+++ b/src/main/java/mil/dds/anet/resources/AttachmentResource.java
@@ -187,11 +187,16 @@ public class AttachmentResource {
     final boolean isAuthor = Objects.equals(existing.getAuthorUuid(), DaoUtils.getUuid(user));
     final boolean canEditMetadata = isAdmin || isAuthor;
     final boolean hasRelatedObjectsUpdate = attachment.getAttachmentRelatedObjects() != null;
+    final boolean hasMetadataChanges = hasAttachmentMetadataChanges(attachment, existing);
 
     if (!canEditMetadata) {
       final var attachmentSettings = getAttachmentSettings();
       final Boolean restrictToAdmins = (Boolean) attachmentSettings.get("restrictToAdmins");
       if (Boolean.TRUE.equals(restrictToAdmins) && !isAdmin) {
+        throw new ResponseStatusException(HttpStatus.FORBIDDEN,
+            "You don't have permission to update this attachment");
+      }
+      if (hasMetadataChanges) {
         throw new ResponseStatusException(HttpStatus.FORBIDDEN,
             "You don't have permission to update this attachment");
       }
@@ -292,6 +297,15 @@ public class AttachmentResource {
       Attachment attachment) {
     return ContentDisposition.builder(disposition)
         .filename(attachment.getFileName(), StandardCharsets.UTF_8).build();
+  }
+
+  private boolean hasAttachmentMetadataChanges(final Attachment attachment,
+      final Attachment existing) {
+    return !Objects.equals(attachment.getFileName(), existing.getFileName())
+        || !Objects.equals(attachment.getMimeType(), existing.getMimeType())
+        || !Objects.equals(attachment.getDescription(), existing.getDescription())
+        || !Objects.equals(attachment.getClassification(), existing.getClassification())
+        || !Objects.equals(attachment.getCaption(), existing.getCaption());
   }
 
   private void assertAllowedRelatedObjects(final Person user,

--- a/src/main/java/mil/dds/anet/resources/AttachmentResource.java
+++ b/src/main/java/mil/dds/anet/resources/AttachmentResource.java
@@ -181,19 +181,36 @@ public class AttachmentResource {
     assertAttachmentEnabled();
     final Person user = DaoUtils.getUserFromContext(context);
     final Attachment existing = getAttachment(DaoUtils.getUuid(attachment));
-    assertAttachmentPermission(user, existing,
-        "You don't have permission to update this attachment");
     DaoUtils.assertObjectIsFresh(attachment, existing, force);
 
-    assertAllowedMimeType(attachment.getMimeType());
-    ResourceUtils.assertAllowedClassification(attachment.getClassification());
+    final boolean isAdmin = AuthUtils.isAdmin(user);
+    final boolean isAuthor = Objects.equals(existing.getAuthorUuid(), DaoUtils.getUuid(user));
+    final boolean canEditMetadata = isAdmin || isAuthor;
+    final boolean hasRelatedObjectsUpdate = attachment.getAttachmentRelatedObjects() != null;
 
-    final int numRows = dao.update(attachment);
-    if (numRows == 0) {
-      throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Couldn't process attachment update");
+    if (!canEditMetadata) {
+      final var attachmentSettings = getAttachmentSettings();
+      final Boolean restrictToAdmins = (Boolean) attachmentSettings.get("restrictToAdmins");
+      if (Boolean.TRUE.equals(restrictToAdmins) && !isAdmin) {
+        throw new ResponseStatusException(HttpStatus.FORBIDDEN,
+            "You don't have permission to update this attachment");
+      }
+      if (!hasRelatedObjectsUpdate) {
+        throw new ResponseStatusException(HttpStatus.FORBIDDEN,
+            "You don't have permission to update this attachment");
+      }
+    } else {
+      assertAllowedMimeType(attachment.getMimeType());
+      ResourceUtils.assertAllowedClassification(attachment.getClassification());
+
+      final int numRows = dao.update(attachment);
+      if (numRows == 0) {
+        throw new ResponseStatusException(HttpStatus.NOT_FOUND,
+            "Could not process attachment update");
+      }
     }
 
-    if (attachment.getAttachmentRelatedObjects() != null) {
+    if (hasRelatedObjectsUpdate) {
       logger.debug("Editing related objects for {}", attachment);
       final List<GenericRelatedObject> existingRelatedObjects =
           existing.loadAttachmentRelatedObjects(engine.getContext()).join();

--- a/src/main/java/mil/dds/anet/resources/AttachmentResource.java
+++ b/src/main/java/mil/dds/anet/resources/AttachmentResource.java
@@ -187,11 +187,16 @@ public class AttachmentResource {
     final boolean isAuthor = Objects.equals(existing.getAuthorUuid(), DaoUtils.getUuid(user));
     final boolean canEditMetadata = isAdmin || isAuthor;
     final boolean hasRelatedObjectsUpdate = attachment.getAttachmentRelatedObjects() != null;
+    final boolean hasMetadataChanges = hasAttachmentMetadataChanges(attachment, existing);
 
     if (!canEditMetadata) {
       final var attachmentSettings = getAttachmentSettings();
       final Boolean restrictToAdmins = (Boolean) attachmentSettings.get("restrictToAdmins");
       if (Boolean.TRUE.equals(restrictToAdmins) && !isAdmin) {
+        throw new ResponseStatusException(HttpStatus.FORBIDDEN,
+            "You don't have permission to update this attachment");
+      }
+      if (hasMetadataChanges) {
         throw new ResponseStatusException(HttpStatus.FORBIDDEN,
             "You don't have permission to update this attachment");
       }
@@ -302,6 +307,15 @@ public class AttachmentResource {
       Attachment attachment) {
     return ContentDisposition.builder(disposition)
         .filename(attachment.getFileName(), StandardCharsets.UTF_8).build();
+  }
+
+  private boolean hasAttachmentMetadataChanges(final Attachment attachment,
+      final Attachment existing) {
+    return !Objects.equals(attachment.getFileName(), existing.getFileName())
+        || !Objects.equals(attachment.getMimeType(), existing.getMimeType())
+        || !Objects.equals(attachment.getDescription(), existing.getDescription())
+        || !Objects.equals(attachment.getClassification(), existing.getClassification())
+        || !Objects.equals(attachment.getCaption(), existing.getCaption());
   }
 
   private void assertAllowedRelatedObjects(final Person user,


### PR DESCRIPTION
Adds UI support to link existing attachments from edit forms.
Also adds a more flexible server-side permission checks so non-owners of attachments can link them to objects.

Closes [AB#1094](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1094)

#### User changes
- Users can link existing attachments to objects they can edit.
- Non-owners can link/unlink visible attachments but cannot delete or edit metadata.

#### Superuser changes
- None

#### Admin changes
- None

#### System admin changes
- [ ] application.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
- [x] described the user behavior in PR body
- [x] referenced/updated all related issues
- [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
- [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
- [ ] added and/or updated unit tests
- [x] added and/or updated e2e tests
- [ ] added and/or updated data migrations
- [ ] updated documentation
- [x] resolved all build errors and warnings
- [ ] opened debt issues for anything not resolved here
