### PR TITLE
Be able to select the attendee position in an engagement

### DIFF
--- a/client/src/pages/App.tsx
+++ b/client/src/pages/App.tsx
@@ -114,6 +114,15 @@ const GQL_GET_APP_DATA = gql`
           ${gqlEntityFieldsMap.AuthorizationGroup}
         }
       }
+      additionalPositions {
+        ${gqlEntityFieldsMap.Position}
+        organization {
+          ${gqlEntityFieldsMap.Organization}
+        }
+        location {
+          ${gqlEntityFieldsMap.Location}
+        }
+      }
       previousPositions {
         ${gqlPreviousPositionsFields}
         position {

--- a/client/src/pages/reports/Edit.tsx
+++ b/client/src/pages/reports/Edit.tsx
@@ -61,6 +61,9 @@ const GQL_GET_REPORT = gql`
           organization {
             ${gqlEntityFieldsMap.Organization}
           }
+          location {
+            ${gqlEntityFieldsMap.Location}
+          }
         }
         previousPositions {
           ${gqlPreviousPositionsFields}

--- a/client/src/pages/reports/Edit.tsx
+++ b/client/src/pages/reports/Edit.tsx
@@ -5,6 +5,8 @@ import {
   gqlAssessmentsFields,
   gqlAuthorizedMembersFields,
   gqlEntityFieldsMap,
+  gqlMinimalLocationFields,
+  gqlMinimalOrganizationFields,
   gqlNotesFields,
   gqlPreviousPositionsFields,
   gqlReportCommunitiesFields,
@@ -54,6 +56,12 @@ const GQL_GET_REPORT = gql`
             ${gqlEntityFieldsMap.Location}
           }
         }
+        additionalPositions {
+          ${gqlEntityFieldsMap.Position}
+          organization {
+            ${gqlEntityFieldsMap.Organization}
+          }
+        }
         previousPositions {
           ${gqlPreviousPositionsFields}
           position {
@@ -64,6 +72,15 @@ const GQL_GET_REPORT = gql`
             location {
               ${gqlEntityFieldsMap.Location}
             }
+          }
+        }
+        reportPosition {
+          ${gqlEntityFieldsMap.Position}
+          organization {
+            ${gqlMinimalOrganizationFields}
+          }
+          location {
+            ${gqlMinimalLocationFields}
           }
         }
       }

--- a/client/src/pages/reports/Form.tsx
+++ b/client/src/pages/reports/Form.tsx
@@ -96,11 +96,14 @@ import ReportPeople, {
 const reportPeopleAutocompleteQuery = `
   ${Person.autocompleteQuery}
   additionalPositions {
-        ${gqlEntityFieldsMap.Position}
-        organization {
-          ${gqlEntityFieldsMap.Organization}
-        }
-      }
+    ${gqlEntityFieldsMap.Position}
+    organization {
+      ${gqlEntityFieldsMap.Organization}
+    }
+    location {
+      ${gqlEntityFieldsMap.Location}
+    }
+  }
   previousPositions {
     ${gqlPreviousPositionsFields}
     position {
@@ -1458,20 +1461,7 @@ const ReportForm = ({
       // Make sure field is 'controlled' by defining a value
       rp.interlocutor = rp.interlocutor ?? !rp.user
       // Default to the primary position of the person
-      rp.reportPosition = Position.filterClientSideFields(
-        rp.position,
-        "descendantOrgs",
-        "responsibleTasks",
-        "authorizationGroupsAdministrated",
-        "isApprover",
-        "associatedPositions",
-        "notes",
-        "emailAddresses"
-      )
-      // TODO better way to do this?
-      if (rp.reportPosition.organization) {
-        delete rp.reportPosition.organization.descendantOrgs
-      }
+      rp.reportPosition = rp.position
     })
 
     // if no one else is primary, set that person primary if attending
@@ -1728,7 +1718,7 @@ const ReportForm = ({
       rp.author = !!reportPerson.author
       rp.attendee = !!reportPerson.attendee
       rp.interlocutor = !!reportPerson.interlocutor
-      rp.reportPosition = reportPerson.reportPosition
+      rp.reportPosition = utils.getReference(reportPerson.reportPosition)
       return rp
     })
     // strip tasks fields not in data model

--- a/client/src/pages/reports/Form.tsx
+++ b/client/src/pages/reports/Form.tsx
@@ -663,7 +663,6 @@ const ReportForm = ({
                       setFieldTouched("engagementDate", true, false) // onBlur doesn't work when selecting a date
                       setFieldValue("engagementDate", value, true)
                       setEngagementDate(value)
-                      // We also need to update the value of all positions
                     }}
                     onBlur={() => setFieldTouched("engagementDate")}
                     widget={

--- a/client/src/pages/reports/Form.tsx
+++ b/client/src/pages/reports/Form.tsx
@@ -95,6 +95,12 @@ import ReportPeople, {
 
 const reportPeopleAutocompleteQuery = `
   ${Person.autocompleteQuery}
+  additionalPositions {
+        ${gqlEntityFieldsMap.Position}
+        organization {
+          ${gqlEntityFieldsMap.Organization}
+        }
+      }
   previousPositions {
     ${gqlPreviousPositionsFields}
     position {
@@ -654,6 +660,7 @@ const ReportForm = ({
                       setFieldTouched("engagementDate", true, false) // onBlur doesn't work when selecting a date
                       setFieldValue("engagementDate", value, true)
                       setEngagementDate(value)
+                      // We also need to update the value of all positions
                     }}
                     onBlur={() => setFieldTouched("engagementDate")}
                     widget={
@@ -1450,6 +1457,21 @@ const ReportForm = ({
       // unless it has explicitly been set.
       // Make sure field is 'controlled' by defining a value
       rp.interlocutor = rp.interlocutor ?? !rp.user
+      // Default to the primary position of the person
+      rp.reportPosition = Position.filterClientSideFields(
+        rp.position,
+        "descendantOrgs",
+        "responsibleTasks",
+        "authorizationGroupsAdministrated",
+        "isApprover",
+        "associatedPositions",
+        "notes",
+        "emailAddresses"
+      )
+      // TODO better way to do this?
+      if (rp.reportPosition.organization) {
+        delete rp.reportPosition.organization.descendantOrgs
+      }
     })
 
     // if no one else is primary, set that person primary if attending
@@ -1706,6 +1728,7 @@ const ReportForm = ({
       rp.author = !!reportPerson.author
       rp.attendee = !!reportPerson.attendee
       rp.interlocutor = !!reportPerson.interlocutor
+      rp.reportPosition = reportPerson.reportPosition
       return rp
     })
     // strip tasks fields not in data model

--- a/client/src/pages/reports/Form.tsx
+++ b/client/src/pages/reports/Form.tsx
@@ -95,6 +95,12 @@ import ReportPeople, {
 
 const reportPeopleAutocompleteQuery = `
   ${Person.autocompleteQuery}
+  additionalPositions {
+        ${gqlEntityFieldsMap.Position}
+        organization {
+          ${gqlEntityFieldsMap.Organization}
+        }
+      }
   previousPositions {
     ${gqlPreviousPositionsFields}
     position {
@@ -660,6 +666,7 @@ const ReportForm = ({
                       setFieldTouched("engagementDate", true, false) // onBlur doesn't work when selecting a date
                       setFieldValue("engagementDate", value, true)
                       setEngagementDate(value)
+                      // We also need to update the value of all positions
                     }}
                     onBlur={() => setFieldTouched("engagementDate")}
                     widget={
@@ -1451,6 +1458,21 @@ const ReportForm = ({
       // unless it has explicitly been set.
       // Make sure field is 'controlled' by defining a value
       rp.interlocutor = rp.interlocutor ?? !rp.user
+      // Default to the primary position of the person
+      rp.reportPosition = Position.filterClientSideFields(
+        rp.position,
+        "descendantOrgs",
+        "responsibleTasks",
+        "authorizationGroupsAdministrated",
+        "isApprover",
+        "associatedPositions",
+        "notes",
+        "emailAddresses"
+      )
+      // TODO better way to do this?
+      if (rp.reportPosition.organization) {
+        delete rp.reportPosition.organization.descendantOrgs
+      }
     })
 
     // if no one else is primary, set that person primary if attending
@@ -1707,6 +1729,7 @@ const ReportForm = ({
       rp.author = !!reportPerson.author
       rp.attendee = !!reportPerson.attendee
       rp.interlocutor = !!reportPerson.interlocutor
+      rp.reportPosition = reportPerson.reportPosition
       return rp
     })
     // strip tasks fields not in data model

--- a/client/src/pages/reports/New.tsx
+++ b/client/src/pages/reports/New.tsx
@@ -10,7 +10,7 @@ import {
   useBoilerplate,
   usePageTitle
 } from "components/Page"
-import { Event, Person, Report } from "models"
+import { Event, Person, Position, Report } from "models"
 import { reportTour } from "pages/GuidedTour"
 import React, { useContext } from "react"
 import { legacy_connect as connect } from "react-redux"
@@ -113,12 +113,27 @@ const ReportNewConditional = ({
   initInvisibleFields(report, Settings.fields.report.customFields)
 
   if (currentUser && currentUser.uuid) {
-    const person = new Person(currentUser)
-    person.primary = true
-    person.author = true
-    person.attendee = true
-    person.interlocutor = false
-    report.reportPeople.push(person)
+    const reportPerson = new Person(currentUser)
+    reportPerson.primary = true
+    reportPerson.author = true
+    reportPerson.attendee = true
+    reportPerson.interlocutor = false
+    reportPerson.reportPosition = Position.filterClientSideFields(
+      currentUser.position,
+      "descendantOrgs",
+      "responsibleTasks",
+      "authorizationGroupsAdministrated",
+      "isApprover",
+      "associatedPositions",
+      "notes",
+      "emailAddresses",
+      "organization.descendantOrgs"
+    )
+    // TODO better way to do this?
+    if (reportPerson.reportPosition.organization) {
+      delete reportPerson.reportPosition.organization.descendantOrgs
+    }
+    report.reportPeople.push(reportPerson)
   }
   const reportInitialValues = Object.assign(
     report,

--- a/client/src/pages/reports/New.tsx
+++ b/client/src/pages/reports/New.tsx
@@ -10,7 +10,7 @@ import {
   useBoilerplate,
   usePageTitle
 } from "components/Page"
-import { Event, Person, Position, Report } from "models"
+import { Event, Person, Report } from "models"
 import { reportTour } from "pages/GuidedTour"
 import React, { useContext } from "react"
 import { legacy_connect as connect } from "react-redux"
@@ -118,21 +118,7 @@ const ReportNewConditional = ({
     reportPerson.author = true
     reportPerson.attendee = true
     reportPerson.interlocutor = false
-    reportPerson.reportPosition = Position.filterClientSideFields(
-      currentUser.position,
-      "descendantOrgs",
-      "responsibleTasks",
-      "authorizationGroupsAdministrated",
-      "isApprover",
-      "associatedPositions",
-      "notes",
-      "emailAddresses",
-      "organization.descendantOrgs"
-    )
-    // TODO better way to do this?
-    if (reportPerson.reportPosition.organization) {
-      delete reportPerson.reportPosition.organization.descendantOrgs
-    }
+    reportPerson.reportPosition = currentUser.position
     report.reportPeople.push(reportPerson)
   }
   const reportInitialValues = Object.assign(

--- a/client/src/pages/reports/New.tsx
+++ b/client/src/pages/reports/New.tsx
@@ -10,7 +10,7 @@ import {
   useBoilerplate,
   usePageTitle
 } from "components/Page"
-import { Event, Person, Report } from "models"
+import { Event, Person, Position, Report } from "models"
 import { reportTour } from "pages/GuidedTour"
 import React, { useContext } from "react"
 import { connect } from "react-redux"
@@ -113,12 +113,27 @@ const ReportNewConditional = ({
   initInvisibleFields(report, Settings.fields.report.customFields)
 
   if (currentUser && currentUser.uuid) {
-    const person = new Person(currentUser)
-    person.primary = true
-    person.author = true
-    person.attendee = true
-    person.interlocutor = false
-    report.reportPeople.push(person)
+    const reportPerson = new Person(currentUser)
+    reportPerson.primary = true
+    reportPerson.author = true
+    reportPerson.attendee = true
+    reportPerson.interlocutor = false
+    reportPerson.reportPosition = Position.filterClientSideFields(
+      currentUser.position,
+      "descendantOrgs",
+      "responsibleTasks",
+      "authorizationGroupsAdministrated",
+      "isApprover",
+      "associatedPositions",
+      "notes",
+      "emailAddresses",
+      "organization.descendantOrgs"
+    )
+    // TODO better way to do this?
+    if (reportPerson.reportPosition.organization) {
+      delete reportPerson.reportPosition.organization.descendantOrgs
+    }
+    report.reportPeople.push(reportPerson)
   }
   const reportInitialValues = Object.assign(
     report,

--- a/client/src/pages/reports/ReportPeople.tsx
+++ b/client/src/pages/reports/ReportPeople.tsx
@@ -9,7 +9,14 @@ import RemoveButton from "components/RemoveButton"
 import { Person, Position } from "models"
 import pluralize from "pluralize"
 import React, { useContext } from "react"
-import { Badge, Form, OverlayTrigger, Table, Tooltip } from "react-bootstrap"
+import {
+  Badge,
+  Form,
+  FormSelect,
+  OverlayTrigger,
+  Table,
+  Tooltip
+} from "react-bootstrap"
 import { toast } from "react-toastify"
 import Settings from "settings"
 import utils from "utils"
@@ -98,10 +105,23 @@ const ReportPeople = ({
 
   function renderAttendeeRow(person) {
     const isCurrentEditor = Person.isEqual(person, currentUser)
-    const position = utils.findPrimaryPositionAtDate(
-      person,
-      report.engagementDate
-    )
+    let positions = []
+    if (!disabled) {
+      positions = utils.findPositionsAtDate(person, report.engagementDate) ?? []
+      if (positions.length === 0) {
+        if (person.reportPosition != null) {
+          setReportPosition(person, null)
+        }
+      } else {
+        // If current position not in the new positions list just assign first one available
+        const mustUpdatePosition = !positions.some(
+          p => p.uuid === person.reportPosition?.uuid
+        )
+        if (mustUpdatePosition) {
+          setReportPosition(person, positions[0])
+        }
+      }
+    }
     return (
       <tr key={person.uuid}>
         <td className="primary-attendee">
@@ -151,24 +171,48 @@ const ReportPeople = ({
           <LinkTo modelType="Person" model={person} showIcon={false} />
         </td>
         <td>
-          {position?.uuid && (
-            <LinkTo modelType="Position" model={position}>
-              {Position.toString(position)}
-              {position?.code ? `, ${position.code}` : ""}
+          {(disabled || positions.length === 1) && (
+            <LinkTo
+              modelType="Position"
+              model={person.reportPosition}
+              whenUnspecified=""
+            >
+              {Position.toString(person.reportPosition)}
+              {person.reportPosition?.code
+                ? `, ${person.reportPosition.code}`
+                : ""}
             </LinkTo>
+          )}
+          {!disabled && positions.length > 1 && (
+            <FormSelect
+              value={person.reportPosition?.uuid || ""}
+              onChange={e => {
+                const position = positions.find(p => p.uuid === e.target.value)
+                if (position) {
+                  setReportPosition(person, position)
+                }
+              }}
+            >
+              {positions.map(p => (
+                <option key={p.uuid} value={p.uuid}>
+                  {Position.toString(p)}
+                  {p.code ? `, ${p.code}` : ""}
+                </option>
+              ))}
+            </FormSelect>
           )}
         </td>
         <td>
           <LinkTo
             modelType="Location"
-            model={position?.location}
+            model={person.reportPosition?.location}
             whenUnspecified=""
           />
         </td>
         <td>
           <LinkTo
             modelType="Organization"
-            model={position?.organization}
+            model={person.reportPosition?.organization}
             whenUnspecified=""
           />
         </td>
@@ -236,6 +280,18 @@ const ReportPeople = ({
       }
     })
     onChange(newPeopleList)
+  }
+
+  function setReportPosition(person: Person, position: Position) {
+    const newPeopleList = report.reportPeople.map(rp => new Person(rp))
+    newPeopleList.forEach(rp => {
+      if (Person.isEqual(rp, person)) {
+        rp.reportPosition = position
+      }
+    })
+    if (onChange) {
+      onChange(newPeopleList)
+    }
   }
 
   function passesAuthorValidationSteps(person) {

--- a/client/src/pages/reports/Show.tsx
+++ b/client/src/pages/reports/Show.tsx
@@ -115,6 +115,15 @@ const GQL_GET_REPORT = gql`
             }
           }
         }
+        reportPosition {
+          ${gqlEntityFieldsMap.Position}
+          organization {
+            ${gqlEntityFieldsMap.Organization}
+          }
+          location {
+            ${gqlEntityFieldsMap.Location}
+          }
+        }
       }
       primaryAdvisor {
         ${gqlEntityFieldsMap.Person}

--- a/client/src/utils.tsx
+++ b/client/src/utils.tsx
@@ -521,7 +521,7 @@ export default {
       return [
         normalize(person.position),
         ...(person.additionalPositions ?? []).map(normalize)
-      ].filter(Boolean)
+      ].filter(p => !_isEmpty(p))
     }
 
     const when = moment(date).valueOf()
@@ -529,7 +529,7 @@ export default {
     return (person.previousPositions ?? [])
       .filter(p => p.startTime <= when && (!p.endTime || p.endTime > when))
       .map(p => normalize(p.position))
-      .filter(Boolean)
+      .filter(p => !_isEmpty(p))
   },
 
   getButtonsFromChoices: function (choices) {

--- a/client/src/utils.tsx
+++ b/client/src/utils.tsx
@@ -514,6 +514,24 @@ export default {
     )?.position
   },
 
+  findPositionsAtDate: function (person, date) {
+    const normalize = p => (Array.isArray(p) ? p[0] : p)
+
+    if (!date) {
+      return [
+        normalize(person.position),
+        ...(person.additionalPositions ?? []).map(normalize)
+      ].filter(Boolean)
+    }
+
+    const when = moment(date).valueOf()
+
+    return (person.previousPositions ?? [])
+      .filter(p => p.startTime <= when && (!p.endTime || p.endTime > when))
+      .map(p => normalize(p.position))
+      .filter(Boolean)
+  },
+
   getButtonsFromChoices: function (choices) {
     return Object.entries(choices).map(([value, label]) => ({
       value,

--- a/client/tests/sim/stories/ReportStories.js
+++ b/client/tests/sim/stories/ReportStories.js
@@ -16,7 +16,7 @@ const getRandomPerson = async function () {
   return await getRandomObject(
     "people",
     { positionType: Object.values(Position.TYPE) },
-    "uuid familyName givenName position {uuid name}"
+    "uuid familyName givenName position {uuid name} additionalPositions {uuid name} previousPositions {startTime endTime primary position {uuid name}}"
   )
 }
 
@@ -62,7 +62,32 @@ async function populateReport(report, args) {
       ? Location.LOCATION_TYPES.POINT_LOCATION
       : Location.LOCATION_TYPES.VIRTUAL_LOCATION
   })
-  async function getAttendees() {
+
+  function getReportPosition(person, engagementDate) {
+    if (engagementDate) {
+      // If we have an engagement date we look in position history
+      const engagement = new Date(engagementDate)
+      const positionsAtEngagementDate = (person.previousPositions ?? []).filter(
+        p => {
+          const start = new Date(p.startTime)
+          const end = p.endTime ? new Date(p.endTime) : null
+          return engagement >= start && (!end || engagement <= end)
+        }
+      )
+
+      if (positionsAtEngagementDate.length > 0) {
+        return faker.helpers.arrayElement(positionsAtEngagementDate).position
+      }
+    }
+
+    // Fall back to current position and additional positions
+    return faker.helpers.arrayElement([
+      person.position,
+      ...(person.additionalPositions ?? [])
+    ])
+  }
+
+  async function getAttendees(engagementDate) {
     let reportPeople = []
     const nbOfAdvisors = faker.number.int({ min: 1, max: 5 })
     for (let i = 0; i < nbOfAdvisors; i++) {
@@ -74,7 +99,7 @@ async function populateReport(report, args) {
           attendee: true,
           interlocutor: false,
           author: false,
-          reportPosition: advisor.position
+          reportPosition: getReportPosition(advisor, engagementDate)
         })
       }
     }
@@ -89,7 +114,7 @@ async function populateReport(report, args) {
           attendee: true,
           interlocutor: true,
           author: false,
-          reportPosition: interlocutor.position
+          reportPosition: getReportPosition(interlocutor, engagementDate)
         })
       }
     }
@@ -122,7 +147,6 @@ async function populateReport(report, args) {
     }
     return reportPeople
   }
-  const reportPeople = await getAttendees()
   async function getTasks() {
     const reportTasks = []
     const nbOfTasks = faker.number.int({ min: 1, max: 3 })
@@ -139,6 +163,7 @@ async function populateReport(report, args) {
   const engagementDate = fuzzy.withProbability(0.9)
     ? faker.date.past()
     : faker.date.future()
+  const reportPeople = await getAttendees(engagementDate)
   const state = fuzzy.withProbability(0.05)
     ? Report.STATE.CANCELLED
     : (args && args.state) || Report.STATE.DRAFT

--- a/client/tests/sim/stories/ReportStories.js
+++ b/client/tests/sim/stories/ReportStories.js
@@ -16,7 +16,7 @@ const getRandomPerson = async function () {
   return await getRandomObject(
     "people",
     { positionType: Object.values(Position.TYPE) },
-    "uuid familyName givenName"
+    "uuid familyName givenName position {uuid name}"
   )
 }
 
@@ -73,7 +73,8 @@ async function populateReport(report, args) {
           primary: false,
           attendee: true,
           interlocutor: false,
-          author: false
+          author: false,
+          reportPosition: advisor.position
         })
       }
     }
@@ -87,7 +88,8 @@ async function populateReport(report, args) {
           primary: false,
           attendee: true,
           interlocutor: true,
-          author: false
+          author: false,
+          reportPosition: interlocutor.position
         })
       }
     }

--- a/insertBaseData-psql.sql
+++ b/insertBaseData-psql.sql
@@ -1885,6 +1885,21 @@ INSERT INTO "peoplePositions" ("personUuid", "positionUuid", "createdAt", "prima
   ('31cba227-f6c6-49e9-9483-fce441bea624', '5e2414d2-b440-4e43-85b3-d1c10222cb5d', CURRENT_TIMESTAMP, FALSE),
   ('31cba227-f6c6-49e9-9483-fce441bea624', '44ba17f5-fcf7-4743-a6b9-baf922b172c2', CURRENT_TIMESTAMP, FALSE);
 
+-- Fill in value of reportPosition
+UPDATE "reportPeople"
+SET "reportPositionUuid" = pp."positionUuid"
+FROM reports r, "peoplePositions" pp
+WHERE r.uuid = "reportPeople"."reportUuid"
+  AND pp."personUuid" = "reportPeople"."personUuid"
+  AND pp."primary" IS TRUE
+  AND CASE WHEN r."engagementDate" IS NULL THEN (
+    pp."createdAt" <= CURRENT_TIMESTAMP
+        AND (pp."endedAt" IS NULL OR pp."endedAt" >= CURRENT_TIMESTAMP)
+    ) ELSE (
+    pp."createdAt" <= r."engagementDate"
+        AND (pp."endedAt" IS NULL OR pp."endedAt" >= r."engagementDate")
+    ) END;
+
 -- Update the link-text indexes
 REFRESH MATERIALIZED VIEW CONCURRENTLY "mv_lts_attachments";
 -- authorizationGroups currently have no links

--- a/insertBaseData-psql.sql
+++ b/insertBaseData-psql.sql
@@ -1876,6 +1876,21 @@ INSERT INTO "peoplePositions" ("personUuid", "positionUuid", "createdAt", "prima
   ('31cba227-f6c6-49e9-9483-fce441bea624', '5e2414d2-b440-4e43-85b3-d1c10222cb5d', CURRENT_TIMESTAMP, FALSE),
   ('31cba227-f6c6-49e9-9483-fce441bea624', '44ba17f5-fcf7-4743-a6b9-baf922b172c2', CURRENT_TIMESTAMP, FALSE);
 
+-- Fill in value of reportPosition
+UPDATE "reportPeople"
+SET "reportPositionUuid" = pp."positionUuid"
+FROM reports r, "peoplePositions" pp
+WHERE r.uuid = "reportPeople"."reportUuid"
+  AND pp."personUuid" = "reportPeople"."personUuid"
+  AND pp."primary" IS TRUE
+  AND CASE WHEN r."engagementDate" IS NULL THEN (
+    pp."createdAt" <= CURRENT_TIMESTAMP
+        AND (pp."endedAt" IS NULL OR pp."endedAt" >= CURRENT_TIMESTAMP)
+    ) ELSE (
+    pp."createdAt" <= r."engagementDate"
+        AND (pp."endedAt" IS NULL OR pp."endedAt" >= r."engagementDate")
+    ) END;
+
 -- Update the link-text indexes
 REFRESH MATERIALIZED VIEW CONCURRENTLY "mv_lts_attachments";
 -- authorizationGroups currently have no links

--- a/src/main/java/mil/dds/anet/beans/ReportPerson.java
+++ b/src/main/java/mil/dds/anet/beans/ReportPerson.java
@@ -19,7 +19,7 @@ public class ReportPerson extends Person {
           .thenComparing(ReportPerson::isPrimary, Comparator.reverseOrder())
           .thenComparing(ReportPerson::isAuthor, Comparator.reverseOrder())
           .thenComparing(ReportPerson::getFamilyName).thenComparing(ReportPerson::getGivenName)
-          .thenComparing(ReportPerson::getUuid).thenComparing(ReportPerson::getReportPositionUuid);;
+          .thenComparing(ReportPerson::getUuid).thenComparing(ReportPerson::getReportPositionUuid);
 
   @GraphQLQuery
   @GraphQLInputField

--- a/src/main/java/mil/dds/anet/beans/ReportPerson.java
+++ b/src/main/java/mil/dds/anet/beans/ReportPerson.java
@@ -1,9 +1,15 @@
 package mil.dds.anet.beans;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import graphql.GraphQLContext;
 import io.leangen.graphql.annotations.GraphQLInputField;
 import io.leangen.graphql.annotations.GraphQLQuery;
+import io.leangen.graphql.annotations.GraphQLRootContext;
 import java.util.Comparator;
 import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import mil.dds.anet.utils.IdDataLoaderKey;
+import mil.dds.anet.views.UuidFetcher;
 
 public class ReportPerson extends Person {
 
@@ -13,7 +19,7 @@ public class ReportPerson extends Person {
           .thenComparing(ReportPerson::isPrimary, Comparator.reverseOrder())
           .thenComparing(ReportPerson::isAuthor, Comparator.reverseOrder())
           .thenComparing(ReportPerson::getFamilyName).thenComparing(ReportPerson::getGivenName)
-          .thenComparing(ReportPerson::getUuid);
+          .thenComparing(ReportPerson::getUuid).thenComparing(ReportPerson::getReportPositionUuid);;
 
   @GraphQLQuery
   @GraphQLInputField
@@ -27,6 +33,10 @@ public class ReportPerson extends Person {
   @GraphQLQuery
   @GraphQLInputField
   boolean interlocutor;
+
+  // Lazy Loaded
+  // annotated below
+  private ForeignObjectHolder<Position> reportPosition = new ForeignObjectHolder<>();
 
   public ReportPerson() {
     this.primary = false; // Default
@@ -67,6 +77,38 @@ public class ReportPerson extends Person {
     this.interlocutor = interlocutor;
   }
 
+  @GraphQLQuery(name = "reportPosition")
+  public CompletableFuture<Position> loadReportPosition(
+      @GraphQLRootContext GraphQLContext context) {
+    if (reportPosition.hasForeignObject()) {
+      return CompletableFuture.completedFuture(reportPosition.getForeignObject());
+    }
+    return new UuidFetcher<Position>()
+        .load(context, IdDataLoaderKey.POSITIONS, reportPosition.getForeignUuid()).thenApply(o -> {
+          reportPosition.setForeignObject(o);
+          return o;
+        });
+  }
+
+  @JsonIgnore
+  public void setReportPositionUuid(String reportPositionUuid) {
+    this.reportPosition = new ForeignObjectHolder<>(reportPositionUuid);
+  }
+
+  @JsonIgnore
+  public String getReportPositionUuid() {
+    return reportPosition.getForeignUuid();
+  }
+
+  @GraphQLInputField(name = "reportPosition")
+  public void setReportPosition(Position position) {
+    this.reportPosition = new ForeignObjectHolder<>(position);
+  }
+
+  public Position getReportPosition() {
+    return reportPosition.getForeignObject();
+  }
+
   @Override
   public boolean equals(Object o) {
     if (!(o instanceof ReportPerson)) {
@@ -75,7 +117,8 @@ public class ReportPerson extends Person {
     ReportPerson rp = (ReportPerson) o;
     return super.equals(o) && Objects.equals(rp.isPrimary(), primary)
         && Objects.equals(rp.isAuthor(), author) && Objects.equals(rp.isAttendee(), attendee)
-        && Objects.equals(rp.isInterlocutor(), interlocutor);
+        && Objects.equals(rp.isInterlocutor(), interlocutor)
+        && Objects.equals(rp.getReportPositionUuid(), getReportPositionUuid());
   }
 
   @Override

--- a/src/main/java/mil/dds/anet/database/OrganizationDao.java
+++ b/src/main/java/mil/dds/anet/database/OrganizationDao.java
@@ -132,20 +132,17 @@ public class OrganizationDao
   }
 
   public CompletableFuture<List<Organization>> getOrganizationsForPerson(GraphQLContext context,
-      String personUuid, Instant when) {
-    return when == null
-        ? new ForeignKeyFetcher<Organization>().load(context, FkDataLoaderKey.PERSON_ORGANIZATIONS,
-            personUuid)
-        : new ForeignKeyByDateFetcher<Organization>().load(context,
-            FkDataLoaderKey.PERSON_ORGANIZATIONS_WHEN, new ImmutablePair<>(personUuid, when));
+      String personUuid) {
+    return new ForeignKeyFetcher<Organization>().load(context, FkDataLoaderKey.PERSON_ORGANIZATIONS,
+        personUuid);
   }
 
   public CompletableFuture<Organization> getOrganizationForPerson(GraphQLContext context,
-      String personUuid, Instant when) {
+      String personUuid) {
     if (personUuid == null) {
       return CompletableFuture.completedFuture(null);
     }
-    return getOrganizationsForPerson(context, personUuid, when)
+    return getOrganizationsForPerson(context, personUuid)
         .thenApply(l -> l.isEmpty() ? null : l.get(0));
   }
 

--- a/src/main/java/mil/dds/anet/database/OrganizationDao.java
+++ b/src/main/java/mil/dds/anet/database/OrganizationDao.java
@@ -74,44 +74,6 @@ public class OrganizationDao
     return new SelfIdBatcher().getByIds(uuids);
   }
 
-  class OrganizationsBatcher extends ForeignKeyBatcher<Organization> {
-    private static final String SQL =
-        "/* batch.getOrganizationForPerson */ SELECT positions.\"currentPersonUuid\" AS \"personUuid\", "
-            + ORGANIZATION_FIELDS + "FROM organizations, positions WHERE "
-            + "positions.\"currentPersonUuid\" IN ( <foreignKeys> ) AND positions.\"organizationUuid\" = organizations.uuid";
-
-    public OrganizationsBatcher() {
-      super(OrganizationDao.this.databaseHandler, SQL, "foreignKeys", new OrganizationMapper(),
-          "personUuid");
-    }
-  }
-
-  public List<List<Organization>> getOrganizations(List<String> foreignKeys) {
-    return new OrganizationsBatcher().getByForeignKeys(foreignKeys);
-  }
-
-  class OrganizationsByDateBatcher extends ForeignKeyByDateBatcher<Organization> {
-    private static final String sql =
-        "/* batch.getOrganizationForPerson */ SELECT \"peoplePositions\".\"personUuid\" AS \"personUuid\", "
-            + ORGANIZATION_FIELDS + " FROM organizations, \"peoplePositions\", positions "
-            + "WHERE \"peoplePositions\".\"personUuid\" IN ( <foreignKeys> ) "
-            + "AND \"peoplePositions\".\"positionUuid\" = positions.uuid "
-            + "AND positions.\"organizationUuid\" = organizations.uuid "
-            + "AND \"peoplePositions\".\"createdAt\" <= :when "
-            + "AND \"peoplePositions\".\"primary\" IS TRUE "
-            + "AND (\"peoplePositions\".\"endedAt\" IS NULL"
-            + " OR \"peoplePositions\".\"endedAt\" > :when)";
-
-    public OrganizationsByDateBatcher() {
-      super(OrganizationDao.this.databaseHandler, sql, "foreignKeys", new OrganizationMapper(),
-          "personUuid");
-    }
-  }
-
-  public List<List<Organization>> getOrganizationsByDate(
-      List<ImmutablePair<String, Instant>> foreignKeys) {
-    return new OrganizationsByDateBatcher().getByForeignKeys(foreignKeys);
-  }
 
   class OrganizationSearchBatcher
       extends SearchQueryBatcher<Organization, OrganizationSearchQuery> {
@@ -129,21 +91,6 @@ public class OrganizationDao
       String uuid, OrganizationSearchQuery query) {
     return new SearchQueryFetcher<Organization, OrganizationSearchQuery>().load(context,
         SqDataLoaderKey.ORGANIZATIONS_SEARCH, new ImmutablePair<>(uuid, query));
-  }
-
-  public CompletableFuture<List<Organization>> getOrganizationsForPerson(GraphQLContext context,
-      String personUuid) {
-    return new ForeignKeyFetcher<Organization>().load(context, FkDataLoaderKey.PERSON_ORGANIZATIONS,
-        personUuid);
-  }
-
-  public CompletableFuture<Organization> getOrganizationForPerson(GraphQLContext context,
-      String personUuid) {
-    if (personUuid == null) {
-      return CompletableFuture.completedFuture(null);
-    }
-    return getOrganizationsForPerson(context, personUuid)
-        .thenApply(l -> l.isEmpty() ? null : l.get(0));
   }
 
   class AdministratingPositionsBatcher extends ForeignKeyBatcher<Position> {

--- a/src/main/java/mil/dds/anet/database/PersonDao.java
+++ b/src/main/java/mil/dds/anet/database/PersonDao.java
@@ -304,15 +304,15 @@ public class PersonDao extends AnetSubscribableObjectDao<Person, PersonSearchQue
           + "  rpw.\"isAttendee\" AS wattendee, rpl.\"isAttendee\" AS lattendee,"
           + "  rpw.\"isAuthor\" AS wauthor, rpl.\"isAuthor\" AS lauthor,"
           + "  rpw.\"isInterlocutor\" AS winterlocutor, rpl.\"isInterlocutor\" AS linterlocutor,"
-          + "  rpl.\"reportPositionUuid\" AS lreportpositionuuid" + "  FROM \"reportPeople\" rpw"
+          + "  rpl.\"reportPositionUuid\" AS lreportpositionuuid FROM \"reportPeople\" rpw"
           + "  JOIN \"reportPeople\" rpl ON rpl.\"reportUuid\" = rpw.\"reportUuid\""
-          + "  WHERE rpw.\"personUuid\" = :winnerUuid" + "  AND rpl.\"personUuid\" = :loserUuid )"
-          + " UPDATE \"reportPeople\" SET" + " \"isPrimary\" = (dups.wprimary OR dups.lprimary),"
+          + "  WHERE rpw.\"personUuid\" = :winnerUuid AND rpl.\"personUuid\" = :loserUuid )"
+          + " UPDATE \"reportPeople\" SET \"isPrimary\" = (dups.wprimary OR dups.lprimary),"
           + " \"isAttendee\" = (dups.wattendee OR dups.lattendee),"
           + " \"isAuthor\" = (dups.wauthor OR dups.lauthor),"
           + " \"isInterlocutor\" = (dups.winterlocutor OR dups.linterlocutor)"
           + (useWinnerPositionHistory ? "" : ", \"reportPositionUuid\" = dups.lreportpositionuuid")
-          + " FROM dups" + " WHERE \"reportPeople\".\"reportUuid\" = dups.wreportuuid"
+          + " FROM dups WHERE \"reportPeople\".\"reportUuid\" = dups.wreportuuid"
           + " AND \"reportPeople\".\"personUuid\" = dups.wpersonuuid";
 
       handle.createUpdate(sqlUpd).bind("winnerUuid", winnerUuid).bind("loserUuid", loserUuid)

--- a/src/main/java/mil/dds/anet/database/PersonDao.java
+++ b/src/main/java/mil/dds/anet/database/PersonDao.java
@@ -303,18 +303,21 @@ public class PersonDao extends AnetSubscribableObjectDao<Person, PersonSearchQue
           + "  rpw.\"isPrimary\" AS wprimary, rpl.\"isPrimary\" AS lprimary,"
           + "  rpw.\"isAttendee\" AS wattendee, rpl.\"isAttendee\" AS lattendee,"
           + "  rpw.\"isAuthor\" AS wauthor, rpl.\"isAuthor\" AS lauthor,"
-          + "  rpw.\"isInterlocutor\" AS winterlocutor, rpl.\"isInterlocutor\" AS linterlocutor"
-          + "  FROM \"reportPeople\" rpw"
+          + "  rpw.\"isInterlocutor\" AS winterlocutor, rpl.\"isInterlocutor\" AS linterlocutor,"
+          + "  rpl.\"reportPositionUuid\" AS lreportpositionuuid" + "  FROM \"reportPeople\" rpw"
           + "  JOIN \"reportPeople\" rpl ON rpl.\"reportUuid\" = rpw.\"reportUuid\""
-          + "  WHERE rpw.\"personUuid\" = :winnerUuid AND rpl.\"personUuid\" = :loserUuid )"
-          + " UPDATE \"reportPeople\" SET \"isPrimary\" = (dups.wprimary OR dups.lprimary),"
+          + "  WHERE rpw.\"personUuid\" = :winnerUuid" + "  AND rpl.\"personUuid\" = :loserUuid )"
+          + " UPDATE \"reportPeople\" SET" + " \"isPrimary\" = (dups.wprimary OR dups.lprimary),"
           + " \"isAttendee\" = (dups.wattendee OR dups.lattendee),"
           + " \"isAuthor\" = (dups.wauthor OR dups.lauthor),"
-          + " \"isInterlocutor\" = (dups.winterlocutor OR dups.linterlocutor) FROM dups"
-          + " WHERE \"reportPeople\".\"reportUuid\" = dups.wreportuuid"
+          + " \"isInterlocutor\" = (dups.winterlocutor OR dups.linterlocutor)"
+          + (useWinnerPositionHistory ? "" : ", \"reportPositionUuid\" = dups.lreportpositionuuid")
+          + " FROM dups" + " WHERE \"reportPeople\".\"reportUuid\" = dups.wreportuuid"
           + " AND \"reportPeople\".\"personUuid\" = dups.wpersonuuid";
+
       handle.createUpdate(sqlUpd).bind("winnerUuid", winnerUuid).bind("loserUuid", loserUuid)
           .execute();
+
       // 2. delete the loser so we don't have duplicates
       final String sqlDel = "WITH dups AS ( SELECT"
           + "  rpl.\"reportUuid\" AS lreportuuid, rpl.\"personUuid\" AS lpersonuuid"

--- a/src/main/java/mil/dds/anet/database/PositionDao.java
+++ b/src/main/java/mil/dds/anet/database/PositionDao.java
@@ -599,16 +599,6 @@ public class PositionDao extends AnetSubscribableObjectDao<Position, PositionSea
     }
   }
 
-  public static String generatePositionFilterAtDate(String personJoinColumn,
-      String dateFilterColumn, String placeholderName) {
-    return String.format(
-        "JOIN \"peoplePositions\" pp ON pp.\"personUuid\" = %1$s"
-            + " WHERE pp.primary IS TRUE AND pp.\"createdAt\" <= %2$s"
-            + " AND (pp.\"endedAt\" IS NULL OR pp.\"endedAt\" > %2$s)"
-            + " AND pp.\"positionUuid\" = :%3$s",
-        personJoinColumn, dateFilterColumn, placeholderName);
-  }
-
   @Override
   public SubscriptionUpdateGroup getSubscriptionUpdate(Position obj, String auditTrailUuid,
       boolean isDelete) {

--- a/src/main/java/mil/dds/anet/database/PositionDao.java
+++ b/src/main/java/mil/dds/anet/database/PositionDao.java
@@ -758,6 +758,9 @@ public class PositionDao extends AnetSubscribableObjectDao<Position, PositionSea
       // Update subscriptionUpdates
       updateForMerge("subscriptionUpdates", "updatedObjectUuid", winnerUuid, loserUuid);
 
+      // If looser id happens to be in reportPeople set to null
+      updateForMerge("reportPeople", "reportPositionUuid", null, loserUuid);
+
       // Finally, delete loser
       final int nrDeleted = deleteForMerge(PositionDao.TABLE_NAME, "uuid", loserUuid);
       if (nrDeleted > 0) {

--- a/src/main/java/mil/dds/anet/database/PositionDao.java
+++ b/src/main/java/mil/dds/anet/database/PositionDao.java
@@ -758,7 +758,7 @@ public class PositionDao extends AnetSubscribableObjectDao<Position, PositionSea
       // Update subscriptionUpdates
       updateForMerge("subscriptionUpdates", "updatedObjectUuid", winnerUuid, loserUuid);
 
-      // If looser id happens to be in reportPeople set to null
+      // If loser id happens to be in reportPeople set to null
       updateForMerge("reportPeople", "reportPositionUuid", null, loserUuid);
 
       // Finally, delete loser

--- a/src/main/java/mil/dds/anet/database/ReportDao.java
+++ b/src/main/java/mil/dds/anet/database/ReportDao.java
@@ -172,8 +172,8 @@ public class ReportDao extends AnetSubscribableObjectDao<Report, ReportSearchQue
 
   public interface ReportBatch {
     @SqlBatch("INSERT INTO \"reportPeople\""
-        + " (\"reportUuid\", \"personUuid\", \"isPrimary\", \"isAuthor\", \"isAttendee\", \"isInterlocutor\")"
-        + " VALUES (:reportUuid, :uuid, :primary, :author, :attendee, :interlocutor)")
+        + " (\"reportUuid\", \"personUuid\", \"isPrimary\", \"isAuthor\", \"isAttendee\", \"isInterlocutor\", \"reportPositionUuid\")"
+        + " VALUES (:reportUuid, :uuid, :primary, :author, :attendee, :interlocutor, :reportPositionUuid)")
     void insertReportPeople(@Bind("reportUuid") String reportUuid,
         @BindBean List<ReportPerson> reportPeople);
 
@@ -280,8 +280,8 @@ public class ReportDao extends AnetSubscribableObjectDao<Report, ReportSearchQue
     final Handle handle = getDbHandle();
     try {
       return handle.createUpdate("/* addReportPerson */ INSERT INTO \"reportPeople\" "
-          + "(\"personUuid\", \"reportUuid\", \"isPrimary\", \"isAuthor\", \"isAttendee\", \"isInterlocutor\")"
-          + " VALUES (:personUuid, :reportUuid, :primary, :author, :attendee, :interlocutor)")
+          + "(\"personUuid\", \"reportUuid\", \"isPrimary\", \"isAuthor\", \"isAttendee\", \"isInterlocutor\", \"reportPositionUuid\")"
+          + " VALUES (:personUuid, :reportUuid, :primary, :author, :attendee, :interlocutor, :reportPositionUuid)")
           .bind("personUuid", rp.getUuid()).bind("reportUuid", r.getUuid()).bindBean(rp).execute();
     } finally {
       closeDbHandle(handle);
@@ -306,7 +306,7 @@ public class ReportDao extends AnetSubscribableObjectDao<Report, ReportSearchQue
     final Handle handle = getDbHandle();
     try {
       return handle.createUpdate("/* updatePersonOnReport*/ UPDATE \"reportPeople\" "
-          + "SET \"isPrimary\" = :primary, \"isAuthor\" = :author, \"isAttendee\" = :attendee, \"isInterlocutor\" = :interlocutor"
+          + "SET \"isPrimary\" = :primary, \"isAuthor\" = :author, \"isAttendee\" = :attendee, \"isInterlocutor\" = :interlocutor, \"reportPositionUuid\" = :reportPositionUuid"
           + " WHERE \"reportUuid\" = :reportUuid AND \"personUuid\" = :personUuid")
           .bind("reportUuid", r.getUuid()).bind("personUuid", rp.getUuid()).bindBean(rp).execute();
     } finally {
@@ -533,10 +533,6 @@ public class ReportDao extends AnetSubscribableObjectDao<Report, ReportSearchQue
 
       sql.append(
           "LEFT JOIN \"reportPeople\" rpa ON rpa.\"reportUuid\" = r.uuid AND rpa.\"isInterlocutor\" IS NOT TRUE ");
-      sql.append("LEFT JOIN \"peoplePositions\" ppa ON ppa.\"personUuid\" = rpa.\"personUuid\" ");
-      sql.append(" AND ppa.primary IS TRUE ");
-      sql.append(" AND ppa.\"createdAt\" < r.\"engagementDate\" ");
-      sql.append(" AND (ppa.\"endedAt\" IS NULL OR ppa.\"endedAt\" > r.\"engagementDate\") ");
       sql.append(
           "INNER JOIN \"authorizationGroupRelatedObjects\" agroa ON agroa.\"authorizationGroupUuid\" = :advisorAuthorizationGroupUuid AND ( ");
       sql.append(
@@ -544,15 +540,11 @@ public class ReportDao extends AnetSubscribableObjectDao<Report, ReportSearchQue
       sql.append(
           " OR (agroa.\"relatedObjectType\" = 'people' AND agroa.\"relatedObjectUuid\" = rpa.\"personUuid\") ");
       sql.append(
-          " OR (agroa.\"relatedObjectType\" = 'positions' AND agroa.\"relatedObjectUuid\" = ppa.\"positionUuid\") ");
+          " OR (agroa.\"relatedObjectType\" = 'positions' AND agroa.\"relatedObjectUuid\" = rpa.\"reportPositionUuid\") ");
       sql.append(") ");
 
       sql.append(
           "LEFT JOIN \"reportPeople\" rpi ON rpi.\"reportUuid\" = r.uuid AND rpi.\"isInterlocutor\" IS TRUE ");
-      sql.append("LEFT JOIN \"peoplePositions\" ppi ON ppi.\"personUuid\" = rpi.\"personUuid\" ");
-      sql.append(" AND ppi.primary IS TRUE ");
-      sql.append(" AND ppi.\"createdAt\" < r.\"engagementDate\" ");
-      sql.append(" AND (ppi.\"endedAt\" IS NULL OR ppi.\"endedAt\" > r.\"engagementDate\") ");
       sql.append(
           "INNER JOIN \"authorizationGroupRelatedObjects\" agroi ON agroi.\"authorizationGroupUuid\" = :interlocutorAuthorizationGroupUuid AND ( ");
       sql.append(
@@ -560,7 +552,7 @@ public class ReportDao extends AnetSubscribableObjectDao<Report, ReportSearchQue
       sql.append(
           " OR (agroi.\"relatedObjectType\" = 'people' AND agroi.\"relatedObjectUuid\" = rpi.\"personUuid\") ");
       sql.append(
-          " OR (agroi.\"relatedObjectType\" = 'positions' AND agroi.\"relatedObjectUuid\" = ppi.\"positionUuid\") ");
+          " OR (agroi.\"relatedObjectType\" = 'positions' AND agroi.\"relatedObjectUuid\" = rpi.\"reportPositionUuid\") ");
       sql.append(") ");
 
       sql.append("WHERE r.state in (:approvedState, :publishedState) ");
@@ -622,14 +614,14 @@ public class ReportDao extends AnetSubscribableObjectDao<Report, ReportSearchQue
   }
 
   class ReportPeopleBatcher extends ForeignKeyBatcher<ReportPerson> {
-    private static final String SQL =
-        "/* batch.getPeopleForReport */ SELECT " + PersonDao.PERSON_FIELDS
-            + ", \"reportPeople\".\"reportUuid\", \"reportPeople\".\"isPrimary\""
-            + ", \"reportPeople\".\"isAuthor\", \"reportPeople\".\"isAttendee\""
-            + ", \"reportPeople\".\"isInterlocutor\" FROM \"reportPeople\" "
-            + "LEFT JOIN people ON \"reportPeople\".\"personUuid\" = people.uuid "
-            + "WHERE \"reportPeople\".\"reportUuid\" IN ( <foreignKeys> ) "
-            + "ORDER BY people.\"familyName\", people.\"givenName\", people.uuid";
+    private static final String SQL = "/* batch.getPeopleForReport */ SELECT "
+        + PersonDao.PERSON_FIELDS
+        + ", \"reportPeople\".\"reportUuid\", \"reportPeople\".\"isPrimary\""
+        + ", \"reportPeople\".\"isAuthor\", \"reportPeople\".\"isAttendee\""
+        + ", \"reportPeople\".\"isInterlocutor\", \"reportPeople\".\"reportPositionUuid\" FROM \"reportPeople\" "
+        + "LEFT JOIN people ON \"reportPeople\".\"personUuid\" = people.uuid "
+        + "WHERE \"reportPeople\".\"reportUuid\" IN ( <foreignKeys> ) "
+        + "ORDER BY people.\"familyName\", people.\"givenName\", people.uuid";
 
     public ReportPeopleBatcher() {
       super(ReportDao.this.databaseHandler, SQL, "foreignKeys", new ReportPersonMapper(),

--- a/src/main/java/mil/dds/anet/database/ReportDao.java
+++ b/src/main/java/mil/dds/anet/database/ReportDao.java
@@ -991,8 +991,7 @@ public class ReportDao extends AnetSubscribableObjectDao<Report, ReportSearchQue
                 + " JOIN \"reportPeople\" rp ON rp.\"personUuid\" = pp.\"personUuid\""
                 + " JOIN reports r ON r.uuid = rp.\"reportUuid\"" // -
                 + " WHERE r.uuid = " + paramOrJoin("reports.uuid", isParam)
-                + " AND pp.primary IS TRUE AND pp.\"createdAt\" <= r.\"engagementDate\""
-                + " AND (pp.\"endedAt\" IS NULL OR pp.\"endedAt\" > r.\"engagementDate\")",
+                + " AND rp.\"reportPositionUuid\" = pp.\"positionUuid\"",
             // param is already added above
             Collections.emptyMap()));
     // update organizations

--- a/src/main/java/mil/dds/anet/database/ReportDao.java
+++ b/src/main/java/mil/dds/anet/database/ReportDao.java
@@ -171,8 +171,8 @@ public class ReportDao extends AnetSubscribableObjectDao<Report, ReportSearchQue
 
   public interface ReportBatch {
     @SqlBatch("INSERT INTO \"reportPeople\""
-        + " (\"reportUuid\", \"personUuid\", \"isPrimary\", \"isAuthor\", \"isAttendee\", \"isInterlocutor\")"
-        + " VALUES (:reportUuid, :uuid, :primary, :author, :attendee, :interlocutor)")
+        + " (\"reportUuid\", \"personUuid\", \"isPrimary\", \"isAuthor\", \"isAttendee\", \"isInterlocutor\", \"reportPositionUuid\")"
+        + " VALUES (:reportUuid, :uuid, :primary, :author, :attendee, :interlocutor, :reportPositionUuid)")
     void insertReportPeople(@Bind("reportUuid") String reportUuid,
         @BindBean List<ReportPerson> reportPeople);
 
@@ -297,8 +297,8 @@ public class ReportDao extends AnetSubscribableObjectDao<Report, ReportSearchQue
     final Handle handle = getDbHandle();
     try {
       return handle.createUpdate("/* addReportPerson */ INSERT INTO \"reportPeople\" "
-          + "(\"personUuid\", \"reportUuid\", \"isPrimary\", \"isAuthor\", \"isAttendee\", \"isInterlocutor\")"
-          + " VALUES (:personUuid, :reportUuid, :primary, :author, :attendee, :interlocutor)")
+          + "(\"personUuid\", \"reportUuid\", \"isPrimary\", \"isAuthor\", \"isAttendee\", \"isInterlocutor\", \"reportPositionUuid\")"
+          + " VALUES (:personUuid, :reportUuid, :primary, :author, :attendee, :interlocutor, :reportPositionUuid)")
           .bind("personUuid", rp.getUuid()).bind("reportUuid", r.getUuid()).bindBean(rp).execute();
     } finally {
       closeDbHandle(handle);
@@ -323,7 +323,7 @@ public class ReportDao extends AnetSubscribableObjectDao<Report, ReportSearchQue
     final Handle handle = getDbHandle();
     try {
       return handle.createUpdate("/* updatePersonOnReport*/ UPDATE \"reportPeople\" "
-          + "SET \"isPrimary\" = :primary, \"isAuthor\" = :author, \"isAttendee\" = :attendee, \"isInterlocutor\" = :interlocutor"
+          + "SET \"isPrimary\" = :primary, \"isAuthor\" = :author, \"isAttendee\" = :attendee, \"isInterlocutor\" = :interlocutor, \"reportPositionUuid\" = :reportPositionUuid"
           + " WHERE \"reportUuid\" = :reportUuid AND \"personUuid\" = :personUuid")
           .bind("reportUuid", r.getUuid()).bind("personUuid", rp.getUuid()).bindBean(rp).execute();
     } finally {
@@ -550,10 +550,6 @@ public class ReportDao extends AnetSubscribableObjectDao<Report, ReportSearchQue
 
       sql.append(
           "LEFT JOIN \"reportPeople\" rpa ON rpa.\"reportUuid\" = r.uuid AND rpa.\"isInterlocutor\" IS NOT TRUE ");
-      sql.append("LEFT JOIN \"peoplePositions\" ppa ON ppa.\"personUuid\" = rpa.\"personUuid\" ");
-      sql.append(" AND ppa.primary IS TRUE ");
-      sql.append(" AND ppa.\"createdAt\" < r.\"engagementDate\" ");
-      sql.append(" AND (ppa.\"endedAt\" IS NULL OR ppa.\"endedAt\" > r.\"engagementDate\") ");
       sql.append(
           "INNER JOIN \"authorizationGroupRelatedObjects\" agroa ON agroa.\"authorizationGroupUuid\" = :advisorAuthorizationGroupUuid AND ( ");
       sql.append(
@@ -561,15 +557,11 @@ public class ReportDao extends AnetSubscribableObjectDao<Report, ReportSearchQue
       sql.append(
           " OR (agroa.\"relatedObjectType\" = 'people' AND agroa.\"relatedObjectUuid\" = rpa.\"personUuid\") ");
       sql.append(
-          " OR (agroa.\"relatedObjectType\" = 'positions' AND agroa.\"relatedObjectUuid\" = ppa.\"positionUuid\") ");
+          " OR (agroa.\"relatedObjectType\" = 'positions' AND agroa.\"relatedObjectUuid\" = rpa.\"reportPositionUuid\") ");
       sql.append(") ");
 
       sql.append(
           "LEFT JOIN \"reportPeople\" rpi ON rpi.\"reportUuid\" = r.uuid AND rpi.\"isInterlocutor\" IS TRUE ");
-      sql.append("LEFT JOIN \"peoplePositions\" ppi ON ppi.\"personUuid\" = rpi.\"personUuid\" ");
-      sql.append(" AND ppi.primary IS TRUE ");
-      sql.append(" AND ppi.\"createdAt\" < r.\"engagementDate\" ");
-      sql.append(" AND (ppi.\"endedAt\" IS NULL OR ppi.\"endedAt\" > r.\"engagementDate\") ");
       sql.append(
           "INNER JOIN \"authorizationGroupRelatedObjects\" agroi ON agroi.\"authorizationGroupUuid\" = :interlocutorAuthorizationGroupUuid AND ( ");
       sql.append(
@@ -577,7 +569,7 @@ public class ReportDao extends AnetSubscribableObjectDao<Report, ReportSearchQue
       sql.append(
           " OR (agroi.\"relatedObjectType\" = 'people' AND agroi.\"relatedObjectUuid\" = rpi.\"personUuid\") ");
       sql.append(
-          " OR (agroi.\"relatedObjectType\" = 'positions' AND agroi.\"relatedObjectUuid\" = ppi.\"positionUuid\") ");
+          " OR (agroi.\"relatedObjectType\" = 'positions' AND agroi.\"relatedObjectUuid\" = rpi.\"reportPositionUuid\") ");
       sql.append(") ");
 
       sql.append("WHERE r.state in (:approvedState, :publishedState) ");
@@ -759,14 +751,14 @@ public class ReportDao extends AnetSubscribableObjectDao<Report, ReportSearchQue
   }
 
   class ReportPeopleBatcher extends ForeignKeyBatcher<ReportPerson> {
-    private static final String SQL =
-        "/* batch.getPeopleForReport */ SELECT " + PersonDao.PERSON_FIELDS
-            + ", \"reportPeople\".\"reportUuid\", \"reportPeople\".\"isPrimary\""
-            + ", \"reportPeople\".\"isAuthor\", \"reportPeople\".\"isAttendee\""
-            + ", \"reportPeople\".\"isInterlocutor\" FROM \"reportPeople\" "
-            + "LEFT JOIN people ON \"reportPeople\".\"personUuid\" = people.uuid "
-            + "WHERE \"reportPeople\".\"reportUuid\" IN ( <foreignKeys> ) "
-            + "ORDER BY people.\"familyName\", people.\"givenName\", people.uuid";
+    private static final String SQL = "/* batch.getPeopleForReport */ SELECT "
+        + PersonDao.PERSON_FIELDS
+        + ", \"reportPeople\".\"reportUuid\", \"reportPeople\".\"isPrimary\""
+        + ", \"reportPeople\".\"isAuthor\", \"reportPeople\".\"isAttendee\""
+        + ", \"reportPeople\".\"isInterlocutor\", \"reportPeople\".\"reportPositionUuid\" FROM \"reportPeople\" "
+        + "LEFT JOIN people ON \"reportPeople\".\"personUuid\" = people.uuid "
+        + "WHERE \"reportPeople\".\"reportUuid\" IN ( <foreignKeys> ) "
+        + "ORDER BY people.\"familyName\", people.\"givenName\", people.uuid";
 
     public ReportPeopleBatcher() {
       super(ReportDao.this.databaseHandler, SQL, "foreignKeys", new ReportPersonMapper(),

--- a/src/main/java/mil/dds/anet/database/mappers/ReportPersonMapper.java
+++ b/src/main/java/mil/dds/anet/database/mappers/ReportPersonMapper.java
@@ -15,6 +15,8 @@ public class ReportPersonMapper implements RowMapper<ReportPerson> {
     rp.setAuthor(r.getBoolean("isAuthor"));
     rp.setAttendee(r.getBoolean("isAttendee"));
     rp.setInterlocutor(r.getBoolean("isInterlocutor"));
+    rp.setReportPositionUuid(r.getString("reportPositionUuid"));
+
     return rp;
   }
 

--- a/src/main/java/mil/dds/anet/resources/PositionResource.java
+++ b/src/main/java/mil/dds/anet/resources/PositionResource.java
@@ -38,12 +38,12 @@ public class PositionResource {
   private final PersonDao personDao;
 
   public PositionResource(AnetObjectEngine anetObjectEngine, AuditTrailDao auditTrailDao,
-      PositionDao dao, EmailAddressDao emailAddressDao, PersonDao personDao, PersonDao personDao1) {
+      PositionDao dao, EmailAddressDao emailAddressDao, PersonDao personDao) {
     this.auditTrailDao = auditTrailDao;
     this.dao = dao;
     this.engine = anetObjectEngine;
     this.emailAddressDao = emailAddressDao;
-    this.personDao = personDao1;
+    this.personDao = personDao;
   }
 
   public static boolean hasPermission(final Person user, final String positionUuid) {

--- a/src/main/java/mil/dds/anet/resources/ReportResource.java
+++ b/src/main/java/mil/dds/anet/resources/ReportResource.java
@@ -24,6 +24,8 @@ import mil.dds.anet.beans.Comment;
 import mil.dds.anet.beans.EngagementInformation;
 import mil.dds.anet.beans.GenericRelatedObject;
 import mil.dds.anet.beans.Person;
+import mil.dds.anet.beans.PersonPositionHistory;
+import mil.dds.anet.beans.Position;
 import mil.dds.anet.beans.Report;
 import mil.dds.anet.beans.Report.ReportState;
 import mil.dds.anet.beans.ReportAction;
@@ -157,18 +159,9 @@ public class ReportResource {
     ResourceUtils.assertAllowedClassification(r.getClassification());
 
     // Set advisor org
-    Person primaryAdvisor = findPrimaryAttendee(r, false);
-    logger.debug("Setting advisor org for new report {} based on {} at date {}", r, primaryAdvisor,
-        r.getEngagementDate());
-    r.setAdvisorOrg(organizationDao.getOrganizationForPerson(engine.getContext(),
-        DaoUtils.getUuid(primaryAdvisor), r.getEngagementDate()).join());
-
+    setReportPrimaryAdvisorOrg(r, false);
     // Set interlocutor org
-    Person primaryInterlocutor = findPrimaryAttendee(r, true);
-    logger.debug("Setting interlocutor org for new report {} based on {} at date {}", r,
-        primaryInterlocutor, r.getEngagementDate());
-    r.setInterlocutorOrg(organizationDao.getOrganizationForPerson(engine.getContext(),
-        DaoUtils.getUuid(primaryInterlocutor), r.getEngagementDate()).join());
+    setReportPrimaryInterlocutorOrg(r, false);
 
     r.setReportText(
         Utils.isEmptyHtml(r.getReportText()) ? null : Utils.sanitizeHtml(r.getReportText()));
@@ -217,15 +210,6 @@ public class ReportResource {
 
     // Return the report in the response; used in autoSave by the client form
     return r;
-  }
-
-  private Person findPrimaryAttendee(Report r, boolean isInterlocutor) {
-    if (r.getReportPeople() == null) {
-      return null;
-    }
-    return r.getReportPeople().stream()
-        .filter(p -> p.isAttendee() && p.isPrimary() && p.isInterlocutor() == isInterlocutor)
-        .findFirst().orElse(null);
   }
 
   /**
@@ -278,18 +262,9 @@ public class ReportResource {
     }
 
     // Update the advisor org
-    final Person primaryAdvisor = findPrimaryAttendee(r, false);
-    logger.debug("Updating advisor org for report {} based on {} at date {}", r, primaryAdvisor,
-        r.getEngagementDate());
-    r.setAdvisorOrg(organizationDao.getOrganizationForPerson(engine.getContext(),
-        DaoUtils.getUuid(primaryAdvisor), r.getEngagementDate()).join());
-
+    setReportPrimaryAdvisorOrg(r, false);
     // Update the interlocutor org
-    final Person primaryInterlocutor = findPrimaryAttendee(r, true);
-    logger.debug("Updating interlocutor org for report {} based on {} at date {}", r,
-        primaryInterlocutor, r.getEngagementDate());
-    r.setInterlocutorOrg(organizationDao.getOrganizationForPerson(engine.getContext(),
-        DaoUtils.getUuid(primaryInterlocutor), r.getEngagementDate()).join());
+    setReportPrimaryInterlocutorOrg(r, false);
 
     r.setReportText(
         Utils.isEmptyHtml(r.getReportText()) ? null : Utils.sanitizeHtml(r.getReportText()));
@@ -307,16 +282,19 @@ public class ReportResource {
           reportDao.getPeopleForReport(engine.getContext(), r.getUuid()).join();
       // Find any differences and fix them.
       for (ReportPerson rp : r.getReportPeople()) {
-        Optional<ReportPerson> existingPerson =
+        Optional<ReportPerson> existingPersonOpt =
             existingPeople.stream().filter(el -> el.getUuid().equals(rp.getUuid())).findFirst();
-        if (existingPerson.isPresent()) {
-          if (existingPerson.get().isPrimary() != rp.isPrimary()
-              || existingPerson.get().isAttendee() != rp.isAttendee()
-              || existingPerson.get().isAuthor() != rp.isAuthor()
-              || existingPerson.get().isInterlocutor() != rp.isInterlocutor()) {
+        if (existingPersonOpt.isPresent()) {
+          ReportPerson reportPerson = existingPersonOpt.get();
+          reportPerson.loadReportPosition(engine.getContext());
+          if (reportPerson.isPrimary() != rp.isPrimary()
+              || reportPerson.isAttendee() != rp.isAttendee()
+              || reportPerson.isAuthor() != rp.isAuthor()
+              || reportPerson.isInterlocutor() != rp.isInterlocutor() || !Objects
+                  .equals(reportPerson.getReportPositionUuid(), rp.getReportPositionUuid())) {
             reportDao.updatePersonOnReport(rp, r);
           }
-          existingPeople.remove(existingPerson.get());
+          existingPeople.remove(reportPerson);
         } else {
           reportDao.addPersonToReport(rp, r);
         }
@@ -430,29 +408,9 @@ public class ReportResource {
     }
 
     // Update advisor org
-    final ReportPerson advisor = r.loadPrimaryAdvisor(engine.getContext()).join();
-    final Boolean optionalPrimaryAdvisor =
-        (Boolean) dict.getDictionaryEntry("fields.report.reportPeople.optionalPrimaryAdvisor");
-    if (advisor == null && !Boolean.TRUE.equals(optionalPrimaryAdvisor)) {
-      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Report missing primary advisor");
-    }
-    logger.debug("Updating advisor org for report {} based on {} at date {}", r, advisor,
-        r.getEngagementDate());
-    r.setAdvisorOrg(organizationDao.getOrganizationForPerson(engine.getContext(),
-        DaoUtils.getUuid(advisor), r.getEngagementDate()).join());
-
+    setReportPrimaryAdvisorOrg(r, true);
     // Update interlocutor org
-    final ReportPerson interlocutor = r.loadPrimaryInterlocutor(engine.getContext()).join();
-    final Boolean optionalPrimaryInterlocutor =
-        (Boolean) dict.getDictionaryEntry("fields.report.reportPeople.optionalPrimaryPrincipal");
-    if (interlocutor == null && !Boolean.TRUE.equals(optionalPrimaryInterlocutor)) {
-      throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
-          "Report missing primary interlocutor");
-    }
-    logger.debug("Updating interlocutor org for report {} based on {} at date {}", r, interlocutor,
-        r.getEngagementDate());
-    r.setInterlocutorOrg(organizationDao.getOrganizationForPerson(engine.getContext(),
-        DaoUtils.getUuid(interlocutor), r.getEngagementDate()).join());
+    setReportPrimaryInterlocutorOrg(r, true);
 
     if (r.getEngagementDate() == null) {
       throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Missing engagement date");
@@ -890,6 +848,98 @@ public class ReportResource {
         updateType)) {
       // Don't provide too much information, just say it is "denied"
       throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Permission denied");
+    }
+  }
+
+  private void setReportPrimaryAdvisorOrg(Report r, boolean isSubmit) {
+    if (isSubmit) {
+      final ReportPerson primaryAdvisor = r.loadPrimaryAdvisor(engine.getContext()).join();
+      // When submitting we enforce the dictionary option
+      final Boolean optionalPrimaryAdvisor =
+          (Boolean) dict.getDictionaryEntry("fields.report.reportPeople.optionalPrimaryAdvisor");
+      if (primaryAdvisor == null && !Boolean.TRUE.equals(optionalPrimaryAdvisor)) {
+        throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+            "Report missing primary interlocutor");
+      }
+      if (primaryAdvisor != null && primaryAdvisor.getReportPositionUuid() != null) {
+        // And we validate position with history and assign organization
+        r.setAdvisorOrg(validateReportPositionAndGetOrganization(primaryAdvisor, r));
+      }
+    } else {
+      // Just update the advisor org, no validation
+      final ReportPerson primaryAdvisor = findPrimaryAttendee(r, false);
+      if (primaryAdvisor != null && primaryAdvisor.getReportPosition() != null) {
+        primaryAdvisor.loadReportPosition(engine.getContext()).join();
+        logger.debug("Updating advisor org for report {} based on {} at date {}", r, primaryAdvisor,
+            r.getEngagementDate());
+        r.setAdvisorOrg(primaryAdvisor.getReportPosition().getOrganization());
+      }
+    }
+  }
+
+  private void setReportPrimaryInterlocutorOrg(Report r, boolean isSubmit) {
+    if (isSubmit) {
+      final ReportPerson primaryInterlocutor =
+          r.loadPrimaryInterlocutor(engine.getContext()).join();
+      // When submitting we enforce the dictionary option
+      final Boolean optionalPrimaryInterlocutor =
+          (Boolean) dict.getDictionaryEntry("fields.report.reportPeople.optionalPrimaryPrincipal");
+      if (primaryInterlocutor == null && !Boolean.TRUE.equals(optionalPrimaryInterlocutor)) {
+        throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+            "Report missing primary interlocutor");
+      }
+      if (primaryInterlocutor != null && primaryInterlocutor.getReportPositionUuid() != null) {
+        // Validate position with history and assign organization
+        r.setInterlocutorOrg(validateReportPositionAndGetOrganization(primaryInterlocutor, r));
+      }
+    } else {
+      // Update the interlocutor org
+      final ReportPerson primaryInterlocutor = findPrimaryAttendee(r, true);
+      if (primaryInterlocutor != null && primaryInterlocutor.getReportPosition() != null) {
+        primaryInterlocutor.loadReportPosition(engine.getContext()).join();
+        logger.debug("Updating interlocutor org for report {} based on {} at date {}", r,
+            primaryInterlocutor, r.getEngagementDate());
+        r.setInterlocutorOrg(primaryInterlocutor.getReportPosition().getOrganization());
+      }
+    }
+  }
+
+  private ReportPerson findPrimaryAttendee(Report r, boolean isInterlocutor) {
+    if (r.getReportPeople() == null) {
+      return null;
+    }
+    return r.getReportPeople().stream()
+        .filter(p -> p.isAttendee() && p.isPrimary() && p.isInterlocutor() == isInterlocutor)
+        .findFirst().orElse(null);
+  }
+
+  private Organization validateReportPositionAndGetOrganization(ReportPerson reportPerson,
+      Report r) {
+    // No engagement date, stick to current primary position organization
+    if (r.getEngagementDate() == null) {
+      return organizationDao
+          .getOrganizationForPerson(engine.getContext(), DaoUtils.getUuid(reportPerson)).join();
+    } else {
+      // Engagement date, need to check history
+      Optional<PersonPositionHistory> reportPosition = reportPerson
+          .loadPreviousPositions(
+              engine.getContext())
+          .join().stream()
+          .filter(historyEntry -> historyEntry.getPositionUuid()
+              .equals(reportPerson.getReportPositionUuid())
+              && !historyEntry.getStartTime().isAfter(r.getEngagementDate())
+              && (historyEntry.getEndTime() == null
+                  || !historyEntry.getEndTime().isBefore(r.getEngagementDate())))
+          .findFirst();
+      if (reportPosition.isEmpty()) {
+        throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+            "Report position is not consistent with person history");
+      }
+      PersonPositionHistory positionEntry = reportPosition.get();
+      positionEntry.loadPosition(engine.getContext()).join();
+      Position position = positionEntry.getPosition();
+      position.loadOrganization(engine.getContext()).join();
+      return position.getOrganization();
     }
   }
 }

--- a/src/main/java/mil/dds/anet/resources/ReportResource.java
+++ b/src/main/java/mil/dds/anet/resources/ReportResource.java
@@ -43,6 +43,7 @@ import mil.dds.anet.database.AuditTrailDao;
 import mil.dds.anet.database.CommentDao;
 import mil.dds.anet.database.OrganizationDao;
 import mil.dds.anet.database.PersonDao;
+import mil.dds.anet.database.PositionDao;
 import mil.dds.anet.database.ReportActionDao;
 import mil.dds.anet.database.ReportDao;
 import mil.dds.anet.database.TaskDao;
@@ -77,10 +78,12 @@ public class ReportResource {
   private final OrganizationDao organizationDao;
   private final ReportDao reportDao;
   private final ReportActionDao reportActionDao;
+  private final PositionDao positionDao;
 
   public ReportResource(AnetDictionary dict, AnetObjectEngine anetObjectEngine,
       AuditTrailDao auditTrailDao, CommentDao commentDao, AssessmentDao assessmentDao,
-      OrganizationDao organizationDao, ReportDao reportDao, ReportActionDao reportActionDao) {
+      OrganizationDao organizationDao, ReportDao reportDao, ReportActionDao reportActionDao,
+      PositionDao positionDao) {
     this.dict = dict;
     this.engine = anetObjectEngine;
     this.auditTrailDao = auditTrailDao;
@@ -89,6 +92,7 @@ public class ReportResource {
     this.organizationDao = organizationDao;
     this.reportDao = reportDao;
     this.reportActionDao = reportActionDao;
+    this.positionDao = positionDao;
   }
 
   public static boolean hasPermission(final Person user, final String reportUuid) {
@@ -286,7 +290,6 @@ public class ReportResource {
             existingPeople.stream().filter(el -> el.getUuid().equals(rp.getUuid())).findFirst();
         if (existingPersonOpt.isPresent()) {
           ReportPerson reportPerson = existingPersonOpt.get();
-          reportPerson.loadReportPosition(engine.getContext());
           if (reportPerson.isPrimary() != rp.isPrimary()
               || reportPerson.isAttendee() != rp.isAttendee()
               || reportPerson.isAuthor() != rp.isAuthor()
@@ -863,16 +866,17 @@ public class ReportResource {
       }
       if (primaryAdvisor != null && primaryAdvisor.getReportPositionUuid() != null) {
         // And we validate position with history and assign organization
-        r.setAdvisorOrg(validateReportPositionAndGetOrganization(primaryAdvisor, r));
+        r.setAdvisorOrgUuid(validateReportPositionAndGetOrganization(primaryAdvisor, r));
       }
     } else {
       // Just update the advisor org, no validation
       final ReportPerson primaryAdvisor = findPrimaryAttendee(r, false);
-      if (primaryAdvisor != null && primaryAdvisor.getReportPosition() != null) {
-        primaryAdvisor.loadReportPosition(engine.getContext()).join();
+      if (primaryAdvisor != null && primaryAdvisor.getReportPositionUuid() != null) {
+        final Position primaryAdvisorPosition =
+            positionDao.getByUuid(primaryAdvisor.getReportPositionUuid());
         logger.debug("Updating advisor org for report {} based on {} at date {}", r, primaryAdvisor,
             r.getEngagementDate());
-        r.setAdvisorOrg(primaryAdvisor.getReportPosition().getOrganization());
+        r.setAdvisorOrgUuid(primaryAdvisorPosition.getOrganizationUuid());
       }
     }
   }
@@ -890,16 +894,17 @@ public class ReportResource {
       }
       if (primaryInterlocutor != null && primaryInterlocutor.getReportPositionUuid() != null) {
         // Validate position with history and assign organization
-        r.setInterlocutorOrg(validateReportPositionAndGetOrganization(primaryInterlocutor, r));
+        r.setInterlocutorOrgUuid(validateReportPositionAndGetOrganization(primaryInterlocutor, r));
       }
     } else {
       // Update the interlocutor org
       final ReportPerson primaryInterlocutor = findPrimaryAttendee(r, true);
-      if (primaryInterlocutor != null && primaryInterlocutor.getReportPosition() != null) {
-        primaryInterlocutor.loadReportPosition(engine.getContext()).join();
+      if (primaryInterlocutor != null && primaryInterlocutor.getReportPositionUuid() != null) {
+        final Position primaryAdvisorPosition =
+            positionDao.getByUuid(primaryInterlocutor.getReportPositionUuid());
         logger.debug("Updating interlocutor org for report {} based on {} at date {}", r,
             primaryInterlocutor, r.getEngagementDate());
-        r.setInterlocutorOrg(primaryInterlocutor.getReportPosition().getOrganization());
+        r.setInterlocutorOrgUuid(primaryAdvisorPosition.getOrganizationUuid());
       }
     }
   }
@@ -913,33 +918,23 @@ public class ReportResource {
         .findFirst().orElse(null);
   }
 
-  private Organization validateReportPositionAndGetOrganization(ReportPerson reportPerson,
-      Report r) {
-    // No engagement date, stick to current primary position organization
-    if (r.getEngagementDate() == null) {
-      return organizationDao
-          .getOrganizationForPerson(engine.getContext(), DaoUtils.getUuid(reportPerson)).join();
-    } else {
-      // Engagement date, need to check history
-      Optional<PersonPositionHistory> reportPosition = reportPerson
-          .loadPreviousPositions(
-              engine.getContext())
-          .join().stream()
-          .filter(historyEntry -> historyEntry.getPositionUuid()
-              .equals(reportPerson.getReportPositionUuid())
-              && !historyEntry.getStartTime().isAfter(r.getEngagementDate())
-              && (historyEntry.getEndTime() == null
-                  || !historyEntry.getEndTime().isBefore(r.getEngagementDate())))
-          .findFirst();
-      if (reportPosition.isEmpty()) {
-        throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
-            "Report position is not consistent with person history");
-      }
-      PersonPositionHistory positionEntry = reportPosition.get();
-      positionEntry.loadPosition(engine.getContext()).join();
-      Position position = positionEntry.getPosition();
-      position.loadOrganization(engine.getContext()).join();
-      return position.getOrganization();
+  private String validateReportPositionAndGetOrganization(ReportPerson reportPerson, Report r) {
+    // Check history is consistent with engagement date
+    final Optional<PersonPositionHistory> reportPosition =
+        reportPerson
+            .loadPreviousPositions(
+                engine.getContext())
+            .join().stream()
+            .filter(historyEntry -> historyEntry.getPositionUuid()
+                .equals(reportPerson.getReportPositionUuid())
+                && !historyEntry.getStartTime().isAfter(r.getEngagementDate())
+                && (historyEntry.getEndTime() == null
+                    || !historyEntry.getEndTime().isBefore(r.getEngagementDate())))
+            .findFirst();
+    if (reportPosition.isEmpty()) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+          "Report position is not consistent with person history");
     }
+    return reportPosition.get().loadPosition(engine.getContext()).join().getOrganizationUuid();
   }
 }

--- a/src/main/java/mil/dds/anet/resources/ReportResource.java
+++ b/src/main/java/mil/dds/anet/resources/ReportResource.java
@@ -31,6 +31,8 @@ import mil.dds.anet.beans.EngagementInformation;
 import mil.dds.anet.beans.GenericRelatedObject;
 import mil.dds.anet.beans.Organization;
 import mil.dds.anet.beans.Person;
+import mil.dds.anet.beans.PersonPositionHistory;
+import mil.dds.anet.beans.Position;
 import mil.dds.anet.beans.Report;
 import mil.dds.anet.beans.Report.ReportState;
 import mil.dds.anet.beans.ReportAction;
@@ -162,18 +164,9 @@ public class ReportResource {
     ResourceUtils.assertAllowedClassification(r.getClassification());
 
     // Set advisor org
-    Person primaryAdvisor = findPrimaryAttendee(r, false);
-    logger.debug("Setting advisor org for new report {} based on {} at date {}", r, primaryAdvisor,
-        r.getEngagementDate());
-    r.setAdvisorOrg(organizationDao.getOrganizationForPerson(engine.getContext(),
-        DaoUtils.getUuid(primaryAdvisor), r.getEngagementDate()).join());
-
+    setReportPrimaryAdvisorOrg(r, false);
     // Set interlocutor org
-    Person primaryInterlocutor = findPrimaryAttendee(r, true);
-    logger.debug("Setting interlocutor org for new report {} based on {} at date {}", r,
-        primaryInterlocutor, r.getEngagementDate());
-    r.setInterlocutorOrg(organizationDao.getOrganizationForPerson(engine.getContext(),
-        DaoUtils.getUuid(primaryInterlocutor), r.getEngagementDate()).join());
+    setReportPrimaryInterlocutorOrg(r, false);
 
     r.setReportText(
         Utils.isEmptyHtml(r.getReportText()) ? null : Utils.sanitizeHtml(r.getReportText()));
@@ -212,15 +205,6 @@ public class ReportResource {
 
     // Return the report in the response; used in autoSave by the client form
     return r;
-  }
-
-  private Person findPrimaryAttendee(Report r, boolean isInterlocutor) {
-    if (r.getReportPeople() == null) {
-      return null;
-    }
-    return r.getReportPeople().stream()
-        .filter(p -> p.isAttendee() && p.isPrimary() && p.isInterlocutor() == isInterlocutor)
-        .findFirst().orElse(null);
   }
 
   /**
@@ -273,18 +257,9 @@ public class ReportResource {
     }
 
     // Update the advisor org
-    final Person primaryAdvisor = findPrimaryAttendee(r, false);
-    logger.debug("Updating advisor org for report {} based on {} at date {}", r, primaryAdvisor,
-        r.getEngagementDate());
-    r.setAdvisorOrg(organizationDao.getOrganizationForPerson(engine.getContext(),
-        DaoUtils.getUuid(primaryAdvisor), r.getEngagementDate()).join());
-
+    setReportPrimaryAdvisorOrg(r, false);
     // Update the interlocutor org
-    final Person primaryInterlocutor = findPrimaryAttendee(r, true);
-    logger.debug("Updating interlocutor org for report {} based on {} at date {}", r,
-        primaryInterlocutor, r.getEngagementDate());
-    r.setInterlocutorOrg(organizationDao.getOrganizationForPerson(engine.getContext(),
-        DaoUtils.getUuid(primaryInterlocutor), r.getEngagementDate()).join());
+    setReportPrimaryInterlocutorOrg(r, false);
 
     r.setReportText(
         Utils.isEmptyHtml(r.getReportText()) ? null : Utils.sanitizeHtml(r.getReportText()));
@@ -302,16 +277,19 @@ public class ReportResource {
           reportDao.getPeopleForReport(engine.getContext(), r.getUuid()).join();
       // Find any differences and fix them.
       for (ReportPerson rp : r.getReportPeople()) {
-        Optional<ReportPerson> existingPerson =
+        Optional<ReportPerson> existingPersonOpt =
             existingPeople.stream().filter(el -> el.getUuid().equals(rp.getUuid())).findFirst();
-        if (existingPerson.isPresent()) {
-          if (existingPerson.get().isPrimary() != rp.isPrimary()
-              || existingPerson.get().isAttendee() != rp.isAttendee()
-              || existingPerson.get().isAuthor() != rp.isAuthor()
-              || existingPerson.get().isInterlocutor() != rp.isInterlocutor()) {
+        if (existingPersonOpt.isPresent()) {
+          ReportPerson reportPerson = existingPersonOpt.get();
+          reportPerson.loadReportPosition(engine.getContext());
+          if (reportPerson.isPrimary() != rp.isPrimary()
+              || reportPerson.isAttendee() != rp.isAttendee()
+              || reportPerson.isAuthor() != rp.isAuthor()
+              || reportPerson.isInterlocutor() != rp.isInterlocutor() || !Objects
+                  .equals(reportPerson.getReportPositionUuid(), rp.getReportPositionUuid())) {
             reportDao.updatePersonOnReport(rp, r);
           }
-          existingPeople.remove(existingPerson.get());
+          existingPeople.remove(reportPerson);
         } else {
           reportDao.addPersonToReport(rp, r);
         }
@@ -425,29 +403,9 @@ public class ReportResource {
     }
 
     // Update advisor org
-    final ReportPerson advisor = r.loadPrimaryAdvisor(engine.getContext()).join();
-    final Boolean optionalPrimaryAdvisor =
-        (Boolean) dict.getDictionaryEntry("fields.report.reportPeople.optionalPrimaryAdvisor");
-    if (advisor == null && !Boolean.TRUE.equals(optionalPrimaryAdvisor)) {
-      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Report missing primary advisor");
-    }
-    logger.debug("Updating advisor org for report {} based on {} at date {}", r, advisor,
-        r.getEngagementDate());
-    r.setAdvisorOrg(organizationDao.getOrganizationForPerson(engine.getContext(),
-        DaoUtils.getUuid(advisor), r.getEngagementDate()).join());
-
+    setReportPrimaryAdvisorOrg(r, true);
     // Update interlocutor org
-    final ReportPerson interlocutor = r.loadPrimaryInterlocutor(engine.getContext()).join();
-    final Boolean optionalPrimaryInterlocutor =
-        (Boolean) dict.getDictionaryEntry("fields.report.reportPeople.optionalPrimaryPrincipal");
-    if (interlocutor == null && !Boolean.TRUE.equals(optionalPrimaryInterlocutor)) {
-      throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
-          "Report missing primary interlocutor");
-    }
-    logger.debug("Updating interlocutor org for report {} based on {} at date {}", r, interlocutor,
-        r.getEngagementDate());
-    r.setInterlocutorOrg(organizationDao.getOrganizationForPerson(engine.getContext(),
-        DaoUtils.getUuid(interlocutor), r.getEngagementDate()).join());
+    setReportPrimaryInterlocutorOrg(r, true);
 
     if (r.getEngagementDate() == null) {
       throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Missing engagement date");
@@ -948,6 +906,98 @@ public class ReportResource {
         updateType)) {
       // Don't provide too much information, just say it is "denied"
       throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Permission denied");
+    }
+  }
+
+  private void setReportPrimaryAdvisorOrg(Report r, boolean isSubmit) {
+    if (isSubmit) {
+      final ReportPerson primaryAdvisor = r.loadPrimaryAdvisor(engine.getContext()).join();
+      // When submitting we enforce the dictionary option
+      final Boolean optionalPrimaryAdvisor =
+          (Boolean) dict.getDictionaryEntry("fields.report.reportPeople.optionalPrimaryAdvisor");
+      if (primaryAdvisor == null && !Boolean.TRUE.equals(optionalPrimaryAdvisor)) {
+        throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+            "Report missing primary interlocutor");
+      }
+      if (primaryAdvisor != null && primaryAdvisor.getReportPositionUuid() != null) {
+        // And we validate position with history and assign organization
+        r.setAdvisorOrg(validateReportPositionAndGetOrganization(primaryAdvisor, r));
+      }
+    } else {
+      // Just update the advisor org, no validation
+      final ReportPerson primaryAdvisor = findPrimaryAttendee(r, false);
+      if (primaryAdvisor != null && primaryAdvisor.getReportPosition() != null) {
+        primaryAdvisor.loadReportPosition(engine.getContext()).join();
+        logger.debug("Updating advisor org for report {} based on {} at date {}", r, primaryAdvisor,
+            r.getEngagementDate());
+        r.setAdvisorOrg(primaryAdvisor.getReportPosition().getOrganization());
+      }
+    }
+  }
+
+  private void setReportPrimaryInterlocutorOrg(Report r, boolean isSubmit) {
+    if (isSubmit) {
+      final ReportPerson primaryInterlocutor =
+          r.loadPrimaryInterlocutor(engine.getContext()).join();
+      // When submitting we enforce the dictionary option
+      final Boolean optionalPrimaryInterlocutor =
+          (Boolean) dict.getDictionaryEntry("fields.report.reportPeople.optionalPrimaryPrincipal");
+      if (primaryInterlocutor == null && !Boolean.TRUE.equals(optionalPrimaryInterlocutor)) {
+        throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+            "Report missing primary interlocutor");
+      }
+      if (primaryInterlocutor != null && primaryInterlocutor.getReportPositionUuid() != null) {
+        // Validate position with history and assign organization
+        r.setInterlocutorOrg(validateReportPositionAndGetOrganization(primaryInterlocutor, r));
+      }
+    } else {
+      // Update the interlocutor org
+      final ReportPerson primaryInterlocutor = findPrimaryAttendee(r, true);
+      if (primaryInterlocutor != null && primaryInterlocutor.getReportPosition() != null) {
+        primaryInterlocutor.loadReportPosition(engine.getContext()).join();
+        logger.debug("Updating interlocutor org for report {} based on {} at date {}", r,
+            primaryInterlocutor, r.getEngagementDate());
+        r.setInterlocutorOrg(primaryInterlocutor.getReportPosition().getOrganization());
+      }
+    }
+  }
+
+  private ReportPerson findPrimaryAttendee(Report r, boolean isInterlocutor) {
+    if (r.getReportPeople() == null) {
+      return null;
+    }
+    return r.getReportPeople().stream()
+        .filter(p -> p.isAttendee() && p.isPrimary() && p.isInterlocutor() == isInterlocutor)
+        .findFirst().orElse(null);
+  }
+
+  private Organization validateReportPositionAndGetOrganization(ReportPerson reportPerson,
+      Report r) {
+    // No engagement date, stick to current primary position organization
+    if (r.getEngagementDate() == null) {
+      return organizationDao
+          .getOrganizationForPerson(engine.getContext(), DaoUtils.getUuid(reportPerson)).join();
+    } else {
+      // Engagement date, need to check history
+      Optional<PersonPositionHistory> reportPosition = reportPerson
+          .loadPreviousPositions(
+              engine.getContext())
+          .join().stream()
+          .filter(historyEntry -> historyEntry.getPositionUuid()
+              .equals(reportPerson.getReportPositionUuid())
+              && !historyEntry.getStartTime().isAfter(r.getEngagementDate())
+              && (historyEntry.getEndTime() == null
+                  || !historyEntry.getEndTime().isBefore(r.getEngagementDate())))
+          .findFirst();
+      if (reportPosition.isEmpty()) {
+        throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+            "Report position is not consistent with person history");
+      }
+      PersonPositionHistory positionEntry = reportPosition.get();
+      positionEntry.loadPosition(engine.getContext()).join();
+      Position position = positionEntry.getPosition();
+      position.loadOrganization(engine.getContext()).join();
+      return position.getOrganization();
     }
   }
 }

--- a/src/main/java/mil/dds/anet/search/AbstractReportSearcher.java
+++ b/src/main/java/mil/dds/anet/search/AbstractReportSearcher.java
@@ -261,12 +261,10 @@ public abstract class AbstractReportSearcher extends AbstractSearcher<Report, Re
     }
 
     if (query.getAuthorPositionUuid() != null) {
-      // Search for reports authored by people serving in that position at the report's creation
-      // date
+      // Search for reports authored by people serving in that position
       qb.addWhereClause("reports.uuid IN (SELECT r.uuid FROM reports r"
-          + " JOIN \"reportPeople\" rp ON rp.\"reportUuid\" = r.uuid "
-          + PositionDao.generatePositionFilterAtDate("rp.\"personUuid\"", "r.\"createdAt\"",
-              "authorPositionUuid")
+          + " JOIN \"reportPeople\" rp ON rp.\"reportUuid\" = r.uuid"
+          + " WHERE rp.\"reportPositionUuid\" = :authorPositionUuid"
           + " AND rp.\"isAuthor\" = :isAuthor)");
       qb.addSqlArg("isAuthor", true);
       qb.addSqlArg("authorPositionUuid", query.getAuthorPositionUuid());
@@ -285,13 +283,11 @@ public abstract class AbstractReportSearcher extends AbstractSearcher<Report, Re
     }
 
     if (query.getAttendeePositionUuid() != null) {
-      // Search for reports attended by people serving in that position at the engagement date
-      qb.addWhereClause(
-          "reports.uuid IN (SELECT r.uuid FROM reports r"
-              + " JOIN \"reportPeople\" rp ON rp.\"reportUuid\" = r.uuid "
-              + PositionDao.generatePositionFilterAtDate("rp.\"personUuid\"",
-                  "r.\"engagementDate\"", "attendeePositionUuid")
-              + " AND rp.\"isAttendee\" = :isAttendee)");
+      // Search for reports attended by people serving in that position
+      qb.addWhereClause("reports.uuid IN (SELECT r.uuid FROM reports r"
+          + " JOIN \"reportPeople\" rp ON rp.\"reportUuid\" = r.uuid"
+          + " WHERE rp.\"reportPositionUuid\" = :attendeePositionUuid"
+          + " AND rp.\"isAttendee\" = :isAttendee)");
       qb.addSqlArg("isAttendee", true);
       qb.addSqlArg("attendeePositionUuid", query.getAttendeePositionUuid());
     }

--- a/src/main/java/mil/dds/anet/services/MartReportImporterService.java
+++ b/src/main/java/mil/dds/anet/services/MartReportImporterService.java
@@ -506,6 +506,7 @@ public class MartReportImporterService implements IMartReportImporterService {
     rp.setAttendee(true);
     rp.setPrimary(true);
     rp.setInterlocutor(false);
+    rp.setReportPosition(person.getPosition());
     BeanUtils.copyProperties(person, rp);
     return rp;
   }

--- a/src/main/java/mil/dds/anet/services/MartReportImporterService.java
+++ b/src/main/java/mil/dds/anet/services/MartReportImporterService.java
@@ -480,6 +480,7 @@ public class MartReportImporterService implements IMartReportImporterService {
     rp.setAttendee(true);
     rp.setPrimary(true);
     rp.setInterlocutor(false);
+    rp.setReportPosition(person.getPosition());
     BeanUtils.copyProperties(person, rp);
     return rp;
   }

--- a/src/main/java/mil/dds/anet/utils/BatchingUtils.java
+++ b/src/main/java/mil/dds/anet/utils/BatchingUtils.java
@@ -275,12 +275,6 @@ public final class BatchingUtils {
             (BatchLoader<String, List<Organization>>) foreignKeys -> CompletableFuture.supplyAsync(
                 () -> engine.getOrganizationDao().getOrganizations(foreignKeys), dispatcherService),
             dataLoaderOptions));
-    dataLoaderRegistry.register(FkDataLoaderKey.PERSON_ORGANIZATIONS_WHEN.toString(),
-        DataLoaderFactory.newDataLoader(
-            (BatchLoader<ImmutablePair<String, Instant>, List<Organization>>) foreignKeys -> CompletableFuture
-                .supplyAsync(() -> engine.getOrganizationDao().getOrganizationsByDate(foreignKeys),
-                    dispatcherService),
-            dataLoaderOptions));
     dataLoaderRegistry.register(FkDataLoaderKey.PERSON_PERSON_ADDITIONAL_POSITIONS.toString(),
         DataLoaderFactory.newDataLoader(
             (BatchLoader<String, List<Position>>) foreignKeys -> CompletableFuture.supplyAsync(

--- a/src/main/java/mil/dds/anet/utils/BatchingUtils.java
+++ b/src/main/java/mil/dds/anet/utils/BatchingUtils.java
@@ -270,11 +270,6 @@ public final class BatchingUtils {
             (BatchLoader<String, Person>) keys -> CompletableFuture
                 .supplyAsync(() -> engine.getPersonDao().getByIds(keys), dispatcherService),
             dataLoaderOptions));
-    dataLoaderRegistry.register(FkDataLoaderKey.PERSON_ORGANIZATIONS.toString(),
-        DataLoaderFactory.newDataLoader(
-            (BatchLoader<String, List<Organization>>) foreignKeys -> CompletableFuture.supplyAsync(
-                () -> engine.getOrganizationDao().getOrganizations(foreignKeys), dispatcherService),
-            dataLoaderOptions));
     dataLoaderRegistry.register(FkDataLoaderKey.PERSON_PERSON_ADDITIONAL_POSITIONS.toString(),
         DataLoaderFactory.newDataLoader(
             (BatchLoader<String, List<Position>>) foreignKeys -> CompletableFuture.supplyAsync(

--- a/src/main/java/mil/dds/anet/utils/BatchingUtils.java
+++ b/src/main/java/mil/dds/anet/utils/BatchingUtils.java
@@ -274,12 +274,6 @@ public final class BatchingUtils {
             (BatchLoader<String, List<Organization>>) foreignKeys -> CompletableFuture.supplyAsync(
                 () -> engine.getOrganizationDao().getOrganizations(foreignKeys), dispatcherService),
             dataLoaderOptions));
-    dataLoaderRegistry.register(FkDataLoaderKey.PERSON_ORGANIZATIONS_WHEN.toString(),
-        DataLoaderFactory.newDataLoader(
-            (BatchLoader<ImmutablePair<String, Instant>, List<Organization>>) foreignKeys -> CompletableFuture
-                .supplyAsync(() -> engine.getOrganizationDao().getOrganizationsByDate(foreignKeys),
-                    dispatcherService),
-            dataLoaderOptions));
     dataLoaderRegistry.register(FkDataLoaderKey.PERSON_PERSON_ADDITIONAL_POSITIONS.toString(),
         DataLoaderFactory.newDataLoader(
             (BatchLoader<String, List<Position>>) foreignKeys -> CompletableFuture.supplyAsync(

--- a/src/main/java/mil/dds/anet/utils/FkDataLoaderKey.java
+++ b/src/main/java/mil/dds/anet/utils/FkDataLoaderKey.java
@@ -19,7 +19,6 @@ public enum FkDataLoaderKey {
   NOTE_NOTE_RELATED_OBJECTS, // note.noteRelatedObjects
   NOTE_RELATED_OBJECT_NOTES, // noteRelatedObject.notes
   ORGANIZATION_ADMINISTRATIVE_POSITIONS, // organization.responsiblePositions
-  PERSON_ORGANIZATIONS, // person.organizations
   PERSON_PERSON_ADDITIONAL_POSITIONS, // person.personAdditionalPositions
   PERSON_PERSON_POSITION_HISTORY, // person.personPositionHistory
   PERSON_PERSON_PREFERENCES, // person.personPreferences

--- a/src/main/java/mil/dds/anet/utils/FkDataLoaderKey.java
+++ b/src/main/java/mil/dds/anet/utils/FkDataLoaderKey.java
@@ -20,7 +20,6 @@ public enum FkDataLoaderKey {
   NOTE_RELATED_OBJECT_NOTES, // noteRelatedObject.notes
   ORGANIZATION_ADMINISTRATIVE_POSITIONS, // organization.responsiblePositions
   PERSON_ORGANIZATIONS, // person.organizations
-  PERSON_ORGANIZATIONS_WHEN, // person.organizations at a given date
   PERSON_PERSON_ADDITIONAL_POSITIONS, // person.personAdditionalPositions
   PERSON_PERSON_POSITION_HISTORY, // person.personPositionHistory
   PERSON_PERSON_PREFERENCES, // person.personPreferences

--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -7309,6 +7309,38 @@
 		</sql>
 	</changeSet>
 
+	<changeSet id="add-position-to-report-people" author="fdelcastillo">
+		<addColumn tableName="reportPeople">
+			<column name="reportPositionUuid" type="${uuid_type}" />
+		</addColumn>
+		<addForeignKeyConstraint
+			constraintName="FK_reportPeople_reportPosition"
+			baseTableName="reportPeople"
+			baseColumnNames="reportPositionUuid"
+			referencedTableName="positions"
+			referencedColumnNames="uuid"
+			onDelete="NO ACTION" onUpdate="NO ACTION"
+		/>
+		<!-- Add their primary position at the engagementDate to existing reportPeople -->
+		<sql>
+		<![CDATA[
+			UPDATE "reportPeople"
+			SET "reportPositionUuid" = pp."positionUuid"
+			FROM reports r, "peoplePositions" pp
+			WHERE r.uuid = "reportPeople"."reportUuid"
+			AND pp."personUuid" = "reportPeople"."personUuid"
+			AND pp."primary" IS TRUE
+			AND CASE WHEN r."engagementDate" IS NULL THEN (
+				pp."createdAt" <= CURRENT_TIMESTAMP
+				AND (pp."endedAt" IS NULL OR pp."endedAt" >= CURRENT_TIMESTAMP)
+			) ELSE (
+				pp."createdAt" <= r."engagementDate"
+				AND (pp."endedAt" IS NULL OR pp."endedAt" >= r."engagementDate")
+			) END;
+		]]>
+		</sql>
+	</changeSet>
+
 	<!-- Keep this change set as the last one in the change log;
 	     it will be re-run whenever it changes. -->
 	<changeSet id="set-up-full-text-search" runOnChange="true" author="gjvoosten">

--- a/src/main/resources/migrations.xml
+++ b/src/main/resources/migrations.xml
@@ -7301,6 +7301,38 @@
 		</sql>
 	</changeSet>
 
+	<changeSet id="add-position-to-report-people" author="fdelcastillo">
+		<addColumn tableName="reportPeople">
+			<column name="reportPositionUuid" type="${uuid_type}" />
+		</addColumn>
+		<addForeignKeyConstraint
+			constraintName="FK_reportPeople_reportPosition"
+			baseTableName="reportPeople"
+			baseColumnNames="reportPositionUuid"
+			referencedTableName="positions"
+			referencedColumnNames="uuid"
+			onDelete="NO ACTION" onUpdate="NO ACTION"
+		/>
+		<!-- Add their primary position at the engagementDate to existing reportPeople -->
+		<sql>
+		<![CDATA[
+			UPDATE "reportPeople"
+			SET "reportPositionUuid" = pp."positionUuid"
+			FROM reports r, "peoplePositions" pp
+			WHERE r.uuid = "reportPeople"."reportUuid"
+			AND pp."personUuid" = "reportPeople"."personUuid"
+			AND pp."primary" IS TRUE
+			AND CASE WHEN r."engagementDate" IS NULL THEN (
+				pp."createdAt" <= CURRENT_TIMESTAMP
+				AND (pp."endedAt" IS NULL OR pp."endedAt" >= CURRENT_TIMESTAMP)
+			) ELSE (
+				pp."createdAt" <= r."engagementDate"
+				AND (pp."endedAt" IS NULL OR pp."endedAt" >= r."engagementDate")
+			) END;
+		]]>
+		</sql>
+	</changeSet>
+
 	<!-- Keep this change set as the last one in the change log;
 	     it will be re-run whenever it changes. -->
 	<changeSet id="set-up-full-text-search" runOnChange="true" author="gjvoosten">

--- a/src/test/java/mil/dds/anet/test/resources/AbstractResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/AbstractResourceTest.java
@@ -496,6 +496,8 @@ public abstract class AbstractResourceTest extends AnetApplicationTest {
     final ReportPerson rp = ReportPerson.builder().withPrimary(false).withAuthor(false)
         .withAttendee(true).withInterlocutor(interlocutor).build();
     BeanUtils.copyProperties(p, rp);
+    // Pick up the primary position for the Report Person
+    rp.setReportPosition(p.getPosition());
     return rp;
   }
 
@@ -527,6 +529,8 @@ public abstract class AbstractResourceTest extends AnetApplicationTest {
     rp.setAuthor(false);
     rp.setAttendee(true);
     rp.setInterlocutor(interlocutor);
+    // Pick up the primary position for the Report Person
+    rp.setReportPosition(p.getPosition());
     BeanUtils.copyProperties(p, rp);
     return rp;
   }

--- a/src/test/java/mil/dds/anet/test/resources/AssessmentResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/AssessmentResourceTest.java
@@ -43,7 +43,7 @@ class AssessmentResourceTest extends AbstractResourceTest {
   private static final String PERSON_FIELDS =
       String.format("{ uuid familyName givenName %1$s }", _ASSESSMENTS_FIELDS);
   private static final String REPORT_FIELDS = String.format(
-      "{ uuid updatedAt intent state reportPeople { uuid familyName givenName author attendee primary interlocutor }"
+      "{ uuid updatedAt intent state reportPeople { uuid familyName givenName author attendee primary interlocutor reportPosition { uuid organization { uuid } }}"
           + " tasks { uuid shortName } %1$s }",
       _ASSESSMENTS_FIELDS);
   private static final String TASK_FIELDS =

--- a/src/test/java/mil/dds/anet/test/resources/AssessmentResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/AssessmentResourceTest.java
@@ -42,7 +42,7 @@ class AssessmentResourceTest extends AbstractResourceTest {
   private static final String PERSON_FIELDS =
       String.format("{ uuid familyName givenName %1$s }", _ASSESSMENTS_FIELDS);
   private static final String REPORT_FIELDS = String.format(
-      "{ uuid updatedAt intent state reportPeople { uuid familyName givenName author attendee primary interlocutor }"
+      "{ uuid updatedAt intent state reportPeople { uuid familyName givenName author attendee primary interlocutor reportPosition { uuid organization { uuid } }}"
           + " tasks { uuid shortName } %1$s }",
       _ASSESSMENTS_FIELDS);
   private static final String TASK_FIELDS =

--- a/src/test/java/mil/dds/anet/test/resources/ReportResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/ReportResourceTest.java
@@ -103,8 +103,9 @@ public class ReportResourceTest extends AbstractResourceTest {
           + " gender endOfTourDate users { uuid domainUsername } pendingVerification createdAt updatedAt";
   private static final String PERSON_FIELDS =
       String.format("{ %1$s %2$s }", _PERSON_FIELDS, _EMAIL_ADDRESSES_FIELDS);
-  private static final String REPORT_PEOPLE_FIELDS =
-      String.format("{ %1$s primary author attendee interlocutor }", _PERSON_FIELDS);
+  private static final String REPORT_PEOPLE_FIELDS = String.format(
+      "{ %1$s primary author attendee interlocutor reportPosition { uuid organization { uuid } }}",
+      _PERSON_FIELDS);
   private static final String POSITION_FIELDS =
       String.format("{ uuid isApprover person { uuid } organization { %1$s } %2$s }",
           _ORGANIZATION_FIELDS, _EMAIL_ADDRESSES_FIELDS);
@@ -217,7 +218,8 @@ public class ReportResourceTest extends AbstractResourceTest {
         t -> queryExecutor.position(POSITION_FIELDS, authorBillet.getUuid()));
     assertThat(checkit.getPerson()).isNotNull();
     assertThat(checkit.getPerson().getUuid()).isEqualTo(author.getUuid());
-
+    // Update author with his new position so we can build ReportPeople properly
+    author.setPosition(checkit);
     // Create Approval workflow for Advising Organization
     final List<ApprovalStepInput> approvalStepsInput = new ArrayList<>();
     final ApprovalStepInput approvalStepInput =
@@ -636,7 +638,8 @@ public class ReportResourceTest extends AbstractResourceTest {
         t -> queryExecutor.position(POSITION_FIELDS, authorBillet.getUuid()));
     assertThat(checkit.getPerson()).isNotNull();
     assertThat(checkit.getPerson().getUuid()).isEqualTo(author.getUuid());
-
+    // Update author with his new position so we can build ReportPeople properly
+    author.setPosition(checkit);
     // Create Approval workflow for Advising Organization
     final List<ApprovalStepInput> approvalStepsInput = new ArrayList<>();
     final ApprovalStepInput approvalStepInput =

--- a/src/test/java/mil/dds/anet/test/resources/ReportResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/ReportResourceTest.java
@@ -104,8 +104,9 @@ public class ReportResourceTest extends AbstractResourceTest {
           + " gender endOfTourDate users { uuid domainUsername } pendingVerification createdAt updatedAt";
   private static final String PERSON_FIELDS =
       String.format("{ %1$s %2$s }", _PERSON_FIELDS, _EMAIL_ADDRESSES_FIELDS);
-  private static final String REPORT_PEOPLE_FIELDS =
-      String.format("{ %1$s primary author attendee interlocutor }", _PERSON_FIELDS);
+  private static final String REPORT_PEOPLE_FIELDS = String.format(
+      "{ %1$s primary author attendee interlocutor reportPosition { uuid organization { uuid } }}",
+      _PERSON_FIELDS);
   private static final String POSITION_FIELDS =
       String.format("{ uuid isApprover person { uuid } organization { %1$s } %2$s }",
           _ORGANIZATION_FIELDS, _EMAIL_ADDRESSES_FIELDS);
@@ -218,7 +219,8 @@ public class ReportResourceTest extends AbstractResourceTest {
         t -> queryExecutor.position(POSITION_FIELDS, authorBillet.getUuid()));
     assertThat(checkit.getPerson()).isNotNull();
     assertThat(checkit.getPerson().getUuid()).isEqualTo(author.getUuid());
-
+    // Update author with his new position so we can build ReportPeople properly
+    author.setPosition(checkit);
     // Create Approval workflow for Advising Organization
     final List<ApprovalStepInput> approvalStepsInput = new ArrayList<>();
     final ApprovalStepInput approvalStepInput =
@@ -637,7 +639,8 @@ public class ReportResourceTest extends AbstractResourceTest {
         t -> queryExecutor.position(POSITION_FIELDS, authorBillet.getUuid()));
     assertThat(checkit.getPerson()).isNotNull();
     assertThat(checkit.getPerson().getUuid()).isEqualTo(author.getUuid());
-
+    // Update author with his new position so we can build ReportPeople properly
+    author.setPosition(checkit);
     // Create Approval workflow for Advising Organization
     final List<ApprovalStepInput> approvalStepsInput = new ArrayList<>();
     final ApprovalStepInput approvalStepInput =

--- a/src/test/java/mil/dds/anet/test/resources/TaskApprovalTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/TaskApprovalTest.java
@@ -67,7 +67,7 @@ class TaskApprovalTest extends AbstractResourceTest {
   private static final String REPORT_FIELDS =
       "{ uuid updatedAt state workflow { type createdAt person { uuid } step "
           + APPROVAL_STEP_FIELDS
-          + " } reportPeople { uuid primary author attendee interlocutor } }";
+          + " } reportPeople { uuid primary author attendee interlocutor reportPosition { uuid organization { uuid } }} }";
   private static final String TASK_FIELDS =
       "{ uuid updatedAt shortName longName status plannedCompletion projectedCompletion"
           + " taskedOrganizations { uuid shortName longName identificationCode }"

--- a/src/test/java/mil/dds/anet/test/resources/TaskApprovalTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/TaskApprovalTest.java
@@ -66,7 +66,7 @@ class TaskApprovalTest extends AbstractResourceTest {
   private static final String REPORT_FIELDS =
       "{ uuid updatedAt state workflow { type createdAt person { uuid } step "
           + APPROVAL_STEP_FIELDS
-          + " } reportPeople { uuid primary author attendee interlocutor } }";
+          + " } reportPeople { uuid primary author attendee interlocutor reportPosition { uuid organization { uuid } }} }";
   private static final String TASK_FIELDS =
       "{ uuid updatedAt shortName longName status plannedCompletion projectedCompletion"
           + " taskedOrganizations { uuid shortName longName identificationCode }"

--- a/src/test/java/mil/dds/anet/test/resources/merge/PositionMergeTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/merge/PositionMergeTest.java
@@ -10,6 +10,7 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import mil.dds.anet.database.PositionDao;
 import mil.dds.anet.resources.AttachmentResource;
 import mil.dds.anet.test.client.AnetBeanList_Organization;
@@ -23,9 +24,15 @@ import mil.dds.anet.test.client.Position;
 import mil.dds.anet.test.client.PositionInput;
 import mil.dds.anet.test.client.PositionRole;
 import mil.dds.anet.test.client.PositionType;
+import mil.dds.anet.test.client.Report;
+import mil.dds.anet.test.client.ReportInput;
+import mil.dds.anet.test.client.ReportPerson;
 import mil.dds.anet.test.client.Status;
 import mil.dds.anet.test.resources.AbstractResourceTest;
+import mil.dds.anet.test.resources.PersonResourceTest;
 import mil.dds.anet.test.resources.PositionResourceTest;
+import mil.dds.anet.test.resources.ReportResourceTest;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -150,4 +157,87 @@ class PositionMergeTest extends AbstractResourceTest {
     deleteSubscription(false, winnerSubscriptionUuid);
   }
 
+  @Test
+  void testMergeReportPositions() {
+    final OrganizationSearchQueryInput queryOrgs =
+        OrganizationSearchQueryInput.builder().withText("Ministry").build();
+    final AnetBeanList_Organization orgs = withCredentials(adminUser,
+        t -> queryExecutor.organizationList(getListFields(ORGANIZATION_FIELDS), queryOrgs));
+    assertThat(orgs.getList()).isNotEmpty();
+
+    // Create a report attendee person and give him a position
+    final PersonInput testPersonInput = PersonInput.builder()
+        .withFamilyName("ReportAttendee Person").withStatus(Status.ACTIVE).build();
+    final Person testPerson = withCredentials(adminUser,
+        t -> mutationExecutor.createPerson(PERSON_FIELDS, testPersonInput));
+    final PositionInput firstPositionInput = PositionInput.builder()
+        .withName("ReportAttendee First Position").withType(PositionType.REGULAR)
+        .withRole(PositionRole.MEMBER).withOrganization(getOrganizationInput(orgs.getList().get(0)))
+        .withStatus(Status.ACTIVE).build();
+    final Position firstPosition = withCredentials(adminUser,
+        t -> mutationExecutor.createPosition(FIELDS, firstPositionInput));
+    withCredentials(adminUser, t -> mutationExecutor.putPersonInPosition("",
+        getPersonInput(testPerson), null, true, firstPosition.getUuid()));
+    final Person updatedTestPerson = withCredentials(adminUser,
+        t -> queryExecutor.person(PersonResourceTest.FIELDS, testPerson.getUuid()));
+
+    // Create a report attendee person and give him a position
+    final PersonInput testPersonInput2 = PersonInput.builder()
+        .withFamilyName("ReportAttendee Person 2").withStatus(Status.ACTIVE).build();
+    final Person testPerson2 = withCredentials(adminUser,
+        t -> mutationExecutor.createPerson(PERSON_FIELDS, testPersonInput2));
+    final PositionInput firstPositionInput2 = PositionInput.builder()
+        .withName("ReportAttendee Second Position").withType(PositionType.REGULAR)
+        .withRole(PositionRole.MEMBER).withOrganization(getOrganizationInput(orgs.getList().get(0)))
+        .withStatus(Status.ACTIVE).build();
+    final Position secondPosition = withCredentials(adminUser,
+        t -> mutationExecutor.createPosition(FIELDS, firstPositionInput));
+    withCredentials(adminUser, t -> mutationExecutor.putPersonInPosition("",
+        getPersonInput(testPerson2), null, true, secondPosition.getUuid()));
+    final Person updatedTestPerson2 = withCredentials(adminUser,
+        t -> queryExecutor.person(PersonResourceTest.FIELDS, testPerson2.getUuid()));
+
+    // Put these two people in a report
+    final ReportPerson reportAuthor = personToReportAuthor(getElizabethElizawell());
+    final ReportPerson reportAdvisor = personToPrimaryReportPerson(updatedTestPerson2, false);
+    final List<ReportPerson> reportPeople =
+        List.of(reportAdvisor, personToPrimaryReportAuthor(updatedTestPerson));
+    final ReportInput rInput = ReportInput.builder().withEngagementDate(Instant.now())
+        .withDuration(120).withReportPeople(getReportPeopleInput(reportPeople)).build();
+    final Report created = withCredentials(adminUser,
+        t -> mutationExecutor.createReport(ReportResourceTest.FIELDS, rInput));
+
+    // Remove testPerson2 from the position
+    Integer nrDeleted = withCredentials(adminUser,
+        t -> mutationExecutor.deletePersonFromPosition("", secondPosition.getUuid()));
+    assertThat(nrDeleted).isEqualTo(1);
+
+
+    final PersonPositionHistoryInput hist =
+        PersonPositionHistoryInput.builder().withCreatedAt(Instant.now().minus(49, ChronoUnit.DAYS))
+            .withStartTime(Instant.now().minus(49, ChronoUnit.DAYS)).withEndTime(null)
+            .withPrimary(true).withPerson(getPersonInput(testPerson))
+            .withPosition(getPositionInput(secondPosition)).build();
+    final List<PersonPositionHistoryInput> historyList = new ArrayList<>();
+    historyList.add(hist);
+
+    final PositionInput mergedPositionInput = getPositionInput(firstPosition);
+    mergedPositionInput.setPreviousPeople(historyList);
+    mergedPositionInput.setPerson(getPersonInput(testPerson));
+    mergedPositionInput.setStatus(secondPosition.getStatus());
+    mergedPositionInput.setType(secondPosition.getType());
+
+    // Merge the two positions
+    withCredentials(adminUser, t -> mutationExecutor.mergePositions("", secondPosition.getUuid(),
+        false, mergedPositionInput));
+
+    // Check that the created report now has a reportPositionUUid = null for testPerson2, the non
+    // author
+    final Report updatedReport = withCredentials(adminUser,
+        t -> queryExecutor.report(ReportResourceTest.FIELDS, created.getUuid()));
+    final Optional<ReportPerson> nonAuthorPerson =
+        updatedReport.getReportPeople().stream().filter(rp -> !rp.getAuthor()).findFirst();
+    assertThat(nonAuthorPerson).isPresent();
+    assertThat(nonAuthorPerson.get().getReportPosition()).isNull();
+  }
 }

--- a/src/test/resources/anet.graphql
+++ b/src/test/resources/anet.graphql
@@ -1563,6 +1563,7 @@ type ReportPerson {
   previousPositions: [PersonPositionHistory]
   primary: Boolean!
   rank: String
+  reportPosition: Position
   status: Status
   updatedAt: Instant
   user: Boolean
@@ -1596,6 +1597,7 @@ input ReportPersonInput {
   previousPositions: [PersonPositionHistoryInput]
   primary: Boolean!
   rank: String
+  reportPosition: PositionInput
   status: Status
   updatedAt: Instant
   user: Boolean

--- a/src/test/resources/anet.graphql
+++ b/src/test/resources/anet.graphql
@@ -1573,6 +1573,7 @@ type ReportPerson {
   previousPositions: [PersonPositionHistory]
   primary: Boolean!
   rank: String
+  reportPosition: Position
   status: Status
   updatedAt: Instant
   user: Boolean
@@ -1606,6 +1607,7 @@ input ReportPersonInput {
   previousPositions: [PersonPositionHistoryInput]
   primary: Boolean!
   rank: String
+  reportPosition: PositionInput
   status: Status
   updatedAt: Instant
   user: Boolean


### PR DESCRIPTION
Following the multiple positions story, this allows users to select a specific position a person held during an engagement (for people that have multiple positions).

Closes [AB#1607](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1607)

#### User changes
- When a person is added to a report, if that person holds more than one position on the date of the engagement the user can select one of them and that will determine the advisor or interlocutor organization of the report.

#### Superuser changes
- None

#### Admin changes
- None

#### System admin changes
- [ ] application.yml or anet-dictionary.yml needs change
- [x] db needs migration
- [ ] documentation has changed
- [x] graphql schema has changed

### Checklist
- [x] described the user behavior in PR body
- [x] referenced/updated all related issues
- [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
- [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
- [x] added and/or updated unit tests
- [ ] added and/or updated e2e tests
- [x] added and/or updated data migrations
- [ ] updated documentation
- [x] resolved all build errors and warnings
- [ ] opened debt issues for anything not resolved here
