### PR TITLE
Make first row and column in Sync Matrix stay sticky

### DIFF
--- a/client/src/components/EventMatrix.tsx
+++ b/client/src/components/EventMatrix.tsx
@@ -582,9 +582,7 @@ const EventMatrix = ({
               </tr>
               {_isEmpty(includedEventSeries) ? (
                 <tr className="event-series-row">
-                  <td colSpan={periodDays.length + 1}>
-                    No matching Event Series
-                  </td>
+                  <td>No matching Event Series</td>
                 </tr>
               ) : (
                 includedEventSeries.map(es => {
@@ -622,9 +620,7 @@ const EventMatrix = ({
               </tr>
               {_isEmpty(includedTasks) ? (
                 <tr className="event-series-task-row">
-                  <td colSpan={periodDays.length + 1}>
-                    No matching {Settings.fields.task.shortLabel}
-                  </td>
+                  <td>No matching {Settings.fields.task.shortLabel}</td>
                 </tr>
               ) : (
                 includedTasks.map(task => {

--- a/client/src/components/EventMatrix.tsx
+++ b/client/src/components/EventMatrix.tsx
@@ -4,7 +4,10 @@ import {
   gqlPreferenceFields
 } from "constants/GraphQLDefinitions"
 import { gql } from "@apollo/client"
+import { Icon, Tooltip } from "@blueprintjs/core"
+import { IconNames } from "@blueprintjs/icons"
 import API from "api"
+import classNames from "classnames"
 import { buildTree } from "components/advancedSelectWidget/utils"
 import AppContext from "components/AppContext"
 import { BreadcrumbTrail } from "components/BreadcrumbTrail"
@@ -21,6 +24,7 @@ import {
   CATEGORY_SYNC_MATRIX,
   NAME_SYNC_MATRIX_PERIOD
 } from "components/preferences/PreferencesFieldSet"
+import ResponsiveLayoutContext from "components/ResponsiveLayoutContext"
 import _isEmpty from "lodash/isEmpty"
 import moment from "moment/moment"
 import React, { useContext, useEffect, useMemo, useRef, useState } from "react"
@@ -145,12 +149,14 @@ const EventMatrix = ({
 }: EventMatrixProps) => {
   const scrollContainerRef = useRef<HTMLDivElement | null>(null)
   const { currentUser } = useContext(AppContext)
+  const { securityBannerOffset } = useContext(ResponsiveLayoutContext)
   const [periodLengthInDays, setPeriodLengthInDays] = useState<number>(0)
   const [startDay, setStartDay] = useState(moment())
   const [periodDays, setPeriodDays] = useState([])
   const [events, setEvents] = useState([])
   const [reports, setReports] = useState([])
   const [fetchError, setFetchError] = useState(null)
+  const [isFullScreen, setIsFullScreen] = useState(false)
   const includeTask = !!taskUuid
 
   useEffect(() => {
@@ -485,191 +491,214 @@ const EventMatrix = ({
   return (
     <>
       <Messages error={fetchError} />
-      <div className="float-start w-100 pb-3">
-        <div className="rollup-date-range-container d-flex align-items-end gap-2">
-          <div className="form-group" style={{ width: "170px" }}>
-            <label className="form-label text-start mb-0">
-              <div>Period in days</div>
-              <input
-                type="number"
-                min={1}
-                value={periodLengthInDays}
-                onChange={e => setPeriodLengthInDays(Number(e.target.value))}
-                className="form-control"
-              />
-            </label>
-          </div>
+      <div
+        className={classNames("event-matrix-panel", {
+          fullscreen: isFullScreen
+        })}
+        style={{
+          ["--banner-height" as any]: `${securityBannerOffset}px`
+        }}
+      >
+        <div className="float-start w-100 pb-3">
+          <div className="rollup-date-range-container d-flex align-items-end gap-2">
+            <div className="form-group" style={{ width: "170px" }}>
+              <label className="form-label text-start mb-0">
+                <div>Period in days</div>
+                <input
+                  type="number"
+                  min={1}
+                  value={periodLengthInDays}
+                  onChange={e => setPeriodLengthInDays(Number(e.target.value))}
+                  className="form-control"
+                />
+              </label>
+            </div>
 
-          <div className="form-group" style={{ width: "170px" }}>
-            <label className="form-label text-start mb-0">
-              <div>Start day</div>
-              <CustomDateInput
-                showIcon={false}
-                placement="right"
-                value={startDay?.toDate()}
-                onChange={v => setStartDay(moment(v))}
-              />
-            </label>
-          </div>
-          <Button
-            id="previous-period"
-            variant="outline-secondary"
-            onClick={() => shiftPeriod(-periodLengthInDays)}
-          >
-            -1 period
-          </Button>
-          <Button
-            id="previous-week"
-            variant="outline-secondary"
-            onClick={() => shiftPeriod(-7)}
-          >
-            -1 week
-          </Button>
-          <Button
-            id="previous-day"
-            variant="outline-secondary"
-            onClick={() => shiftPeriod(-1)}
-          >
-            -1 day
-          </Button>
-          <Button
-            id="next-day"
-            variant="outline-secondary"
-            onClick={() => shiftPeriod(1)}
-          >
-            +1 day
-          </Button>
-          <Button
-            id="next-week"
-            variant="outline-secondary"
-            onClick={() => shiftPeriod(7)}
-          >
-            +1 week
-          </Button>
-          <Button
-            id="next-period"
-            variant="outline-secondary"
-            onClick={() => shiftPeriod(periodLengthInDays)}
-          >
-            +1 period
-          </Button>
+            <div className="form-group" style={{ width: "170px" }}>
+              <label className="form-label text-start mb-0">
+                <div>Start day</div>
+                <CustomDateInput
+                  showIcon={false}
+                  placement="right"
+                  value={startDay?.toDate()}
+                  onChange={v => setStartDay(moment(v))}
+                />
+              </label>
+            </div>
+            <Button
+              id="previous-period"
+              variant="outline-secondary"
+              onClick={() => shiftPeriod(-periodLengthInDays)}
+            >
+              -1 period
+            </Button>
+            <Button
+              id="previous-week"
+              variant="outline-secondary"
+              onClick={() => shiftPeriod(-7)}
+            >
+              -1 week
+            </Button>
+            <Button
+              id="previous-day"
+              variant="outline-secondary"
+              onClick={() => shiftPeriod(-1)}
+            >
+              -1 day
+            </Button>
+            <Button
+              id="next-day"
+              variant="outline-secondary"
+              onClick={() => shiftPeriod(1)}
+            >
+              +1 day
+            </Button>
+            <Button
+              id="next-week"
+              variant="outline-secondary"
+              onClick={() => shiftPeriod(7)}
+            >
+              +1 week
+            </Button>
+            <Button
+              id="next-period"
+              variant="outline-secondary"
+              onClick={() => shiftPeriod(periodLengthInDays)}
+            >
+              +1 period
+            </Button>
 
-          {emptyMsgComponent}
+            {emptyMsgComponent}
+            <div className="ms-auto">
+              <Tooltip
+                content={
+                  isFullScreen ? "Exit fullscreen" : "View in fullscreen"
+                }
+              >
+                <Button
+                  variant="outline-secondary"
+                  onClick={() => setIsFullScreen(prev => !prev)}
+                >
+                  <Icon
+                    icon={
+                      isFullScreen ? IconNames.MINIMIZE : IconNames.FULLSCREEN
+                    }
+                  />
+                </Button>
+              </Tooltip>
+            </div>
+          </div>
         </div>
-      </div>
-      <div style={{ clear: "both", marginTop: "1rem" }}>
-        <div
-          ref={scrollContainerRef}
-          style={{
-            overflow: "auto",
-            whiteSpace: "nowrap",
-            width: "100%",
-            maxHeight: "calc(100vh - 250px)"
-          }}
-        >
-          <Table
-            className="event-matrix"
-            hover
-            id="events-matrix"
-            style={{ minWidth: `${periodDays.length * 250}px` }}
+        <div style={{ clear: "both", marginTop: "1rem" }}>
+          <div
+            ref={scrollContainerRef}
+            style={{ overflowX: "auto", whiteSpace: "nowrap", width: "100%" }}
           >
-            <tbody>
-              <tr id="event-series-table-header" className="table-primary">
-                <th>Event Series</th>
-                {periodDays.map(weekDay => (
-                  <th key={weekDay} style={{ minWidth: "120px" }}>
-                    {weekDay.format("YYYY-MM-DD")}
-                    <br />
-                    {weekDay.format("dddd")}
-                  </th>
-                ))}
-              </tr>
-              {_isEmpty(includedEventSeries) ? (
-                <tr className="event-series-row">
-                  <td>No matching Event Series</td>
-                  <td colSpan={periodDays.length} />
+            <Table
+              className="event-matrix"
+              hover
+              id="events-matrix"
+              style={{ minWidth: `${periodDays.length * 250}px` }}
+            >
+              <tbody>
+                <tr id="event-series-table-header" className="table-primary">
+                  <th>Event Series</th>
+                  {periodDays.map(weekDay => (
+                    <th key={weekDay} style={{ minWidth: "120px" }}>
+                      {weekDay.format("YYYY-MM-DD")}
+                      <br />
+                      {weekDay.format("dddd")}
+                    </th>
+                  ))}
                 </tr>
-              ) : (
-                includedEventSeries.map(es => {
-                  const eventSeriesEvents = events.filter(
-                    e => e.eventSeries?.uuid === es.uuid
-                  )
-                  return (
-                    <tr key={es.uuid} className="event-series-row">
-                      <td
-                        style={{
-                          whiteSpace: "nowrap",
-                          overflow: "hidden",
-                          textOverflow: "ellipsis"
-                        }}
-                      >
-                        <LinkTo modelType="EventSeries" model={es} />
-                      </td>
-                      {periodDays.map((p, idx) => (
-                        <td key={p}>{getEvent(eventSeriesEvents, idx)}</td>
-                      ))}
-                    </tr>
-                  )
-                })
-              )}
-            </tbody>
-            <tbody>
-              <tr id="tasks-table-header" className="table-primary">
-                <th>{Settings.fields.task.shortLabel}</th>
-                {periodDays.map(weekDay => (
-                  <th key={weekDay} style={{ width: "12%" }}>
-                    {weekDay.format("YYYY-MM-DD")}
-                    <br />
-                    {weekDay.format("dddd")}
-                  </th>
-                ))}
-              </tr>
-              {_isEmpty(includedTasks) ? (
-                <tr className="event-series-task-row">
-                  <td>No matching {Settings.fields.task.shortLabel}</td>
-                  <td colSpan={periodDays.length} />
+                {_isEmpty(includedEventSeries) ? (
+                  <tr className="event-series-row">
+                    <td>No matching Event Series</td>
+                    <td colSpan={periodDays.length} />
+                  </tr>
+                ) : (
+                  includedEventSeries.map(es => {
+                    const eventSeriesEvents = events.filter(
+                      e => e.eventSeries?.uuid === es.uuid
+                    )
+                    return (
+                      <tr key={es.uuid} className="event-series-row">
+                        <td
+                          style={{
+                            whiteSpace: "nowrap",
+                            overflow: "hidden",
+                            textOverflow: "ellipsis"
+                          }}
+                        >
+                          <LinkTo modelType="EventSeries" model={es} />
+                        </td>
+                        {periodDays.map((p, idx) => (
+                          <td key={p}>{getEvent(eventSeriesEvents, idx)}</td>
+                        ))}
+                      </tr>
+                    )
+                  })
+                )}
+
+                <tr id="tasks-table-header" className="table-primary">
+                  <th>{Settings.fields.task.shortLabel}</th>
+                  {periodDays.map(weekDay => (
+                    <th key={weekDay} style={{ width: "12%" }}>
+                      {weekDay.format("YYYY-MM-DD")}
+                      <br />
+                      {weekDay.format("dddd")}
+                    </th>
+                  ))}
                 </tr>
-              ) : (
-                includedTasks.map(task => {
-                  const taskEvents = events.filter(e => hasTask(e.tasks, task))
-                  const hideParents = includeTask
-                    ? task.uuid !== taskUuid
-                    : !!task.parentTask?.uuid
-                  const ascendantTasks = task.ascendantTasks || [task]
-                  const ascendantTaskUuids = new Set(
-                    hideParents ? ascendantTasks.map(t => t.uuid) : [taskUuid]
-                  )
-                  const paddingLeft = Math.min(task.level * 20, 200)
-                  const linkWidth =
-                    300 - paddingLeft - (task.level === 0 ? 0 : 30)
+                {_isEmpty(includedTasks) ? (
+                  <tr className="event-series-task-row">
+                    <td>No matching {Settings.fields.task.shortLabel}</td>
+                    <td colSpan={periodDays.length} />
+                  </tr>
+                ) : (
+                  includedTasks.map(task => {
+                    const taskEvents = events.filter(e =>
+                      hasTask(e.tasks, task)
+                    )
+                    const hideParents = includeTask
+                      ? task.uuid !== taskUuid
+                      : !!task.parentTask?.uuid
+                    const ascendantTasks = task.ascendantTasks || [task]
+                    const ascendantTaskUuids = new Set(
+                      hideParents ? ascendantTasks.map(t => t.uuid) : [taskUuid]
+                    )
+                    const paddingLeft = Math.min(task.level * 20, 200)
+                    const linkWidth =
+                      300 - paddingLeft - (task.level === 0 ? 0 : 30)
 
-                  return (
-                    <tr key={task.uuid} className="event-series-task-row">
-                      <td
-                        style={{
-                          paddingLeft: `${paddingLeft}px`,
-                          ["--task-link-width" as any]: `${linkWidth}px`
-                        }}
-                      >
-                        <BreadcrumbTrail
-                          modelType="Task"
-                          leaf={task}
-                          ascendantObjects={ascendantTasks}
-                          parentField="parentTask"
-                          hideParents={hideParents}
-                          ascendantTaskUuids={ascendantTaskUuids}
-                        />
-                      </td>
+                    return (
+                      <tr key={task.uuid} className="event-series-task-row">
+                        <td
+                          style={{
+                            paddingLeft: `${paddingLeft}px`,
+                            ["--task-link-width" as any]: `${linkWidth}px`
+                          }}
+                        >
+                          <BreadcrumbTrail
+                            modelType="Task"
+                            leaf={task}
+                            ascendantObjects={ascendantTasks}
+                            parentField="parentTask"
+                            hideParents={hideParents}
+                            ascendantTaskUuids={ascendantTaskUuids}
+                          />
+                        </td>
 
-                      {periodDays.map((p, idx) => (
-                        <td key={p}>{getEvent(taskEvents, idx, task)}</td>
-                      ))}
-                    </tr>
-                  )
-                })
-              )}
-            </tbody>
-          </Table>
+                        {periodDays.map((p, idx) => (
+                          <td key={p}>{getEvent(taskEvents, idx, task)}</td>
+                        ))}
+                      </tr>
+                    )
+                  })
+                )}
+              </tbody>
+            </Table>
+          </div>
         </div>
       </div>
     </>

--- a/client/src/components/EventMatrix.tsx
+++ b/client/src/components/EventMatrix.tsx
@@ -587,6 +587,7 @@ const EventMatrix = ({
               {_isEmpty(includedEventSeries) ? (
                 <tr className="event-series-row">
                   <td>No matching Event Series</td>
+                  <td colSpan={periodDays.length} />
                 </tr>
               ) : (
                 includedEventSeries.map(es => {
@@ -626,6 +627,7 @@ const EventMatrix = ({
               {_isEmpty(includedTasks) ? (
                 <tr className="event-series-task-row">
                   <td>No matching {Settings.fields.task.shortLabel}</td>
+                  <td colSpan={periodDays.length} />
                 </tr>
               ) : (
                 includedTasks.map(task => {

--- a/client/src/components/EventMatrix.tsx
+++ b/client/src/components/EventMatrix.tsx
@@ -485,7 +485,7 @@ const EventMatrix = ({
   return (
     <>
       <Messages error={fetchError} />
-      <div className="float-start">
+      <div className="float-start w-100 pb-3">
         <div className="rollup-date-range-container d-flex align-items-end gap-2">
           <div className="form-group" style={{ width: "170px" }}>
             <label className="form-label text-start mb-0">
@@ -560,11 +560,15 @@ const EventMatrix = ({
       <div style={{ clear: "both", marginTop: "1rem" }}>
         <div
           ref={scrollContainerRef}
-          style={{ overflowX: "auto", whiteSpace: "nowrap", width: "100%" }}
+          style={{
+            overflow: "auto",
+            whiteSpace: "nowrap",
+            width: "100%",
+            maxHeight: "calc(100vh - 250px)"
+          }}
         >
           <Table
             className="event-matrix"
-            responsive
             hover
             id="events-matrix"
             style={{ minWidth: `${periodDays.length * 250}px` }}
@@ -607,7 +611,8 @@ const EventMatrix = ({
                   )
                 })
               )}
-
+            </tbody>
+            <tbody>
               <tr id="tasks-table-header" className="table-primary">
                 <th>{Settings.fields.task.shortLabel}</th>
                 {periodDays.map(weekDay => (

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1430,8 +1430,23 @@ table.event-matrix > :not(caption) > * > * {
   padding: 0;
 }
 
-table.event-matrix > :not(caption) > * > :is(th, td):first-child {
+table.event-matrix :is(th, td):first-child {
   width: 300px;
+  position: sticky;
+  left: 0;
+  z-index: 2;
+  background-color: white;
+}
+
+table.event-matrix-cell :is(th, td):first-child {
+  position: static;
+  background-color: unset;
+  z-index: unset;
+  width: unset;
+}
+
+table.event-matrix tr.table-primary > :is(th, td):first-child {
+  background-color: var(--bs-table-bg);
 }
 
 table.event-matrix tr.table-primary {

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1445,12 +1445,16 @@ table.event-matrix-cell :is(th, td):first-child {
   width: unset;
 }
 
-table.event-matrix tr.table-primary > :is(th, td):first-child {
+table.event-matrix tr.table-primary > :is(th, td) {
+  position: sticky;
+  top: 0;
+  z-index: 3;
   background-color: var(--bs-table-bg);
 }
 
-table.event-matrix tr.table-primary {
-  border-top: 1.25rem solid white;
+table.event-matrix tr.table-primary > :is(th, td):first-child {
+  left: 0;
+  z-index: 4;
 }
 
 table.event-matrix-cell {

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1445,17 +1445,6 @@ table.event-matrix-cell :is(th, td):first-child {
   width: unset;
 }
 
-table.event-matrix tr.table-primary > :is(th, td) {
-  position: sticky;
-  top: 0;
-  z-index: 3;
-  background-color: var(--bs-table-bg);
-}
-
-table.event-matrix tr.table-primary > :is(th, td):first-child {
-  left: 0;
-  z-index: 4;
-}
 
 table.event-matrix-cell {
   table-layout: fixed;
@@ -1501,6 +1490,52 @@ table.cadence-dashboard thead tr.table-primary {
 .cadence-dashboard-panel.fullscreen label,
 .cadence-dashboard-panel.fullscreen select {
   display: none;
+}
+
+.event-matrix-panel.fullscreen {
+  position: absolute;
+  top: var(--banner-height);
+  left: 0;
+  right: 0;
+  width: 100%;
+  height: calc(100% - var(--banner-height));
+  max-height: calc(100% - var(--banner-height));
+  z-index: 10;
+  background: #f2f2f2;
+  margin: 0 !important;
+  padding: 1rem 2rem;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.event-matrix-panel.fullscreen > .float-start + div {
+  flex: 1 1 auto;
+  min-height: 0;
+  margin-top: 0 !important;
+  display: flex;
+  flex-direction: column;
+}
+
+.event-matrix-panel.fullscreen > .float-start + div > div {
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
+.event-matrix-panel.fullscreen table.event-matrix tr.table-primary > :is(th, td) {
+  position: sticky;
+  top: 0;
+  z-index: 3;
+  background-color: var(--bs-table-bg);
+}
+
+.event-matrix-panel.fullscreen table.event-matrix tr.table-primary > :is(th, td):first-child {
+  left: 0;
+  z-index: 4;
+}
+
+.event-matrix-panel table.event-matrix tr.table-primary > :is(th, td) {
+  background-color: var(--bs-table-bg);
 }
 
 .event-series-task-row > td a {


### PR DESCRIPTION
The first column for the Sync Matrix (Event Series or Objectives) would disappear if the user scrolled horizontally.
The same thing would happen if we scrolled vertically inside the table, the headers of the table would not be visible

Closes [AB#1611](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1611)

#### User changes
- First column in the Sync Matrix for objectives and event series now has a sticky first column.
- The headers of the tables are also sticky

#### Superuser changes
- None

#### Admin changes
- None

#### System admin changes
- [ ] application.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
- [x] described the user behavior in PR body
- [x] referenced/updated all related issues
- [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
- [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
- [ ] added and/or updated unit tests
- [ ] added and/or updated e2e tests
- [ ] added and/or updated data migrations
- [ ] updated documentation
- [x] resolved all build errors and warnings
- [ ] opened debt issues for anything not resolved here
