### PR TITLE
Allow selection of engagement date in reports aggregation

### DIFF
--- a/client/src/components/ReportsAggregatedOverTime.tsx
+++ b/client/src/components/ReportsAggregatedOverTime.tsx
@@ -73,11 +73,7 @@ function getDateField(
 ): moment.Moment {
   const selectedDate =
     obj?.[`${usePublicationDate ? "releasedAt" : "engagementDate"}${mark}`]
-  if (selectedDate) {
-    return moment(selectedDate)
-  } else {
-    return null
-  }
+  return selectedDate ? moment(selectedDate) : null
 }
 
 function getStartDate(queryParams, usePublicationDate: boolean): moment.Moment {
@@ -154,18 +150,15 @@ const ReportsAggregatedOverTime = ({
   }, [data, queryParams, usePublicationDate, granularity])
   const startDate = getStartDate(queryParams, usePublicationDate)
   const endDate = getEndDate(queryParams, usePublicationDate)
+  const hasRange = startDate && endDate
 
-  const getNoDateRangeMessage = () => {
-    return `Select a ${usePublicationDate ? "Release" : "Engagement"} Date range in search filters to view results.`
-  }
+  const noDateRangeMessage = `Select ${usePublicationDate ? "a Release" : "an Engagement"} Date range in search filters to view results.`
 
   const displayedRangeLabel = (() => {
     if (!startDate || !endDate) {
-      return getNoDateRangeMessage()
+      return noDateRangeMessage
     }
-    const start = getStartDate(queryParams, usePublicationDate)
-    const end = getEndDate(queryParams, usePublicationDate)
-    return `${start.format(Settings.dateFormats.forms.displayShort.date)} — ${end.format(Settings.dateFormats.forms.displayShort.date)}`
+    return `${startDate.format(Settings.dateFormats.forms.displayShort.date)} — ${endDate.format(Settings.dateFormats.forms.displayShort.date)}`
   })()
 
   const totalReports = graphData.reduce(
@@ -176,13 +169,8 @@ const ReportsAggregatedOverTime = ({
   const barPadding = 0.1
   const hasData = graphData.length > 0
 
-  const rangeStart = getStartDate(queryParams, usePublicationDate)
-  const rangeEnd = getEndDate(queryParams, usePublicationDate)
-  const hasRange = rangeStart && rangeEnd
-
   const canGoNext =
-    hasRange &&
-    (!usePublicationDate || rangeEnd.isBefore(moment().endOf("day")))
+    hasRange && (!usePublicationDate || endDate.isBefore(moment().endOf("day")))
   const canGoPrevious = hasRange
 
   const updateQueryParams = (
@@ -190,7 +178,7 @@ const ReportsAggregatedOverTime = ({
     direction: number = 0
   ) => {
     const newRangeStart = getRangeStart(
-      getStartDate(queryParams, usePublicationDate).add(direction, "year"),
+      startDate.add(direction, "year"),
       newUsePublicationDate
     )
     const newRangeEnd = getRangeEnd(newRangeStart, newUsePublicationDate)
@@ -287,7 +275,7 @@ const ReportsAggregatedOverTime = ({
         </div>
 
         {!hasRange ? (
-          <em>{getNoDateRangeMessage()}</em>
+          <em>{noDateRangeMessage}</em>
         ) : !hasData ? (
           <em>No reports found for the selected range.</em>
         ) : (

--- a/client/src/components/ReportsAggregatedOverTime.tsx
+++ b/client/src/components/ReportsAggregatedOverTime.tsx
@@ -12,9 +12,10 @@ import {
 import _escape from "lodash/escape"
 import moment from "moment"
 import { WEEK_PERIOD_FORMAT, WEEK_PERIOD_KEY } from "periodUtils"
-import React, { useEffect, useMemo, useState } from "react"
+import React, { useMemo, useState } from "react"
 import { Button, Table } from "react-bootstrap"
 import { useResizeDetector } from "react-resize-detector"
+import Settings from "settings"
 
 const GQL_GET_REPORT_LIST = gql`
   query ($reportQuery: ReportSearchQueryInput) {
@@ -24,6 +25,7 @@ const GQL_GET_REPORT_LIST = gql`
         uuid
         state
         releasedAt
+        engagementDate
       }
     }
   }
@@ -35,15 +37,55 @@ const GRANULARITY = {
   WEEK: "week"
 }
 
-// Helper to resolve various date value types to a moment object
-function resolveDateValue(value) {
-  if (value === null || value === undefined) {
+enum ReportDate {
+  ENGAGEMENT = "Engagement Date",
+  PUBLICATION = "Publication Date"
+}
+
+function getRangeStart(
+  rangeStart: moment.Moment,
+  usePublicationDate: boolean
+): moment.Moment {
+  const newRangeStart = rangeStart.startOf("year")
+  const startOfYear = moment().startOf("year")
+  if (usePublicationDate && newRangeStart.isAfter(startOfYear)) {
+    return startOfYear
+  }
+  return newRangeStart
+}
+
+function getRangeEnd(
+  rangeStart: moment.Moment,
+  usePublicationDate: boolean
+): moment.Moment {
+  const rangeEnd = moment(rangeStart).add(1, "year").add(-1, "day").endOf("day")
+  const endOfDay = moment().endOf("day")
+  if (usePublicationDate && rangeEnd.isAfter(endOfDay)) {
+    return endOfDay
+  }
+  return rangeEnd
+}
+
+function getDateField(
+  obj,
+  usePublicationDate: boolean,
+  mark: string = ""
+): moment.Moment {
+  const selectedDate =
+    obj?.[`${usePublicationDate ? "releasedAt" : "engagementDate"}${mark}`]
+  if (selectedDate) {
+    return moment(selectedDate)
+  } else {
     return null
   }
-  if (typeof value === "number") {
-    return moment().add(value, "milliseconds")
-  }
-  return moment(value)
+}
+
+function getStartDate(queryParams, usePublicationDate: boolean): moment.Moment {
+  return getDateField(queryParams, usePublicationDate, "Start")
+}
+
+function getEndDate(queryParams, usePublicationDate: boolean) {
+  return getDateField(queryParams, usePublicationDate, "End")
 }
 
 interface PublishedReportsOverTimeProps {
@@ -52,29 +94,16 @@ interface PublishedReportsOverTimeProps {
   setQueryParams?: (...args: unknown[]) => unknown
 }
 
-const PublishedReportsOverTime = ({
+const ReportsAggregatedOverTime = ({
   pageDispatchers,
   queryParams,
   setQueryParams
 }: PublishedReportsOverTimeProps) => {
   const [granularity, setGranularity] = useState(GRANULARITY.MONTH)
-  usePageTitle("Reports Published Over Time")
+  const [usePublicationDate, setUsePublicationDate] = useState(true)
+  usePageTitle("Aggregated Reports Over Time")
 
   const { width, ref } = useResizeDetector()
-  const rangeStart = useMemo(
-    () => resolveDateValue(queryParams?.releasedAtStart),
-    [queryParams?.releasedAtStart]
-  )
-  const rangeEnd = useMemo(
-    () => resolveDateValue(queryParams?.releasedAtEnd),
-    [queryParams?.releasedAtEnd]
-  )
-  const todayEnd = moment().endOf("day")
-  const displayRangeEnd =
-    rangeEnd && rangeEnd.isAfter(todayEnd) ? todayEnd : rangeEnd
-  const hasRange = Boolean(
-    rangeStart && displayRangeEnd && rangeStart.isSameOrBefore(displayRangeEnd)
-  )
   const reportQuery = useMemo(
     () => ({
       ...queryParams,
@@ -92,26 +121,29 @@ const PublishedReportsOverTime = ({
     pageDispatchers
   })
   const graphData = useMemo(() => {
-    if (!data || !hasRange) {
+    if (!data) {
       return []
     }
     const reportsList = data.reportList.list || []
     if (!reportsList.length) {
       return []
     }
+    const startDate = getStartDate(queryParams, usePublicationDate)
+    const endDate = getEndDate(queryParams, usePublicationDate)
     const periods =
       granularity === GRANULARITY.MONTH
-        ? buildMonthlyPeriods(rangeStart, displayRangeEnd)
-        : buildWeeklyPeriods(rangeStart, displayRangeEnd)
+        ? buildMonthlyPeriods(startDate, endDate)
+        : buildWeeklyPeriods(startDate, endDate)
     const counts = reportsList.reduce((acc, report) => {
-      if (!report.releasedAt) {
+      const dateField = getDateField(report, usePublicationDate)
+      if (!dateField) {
         return acc
       }
-      const releasedAt = moment(report.releasedAt)
+      const dateValue = moment(dateField)
       const key =
         granularity === GRANULARITY.MONTH
-          ? releasedAt.format("YYYY-MM")
-          : getWeekKey(releasedAt)
+          ? getMonthKey(dateValue)
+          : getWeekKey(dateValue)
       acc[key] = (acc[key] || 0) + 1
       return acc
     }, {})
@@ -119,14 +151,23 @@ const PublishedReportsOverTime = ({
       ...period,
       reportsCount: counts[period.periodKey] || 0
     }))
-  }, [data, displayRangeEnd, granularity, hasRange, rangeStart])
+  }, [data, queryParams, usePublicationDate, granularity])
+  const startDate = getStartDate(queryParams, usePublicationDate)
+  const endDate = getEndDate(queryParams, usePublicationDate)
 
-  const displayedRangeLabel =
-    hasRange && rangeStart.year() === displayRangeEnd.year()
-      ? `Year ${rangeStart.year()}`
-      : hasRange
-        ? `${rangeStart.format("YYYY")}–${displayRangeEnd.format("YYYY")}`
-        : "Release Date range"
+  const getNoDateRangeMessage = () => {
+    return `Select a ${usePublicationDate ? "Release" : "Engagement"} Date range in search filters to view results.`
+  }
+
+  const displayedRangeLabel = (() => {
+    if (!startDate || !endDate) {
+      return getNoDateRangeMessage()
+    }
+    const start = getStartDate(queryParams, usePublicationDate)
+    const end = getEndDate(queryParams, usePublicationDate)
+    return `${start.format(Settings.dateFormats.forms.displayShort.date)} — ${end.format(Settings.dateFormats.forms.displayShort.date)}`
+  })()
+
   const totalReports = graphData.reduce(
     (total, period) => total + period.reportsCount,
     0
@@ -134,62 +175,51 @@ const PublishedReportsOverTime = ({
   const chartWidth = width || 0
   const barPadding = 0.1
   const hasData = graphData.length > 0
-  const rangeStartOfYear = moment(rangeStart).startOf("year")
-  const isCurrentYearClampedRange =
+
+  const rangeStart = getStartDate(queryParams, usePublicationDate)
+  const rangeEnd = getEndDate(queryParams, usePublicationDate)
+  const hasRange = rangeStart && rangeEnd
+
+  const canGoNext =
     hasRange &&
-    rangeStart.isSame(rangeStartOfYear, "day") &&
-    displayRangeEnd.isSame(todayEnd, "day") &&
-    rangeStart.isSame(todayEnd, "year")
-  const isFullYearRange =
-    hasRange &&
-    rangeStart.isSame(rangeStartOfYear, "day") &&
-    displayRangeEnd.isSame(moment(displayRangeEnd).endOf("year"), "day")
-  const getShiftedRange = direction => {
-    if (!hasRange) {
-      return null
+    (!usePublicationDate || rangeEnd.isBefore(moment().endOf("day")))
+  const canGoPrevious = hasRange
+
+  const updateQueryParams = (
+    newUsePublicationDate: boolean,
+    direction: number = 0
+  ) => {
+    const newRangeStart = getRangeStart(
+      getStartDate(queryParams, usePublicationDate).add(direction, "year"),
+      newUsePublicationDate
+    )
+    const newRangeEnd = getRangeEnd(newRangeStart, newUsePublicationDate)
+    if (newUsePublicationDate) {
+      setQueryParams({
+        ...Object.without(
+          queryParams,
+          "engagementDateStart",
+          "engagementDateEnd"
+        ),
+        releasedAtStart: newRangeStart.toISOString(),
+        releasedAtEnd: newRangeEnd.toISOString()
+      })
+    } else {
+      setQueryParams({
+        ...Object.without(queryParams, "releasedAtStart", "releasedAtEnd"),
+        engagementDateStart: newRangeStart.toISOString(),
+        engagementDateEnd: newRangeEnd.toISOString()
+      })
     }
-    let nextStart = moment(rangeStart).add(direction, "year")
-    let nextEnd = moment(displayRangeEnd).add(direction, "year")
-    if (direction < 0 && isCurrentYearClampedRange) {
-      nextStart = nextStart.startOf("year")
-      nextEnd = moment(nextStart).endOf("year")
-    } else if (direction > 0 && isFullYearRange) {
-      nextStart = nextStart.startOf("year")
-      if (nextStart.isSame(todayEnd, "year")) {
-        nextEnd = moment(todayEnd)
-      } else {
-        nextEnd = moment(nextStart).endOf("year")
-      }
-    } else if (direction > 0 && nextEnd.isAfter(todayEnd)) {
-      nextEnd = moment(todayEnd)
-    }
-    if (direction > 0 && nextStart.isAfter(todayEnd, "day")) {
-      return null
-    }
-    return { start: nextStart, end: nextEnd }
+    setUsePublicationDate(newUsePublicationDate)
   }
 
-  const canGoNext = Boolean(getShiftedRange(1))
-  const canGoPrevious = Boolean(getShiftedRange(-1))
-  useEffect(() => {
-    if (!rangeEnd || !rangeEnd.isAfter(todayEnd)) {
-      return
-    }
-    setQueryParams({
-      ...queryParams,
-      releasedAtEnd: todayEnd.toISOString()
-    })
-  }, [queryParams, rangeEnd, setQueryParams, todayEnd])
-  const shiftRange = direction => {
-    const shifted = getShiftedRange(direction)
-    if (!shifted) {
-      return
-    }
-    setQueryParams({
-      ...queryParams,
-      releasedAtStart: shifted.start.toISOString(),
-      releasedAtEnd: shifted.end.toISOString()
-    })
+  const shiftRange = (direction: number) => {
+    updateQueryParams(usePublicationDate, direction)
+  }
+
+  const updateUsePublicationDate = (newUsePublicationDate: boolean) => {
+    updateQueryParams(newUsePublicationDate)
   }
 
   if (done) {
@@ -201,6 +231,26 @@ const PublishedReportsOverTime = ({
       <div className="p-3">
         <div className="d-flex flex-wrap align-items-center justify-content-between mb-3 gap-2">
           <div className="d-flex align-items-center gap-2">
+            <div className="fw-semibold">Date to use in the report</div>
+            <select
+              id="report-date-type"
+              style={{ width: "unset" }}
+              disabled={!hasRange}
+              value={
+                usePublicationDate
+                  ? ReportDate.PUBLICATION
+                  : ReportDate.ENGAGEMENT
+              }
+              onChange={e =>
+                updateUsePublicationDate(
+                  e.target.value === ReportDate.PUBLICATION
+                )
+              }
+              className="form-select"
+            >
+              <option value={ReportDate.PUBLICATION}>Publication Date</option>
+              <option value={ReportDate.ENGAGEMENT}>Engagement Date</option>
+            </select>
             <Button
               variant="outline-secondary"
               disabled={!canGoPrevious}
@@ -208,7 +258,9 @@ const PublishedReportsOverTime = ({
             >
               <Icon icon={IconNames.DOUBLE_CHEVRON_LEFT} /> previous year
             </Button>
-            <div className="fw-semibold">{displayedRangeLabel}</div>
+            <div className="fw-semibold" data-testid="range-label">
+              {displayedRangeLabel}
+            </div>
             <Button
               variant="outline-secondary"
               disabled={!canGoNext}
@@ -235,9 +287,7 @@ const PublishedReportsOverTime = ({
         </div>
 
         {!hasRange ? (
-          <em>
-            Select a Release Date range in search filters to view results.
-          </em>
+          <em>{getNoDateRangeMessage()}</em>
         ) : !hasData ? (
           <em>No reports found for the selected range.</em>
         ) : (
@@ -285,7 +335,10 @@ const PublishedReportsOverTime = ({
   )
 }
 
-const buildMonthlyPeriods = (rangeStart, rangeEnd) => {
+const buildMonthlyPeriods = (
+  rangeStart: moment.Moment,
+  rangeEnd: moment.Moment
+) => {
   const startOfFirstMonth = moment(rangeStart).startOf("month")
   const startOfLastMonth = moment(rangeEnd).startOf("month")
   const totalMonths = startOfLastMonth.diff(startOfFirstMonth, "months") + 1
@@ -296,9 +349,10 @@ const buildMonthlyPeriods = (rangeStart, rangeEnd) => {
     const isLast = index === totalMonths - 1
     const periodStart = isFirst ? moment(rangeStart) : start
     const periodEnd = isLast ? moment(rangeEnd) : monthEnd
+    const monthLabel = getMonthKey(periodStart)
     return {
-      periodKey: start.format("YYYY-MM"),
-      label: start.format("MMM"),
+      periodKey: monthLabel,
+      label: monthLabel,
       periodRange: `${periodStart.format("MMM D")} - ${periodEnd.format(
         "MMM D"
       )}`
@@ -306,7 +360,10 @@ const buildMonthlyPeriods = (rangeStart, rangeEnd) => {
   })
 }
 
-const buildWeeklyPeriods = (rangeStart, rangeEnd) => {
+const buildWeeklyPeriods = (
+  rangeStart: moment.Moment,
+  rangeEnd: moment.Moment
+) => {
   const startOfRange = moment(rangeStart).startOf(WEEK_PERIOD_KEY)
   const endOfRange = moment(rangeEnd).startOf(WEEK_PERIOD_KEY)
   const totalWeeks = endOfRange.diff(startOfRange, "weeks") + 1
@@ -330,6 +387,7 @@ const buildWeeklyPeriods = (rangeStart, rangeEnd) => {
   })
 }
 
-const getWeekKey = date => date.format(WEEK_PERIOD_FORMAT)
+const getMonthKey = (date: moment.Moment) => date.format("MMM YYYY")
+const getWeekKey = (date: moment.Moment) => date.format(WEEK_PERIOD_FORMAT)
 
-export default PublishedReportsOverTime
+export default ReportsAggregatedOverTime

--- a/client/src/pages/insights/Show.tsx
+++ b/client/src/pages/insights/Show.tsx
@@ -19,7 +19,7 @@ import {
 import PendingApprovalReports from "components/PendingApprovalReports"
 import PendingAssessmentsByPosition from "components/PendingAssessmentsByPosition"
 import PollingContext from "components/PollingContext"
-import PublishedReportsOverTime from "components/PublishedReportsOverTime"
+import ReportsAggregatedOverTime from "components/ReportsAggregatedOverTime"
 import ReportsByDayOfWeek from "components/ReportsByDayOfWeek"
 import ReportsByTask from "components/ReportsByTask"
 import {
@@ -43,7 +43,7 @@ export const FUTURE_ENGAGEMENTS_BY_LOCATION = "future-engagements-by-location"
 export const PENDING_ASSESSMENTS_BY_POSITION = "pending-assessments-by-position"
 export const ADVISOR_REPORTS = "advisor-reports"
 export const CADENCE_DASHBOARD = "cadence-dashboard"
-export const PUBLISHED_REPORTS_OVER_TIME = "published-reports-over-time"
+export const AGGREGATED_REPORTS_OVER_TIME = "aggregated-reports-over-time"
 
 export const INSIGHTS = [
   NOT_APPROVED_REPORTS,
@@ -51,7 +51,7 @@ export const INSIGHTS = [
   REPORTS_BY_TASK,
   FUTURE_ENGAGEMENTS_BY_LOCATION,
   REPORTS_BY_DAY_OF_WEEK,
-  PUBLISHED_REPORTS_OVER_TIME,
+  AGGREGATED_REPORTS_OVER_TIME,
   PENDING_ASSESSMENTS_BY_POSITION,
   ADVISOR_REPORTS,
   CADENCE_DASHBOARD
@@ -116,11 +116,11 @@ export const INSIGHT_DETAILS = {
     navTitle: "Cadence Dashboard",
     title: "Cadence Dashboard"
   },
-  [PUBLISHED_REPORTS_OVER_TIME]: {
+  [AGGREGATED_REPORTS_OVER_TIME]: {
     searchProps: REPORT_SEARCH_PROPS,
-    component: PublishedReportsOverTime,
-    navTitle: "Reports Published Over Time",
-    title: "Reports Published Over Time"
+    component: ReportsAggregatedOverTime,
+    navTitle: "Aggregated Reports Over Time",
+    title: "Aggregated Reports Over Time"
   }
 }
 
@@ -216,10 +216,10 @@ const InsightsShow = ({
     },
     [ADVISOR_REPORTS]: {},
     [CADENCE_DASHBOARD]: {},
-    [PUBLISHED_REPORTS_OVER_TIME]: {
+    [AGGREGATED_REPORTS_OVER_TIME]: {
       state: [Report.STATE.PUBLISHED],
       releasedAtStart: getCurrentDateTime().startOf("year").toISOString(),
-      releasedAtEnd: getCurrentDateTime().endOf("year").toISOString()
+      releasedAtEnd: getCurrentDateTime().endOf("day").toISOString()
     }
   }
   let queryParams

--- a/client/tests/webdriver/baseSpecs/reportsAggregatedOverTime.spec.js
+++ b/client/tests/webdriver/baseSpecs/reportsAggregatedOverTime.spec.js
@@ -2,27 +2,28 @@ import { expect } from "chai"
 import moment from "moment"
 import Settings from "../../../platform/node/settings"
 import AdvancedSearch from "../pages/advancedSearch.page"
-import Insights, { PUBLISHED_REPORTS_OVER_TIME } from "../pages/insights.page"
+import Insights, { AGGREGATED_REPORTS_OVER_TIME } from "../pages/insights.page"
 
 const RELEASE_DATE_LABEL = "Release Date"
 const NO_RANGE_MESSAGE =
   "Select a Release Date range in search filters to view results."
-const RANGE_LABEL_SELECTOR = `#${PUBLISHED_REPORTS_OVER_TIME} .d-flex.align-items-center.gap-2 .fw-semibold`
-const GRANULARITY_SELECTOR = `#${PUBLISHED_REPORTS_OVER_TIME} .btn-group`
-const TOTAL_REPORTS_SELECTOR = `//div[@id="${PUBLISHED_REPORTS_OVER_TIME}"]//div[contains(text(),"Total reports:")]`
+const RANGE_LABEL_SELECTOR = '[data-testid="range-label"]'
+const GRANULARITY_SELECTOR = `#${AGGREGATED_REPORTS_OVER_TIME} .btn-group`
+const TOTAL_REPORTS_SELECTOR = `//div[@id="${AGGREGATED_REPORTS_OVER_TIME}"]//div[contains(text(),"Total reports:")]`
 const CHART_ID = "reports_published_over_time"
 const BAR_SELECTOR = `#${CHART_ID} g.bars-group`
 const EXPECTED_PUBLISHED_RANGE = { min: 27, max: 29 }
 const WEEK_PERIOD_KEY = Settings.useISO8601 ? "isoWeek" : "week"
 
-describe("Published reports over time insight", () => {
+describe("Aggregated reports over time insight", () => {
   it("Should show the default release date range in the search summary", async () => {
     await openPublishedReportsInsight()
 
     const rangeLabel = await browser.$(RANGE_LABEL_SELECTOR)
-    expect(await rangeLabel.getText()).to.equal(
-      `Year ${new Date().getFullYear()}`
-    )
+    const expectedRangeLabelText = `${moment()
+      .startOf("year")
+      .format("D MMMM YYYY")} — ${moment().format("D MMMM YYYY")}`
+    expect(await rangeLabel.getText()).to.equal(expectedRangeLabelText)
 
     const totalReportsLabel = await browser.$(TOTAL_REPORTS_SELECTOR)
     await totalReportsLabel.waitForExist()
@@ -121,9 +122,11 @@ describe("Published reports over time insight", () => {
     expect(await searchSummary.getText()).to.not.include(RELEASE_DATE_LABEL)
 
     const rangeLabel = await browser.$(RANGE_LABEL_SELECTOR)
-    expect(await rangeLabel.getText()).to.equal("Release Date range")
+    expect(await rangeLabel.getText()).to.equal(NO_RANGE_MESSAGE)
 
-    const noRangeMessage = await browser.$(`#${PUBLISHED_REPORTS_OVER_TIME} em`)
+    const noRangeMessage = await browser.$(
+      `#${AGGREGATED_REPORTS_OVER_TIME} em`
+    )
     expect(await noRangeMessage.getText()).to.equal(NO_RANGE_MESSAGE)
 
     await Insights.logout()
@@ -131,9 +134,9 @@ describe("Published reports over time insight", () => {
 })
 
 async function openPublishedReportsInsight() {
-  await Insights.open(`/insights/${PUBLISHED_REPORTS_OVER_TIME}`)
+  await Insights.open(`/insights/${AGGREGATED_REPORTS_OVER_TIME}`)
   await (
-    await Insights.getInsightDiv(PUBLISHED_REPORTS_OVER_TIME)
+    await Insights.getInsightDiv(AGGREGATED_REPORTS_OVER_TIME)
   ).waitForExist()
   await (await AdvancedSearch.getAdvancedSearchForm()).waitForExist()
 }
@@ -162,7 +165,7 @@ async function expectBarCountToEqual(expectedCount) {
 
 async function expectLastTableCountWithinRange(range) {
   const rows = await browser.$$(
-    `#${PUBLISHED_REPORTS_OVER_TIME} table tbody tr`
+    `#${AGGREGATED_REPORTS_OVER_TIME} table tbody tr`
   )
   if (!rows.length) {
     throw new Error("Expected report table to have rows")

--- a/client/tests/webdriver/pages/insights.page.js
+++ b/client/tests/webdriver/pages/insights.page.js
@@ -9,7 +9,7 @@ const FUTURE_ENGAGEMENTS_BY_LOCATION = "future-engagements-by-location"
 export const PENDING_ASSESSMENTS_BY_POSITION = "pending-assessments-by-position"
 const ADVISOR_REPORTS = "advisor-reports"
 const CADENCE_DASHBOARD = "cadence-dashboard"
-export const PUBLISHED_REPORTS_OVER_TIME = "published-reports-over-time"
+export const AGGREGATED_REPORTS_OVER_TIME = "aggregated-reports-over-time"
 export const INSIGHTS = [
   NOT_APPROVED_REPORTS,
   CANCELLED_REPORTS,
@@ -19,7 +19,7 @@ export const INSIGHTS = [
   PENDING_ASSESSMENTS_BY_POSITION,
   ADVISOR_REPORTS,
   CADENCE_DASHBOARD,
-  PUBLISHED_REPORTS_OVER_TIME
+  AGGREGATED_REPORTS_OVER_TIME
 ]
 
 class Insights extends Page {


### PR DESCRIPTION
Allow selection of engagement date in reports aggregation

Closes [AB#1610](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1610)

#### User changes
- In Insights, Reports Published Over Time the user can no chose between Publication Date and Engagement Date to generate the report.

#### Superuser changes
- None

#### Admin changes
- None

#### System admin changes
- [ ] application.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
- [x] described the user behavior in PR body
- [x] referenced/updated all related issues
- [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
- [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
- [ ] added and/or updated unit tests
- [x] added and/or updated e2e tests
- [ ] added and/or updated data migrations
- [ ] updated documentation
- [x] resolved all build errors and warnings
- [ ] opened debt issues for anything not resolved here
