### PR TITLE
Add attachments to report email

### DIFF
--- a/src/main/java/mil/dds/anet/beans/AuditTrail.java
+++ b/src/main/java/mil/dds/anet/beans/AuditTrail.java
@@ -173,7 +173,7 @@ public class AuditTrail extends GenericRelatedObject {
 
   @JsonIgnore
   public String getUpdateDetailsWithLinks() {
-    return Utils.replaceAnetLinks(updateDetails);
+    return Utils.replaceAnetLinks(updateDetails, false);
   }
 
   @Override

--- a/src/main/java/mil/dds/anet/database/AttachmentDao.java
+++ b/src/main/java/mil/dds/anet/database/AttachmentDao.java
@@ -4,6 +4,7 @@ import static org.jdbi.v3.core.statement.EmptyHandling.NULL_KEYWORD;
 import static org.jdbi.v3.sqlobject.customizer.BindList.EmptyHandling.NULL_STRING;
 
 import graphql.GraphQLContext;
+import jakarta.mail.util.ByteArrayDataSource;
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
@@ -148,6 +149,22 @@ public class AttachmentDao extends AnetBaseDao<Attachment, AttachmentSearchQuery
 
     @SqlQuery("SELECT content FROM attachments WHERE uuid = :uuid")
     InputStream readContent(@Bind("uuid") String uuid);
+  }
+
+  @Transactional
+  public ByteArrayDataSource getContentBlob(final String uuid, String mimeType) {
+    final Handle handle = getDbHandle();
+    try {
+      try (final InputStream inputStream =
+          handle.attach(AttachmentContent.class).readContent(uuid)) {
+        return new ByteArrayDataSource(inputStream, mimeType);
+      } catch (IOException e) {
+        logger.error("Could not transfer content of attachment {}: {}", uuid, e.getMessage());
+        return new ByteArrayDataSource(new byte[0], mimeType);
+      }
+    } finally {
+      closeDbHandle(handle);
+    }
   }
 
   @Transactional

--- a/src/main/java/mil/dds/anet/emails/ReportEmail.java
+++ b/src/main/java/mil/dds/anet/emails/ReportEmail.java
@@ -9,6 +9,7 @@ import mil.dds.anet.beans.Report;
 import mil.dds.anet.beans.ReportPerson;
 import mil.dds.anet.config.AnetDictionary;
 import mil.dds.anet.config.ApplicationContextProvider;
+import mil.dds.anet.utils.Utils;
 
 public class ReportEmail implements AnetEmailAction {
   private Report report;
@@ -40,7 +41,8 @@ public class ReportEmail implements AnetEmailAction {
     context.put("reportPeople", getReportPeople(r));
     context.put("sender", sender);
     context.put("comment", comment);
-    context.put("attachments", r.loadAttachments(engine().getContext()).join());
+    // Gather all attachments, either directly linked, or referenced in rich-text
+    context.put("attachments", Utils.getAttachments(r, r.getReportText()));
     // Override the classification
     final AnetDictionary dict = ApplicationContextProvider.getDictionary();
     final var siteClassification = ConfidentialityRecord.getConfidentialityLabelForChoice(dict,

--- a/src/main/java/mil/dds/anet/emails/ReportEmail.java
+++ b/src/main/java/mil/dds/anet/emails/ReportEmail.java
@@ -40,6 +40,7 @@ public class ReportEmail implements AnetEmailAction {
     context.put("reportPeople", getReportPeople(r));
     context.put("sender", sender);
     context.put("comment", comment);
+    context.put("attachments", r.loadAttachments(engine().getContext()).join());
     // Override the classification
     final AnetDictionary dict = ApplicationContextProvider.getDictionary();
     final var siteClassification = ConfidentialityRecord.getConfidentialityLabelForChoice(dict,

--- a/src/main/java/mil/dds/anet/threads/AnetEmailWorker.java
+++ b/src/main/java/mil/dds/anet/threads/AnetEmailWorker.java
@@ -8,6 +8,7 @@ import jakarta.mail.Authenticator;
 import jakarta.mail.PasswordAuthentication;
 import jakarta.mail.Session;
 import jakarta.mail.internet.InternetAddress;
+import jakarta.mail.util.ByteArrayDataSource;
 import java.io.StringWriter;
 import java.lang.invoke.MethodHandles;
 import java.time.Instant;
@@ -21,17 +22,20 @@ import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import mil.dds.anet.beans.AnetEmail;
+import mil.dds.anet.beans.Attachment;
 import mil.dds.anet.beans.ConfidentialityRecord;
 import mil.dds.anet.beans.JobHistory;
 import mil.dds.anet.config.AnetConfig;
 import mil.dds.anet.config.AnetConfig.SmtpConfiguration;
 import mil.dds.anet.config.AnetDictionary;
+import mil.dds.anet.database.AttachmentDao;
 import mil.dds.anet.database.EmailDao;
 import mil.dds.anet.database.JobHistoryDao;
 import mil.dds.anet.database.mappers.MapperUtils;
 import mil.dds.anet.utils.Utils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.simplejavamail.api.email.Email;
+import org.simplejavamail.api.email.EmailPopulatingBuilder;
 import org.simplejavamail.email.EmailBuilder;
 import org.simplejavamail.mailer.MailValidationException;
 import org.simplejavamail.mailer.MailerBuilder;
@@ -53,13 +57,15 @@ public class AnetEmailWorker extends AbstractWorker {
 
   private final AnetConfig config;
   private final EmailDao dao;
+  private final AttachmentDao attachmentDao;
   private final ObjectMapper mapper;
 
   public AnetEmailWorker(AnetConfig config, AnetDictionary dict, JobHistoryDao jobHistoryDao,
-      EmailDao dao) {
+      EmailDao dao, AttachmentDao attachmentDao) {
     super(dict, jobHistoryDao, "AnetEmailWorker waking up to send emails!");
     this.config = config;
     this.dao = dao;
+    this.attachmentDao = attachmentDao;
     this.mapper = MapperUtils.getDefaultMapper();
 
     setInstance(this);
@@ -191,10 +197,11 @@ public class AnetEmailWorker extends AbstractWorker {
     temp.process(emailContext, writer);
 
     final Session session = Session.getInstance(smtpProps, smtpAuth);
-    final Email mail =
-        EmailBuilder.startingBlank().from(new InternetAddress(config.getEmailFromAddr()))
-            .toMultiple(email.getToAddresses()).withSubject(getEmailSubject(email, emailContext))
-            .withHTMLText(writer.toString()).buildEmail();
+    final EmailPopulatingBuilder builder = EmailBuilder.startingBlank()
+        .from(new InternetAddress(config.getEmailFromAddr())).toMultiple(email.getToAddresses())
+        .withSubject(getEmailSubject(email, emailContext)).withHTMLText(writer.toString());
+    addAttachments(emailContext, builder);
+    final Email mail = builder.buildEmail();
 
     try {
       logger.info("Sending email #{} re: \"{}\" to {}", email.getId(),
@@ -205,6 +212,27 @@ public class AnetEmailWorker extends AbstractWorker {
       logger.error("Sending email #{} failed:", email.getId(), e);
     }
     // Other errors are intentionally thrown, as we want ANET to try again.
+  }
+
+  private void addAttachments(Map<String, Object> emailContext, EmailPopulatingBuilder builder) {
+    @SuppressWarnings("unchecked")
+    final List<Attachment> attachments = (List<Attachment>) emailContext.get("attachments");
+    if (attachments != null) {
+      attachments.forEach(attachment -> {
+        if (!Utils.hasContent(attachment)) {
+          builder.withAttachment(attachment.getUuid(),
+              new ByteArrayDataSource(new byte[0], attachment.getMimeType()),
+              attachment.getCaption());
+        } else if (Utils.isImage(attachment)) {
+          builder.withEmbeddedImage(attachment.getUuid(),
+              attachmentDao.getContentBlob(attachment.getUuid(), attachment.getMimeType()));
+        } else {
+          builder.withAttachment(attachment.getUuid(),
+              attachmentDao.getContentBlob(attachment.getUuid(), attachment.getMimeType()),
+              attachment.getCaption());
+        }
+      });
+    }
   }
 
   private static final Logger noWorkerLogger =

--- a/src/main/java/mil/dds/anet/utils/Utils.java
+++ b/src/main/java/mil/dds/anet/utils/Utils.java
@@ -910,7 +910,7 @@ public class Utils {
     return instant == null ? "-" : dateTimeFormatter.format(instant);
   }
 
-  public static String replaceAnetLinks(String htmlString) {
+  public static String replaceAnetLinks(String htmlString, boolean useCids) {
     final AnetDictionary dict = ApplicationContextProvider.getDictionary();
     final String anetServerUrl = ApplicationContextProvider.getConfig().getServerUrl();
     final Document reportDoc = Jsoup.parse(htmlString);
@@ -920,7 +920,7 @@ public class Utils {
           anchor.getElementsByAttributeValueStarting(HREF_ATTRIBUTE, ANET_LINK_PREFIX);
       anetLinks.forEach(anetLink -> {
         final TypeUuidTuple typeUuidTuple = replaceHref(anetLink, anetServerUrl);
-        replaceInnerHtml(anetLink, dict, anetServerUrl, typeUuidTuple.type());
+        replaceInnerHtml(anetLink, dict, anetServerUrl, useCids, typeUuidTuple.type());
       });
     });
     return reportDoc.body().html();
@@ -944,12 +944,12 @@ public class Utils {
   }
 
   private static void replaceInnerHtml(Element anetLink, AnetDictionary dict, String anetServerUrl,
-      String tableName) {
+      boolean useCids, String tableName) {
     final DaoEntityNameTuple daoEntityNameTuple = getDaoEntityNameTuple(tableName);
     final TypeUuidTuple tut = getTypeUuidTuple(anetLink.html().split(":", 2));
     anetLink.empty();
-    anetLink.appendChildren(
-        getInnerNodes(daoEntityNameTuple.dao(), dict, anetServerUrl, tut.type(), tut.uuid()));
+    anetLink.appendChildren(getInnerNodes(daoEntityNameTuple.dao(), dict, anetServerUrl, useCids,
+        tut.type(), tut.uuid()));
   }
 
   private record DaoEntityNameTuple(AnetBaseDao<? extends AbstractAnetBean, ?> dao,
@@ -980,7 +980,7 @@ public class Utils {
 
   private static Collection<? extends Node> getInnerNodes(
       AnetBaseDao<? extends AbstractAnetBean, ?> dao, AnetDictionary dict, String anetServerUrl,
-      String objectType, String objectUuid) {
+      boolean useCids, String objectType, String objectUuid) {
     if (dao != null) {
       final AbstractAnetBean obj = dao.getByUuid(objectUuid);
       if (obj == null) {
@@ -998,8 +998,7 @@ public class Utils {
           innerNode.appendChild(new Element(SPAN_TAG)
               .classNames(Set.of("rich-text-image-classification")).text(classification));
           innerNode.appendChild(new Element("img").classNames(Set.of("rich-text-image"))
-              .attr("src",
-                  String.format("%1$s/api/attachment/view/%2$s", anetServerUrl, objectUuid))
+              .attr("src", getAttachmentUrl(anetServerUrl, useCids, objectUuid))
               .attr("alt", label));
           innerNode.appendChild(
               new Element(SPAN_TAG).classNames(Set.of("rich-text-image-caption")).text(label));
@@ -1018,6 +1017,11 @@ public class Utils {
       }
     }
     return List.of(new TextNode(String.format("entity %s::%s", objectType, objectUuid)));
+  }
+
+  public static String getAttachmentUrl(String anetServerUrl, boolean useCids, String objectUuid) {
+    return useCids ? String.format("cid:%s", objectUuid)
+        : String.format("%1$s/api/attachment/view/%2$s", anetServerUrl, objectUuid);
   }
 
   public static String getAttachmentConfidentialityLabel(AnetDictionary dict,

--- a/src/main/java/mil/dds/anet/utils/Utils.java
+++ b/src/main/java/mil/dds/anet/utils/Utils.java
@@ -27,6 +27,7 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import mil.dds.anet.AnetObjectEngine;
 import mil.dds.anet.beans.ApprovalStep;
 import mil.dds.anet.beans.ApprovalStep.ApprovalStepType;
@@ -55,6 +56,7 @@ import mil.dds.anet.database.ReportDao;
 import mil.dds.anet.database.TaskDao;
 import mil.dds.anet.database.mappers.MapperUtils;
 import mil.dds.anet.views.AbstractAnetBean;
+import mil.dds.anet.views.AbstractCustomizableAnetBean;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Attribute;
 import org.jsoup.nodes.Document;
@@ -910,6 +912,38 @@ public class Utils {
     return instant == null ? "-" : dateTimeFormatter.format(instant);
   }
 
+  public static List<Attachment> getAttachments(AbstractCustomizableAnetBean entity,
+      String richText) {
+    final AnetObjectEngine engine = ApplicationContextProvider.getEngine();
+    final List<Attachment> directAttachments = entity.loadAttachments(engine.getContext()).join();
+    final Set<String> directAttachmentUuids =
+        directAttachments.stream().map(Attachment::getUuid).collect(Collectors.toSet());
+    final Set<String> richTextAttachmentUuids = Utils.getAttachmentUuids(richText);
+    richTextAttachmentUuids.removeAll(directAttachmentUuids);
+    final List<Attachment> richTextAttachments =
+        engine.getAttachmentDao().getByIds(new ArrayList<>(richTextAttachmentUuids));
+    return Stream.concat(directAttachments.stream(), richTextAttachments.stream()).toList();
+  }
+
+  private static Set<String> getAttachmentUuids(String htmlString) {
+    final Set<String> attachmentUuids = new HashSet<>();
+    if (!Utils.isEmptyOrNull(htmlString)) {
+      final Document reportDoc = Jsoup.parse(htmlString);
+      final Elements anchors = reportDoc.getElementsByTag(ANCHOR_TAG);
+      anchors.forEach(anchor -> {
+        final Elements anetLinks =
+            anchor.getElementsByAttributeValueStarting(HREF_ATTRIBUTE, ANET_LINK_PREFIX);
+        anetLinks.forEach(anetLink -> {
+          final TypeUuidTuple typeUuidTuple = getTypeUuidTuple(anetLink);
+          if (AttachmentDao.TABLE_NAME.equals(typeUuidTuple.type())) {
+            attachmentUuids.add(typeUuidTuple.uuid());
+          }
+        });
+      });
+    }
+    return attachmentUuids;
+  }
+
   public static String replaceAnetLinks(String htmlString, boolean useCids) {
     final AnetDictionary dict = ApplicationContextProvider.getDictionary();
     final String anetServerUrl = ApplicationContextProvider.getConfig().getServerUrl();
@@ -936,11 +970,15 @@ public class Utils {
   }
 
   private static TypeUuidTuple replaceHref(Element anetLink, String anetServerUrl) {
-    final Attribute href = anetLink.attribute(HREF_ATTRIBUTE);
-    final TypeUuidTuple tut = getTypeUuidTuple(
-        Objects.requireNonNull(href).getValue().replace(ANET_LINK_PREFIX, "").split(":", 2));
+    final TypeUuidTuple tut = getTypeUuidTuple(anetLink);
     anetLink.attr(HREF_ATTRIBUTE, String.format("%s/%s/%s", anetServerUrl, tut.type(), tut.uuid()));
     return tut;
+  }
+
+  private static TypeUuidTuple getTypeUuidTuple(Element anetLink) {
+    final Attribute href = anetLink.attribute(HREF_ATTRIBUTE);
+    return getTypeUuidTuple(
+        Objects.requireNonNull(href).getValue().replace(ANET_LINK_PREFIX, "").split(":", 2));
   }
 
   private static void replaceInnerHtml(Element anetLink, AnetDictionary dict, String anetServerUrl,

--- a/src/main/resources/emails/emailReport.ftlh
+++ b/src/main/resources/emails/emailReport.ftlh
@@ -653,7 +653,7 @@
             <div class="d-grid text-center">
               <a href="${serverUrl}/attachments/${attachment.uuid}">
                 <#if Utils.isImage(attachment) && Utils.hasContent(attachment)>
-                  <img class="card-image" src="${serverUrl}/api/attachment/view/${attachment.uuid}" alt="${attachment.objectLabel}" style="object-fit: contain;" />
+                  <img class="card-image" src="${Utils.getAttachmentUrl(serverUrl, true, attachment.uuid)}" alt="${attachment.objectLabel}" style="object-fit: contain;" />
                 <#else>
                   <#assign icon = Utils.getAttachmentIcon(attachment)>
                   <span class="card-icon">${icon}</span>
@@ -823,7 +823,7 @@
       <fieldset>
         <div>
           <p>
-            ${Utils.replaceAnetLinks(report.reportText)?no_esc}
+            ${Utils.replaceAnetLinks(report.reportText, true)?no_esc}
           </p>
         </div>
       </fieldset>

--- a/src/test/java/mil/dds/anet/test/integration/db/FutureEngagementWorkerTest.java
+++ b/src/test/java/mil/dds/anet/test/integration/db/FutureEngagementWorkerTest.java
@@ -22,6 +22,7 @@ import mil.dds.anet.beans.Report.ReportState;
 import mil.dds.anet.beans.ReportPerson;
 import mil.dds.anet.config.ApplicationContextProvider;
 import mil.dds.anet.database.ApprovalStepDao;
+import mil.dds.anet.database.AttachmentDao;
 import mil.dds.anet.database.EmailAddressDao;
 import mil.dds.anet.database.EmailDao;
 import mil.dds.anet.database.JobHistoryDao;
@@ -56,6 +57,9 @@ class FutureEngagementWorkerTest extends AbstractResourceTest {
   private EmailDao emailDao;
 
   @Autowired
+  private AttachmentDao attachmentDao;
+
+  @Autowired
   private EmailAddressDao emailAddressDao;
 
   @Autowired
@@ -86,7 +90,7 @@ class FutureEngagementWorkerTest extends AbstractResourceTest {
 
     allowedEmail = "@" + ((List<String>) dict.getDictionaryEntry("domainNames")).get(0);
 
-    emailWorker = new AnetEmailWorker(config, dict, jobHistoryDao, emailDao);
+    emailWorker = new AnetEmailWorker(config, dict, jobHistoryDao, emailDao, attachmentDao);
     futureEngagementWorker = new FutureEngagementWorker(dict, jobHistoryDao, reportDao);
     emailServer = new FakeSmtpServer(config.getSmtp());
 

--- a/src/test/java/mil/dds/anet/test/integration/db/PendingAssessmentsNotificationWorkerTest.java
+++ b/src/test/java/mil/dds/anet/test/integration/db/PendingAssessmentsNotificationWorkerTest.java
@@ -14,6 +14,7 @@ import mil.dds.anet.beans.AnetEmail;
 import mil.dds.anet.beans.JobHistory;
 import mil.dds.anet.config.AnetConfig;
 import mil.dds.anet.config.AnetDictionary;
+import mil.dds.anet.database.AttachmentDao;
 import mil.dds.anet.database.EmailDao;
 import mil.dds.anet.database.JobHistoryDao;
 import mil.dds.anet.database.PositionDao;
@@ -51,6 +52,9 @@ class PendingAssessmentsNotificationWorkerTest extends AnetApplicationTest {
   private EmailDao emailDao;
 
   @Autowired
+  private AttachmentDao attachmentDao;
+
+  @Autowired
   private PositionDao positionDao;
 
   @Autowired
@@ -73,7 +77,7 @@ class PendingAssessmentsNotificationWorkerTest extends AnetApplicationTest {
 
     pendingAssessmentsNotificationWorker =
         new PendingAssessmentsNotificationWorker(dict, jobHistoryDao);
-    emailWorker = new AnetEmailWorker(config, dict, jobHistoryDao, emailDao);
+    emailWorker = new AnetEmailWorker(config, dict, jobHistoryDao, emailDao, attachmentDao);
     emailServer = new FakeSmtpServer(config.getSmtp());
 
     // Flush all assessment notifications

--- a/src/test/java/mil/dds/anet/test/integration/db/ReportPublicationWorkerTest.java
+++ b/src/test/java/mil/dds/anet/test/integration/db/ReportPublicationWorkerTest.java
@@ -24,6 +24,7 @@ import mil.dds.anet.config.AnetConfig;
 import mil.dds.anet.config.AnetDictionary;
 import mil.dds.anet.config.ApplicationContextProvider;
 import mil.dds.anet.database.ApprovalStepDao;
+import mil.dds.anet.database.AttachmentDao;
 import mil.dds.anet.database.AuditTrailDao;
 import mil.dds.anet.database.EmailAddressDao;
 import mil.dds.anet.database.EmailDao;
@@ -65,6 +66,9 @@ class ReportPublicationWorkerTest extends AnetApplicationTest {
 
   @Autowired
   private EmailDao emailDao;
+
+  @Autowired
+  private AttachmentDao attachmentDao;
 
   @Autowired
   private EmailAddressDao emailAddressDao;
@@ -110,7 +114,7 @@ class ReportPublicationWorkerTest extends AnetApplicationTest {
 
     allowedEmail = "@" + ((List<String>) dict.getDictionaryEntry("domainNames")).get(0);
 
-    emailWorker = new AnetEmailWorker(config, dict, jobHistoryDao, emailDao);
+    emailWorker = new AnetEmailWorker(config, dict, jobHistoryDao, emailDao, attachmentDao);
     reportPublicationWorker =
         new ReportPublicationWorker(dict, jobHistoryDao, auditTrailDao, reportDao);
     emailServer = new FakeSmtpServer(config.getSmtp());

--- a/src/test/java/mil/dds/anet/test/integration/emails/AnetEmailWorkerTest.java
+++ b/src/test/java/mil/dds/anet/test/integration/emails/AnetEmailWorkerTest.java
@@ -11,6 +11,7 @@ import java.util.List;
 import mil.dds.anet.beans.AnetEmail;
 import mil.dds.anet.config.AnetConfig;
 import mil.dds.anet.config.AnetDictionary;
+import mil.dds.anet.database.AttachmentDao;
 import mil.dds.anet.database.EmailDao;
 import mil.dds.anet.database.JobHistoryDao;
 import mil.dds.anet.test.AnetApplicationTest;
@@ -35,6 +36,9 @@ class AnetEmailWorkerTest extends AnetApplicationTest {
   @Autowired
   private JobHistoryDao jobHistoryDao;
 
+  @Autowired
+  private AttachmentDao attachmentDao;
+
   private String allowedEmail;
   private EmailDao emailDao;
   private FakeSmtpServer emailServer;
@@ -49,7 +53,7 @@ class AnetEmailWorkerTest extends AnetApplicationTest {
     assumeTrue(executeEmailServerTests, "Email server tests configured to be skipped.");
 
     emailDao = mock(EmailDao.class, Mockito.RETURNS_DEEP_STUBS);
-    emailWorker = new AnetEmailWorker(config, dict, jobHistoryDao, emailDao);
+    emailWorker = new AnetEmailWorker(config, dict, jobHistoryDao, emailDao, attachmentDao);
 
     allowedEmail = "@" + ((List<String>) dict.getDictionaryEntry("domainNames")).get(0);
     config.setEmailFromAddr("test_from_address" + allowedEmail);

--- a/src/test/java/mil/dds/anet/test/integration/emails/EmailTemplateTest.java
+++ b/src/test/java/mil/dds/anet/test/integration/emails/EmailTemplateTest.java
@@ -9,6 +9,7 @@ import java.util.List;
 import mil.dds.anet.beans.Comment;
 import mil.dds.anet.beans.Person;
 import mil.dds.anet.beans.Report;
+import mil.dds.anet.database.AttachmentDao;
 import mil.dds.anet.database.CommentDao;
 import mil.dds.anet.database.EmailDao;
 import mil.dds.anet.database.JobHistoryDao;
@@ -42,6 +43,9 @@ class EmailTemplateTest extends AbstractResourceTest {
   private EmailDao emailDao;
 
   @Autowired
+  private AttachmentDao attachmentDao;
+
+  @Autowired
   private CommentDao commentDao;
 
   @Autowired
@@ -56,7 +60,7 @@ class EmailTemplateTest extends AbstractResourceTest {
       fail("'ANET_SMTP_DISABLE' system environment variable must have value 'false' to run test.");
     }
 
-    emailWorker = new AnetEmailWorker(config, dict, jobHistoryDao, emailDao);
+    emailWorker = new AnetEmailWorker(config, dict, jobHistoryDao, emailDao, attachmentDao);
     emailServer = new FakeSmtpServer(config.getSmtp());
 
     // Flush all emails from previous tests

--- a/src/test/java/mil/dds/anet/test/resources/AnetEmailResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/AnetEmailResourceTest.java
@@ -2,6 +2,7 @@ package mil.dds.anet.test.resources;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import mil.dds.anet.database.AttachmentDao;
 import mil.dds.anet.database.EmailDao;
 import mil.dds.anet.database.JobHistoryDao;
 import mil.dds.anet.emails.ReportEmail;
@@ -22,11 +23,14 @@ class AnetEmailResourceTest extends AbstractResourceTest {
   @Autowired
   private EmailDao emailDao;
 
+  @Autowired
+  private AttachmentDao attachmentDao;
+
   private AnetEmailWorker emailWorker;
 
   @BeforeAll
   void setUpClass() {
-    emailWorker = new AnetEmailWorker(config, dict, jobHistoryDao, emailDao);
+    emailWorker = new AnetEmailWorker(config, dict, jobHistoryDao, emailDao, attachmentDao);
     emailWorker.run();
   }
 

--- a/src/test/java/mil/dds/anet/test/resources/TaskApprovalTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/TaskApprovalTest.java
@@ -17,6 +17,7 @@ import java.util.Objects;
 import java.util.Optional;
 import mil.dds.anet.config.AnetConfig;
 import mil.dds.anet.config.AnetDictionary;
+import mil.dds.anet.database.AttachmentDao;
 import mil.dds.anet.database.EmailDao;
 import mil.dds.anet.database.JobHistoryDao;
 import mil.dds.anet.test.client.AnetBeanList_Person;
@@ -105,6 +106,9 @@ class TaskApprovalTest extends AbstractResourceTest {
   @Autowired
   private EmailDao emailDao;
 
+  @Autowired
+  private AttachmentDao attachmentDao;
+
   @BeforeAll
   void setUpEmailServer() throws Exception {
     if (config.getSmtp().isDisabled()) {
@@ -115,7 +119,7 @@ class TaskApprovalTest extends AbstractResourceTest {
     final List<String> activeDomainNames = (List<String>) newDict.get("activeDomainNames");
     activeDomainNames.add("example.com");
     dict.setDictionary(newDict);
-    emailWorker = new AnetEmailWorker(config, dict, jobHistoryDao, emailDao);
+    emailWorker = new AnetEmailWorker(config, dict, jobHistoryDao, emailDao, attachmentDao);
     emailServer = new FakeSmtpServer(config.getSmtp());
   }
 


### PR DESCRIPTION
When emailing a report, all attachments, either directly linked to the report, or referenced in the report text, are now sent as email attachments.

Closes [AB#1609](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1609)

#### User changes
- Emailing a report will include all attachments.

#### Superuser changes
- None

#### Admin changes
- None

#### System admin changes
- [ ] application.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
- [x] described the user behavior in PR body
- [x] referenced/updated all related issues
- [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
- [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
- [x] added and/or updated unit tests
- [ ] added and/or updated e2e tests
- [ ] added and/or updated data migrations
- [ ] updated documentation
- [x] resolved all build errors and warnings
- [ ] opened debt issues for anything not resolved here