### PR TITLE
Don't allow unverified users to search for events and event series

### DIFF
--- a/src/main/java/mil/dds/anet/resources/EventResource.java
+++ b/src/main/java/mil/dds/anet/resources/EventResource.java
@@ -16,7 +16,6 @@ import mil.dds.anet.beans.search.EventSearchQuery;
 import mil.dds.anet.config.AnetDictionary;
 import mil.dds.anet.database.AuditTrailDao;
 import mil.dds.anet.database.EventDao;
-import mil.dds.anet.graphql.AllowUnverifiedUsers;
 import mil.dds.anet.utils.AuthUtils;
 import mil.dds.anet.utils.DaoUtils;
 import mil.dds.anet.utils.Utils;
@@ -63,7 +62,6 @@ public class EventResource {
   }
 
   @GraphQLQuery(name = "eventList")
-  @AllowUnverifiedUsers
   public AnetBeanList<Event> search(@GraphQLRootContext GraphQLContext context,
       @GraphQLArgument(name = "query") EventSearchQuery query) {
     query.setUser(DaoUtils.getUserFromContext(context));

--- a/src/main/java/mil/dds/anet/resources/EventSeriesResource.java
+++ b/src/main/java/mil/dds/anet/resources/EventSeriesResource.java
@@ -12,7 +12,6 @@ import mil.dds.anet.beans.search.EventSeriesSearchQuery;
 import mil.dds.anet.config.AnetDictionary;
 import mil.dds.anet.database.AuditTrailDao;
 import mil.dds.anet.database.EventSeriesDao;
-import mil.dds.anet.graphql.AllowUnverifiedUsers;
 import mil.dds.anet.utils.AuthUtils;
 import mil.dds.anet.utils.DaoUtils;
 import mil.dds.anet.utils.Utils;
@@ -56,7 +55,6 @@ public class EventSeriesResource {
   }
 
   @GraphQLQuery(name = "eventSeriesList")
-  @AllowUnverifiedUsers
   public AnetBeanList<EventSeries> search(@GraphQLRootContext GraphQLContext context,
       @GraphQLArgument(name = "query") EventSeriesSearchQuery query) {
     query.setUser(DaoUtils.getUserFromContext(context));


### PR DESCRIPTION
Unverified users were able to retrieve (just) the total number of events and event series by calling the GraphQL search query directly. This is now no longer possible.

Closes [AB#1624](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1624)

#### User changes
- Unverified users can no longer search for events and event series.

#### Superuser changes
- None

#### Admin changes
- None

#### System admin changes
- [ ] application.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
- [x] described the user behavior in PR body
- [x] referenced/updated all related issues
- [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
- [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
- [ ] added and/or updated unit tests
- [ ] added and/or updated e2e tests
- [ ] added and/or updated data migrations
- [ ] updated documentation
- [x] resolved all build errors and warnings
- [ ] opened debt issues for anything not resolved here