### PR TITLE
Do not have mailto: links when selecting mail recipients of a report

### DIFF
--- a/client/src/components/EmailAddressList.tsx
+++ b/client/src/components/EmailAddressList.tsx
@@ -5,13 +5,13 @@ import utils from "utils"
 interface EmailAddressListProps {
   label: string
   emailAddresses?: any[]
-  noMailLinks?: boolean
+  isLink?: boolean
 }
 
 const EmailAddressList = ({
   label,
   emailAddresses,
-  noMailLinks
+  isLink = true
 }: EmailAddressListProps) => {
   if (_get(emailAddresses, "length", 0) === 0) {
     return <em>No {label.toLowerCase()} available</em>
@@ -21,7 +21,7 @@ const EmailAddressList = ({
     <>
       {emailAddresses?.map(ea => (
         <div key={ea.network}>
-          {noMailLinks ? ea.address : utils.createMailtoLink(ea.address)}
+          {isLink ? utils.createMailtoLink(ea.address) : ea.address}
         </div>
       ))}
     </>

--- a/client/src/components/EmailAddressList.tsx
+++ b/client/src/components/EmailAddressList.tsx
@@ -5,9 +5,14 @@ import utils from "utils"
 interface EmailAddressListProps {
   label: string
   emailAddresses?: any[]
+  noMailLinks?: boolean
 }
 
-const EmailAddressList = ({ label, emailAddresses }: EmailAddressListProps) => {
+const EmailAddressList = ({
+  label,
+  emailAddresses,
+  noMailLinks
+}: EmailAddressListProps) => {
   if (_get(emailAddresses, "length", 0) === 0) {
     return <em>No {label.toLowerCase()} available</em>
   }
@@ -15,7 +20,9 @@ const EmailAddressList = ({ label, emailAddresses }: EmailAddressListProps) => {
   return (
     <>
       {emailAddresses?.map(ea => (
-        <div key={ea.network}>{utils.createMailtoLink(ea.address)}</div>
+        <div key={ea.network}>
+          {noMailLinks ? ea.address : utils.createMailtoLink(ea.address)}
+        </div>
       ))}
     </>
   )

--- a/client/src/components/EmailModal.tsx
+++ b/client/src/components/EmailModal.tsx
@@ -177,7 +177,7 @@ const ToAnetUsersOverlayRow = (item: any) => (
       <LinkTo modelType="Person" model={item} isLink={false} />
     </td>
     <td>
-      <LinkTo modelType="Position" model={item.position}>
+      <LinkTo modelType="Position" model={item.position} isLink={false}>
         {Position.toString(item.position)}
         {item.position?.code ? `, ${item.position.code}` : ""}
       </LinkTo>
@@ -187,6 +187,7 @@ const ToAnetUsersOverlayRow = (item: any) => (
         modelType="Location"
         model={item.position?.location}
         whenUnspecified=""
+        isLink={false}
       />
     </td>
     <td>

--- a/client/src/components/EmailModal.tsx
+++ b/client/src/components/EmailModal.tsx
@@ -170,7 +170,7 @@ const ToAnetUsersOverlayRow = (item: any) => (
       <EmailAddressList
         label={Settings.fields.person.emailAddresses.label}
         emailAddresses={item.emailAddresses}
-        noMailLinks
+        isLink={false}
       />
     </td>
     <td>

--- a/client/src/components/EmailModal.tsx
+++ b/client/src/components/EmailModal.tsx
@@ -170,6 +170,7 @@ const ToAnetUsersOverlayRow = (item: any) => (
       <EmailAddressList
         label={Settings.fields.person.emailAddresses.label}
         emailAddresses={item.emailAddresses}
+        noMailLinks
       />
     </td>
     <td>


### PR DESCRIPTION
When selecting somebody to receive a report by email, in the list of people the email address is not a mailto: link (which can accidentally be clicked)

Closes [AB#1622](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1622)

#### User changes
- When selecting somebody to receive a report by email, in the list of people the email address is not a mailto: link (which can accidentally be clicked)


#### Superuser changes
- None

#### Admin changes
- None

#### System admin changes
- [ ] application.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
- [x] described the user behavior in PR body
- [x] referenced/updated all related issues
- [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
- [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
- [ ] added and/or updated unit tests
- [ ] added and/or updated e2e tests
- [ ] added and/or updated data migrations
- [ ] updated documentation
- [x] resolved all build errors and warnings
- [ ] opened debt issues for anything not resolved here
