### PR TITLE
Refactor onboarding

### DIFF
--- a/client/src/components/ResponsiveLayout.tsx
+++ b/client/src/components/ResponsiveLayout.tsx
@@ -96,7 +96,11 @@ const ResponsiveLayout = ({ pageProps }: ResponsiveLayoutProps) => {
     !location.pathname.startsWith("/onboarding")
   ) {
     return (
-      <Navigate replace to="/onboarding/new" state={{ nextUrl: location }} />
+      <Navigate
+        replace
+        to={`/onboarding/${!currentUser.uuid ? "new" : "show"}`}
+        state={{ nextUrl: location }}
+      />
     )
   } else if (
     !currentUser.isPendingVerification() &&

--- a/client/src/pages/onboarding/Edit.tsx
+++ b/client/src/pages/onboarding/Edit.tsx
@@ -69,7 +69,7 @@ const OnboardingEdit = ({ pageDispatchers }: OnboardingEditProps) => {
         edit
         forOnboarding
         title="Fill in your profile"
-        saveText="Save"
+        saveText={!person.uuid ? "Enroll in ANET" : "Save"}
       />
     </div>
   )

--- a/client/src/pages/onboarding/New.tsx
+++ b/client/src/pages/onboarding/New.tsx
@@ -9,7 +9,6 @@ import React from "react"
 import { Button } from "react-bootstrap"
 import { connect } from "react-redux"
 import { useLocation, useNavigate } from "react-router"
-import Settings from "settings"
 
 interface OnboardingNewProps {
   pageDispatchers?: PageDispatchersPropType
@@ -24,9 +23,6 @@ const OnboardingNew = ({ pageDispatchers }: OnboardingNewProps) => {
   })
   usePageTitle("Welcome to ANET")
   const navigate = useNavigate()
-  const approvalMsg = Settings.automaticallyAllowAllNewUsers
-    ? "Let's create a new account for you. We'll grab your basic information and help your superuser get you set up."
-    : "Your access to ANET has been requested. While your approval is pending, please take a moment to fill in your profile."
 
   return (
     <div className="onboarding-new">
@@ -35,10 +31,13 @@ const OnboardingNew = ({ pageDispatchers }: OnboardingNewProps) => {
         ANET is a training system for reporting TAA engagements, and learning
         about past engagements and people.
       </p>
-      <p>{approvalMsg}</p>
+      <p>
+        Before you can start using ANET you need to fill in your basic profile
+        and enroll in ANET.
+      </p>
       <div className="create-account-button-wrapper">
         <Button variant="primary" onClick={onCreateAccountClick}>
-          Fill in your profile
+          Fill in your profile and enroll in ANET
         </Button>
       </div>
     </div>

--- a/client/src/pages/onboarding/Show.tsx
+++ b/client/src/pages/onboarding/Show.tsx
@@ -97,7 +97,10 @@ const OnboardingShow = ({ pageDispatchers }: OnboardingShowProps) => {
 
   return (
     <div>
-      <Alert variant="warning">Your account is pending approval</Alert>
+      <Alert variant="warning">
+        Your access to ANET has been requested. Your account is pending approval
+        by an administrator.
+      </Alert>
       <Messages error={stateError} success={stateSuccess} />
       <div className="form-horizontal">
         <Fieldset

--- a/src/main/java/mil/dds/anet/resources/PersonResource.java
+++ b/src/main/java/mil/dds/anet/resources/PersonResource.java
@@ -122,6 +122,12 @@ public class PersonResource {
   }
 
   private static boolean canCreateOrUpdatePerson(Person editor, Person subject, boolean create) {
+    if (editor == null || subject == null) {
+      return false;
+    }
+    if (DaoUtils.isNewUser(editor)) {
+      return DaoUtils.usersHaveMatchingDomainUsername(editor, subject);
+    }
     if (editor.getUuid().equals(subject.getUuid())) {
       return true;
     }
@@ -346,7 +352,11 @@ public class PersonResource {
   @GraphQLQuery(name = "me")
   @AllowUnverifiedUsers
   public Person getCurrentUser(@GraphQLRootContext GraphQLContext context) {
-    return dao.getByUuid(DaoUtils.getUuid(DaoUtils.getUserFromContext(context)));
+    final Person user = DaoUtils.getUserFromContext(context);
+    if (DaoUtils.isNewUser(user)) {
+      return user; // New user tries to onboard!
+    }
+    return dao.getByUuid(DaoUtils.getUuid(user));
   }
 
   @GraphQLMutation(name = "updateMe")
@@ -361,8 +371,13 @@ public class PersonResource {
       throw new ResponseStatusException(HttpStatus.FORBIDDEN, "You can only update yourself");
     }
 
-    final Person existing = dao.getByUuid(p.getUuid());
-    DaoUtils.assertObjectIsFresh(p, existing, force);
+    final Person existing;
+    if (DaoUtils.isNewUser(user)) {
+      existing = user; // New user tries to onboard!
+    } else {
+      existing = dao.getByUuid(p.getUuid());
+      DaoUtils.assertObjectIsFresh(p, existing, force);
+    }
 
     // Only admins can update user/domainUsername
     if (!AuthUtils.isAdmin(user)) {
@@ -383,17 +398,31 @@ public class PersonResource {
 
     p.setBiography(
         Utils.isEmptyHtml(p.getBiography()) ? null : Utils.sanitizeHtml(p.getBiography()));
-    final int numRows = dao.update(p);
-    if (numRows == 0) {
-      throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Couldn't process person update");
+
+    final int numRows;
+    if (DaoUtils.isNewUser(user)) {
+      dao.insert(p);
+      numRows = 1;
+    } else {
+      numRows = dao.update(p);
+      if (numRows == 0) {
+        throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Couldn't process person update");
+      }
     }
 
     emailAddressDao.updateEmailAddresses(PersonDao.TABLE_NAME, p.getUuid(), p.getEmailAddresses());
 
-    // Log the change
-    final String auditTrailUuid = auditTrailDao.logUpdate(user, PersonDao.TABLE_NAME, p);
-    // Update any subscriptions
-    dao.updateSubscriptions(p, auditTrailUuid, false);
+    if (DaoUtils.isNewUser(user)) {
+      userDao.updateUsers(p, p.getUsers());
+
+      // Log the change
+      auditTrailDao.logCreate(user, PersonDao.TABLE_NAME, p);
+    } else {
+      // Log the change
+      final String auditTrailUuid = auditTrailDao.logUpdate(user, PersonDao.TABLE_NAME, p);
+      // Update any subscriptions
+      dao.updateSubscriptions(p, auditTrailUuid, false);
+    }
 
     // GraphQL mutations *have* to return something, so we return the number of updated rows
     return numRows;

--- a/src/main/java/mil/dds/anet/utils/DaoUtils.java
+++ b/src/main/java/mil/dds/anet/utils/DaoUtils.java
@@ -21,6 +21,7 @@ import mil.dds.anet.beans.Assessment;
 import mil.dds.anet.beans.CustomSensitiveInformation;
 import mil.dds.anet.beans.Person;
 import mil.dds.anet.beans.Position;
+import mil.dds.anet.beans.User;
 import mil.dds.anet.config.ApplicationContextProvider;
 import mil.dds.anet.database.AuthorizationGroupDao;
 import mil.dds.anet.database.OrganizationDao;
@@ -122,6 +123,17 @@ public class DaoUtils {
       return null;
     }
     return user;
+  }
+
+  public static boolean isNewUser(Person user) {
+    return user == null || Utils.isEmptyOrNull(user.getUuid());
+  }
+
+  public static boolean usersHaveMatchingDomainUsername(Person editor, Person subject) {
+    final Set<User> editorUsers = new HashSet<>(editor.getUsers());
+    final Set<User> subjectUsers = new HashSet<>(subject.getUsers());
+    editorUsers.retainAll(subjectUsers);
+    return !editorUsers.isEmpty();
   }
 
   public static Position getPosition(final Person user) {

--- a/src/main/java/mil/dds/anet/utils/SecurityUtils.java
+++ b/src/main/java/mil/dds/anet/utils/SecurityUtils.java
@@ -10,9 +10,7 @@ import mil.dds.anet.beans.User;
 import mil.dds.anet.beans.WithStatus;
 import mil.dds.anet.config.ApplicationContextProvider;
 import mil.dds.anet.database.AuditTrailDao;
-import mil.dds.anet.database.EmailAddressDao;
 import mil.dds.anet.database.PersonDao;
-import mil.dds.anet.database.UserDao;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
@@ -49,7 +47,7 @@ public class SecurityUtils {
     Person person = findUser(dao, (String) claims.get(StandardClaimNames.PREFERRED_USERNAME), true);
     if (person == null) {
       // Call synchronized method
-      person = findOrCreateUser(dao, claims);
+      person = findOrPrepareUser(dao, claims);
     }
     return person;
   }
@@ -59,7 +57,7 @@ public class SecurityUtils {
       final boolean activeUser) {
     final List<Person> p = dao.findByDomainUsername(domainUsername, activeUser);
     if (!p.isEmpty()) {
-      final Person existingPerson = p.get(0);
+      final Person existingPerson = p.getFirst();
       logger.trace("found existing user={} by domainUsername={}", existingPerson, domainUsername);
       return existingPerson;
     }
@@ -67,9 +65,9 @@ public class SecurityUtils {
     return null;
   }
 
-  // Synchronized method, so we create/update at most one user in the face of multiple
+  // Synchronized method, so we prepare/update at most one user in the face of multiple
   // simultaneous authentication requests
-  private static synchronized Person findOrCreateUser(final PersonDao dao,
+  private static synchronized Person findOrPrepareUser(final PersonDao dao,
       final Map<String, Object> claims) {
     final String username = (String) claims.get(StandardClaimNames.PREFERRED_USERNAME);
     final Person person = findUser(dao, username, false);
@@ -78,7 +76,7 @@ public class SecurityUtils {
     }
 
     // Not found, first time this user has ever logged in
-    return createPerson(dao, username, (String) claims.get(StandardClaimNames.EMAIL),
+    return preparePerson(username, (String) claims.get(StandardClaimNames.EMAIL),
         Utils.trimStringReturnNull((String) claims.get(StandardClaimNames.FAMILY_NAME)),
         Utils.trimStringReturnNull((String) claims.get(StandardClaimNames.GIVEN_NAME)));
   }
@@ -99,10 +97,10 @@ public class SecurityUtils {
     return person;
   }
 
-  private static Person createPerson(final PersonDao dao, final String username, final String email,
+  private static Person preparePerson(final String username, final String email,
       final String familyName, String givenName) {
     final Person newPerson = new Person();
-    logger.trace("creating new user with domainUsername={} and email={}", username, email);
+    logger.trace("preparing new user with domainUsername={} and email={}", username, email);
     newPerson.setUser(true);
     newPerson.setPendingVerification(true);
     // Copy some data from the authentication token
@@ -113,27 +111,18 @@ public class SecurityUtils {
      * token.getPhoneNumber(), but that requires scope="openid phone" on the authentication request,
      * which is hard to accomplish with current Keycloak code.
      */
-    final Person person = dao.insert(newPerson);
 
+    // Copy some more data from the authentication token
     final User newUser = new User();
-    // Copy some data from the authentication token
     newUser.setDomainUsername(username);
-    newUser.setPersonUuid(person.getUuid());
-    final UserDao userDao = ApplicationContextProvider.getEngine().getUserDao();
-    final User user = userDao.insert(newUser);
-    person.setUsers(List.of(user));
+    newPerson.setUsers(List.of(newUser));
 
     if (!Utils.isEmptyOrNull(email)) {
-      final EmailAddressDao emailAddressDao =
-          ApplicationContextProvider.getEngine().getEmailAddressDao();
       final EmailAddress emailAddress =
           new EmailAddress(Utils.getEmailNetworkForNotifications(), email);
-      emailAddressDao.updateEmailAddresses(PersonDao.TABLE_NAME, person.getUuid(),
-          List.of(emailAddress));
+      newPerson.setEmailAddresses(List.of(emailAddress));
     }
-    final AuditTrailDao auditTrailDao = ApplicationContextProvider.getEngine().getAuditTrailDao();
-    auditTrailDao.logCreate(person, PersonDao.TABLE_NAME, person,
-        "person signed in for the first time");
-    return person;
+
+    return newPerson;
   }
 }

--- a/src/main/java/mil/dds/anet/views/UserActivityFilter.java
+++ b/src/main/java/mil/dds/anet/views/UserActivityFilter.java
@@ -32,15 +32,17 @@ public class UserActivityFilter extends OncePerRequestFilter {
     // Record activity only if the user is fully authenticated
     if (request.getUserPrincipal() != null) {
       final Person person = SecurityUtils.getPersonFromPrincipal(request.getUserPrincipal());
-      // Store recent user activities in Person bean
-      final Activity activity = new Activity(ResponseUtils.getRemoteAddr(request),
-          ResponseUtils.getReferer(request), DaoUtils.getCurrentMinute());
-      personCache.logActivitiesByPersonUuid(DaoUtils.getUuid(person), activity);
-      // Store this request in the database (only once per minute)
-      final Position position = person.getPosition();
-      final UserActivity userActivity = new UserActivity(person.getUuid(),
-          position == null ? null : position.getOrganizationUuid(), DaoUtils.getCurrentMinute());
-      userActivityDao.insert(userActivity);
+      if (!DaoUtils.isNewUser(person)) {
+        // Store recent user activities in Person bean
+        final Activity activity = new Activity(ResponseUtils.getRemoteAddr(request),
+            ResponseUtils.getReferer(request), DaoUtils.getCurrentMinute());
+        personCache.logActivitiesByPersonUuid(DaoUtils.getUuid(person), activity);
+        // Store this request in the database (only once per minute)
+        final Position position = person.getPosition();
+        final UserActivity userActivity = new UserActivity(person.getUuid(),
+            position == null ? null : position.getOrganizationUuid(), DaoUtils.getCurrentMinute());
+        userActivityDao.insert(userActivity);
+      }
     }
     filterChain.doFilter(request, response);
   }

--- a/src/test/java/mil/dds/anet/test/resources/AbstractResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/AbstractResourceTest.java
@@ -151,7 +151,7 @@ public abstract class AbstractResourceTest extends AnetApplicationTest {
     try {
       if (domainUsername != null) {
         final Person user = findPerson(domainUsername);
-        if (user != null) {
+        if (user != null && !Utils.isEmptyOrNull(user.getUuid())) {
           return user;
         }
       } else {


### PR DESCRIPTION
Only create a user in the database if they explicitly enroll in ANET. Change the flow and the messages of the onboarding for clarity. User activities will only be logged after a user has enrolled.

Closes [AB#1612](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1612) 

#### User changes
- The onboarding flow has been clarified, a new user now needs to fill in their basic profile and enroll in ANET.

#### Superuser changes
- None

#### Admin changes
- Only users who have enrolled in ANET will be logged in the activities.

#### System admin changes
- [ ] application.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
- [x] described the user behavior in PR body
- [x] referenced/updated all related issues
- [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
- [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
- [x] added and/or updated unit tests
- [ ] added and/or updated e2e tests
- [ ] added and/or updated data migrations
- [ ] updated documentation
- [x] resolved all build errors and warnings
- [ ] opened debt issues for anything not resolved here