### PR TITLE
Add tasks to generate SBOMs and VDRs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 import com.bmuschko.gradle.docker.tasks.container.*
 import com.bmuschko.gradle.docker.tasks.image.*
 import io.mateo.cxf.codegen.wsdl2java.Wsdl2Java
+import org.gradle.internal.os.OperatingSystem
 import org.springframework.boot.gradle.plugin.SpringBootPlugin
 
 plugins {
@@ -13,6 +14,7 @@ plugins {
 	id "com.netflix.nebula.rpm" version "12.3.0"
 	id "org.springframework.boot" version "4.0.5" apply false
 	id 'io.mateo.cxf-codegen' version '2.5.0'
+	id 'org.cyclonedx.bom' version '3.2.4'
 }
 
 apply plugin: 'java'
@@ -50,6 +52,8 @@ if (!isTestEnv && file('localSettings.gradle').exists()) {
 // Defaults for development variables
 String DEV_DB = "devAnet"
 String TEST_DB = "testAnet"
+// Allows you to use `env VDR_FORMAT=table ./gradlew generateVdr` to see a human-readable VDR table:
+run.environment("VDR_FORMAT", run.environment["VDR_FORMAT"] ?: "cyclonedx-json")
 run.environment("KEYCLOAK_VERSION", run.environment["KEYCLOAK_VERSION"] ?: "latest")
 run.environment("DB_DRIVER", run.environment["DB_DRIVER"] ?: "postgresql")
 run.environment("DB_VERSION", run.environment["DB_VERSION"] ?: "latest")
@@ -306,6 +310,56 @@ if (run.environment['DB_DRIVER'] == "sqlserver") {
 }
 
 test.environment = run.environment
+
+cyclonedxDirectBom {
+	projectType = org.cyclonedx.model.Component.Type.APPLICATION
+	includeConfigs = ["runtimeClasspath"]
+	xmlOutput.unsetConvention()
+	jsonOutput.set(file("build/reports/SBOM/server-side-bom.json"))
+}
+
+tasks.register('generateVdr') {
+	dependsOn 'checkGrype', 'generateServerSideVdr', 'generateClientSideVdr'
+}
+
+tasks.register('checkGrype', Exec) {
+	def cmd = 'grype'
+	commandLine cmd, '--version'
+	doFirst {
+		def exe = OperatingSystem.current().findInPath(cmd)
+		if (exe == null) {
+			throw new GradleException("${cmd} not found, install with e.g.:\ncurl -sSfL https://get.anchore.io/grype | sh -s -- -b ~/bin")
+		} else {
+			println "Found ${exe.absolutePath} with version:"
+		}
+	}
+}
+
+tasks.register('generateServerSideVdr', Exec) {
+	dependsOn 'cyclonedxDirectBom'
+	doNotTrackState("Needs to re-run every time")
+	def dir = './build/reports'
+	commandLine 'grype', "sbom:${dir}/SBOM/server-side-bom.json", '--output', "${run.environment['VDR_FORMAT']}"
+	outputs.dir "${dir}/VDR"
+	doFirst {
+		if (run.environment['VDR_FORMAT'] != "table") {
+			standardOutput new FileOutputStream("${dir}/VDR/server-side-vdr.json")
+		}
+	}
+}
+
+tasks.register('generateClientSideVdr', Exec) {
+	dependsOn 'yarn_run_generate-sbom'
+	doNotTrackState("Needs to re-run every time")
+	def dir = './client/build/reports'
+	commandLine 'grype', "sbom:${dir}/SBOM/client-side-bom.json", '--output', "${run.environment['VDR_FORMAT']}"
+	outputs.dir "${dir}/VDR"
+	doFirst {
+		if (run.environment['VDR_FORMAT'] != "table") {
+			standardOutput new FileOutputStream("${dir}/VDR/client-side-vdr.json")
+		}
+	}
+}
 
 cxfCodegen {
 	cxfVersion = "${cxfVersion}"

--- a/client/package.json
+++ b/client/package.json
@@ -30,6 +30,7 @@
     "@babel/register": "7.28.6",
     "@babel/runtime": "7.29.2",
     "@colors/colors": "1.6.0",
+    "@cyclonedx/yarn-plugin-cyclonedx": "3.3.1",
     "@faker-js/faker": "10.4.0",
     "@fregante/circular-dependency-plugin": "5.2.5",
     "@graphql-codegen/cli": "6.2.1",
@@ -209,6 +210,7 @@
     "test-wdio-noCF-junit": "yarn run test-wdio-noCF ; e=$? ; yarn run wdio-noCF-junit-merge ; exit $e",
     "wdio-noCF-junit-merge": "bash -c './combine-test-results.sh ./build/test-results/wdio/*.xml > ./build/test-results/wdio-noCF-junit-test-results.xml'",
     "server-junit-merge": "bash -c './combine-test-results.sh ../build/test-results/test/*.xml > ./build/test-results/server-test-results.xml'",
+    "generate-sbom": "yarn run cyclonedx-yarn --prod --mc-type application --output-format JSON --output-file build/reports/SBOM/client-side-bom.json",
     "generate-graphql-schema": "graphql-codegen -p anet -c .graphqlconfig.mjs",
     "sim": "NODE_ENV=development webpack --config config/webpack.sim.dev.cjs && ANET_DICTIONARY=../${ANET_DICTIONARY_NAME:-anet-dictionary.yml} SERVER_URL=${SERVER_URL:-'http://localhost:8080'} node build/anet.sim.dev.cjs"
   },

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -1738,6 +1738,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@cyclonedx/yarn-plugin-cyclonedx@npm:3.3.1":
+  version: 3.3.1
+  resolution: "@cyclonedx/yarn-plugin-cyclonedx@npm:3.3.1"
+  bin:
+    cyclonedx-yarn: bin/cyclonedx-yarn-cli.js
+  checksum: 10c0/d0747f5db7f0e7abe18e67a8e3f23bd7a251bc3151a68cabc64fc7bb381ccd2a96f1a7c63249dc37d5f96993550ad6bf2a3c1851f2658d390018e5c7562086c8
+  languageName: node
+  linkType: hard
+
 "@discoveryjs/json-ext@npm:^1.0.0":
   version: 1.0.0
   resolution: "@discoveryjs/json-ext@npm:1.0.0"
@@ -7240,6 +7249,7 @@ __metadata:
     "@blueprintjs/core": "npm:6.11.3"
     "@blueprintjs/datetime": "npm:6.0.23"
     "@colors/colors": "npm:1.6.0"
+    "@cyclonedx/yarn-plugin-cyclonedx": "npm:3.3.1"
     "@emotion/react": "npm:11.14.0"
     "@emotion/styled": "npm:11.14.1"
     "@faker-js/faker": "npm:10.4.0"


### PR DESCRIPTION
SBOMs are generated with CycloneDX; VDRs are generated with Grype.

To generate human-readable output:
```bash
env VDR_FORMAT=table ./gradlew generateVdr
```
(it will tell you to install Grype if it is missing from your PATH)