### PR TITLE
Have the draft text on the print report draw over attachments

### DIFF
--- a/client/src/components/Compact.tsx
+++ b/client/src/components/Compact.tsx
@@ -79,7 +79,7 @@ const CompactViewS = styled.div`
   width: ${props => props.pageSize.width};
   &:before {
     content: "${props => props.backgroundText}";
-    z-index: -1000;
+    z-index: 1000;
     position: absolute;
     font-weight: 100;
     top: 40%;


### PR DESCRIPTION
DRAFT text was being displayed below image attachments.

Closes [AB#1556](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1556)

#### User changes
- Should view the draft text on the print report being drawn over attachments

#### Superuser changes
- None

#### Admin changes
- None

#### System admin changes
- [ ] application.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
- [x] described the user behavior in PR body
- [x] referenced/updated all related issues
- [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
- [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
- [ ] added and/or updated unit tests
- [ ] added and/or updated e2e tests
- [ ] added and/or updated data migrations
- [ ] updated documentation
- [ ] resolved all build errors and warnings
- [ ] opened debt issues for anything not resolved here
