### PR TITLE
Upon publication, email report to the archive

### DIFF
--- a/anet-dictionary.yml
+++ b/anet-dictionary.yml
@@ -2032,6 +2032,12 @@ emailNetworks:
   - Internet
   - NS
 emailNetworkForNotifications: NS
+emailArchive:
+  enabled: true
+  addresses:
+    - archive@example.ns
+    - archive@example.com
+
 imagery:
   mapOptions:
     crs: EPSG3857

--- a/src/main/java/mil/dds/anet/database/ReportDao.java
+++ b/src/main/java/mil/dds/anet/database/ReportDao.java
@@ -44,6 +44,7 @@ import mil.dds.anet.database.mappers.ReportPersonMapper;
 import mil.dds.anet.database.mappers.TaskMapper;
 import mil.dds.anet.emails.AnetEmailAction;
 import mil.dds.anet.emails.ApprovalNeededEmail;
+import mil.dds.anet.emails.ReportEmail;
 import mil.dds.anet.emails.ReportPublishedEmail;
 import mil.dds.anet.search.pg.PostgresqlReportSearcher;
 import mil.dds.anet.threads.AnetEmailWorker;
@@ -893,6 +894,22 @@ public class ReportDao extends AnetSubscribableObjectDao<Report, ReportSearchQue
   public void sendEmailToReportPeople(AnetEmailAction action, List<String> peopleUuids) {
     final List<String> emailAddresses = getEmailAddressesBasedOnPreference(peopleUuids,
         PreferenceDao.PREFERENCE_REPORTS, PreferenceDao.CATEGORY_EMAILING);
+    sendEmailToAddresses(action, emailAddresses);
+  }
+
+  public void sendReportToArchive(Report r) {
+    final Boolean emailArchiveEnables = (Boolean) dict().getDictionaryEntry("emailArchive.enabled");
+    if (Boolean.TRUE.equals(emailArchiveEnables)) {
+      @SuppressWarnings("unchecked")
+      final List<String> emailArchiveAddresses =
+          (List<String>) dict().getDictionaryEntry("emailArchive.addresses");
+      final ReportEmail action = new ReportEmail();
+      action.setReport(r);
+      sendEmailToAddresses(action, emailArchiveAddresses);
+    }
+  }
+
+  private static void sendEmailToAddresses(AnetEmailAction action, List<String> emailAddresses) {
     if (!emailAddresses.isEmpty()) {
       AnetEmail email = new AnetEmail();
       email.setAction(action);
@@ -1042,6 +1059,8 @@ public class ReportDao extends AnetSubscribableObjectDao<Report, ReportSearchQue
     final int numRows = update(r, firstAuthor.orElse(null));
     if (numRows != 0) {
       sendReportPublishedEmail(r);
+      // Also send the report to the archive
+      sendReportToArchive(r);
     }
     return numRows;
   }

--- a/src/main/java/mil/dds/anet/emails/ReportEmail.java
+++ b/src/main/java/mil/dds/anet/emails/ReportEmail.java
@@ -33,7 +33,9 @@ public class ReportEmail implements AnetEmailAction {
     if (r == null) {
       return null;
     }
-    sender = engine().getPersonDao().getByUuid(sender.getUuid());
+    if (sender != null) {
+      sender = engine().getPersonDao().getByUuid(sender.getUuid());
+    }
 
     context.put("report", r);
     context.put("reportIntent", getReportLabel(r));
@@ -70,7 +72,9 @@ public class ReportEmail implements AnetEmailAction {
   }
 
   public void setSender(Person sender) {
-    this.sender = Person.createWithUuid(sender.getUuid());
+    if (sender != null) {
+      this.sender = Person.createWithUuid(sender.getUuid());
+    }
   }
 
   public String getComment() {

--- a/src/main/java/mil/dds/anet/emails/ReportPublishedEmail.java
+++ b/src/main/java/mil/dds/anet/emails/ReportPublishedEmail.java
@@ -13,7 +13,7 @@ public class ReportPublishedEmail implements AnetEmailAction {
 
   @Override
   public String getSubject(Map<String, Object> context) {
-    return "ANET report approved";
+    return "ANET report published";
   }
 
   @Override

--- a/src/main/java/mil/dds/anet/resources/ReportResource.java
+++ b/src/main/java/mil/dds/anet/resources/ReportResource.java
@@ -185,6 +185,11 @@ public class ReportResource {
 
     // Log the change
     auditTrailDao.logCreate(author, ReportDao.TABLE_NAME, created);
+
+    if (created.getState() == ReportState.PUBLISHED) {
+      // Also send the report to the archive
+      reportDao.sendReportToArchive(created);
+    }
     return created;
   }
 
@@ -208,6 +213,11 @@ public class ReportResource {
         action.setEditor(editor);
         reportDao.sendEmailToReportAuthors(action, existing);
       }
+    }
+
+    if (existing.getState() == ReportState.PUBLISHED) {
+      // Also send the report to the archive
+      reportDao.sendReportToArchive(existing);
     }
 
     // Return the report in the response; used in autoSave by the client form

--- a/src/main/resources/anet-schema.yml
+++ b/src/main/resources/anet-schema.yml
@@ -433,6 +433,7 @@ required:
   - activeDomainNames
   - emailNetworks
   - emailNetworkForNotifications
+  - emailArchive
   - imagery
   - automaticallyAllowAllNewUsers
 properties:
@@ -1401,6 +1402,19 @@ properties:
     type: string
     title: The email network to be used for email notifications sent by ANET
     description: Should be one of the networks listed under `emailNetworks` above.
+
+  emailArchive:
+    type: object
+    additionalProperties: false
+    required: [enabled, addresses]
+    properties:
+      enabled:
+        type: boolean
+      addresses:
+        type: array
+        uniqueItems: true
+        items:
+          type: string
 
   imagery:
     type: object

--- a/src/main/resources/emails/emailReport.ftlh
+++ b/src/main/resources/emails/emailReport.ftlh
@@ -438,18 +438,16 @@
       ${sender.name}
     </a>
   </p>
+  <br>
 </#if>
-
-<br>
 
 <#if comment?has_content>
   <div>
     <h3 style="color: #004ee1;">${sender.name} wrote:</h3>
     <p>${comment}</p>
   </div>
+  <br>
 </#if>
-
-<br>
 
 <div class="form-horizontal">
 

--- a/src/main/resources/emails/reportPublished.ftlh
+++ b/src/main/resources/emails/reportPublished.ftlh
@@ -8,7 +8,7 @@
 <#include "common/securityBanner.ftlh">
 <#include "common/reportAuthors.ftlh">
 
-<p>Your report, <a href="${serverUrl}/reports/${report.uuid}" class="report-intent">${reportIntent!}</a>, has been approved and added to the daily rollup. </p>
+<p>Your report, <a href="${serverUrl}/reports/${report.uuid}" class="report-intent">${reportIntent!}</a>, has been published and added to the daily rollup. </p>
 
 <p>You can view the daily rollup by <a href="${serverUrl}/rollup">clicking here</a>.</p>
 

--- a/src/test/java/mil/dds/anet/test/AnetApplicationTest.java
+++ b/src/test/java/mil/dds/anet/test/AnetApplicationTest.java
@@ -8,4 +8,5 @@ import org.springframework.boot.test.context.SpringBootTest;
     webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public abstract class AnetApplicationTest {
+  protected static final String ARCHIVE_ADDRESS = "archive";
 }

--- a/src/test/java/mil/dds/anet/test/integration/db/FutureEngagementWorkerTest.java
+++ b/src/test/java/mil/dds/anet/test/integration/db/FutureEngagementWorkerTest.java
@@ -410,9 +410,11 @@ class FutureEngagementWorkerTest extends AbstractResourceTest {
     // Publish this report
     final int emailSize = emailDao.getAll().size();
     reportDao.publish(report, null);
-    // Should have sent email for publication
-    assertThat(emailDao.getAll()).hasSize(emailSize + 1);
+
+    // email was sent to author and to archive
+    assertThat(emailDao.getAll()).hasSize(emailSize + 2);
     expectedIds.add(toAddressId);
+    expectedIds.add(ARCHIVE_ADDRESS);
 
     setPastDate(report);
     return report;

--- a/src/test/java/mil/dds/anet/test/integration/db/ReportPublicationWorkerTest.java
+++ b/src/test/java/mil/dds/anet/test/integration/db/ReportPublicationWorkerTest.java
@@ -161,9 +161,10 @@ class ReportPublicationWorkerTest extends AnetApplicationTest {
     ra.setCreatedAt(Instant.now());
     reportActionDao.insert(ra);
 
+    // email was sent to author and to archive
     expectedIds.add("testApprovalStepReport_1");
-
-    testReportPublicationWorker(1);
+    expectedIds.add(ARCHIVE_ADDRESS);
+    testReportPublicationWorker(2);
 
     // Report should be published now
     testReportPublished(report.getUuid(), false);
@@ -186,9 +187,10 @@ class ReportPublicationWorkerTest extends AnetApplicationTest {
     ra.setCreatedAt(Instant.now());
     reportActionDao.insert(ra);
 
+    // email was sent to author and to archive
     expectedIds.add("testPlanningApprovalStepReport_1");
-
-    testReportPublicationWorker(1);
+    expectedIds.add(ARCHIVE_ADDRESS);
+    testReportPublicationWorker(2);
 
     // Report should be published now
     testReportPublished(report.getUuid(), false);
@@ -208,9 +210,10 @@ class ReportPublicationWorkerTest extends AnetApplicationTest {
     ra.setCreatedAt(Instant.now());
     reportActionDao.insert(ra);
 
+    // email was sent to author and to archive
     expectedIds.add("testAutomaticallyApprovedReport_1");
-
-    testReportPublicationWorker(1);
+    expectedIds.add(ARCHIVE_ADDRESS);
+    testReportPublicationWorker(2);
 
     // Report should be published now
     testReportPublished(report.getUuid(), true);

--- a/testDictionaries/no-custom-fields.yml
+++ b/testDictionaries/no-custom-fields.yml
@@ -1561,6 +1561,12 @@ emailNetworks:
   - Internet
   - NS
 emailNetworkForNotifications: NS
+emailArchive:
+  enabled: true
+  addresses:
+    - archive@example.ns
+    - archive@example.com
+
 imagery:
   mapOptions:
     crs: EPSG3857


### PR DESCRIPTION
When so configured, upon publication, a report will be emailed to the archive.
It is also emailed when a published report is edited, so the archive always has an up-to-date copy.

Closes [AB#1581](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1581)

#### User changes
- None

#### Superuser changes
- None

#### Admin changes
- None

#### System admin changes
- [x] application.yml or anet-dictionary.yml needs change
  Add something similar to the following to the dictionary after the `emailNetworkForNotifications` setting (use the actual archive mailbox address(es)):
  ```yaml
  emailNetworkForNotifications: NS
  emailArchive:
    enabled: true
    addresses:
      - archive@example.ns
      - archive@example.com

  ```
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
- [x] described the user behavior in PR body
- [x] referenced/updated all related issues
- [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
- [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
- [x] added and/or updated unit tests
- [ ] added and/or updated e2e tests
- [ ] added and/or updated data migrations
- [ ] updated documentation
- [x] resolved all build errors and warnings
- [ ] opened debt issues for anything not resolved here