### PR TITLE
Restrict getting an accessToken by uuid to admins

### DIFF
--- a/src/main/java/mil/dds/anet/resources/AccessTokenResource.java
+++ b/src/main/java/mil/dds/anet/resources/AccessTokenResource.java
@@ -28,7 +28,10 @@ public class AccessTokenResource {
   }
 
   @GraphQLQuery(name = "accessToken")
-  public AccessToken getByUuid(@GraphQLArgument(name = "uuid") String uuid) {
+  public AccessToken getByUuid(@GraphQLRootContext GraphQLContext context,
+      @GraphQLArgument(name = "uuid") String uuid) {
+    final Person user = DaoUtils.getUserFromContext(context);
+    AuthUtils.assertAdministrator(user);
     final AccessToken accessToken = accessTokenDao.getByUuid(uuid);
     if (accessToken == null) {
       throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Access token not found");


### PR DESCRIPTION
By guessing a uuid it was possible to fetch the metadata of a web service access token.
[Note that the metadata itself is pretty useless, as it doesn't include the token value.]

Closes [AB#1613](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1613)

#### User changes
- All web service access token related requests are now restricted to admins.

#### Superuser changes
- None

#### Admin changes
- None

#### System admin changes
- [ ] application.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
- [x] described the user behavior in PR body
- [x] referenced/updated all related issues
- [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
- [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
- [ ] added and/or updated unit tests
- [ ] added and/or updated e2e tests
- [ ] added and/or updated data migrations
- [ ] updated documentation
- [x] resolved all build errors and warnings
- [ ] opened debt issues for anything not resolved here