### PR TITLE
Set Kosovo ethnic groups to inactive

### DIFF
--- a/client/tests/webdriver/baseSpecs/searchFilters/locationFilter.spec.js
+++ b/client/tests/webdriver/baseSpecs/searchFilters/locationFilter.spec.js
@@ -8,15 +8,15 @@ describe("When using the location filter on the reports search", () => {
 
     // depending on the test run sequence, one more locations may have been created
     expect(await LocationFilter.getLocationCount()).to.be.within(
-      261,
-      265,
+      256,
+      260,
       "Number of locations, searching for any location"
     )
 
     await LocationFilter.openAllCollapsedLocations()
     expect(await LocationFilter.getLocationCount()).to.be.within(
-      293,
-      296,
+      288,
+      291,
       "Number of uncollapsed locations, searching for any location"
     )
   })

--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -7301,6 +7301,14 @@
 		</sql>
 	</changeSet>
 
+	<changeSet id="inactivate-kosovo-ethnic-groups" author="gjvoosten">
+		<sql>
+			UPDATE locations
+			SET status = 1
+			WHERE locations.trigram IN ('KOA', 'KOB', 'KOG', 'KOS', 'KOT');
+		</sql>
+	</changeSet>
+
 	<!-- Keep this change set as the last one in the change log;
 	     it will be re-run whenever it changes. -->
 	<changeSet id="set-up-full-text-search" runOnChange="true" author="gjvoosten">


### PR DESCRIPTION
They're not real countries, and better modeled as a custom "ethnicity" field.

Closes [AB#1476](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1476)

#### User changes
- The Kosovo ethnic groups (as locations of type country) are now inactive.

#### Superuser changes
- None

#### Admin changes
- None

#### System admin changes
- [ ] application.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
- [x] described the user behavior in PR body
- [x] referenced/updated all related issues
- [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
- [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
- [ ] added and/or updated unit tests
- [ ] added and/or updated e2e tests
- [ ] added and/or updated data migrations
- [ ] updated documentation
- [x] resolved all build errors and warnings
- [ ] opened debt issues for anything not resolved here