### PR TITLE
Add quick access to communities in navigation menu

### DIFF
--- a/client/src/components/Nav.tsx
+++ b/client/src/components/Nav.tsx
@@ -461,6 +461,15 @@ const Navigation = ({
       </SidebarLink>
 
       <SidebarLink
+        id="communities-nav"
+        linkTo="/communities"
+        handleOnClick={resetPages}
+        setIsMenuLinksOpened={() => setIsMenuLinksOpened(false)}
+      >
+        Communities
+      </SidebarLink>
+
+      <SidebarLink
         id="daily-rollup-nav"
         linkTo="/rollup"
         handleOnClick={resetPages}

--- a/client/src/pages/Routing.tsx
+++ b/client/src/pages/Routing.tsx
@@ -20,6 +20,7 @@ import AttachmentEdit from "pages/attachments/Edit"
 import MyAttachments from "pages/attachments/MyAttachments"
 import AttachmentShow from "pages/attachments/Show"
 import AuthorizationGroupEdit from "pages/authorizationGroups/Edit"
+import AuthorizationGroupList from "pages/authorizationGroups/List"
 import MyAuthorizationGroups from "pages/authorizationGroups/MyAuthorizationGroups"
 import AuthorizationGroupNew from "pages/authorizationGroups/New"
 import AuthorizationGroupShow from "pages/authorizationGroups/Show"
@@ -328,6 +329,10 @@ const routes = [
       },
       { path: PAGE_URLS.TOP_TASKS, element: <TopTasks /> },
       { path: PAGE_URLS.EVENTS, element: <EventsList /> },
+      {
+        path: PAGE_URLS.AUTHORIZATION_GROUPS,
+        element: <AuthorizationGroupList />
+      },
       {
         path: PAGE_URLS.INSIGHTS,
         children: [{ path: ":insight", element: <InsightsShow /> }]

--- a/client/src/pages/Routing.tsx
+++ b/client/src/pages/Routing.tsx
@@ -230,8 +230,9 @@ const routes = [
         ]
       },
       {
-        path: "communities",
+        path: PAGE_URLS.COMMUNITIES,
         children: [
+          { index: true, element: <AuthorizationGroupList /> },
           {
             element: (
               <ProtectedRoute
@@ -329,10 +330,6 @@ const routes = [
       },
       { path: PAGE_URLS.TOP_TASKS, element: <TopTasks /> },
       { path: PAGE_URLS.EVENTS, element: <EventsList /> },
-      {
-        path: PAGE_URLS.AUTHORIZATION_GROUPS,
-        element: <AuthorizationGroupList />
-      },
       {
         path: PAGE_URLS.INSIGHTS,
         children: [{ path: ":insight", element: <InsightsShow /> }]

--- a/client/src/pages/authorizationGroups/List.tsx
+++ b/client/src/pages/authorizationGroups/List.tsx
@@ -1,0 +1,75 @@
+import {
+  DEFAULT_PAGE_PROPS,
+  DEFAULT_SEARCH_PROPS,
+  setPagination
+} from "actions"
+import Fieldset from "components/Fieldset"
+import {
+  mapPageDispatchersToProps,
+  PageDispatchersPropType,
+  useBoilerplate,
+  usePageTitle
+} from "components/Page"
+import AuthorizationGroupSearchResults from "components/search/AuthorizationGroupSearchResults"
+import React from "react"
+import { connect } from "react-redux"
+
+const queryParams = {
+  pageSize: 10,
+  status: "ACTIVE"
+}
+
+interface AuthorizationGroupListProps {
+  pageDispatchers?: PageDispatchersPropType
+  pagination?: any
+  setPagination?: (...args: unknown[]) => unknown
+}
+
+const AuthorizationGroupList = ({
+  pageDispatchers,
+  pagination,
+  setPagination
+}: AuthorizationGroupListProps) => {
+  const { done, result } = useBoilerplate({
+    pageProps: DEFAULT_PAGE_PROPS,
+    searchProps: DEFAULT_SEARCH_PROPS,
+    pageDispatchers
+  })
+  usePageTitle("Communities")
+
+  if (done) {
+    return result
+  }
+
+  return (
+    <>
+      <Fieldset title="Communities" id="communities">
+        <AuthorizationGroupSearchResults
+          queryParams={queryParams}
+          pageDispatchers={pageDispatchers}
+          paginationKey="authorizationGroups"
+          pagination={pagination}
+          setPagination={setPagination}
+        />
+      </Fieldset>
+    </>
+  )
+}
+
+const mapDispatchToProps = (dispatch, ownProps) => {
+  const pageDispatchers = mapPageDispatchersToProps(dispatch, ownProps)
+  return {
+    setPagination: (pageKey, pageNum) =>
+      dispatch(setPagination(pageKey, pageNum)),
+    ...pageDispatchers
+  }
+}
+
+const mapStateToProps = state => ({
+  pagination: state.pagination
+})
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(AuthorizationGroupList)

--- a/client/src/pages/authorizationGroups/List.tsx
+++ b/client/src/pages/authorizationGroups/List.tsx
@@ -42,17 +42,15 @@ const AuthorizationGroupList = ({
   }
 
   return (
-    <>
-      <Fieldset title="Communities" id="communities">
-        <AuthorizationGroupSearchResults
-          queryParams={queryParams}
-          pageDispatchers={pageDispatchers}
-          paginationKey="authorizationGroups"
-          pagination={pagination}
-          setPagination={setPagination}
-        />
-      </Fieldset>
-    </>
+    <Fieldset title="Communities" id="communities">
+      <AuthorizationGroupSearchResults
+        queryParams={queryParams}
+        pageDispatchers={pageDispatchers}
+        paginationKey="authorizationGroups"
+        pagination={pagination}
+        setPagination={setPagination}
+      />
+    </Fieldset>
   )
 }
 

--- a/client/src/pages/util.ts
+++ b/client/src/pages/util.ts
@@ -12,6 +12,7 @@ export const PAGE_URLS = {
   PEOPLE: "/people",
   PREFERENCES: "/preferences",
   ATTACHMENTS: "/attachments",
+  AUTHORIZATION_GROUPS: "/authorizationGroups",
   ORGANIZATIONS: "/organizations",
   LOCATIONS: "/locations",
   POSITIONS: "/positions",

--- a/client/src/pages/util.ts
+++ b/client/src/pages/util.ts
@@ -12,7 +12,7 @@ export const PAGE_URLS = {
   PEOPLE: "/people",
   PREFERENCES: "/preferences",
   ATTACHMENTS: "/attachments",
-  AUTHORIZATION_GROUPS: "/authorizationGroups",
+  COMMUNITIES: "/communities",
   ORGANIZATIONS: "/organizations",
   LOCATIONS: "/locations",
   POSITIONS: "/positions",

--- a/client/tests/webdriver/baseSpecs/showAllCommunities.spec.js
+++ b/client/tests/webdriver/baseSpecs/showAllCommunities.spec.js
@@ -1,0 +1,25 @@
+import { expect } from "chai"
+import ShowAllCommunities from "../pages/showAllCommunities.page.js"
+
+const COMMUNITIES_NAMES = [
+  "EF 1.1",
+  "EF 2.1",
+  "EF 2.2",
+  "EF 5",
+  "Key Advisors",
+  "Key Interlocutors",
+  "Unlimited exporters"
+]
+
+describe("Show All Communities Page", () => {
+  beforeEach(async () => {
+    await ShowAllCommunities.open()
+  })
+
+  it("Should display all communities", async () => {
+    const communities = await ShowAllCommunities.getCommunitiesList()
+    expect(communities.length).to.be.within(1, 7)
+    const communitiesNames = await ShowAllCommunities.getCommunitiesNames()
+    expect(communitiesNames).to.include.members(COMMUNITIES_NAMES)
+  })
+})

--- a/client/tests/webdriver/pages/showAllCommunities.page.js
+++ b/client/tests/webdriver/pages/showAllCommunities.page.js
@@ -1,0 +1,23 @@
+import Page from "./page"
+
+const PAGE_URL = "/communities"
+
+class ShowAllCommunities extends Page {
+  async open() {
+    await super.open(PAGE_URL)
+  }
+
+  async getCommunitiesList() {
+    await browser.$("#communities fieldset tbody").waitForDisplayed()
+    return browser.$$("#communities fieldset tbody > tr")
+  }
+
+  async getCommunitiesNames() {
+    const elements = await browser.$$(
+      "#communities fieldset tbody > tr td:first-child span"
+    )
+    return elements.map(el => el.getText())
+  }
+}
+
+export default new ShowAllCommunities()


### PR DESCRIPTION
Add quick access to communities in navigation menu.

Closes [AB#1608](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1608)

#### User changes
- Can see a communities link in the navigation menu

#### Superuser changes
- None

#### Admin changes
- None

#### System admin changes
- [ ] application.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
- [x] described the user behavior in PR body
- [x] referenced/updated all related issues
- [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
- [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
- [ ] added and/or updated unit tests
- [ ] added and/or updated e2e tests
- [ ] added and/or updated data migrations
- [ ] updated documentation
- [x] resolved all build errors and warnings
- [ ] opened debt issues for anything not resolved here
