### PR TITLE
Send email to ANET admins when a new user enrolls

### DIFF
--- a/src/main/java/mil/dds/anet/database/PersonDao.java
+++ b/src/main/java/mil/dds/anet/database/PersonDao.java
@@ -5,11 +5,15 @@ import graphql.GraphQLContext;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+import mil.dds.anet.beans.AnetEmail;
 import mil.dds.anet.beans.AuditTrail;
+import mil.dds.anet.beans.EmailAddress;
 import mil.dds.anet.beans.EntityAvatar;
 import mil.dds.anet.beans.MergedEntity;
 import mil.dds.anet.beans.Person;
@@ -24,7 +28,9 @@ import mil.dds.anet.database.mappers.PersonMapper;
 import mil.dds.anet.database.mappers.PersonPositionHistoryMapper;
 import mil.dds.anet.database.mappers.PersonPreferenceMapper;
 import mil.dds.anet.database.mappers.PositionMapper;
+import mil.dds.anet.emails.AnetEmailAction;
 import mil.dds.anet.search.pg.PostgresqlPersonSearcher;
+import mil.dds.anet.threads.AnetEmailWorker;
 import mil.dds.anet.utils.AnetAuditLogger;
 import mil.dds.anet.utils.DaoUtils;
 import mil.dds.anet.utils.FkDataLoaderKey;
@@ -551,5 +557,26 @@ public class PersonDao extends AnetSubscribableObjectDao<Person, PersonSearchQue
       String personUuid) {
     return new ForeignKeyFetcher<PersonPreference>().load(context,
         FkDataLoaderKey.PERSON_PERSON_PREFERENCES, personUuid);
+  }
+
+  public void sendEmailToAdmins(AnetEmailAction action) {
+    final String emailNetworkForNotifications = Utils.getEmailNetworkForNotifications();
+    final PersonSearchQuery adminQuery = new PersonSearchQuery();
+    adminQuery.setPageSize(0);
+    adminQuery.setStatus(WithStatus.Status.ACTIVE);
+    adminQuery.setIsUser(true);
+    adminQuery.setPositionType(List.of(Position.PositionType.ADMINISTRATOR));
+    adminQuery.setEmailNetwork(emailNetworkForNotifications);
+    final AnetBeanList<Person> adminList = search(adminQuery);
+    final Set<String> emailAddresses = adminList.getList().stream()
+        .map(admin -> admin.loadEmailAddresses(engine().getContext(), emailNetworkForNotifications)
+            .join())
+        .flatMap(Collection::stream).map(EmailAddress::getAddress).collect(Collectors.toSet());
+    if (!emailAddresses.isEmpty()) {
+      final AnetEmail email = new AnetEmail();
+      email.setAction(action);
+      email.setToAddresses(emailAddresses.stream().toList());
+      AnetEmailWorker.sendEmailAsync(email);
+    }
   }
 }

--- a/src/main/java/mil/dds/anet/emails/NewUserEmail.java
+++ b/src/main/java/mil/dds/anet/emails/NewUserEmail.java
@@ -1,0 +1,38 @@
+package mil.dds.anet.emails;
+
+import java.util.Map;
+import mil.dds.anet.beans.Person;
+
+public class NewUserEmail implements AnetEmailAction {
+  private String personUuid;
+
+  @Override
+  public String getTemplateName() {
+    return "/emails/newUser.ftlh";
+  }
+
+  @Override
+  public String getSubject(Map<String, Object> context) {
+    return "New ANET user needs approval";
+  }
+
+  @Override
+  public Map<String, Object> buildContext(Map<String, Object> context) {
+    final Person p = engine().getPersonDao().getByUuid(personUuid);
+    if (p == null) {
+      return null;
+    }
+
+    context.put("person", p);
+
+    return context;
+  }
+
+  public String getPersonUuid() {
+    return personUuid;
+  }
+
+  public void setPersonUuid(String personUuid) {
+    this.personUuid = personUuid;
+  }
+}

--- a/src/main/java/mil/dds/anet/resources/PersonResource.java
+++ b/src/main/java/mil/dds/anet/resources/PersonResource.java
@@ -27,6 +27,7 @@ import mil.dds.anet.database.PersonDao;
 import mil.dds.anet.database.PersonPreferenceDao;
 import mil.dds.anet.database.PositionDao;
 import mil.dds.anet.database.UserDao;
+import mil.dds.anet.emails.NewUserEmail;
 import mil.dds.anet.graphql.AllowUnverifiedUsers;
 import mil.dds.anet.utils.AuthUtils;
 import mil.dds.anet.utils.DaoUtils;
@@ -414,6 +415,10 @@ public class PersonResource {
 
     if (DaoUtils.isNewUser(user)) {
       userDao.updateUsers(p, p.getUsers());
+      if (Boolean.FALSE.equals(automaticallyAllowAllNewUsers)) {
+        // Email admins that a new user has enrolled
+        sendNewUserEmail(p);
+      }
 
       // Log the change
       auditTrailDao.logCreate(user, PersonDao.TABLE_NAME, p);
@@ -502,5 +507,11 @@ public class PersonResource {
     final String errorMessage = Utils.isEmptyOrNull(supportEmailAddr) ? messageBody
         : String.format("%s at %s", messageBody, supportEmailAddr);
     return errorMessage;
+  }
+
+  private void sendNewUserEmail(Person p) {
+    final NewUserEmail action = new NewUserEmail();
+    action.setPersonUuid(DaoUtils.getUuid(p));
+    dao.sendEmailToAdmins(action);
   }
 }

--- a/src/main/resources/emails/newUser.ftlh
+++ b/src/main/resources/emails/newUser.ftlh
@@ -1,0 +1,17 @@
+<html lang="en">
+<head>
+    <style>
+        <#include "common/emailStyle.css" parse="false">
+    </style>
+</head>
+<body>
+<#include "common/securityBanner.ftlh">
+
+<p>Dear ANET administrator,</p>
+
+<p>A new user <a href="${serverUrl}/people/${person.uuid}">${person.rank!} ${person.name!}</a> has just enrolled in ANET
+and needs to be approved via <a href="${serverUrl}/admin/usersPendingVerification">Users Pending Verification</a>.</p>
+
+<#include "common/supportFooter.ftlh">
+</body>
+</html>


### PR DESCRIPTION
If a new user enrolls in ANET and `automaticallyAllowAllNewUsers` is set to `false` in the dictionary, admins receive an email that a new user needs to be approved.

Closes [AB#1113](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1113)

#### User changes
- None

#### Superuser changes
- None

#### Admin changes
- Admins receive an email if a new user needs to be approved.

#### System admin changes
- [ ] application.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
- [x] described the user behavior in PR body
- [x] referenced/updated all related issues
- [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
- [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
- [ ] added and/or updated unit tests
- [ ] added and/or updated e2e tests
- [ ] added and/or updated data migrations
- [ ] updated documentation
- [x] resolved all build errors and warnings
- [ ] opened debt issues for anything not resolved here