### PR TITLE
Make pendingAssessmentsNotification template more robust

### DIFF
--- a/src/main/resources/emails/pendingAssessmentsNotification.ftlh
+++ b/src/main/resources/emails/pendingAssessmentsNotification.ftlh
@@ -30,11 +30,11 @@
     <ul>
       <#list positions as position>
         <li>
-          <a href="${serverUrl}/people/${position.person.uuid}">
-            ${(position.person.rank)!} ${(position.person.name)!}, ${(position.name)!}
+          <a href="${serverUrl}/people/${(position.person.uuid)!}">
+            ${(position.person.objectLabel)!}, ${(position.objectLabel)!}
             <#assign organization = (position.loadOrganization(context).get())!>
             <#if organization.uuid??>
-              @ ${(organization.shortName)!}
+              @ ${(organization.objectLabel)!}
             </#if>
           </a>
         </li>


### PR DESCRIPTION
Prevent errors in the unlikely event a position is no longer filled when processing the email. Also use the specific object labels for person, position and organisation.