### PR TITLE
Ask for confirmation before deleting event type

### DIFF
--- a/client/src/pages/admin/configureEventTypes/EventTypeTable.tsx
+++ b/client/src/pages/admin/configureEventTypes/EventTypeTable.tsx
@@ -4,6 +4,7 @@ import { Icon } from "@blueprintjs/core"
 import { IconNames } from "@blueprintjs/icons"
 import { SEARCH_OBJECT_TYPES, setSearchQuery } from "actions"
 import API from "api"
+import ConfirmDestructive from "components/ConfirmDestructive"
 import Fieldset from "components/Fieldset"
 import { MessagesWithConflict } from "components/Messages"
 import Model from "components/Model"
@@ -207,11 +208,17 @@ const EventTypeTable = ({
                           ? "Deactivate"
                           : "Activate"}
                       </Button>
-                      <RemoveButton
-                        title="Delete event type"
-                        onClick={() => deleteEventType(eventType.uuid)}
-                        disabled={eventType.relatedEventsCount > 0}
-                      />
+                      <ConfirmDestructive
+                        onConfirm={() => deleteEventType(eventType.uuid)}
+                        objectType="event type"
+                        objectDisplay={eventType.name}
+                        variant="outline-danger"
+                        buttonSize="xs"
+                        buttonTitle="Delete event type"
+                        buttonDisabled={eventType.relatedEventsCount > 0}
+                      >
+                        <Icon icon={IconNames.TRASH} />
+                      </ConfirmDestructive>
                     </div>
                   </td>
                 </tr>


### PR DESCRIPTION
For consistency with other delete actions, also ask for confirmation when deleting an (unused) event type.

Closes [AB#1606](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1606)

#### User changes
- None

#### Superuser changes
- None

#### Admin changes
- Admins now have to confirm whether they really want to delete an event type.

#### System admin changes
- [ ] application.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
- [x] described the user behavior in PR body
- [x] referenced/updated all related issues
- [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
- [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
- [ ] added and/or updated unit tests
- [ ] added and/or updated e2e tests
- [ ] added and/or updated data migrations
- [ ] updated documentation
- [x] resolved all build errors and warnings
- [ ] opened debt issues for anything not resolved here