### PR TITLE
Fix position assignment after person merge

### DIFF
--- a/client/src/pages/admin/merge/MergePeople.tsx
+++ b/client/src/pages/admin/merge/MergePeople.tsx
@@ -171,6 +171,7 @@ const MergePeople = ({ pageDispatchers }: MergePeopleProps) => {
                     MERGE_SIDES.LEFT
                   )
                 )
+                setSideUsedForHistory(MERGE_SIDES.LEFT)
               },
               MERGE_SIDES.LEFT,
               mergeState,
@@ -201,6 +202,7 @@ const MergePeople = ({ pageDispatchers }: MergePeopleProps) => {
                     MERGE_SIDES.RIGHT
                   )
                 )
+                setSideUsedForHistory(MERGE_SIDES.RIGHT)
               },
               MERGE_SIDES.RIGHT,
               mergeState,

--- a/client/tests/webdriver/baseSpecs/mergePeople.spec.js
+++ b/client/tests/webdriver/baseSpecs/mergePeople.spec.js
@@ -83,6 +83,8 @@ const EXAMPLE_PEOPLE = {
     ],
     biography: "Andrew is the EF 1 Manager",
     notes: ["A really nice person to work with"],
+    perUuid: "1a557db0-5af5-4ea3-b926-28b5f2e88bf7",
+    posUuid: "38274eea-3438-40f7-8f1e-6529fd4f6191",
     colourOptions: "",
     numberField: "",
     birthday: "",
@@ -501,6 +503,9 @@ describe("Merge people who are both non-users", () => {
         await MergePeople.getColumnContent("mid", "Primary Position")
       ).getText()
     ).to.equal(EXAMPLE_PEOPLE.validLeft.position)
+    expect(await MergePeople.getPreviousPositions("mid")).to.eql(
+      EXAMPLE_PEOPLE.validLeft.previousPositions
+    )
 
     await (await MergePeople.getSelectButton("left", "Email addresses")).click()
     await MergePeople.waitForColumnToChange(
@@ -523,18 +528,6 @@ describe("Merge people who are both non-users", () => {
     expect(
       await (await MergePeople.getColumnContent("mid", "Phone")).getText()
     ).to.equal(EXAMPLE_PEOPLE.validLeft.phone)
-
-    await (await MergePeople.getSelectButton("left", "Email addresses")).click()
-    await MergePeople.waitForColumnToChange(
-      EXAMPLE_PEOPLE.validLeft.email,
-      "mid",
-      "Email addresses"
-    )
-    expect(
-      await (
-        await MergePeople.getColumnContent("mid", "Email addresses")
-      ).getText()
-    ).to.equal(EXAMPLE_PEOPLE.validLeft.email)
 
     await (await MergePeople.getSelectButton("left", "Rank")).click()
     await MergePeople.waitForColumnToChange(
@@ -565,13 +558,6 @@ describe("Merge people who are both non-users", () => {
     expect(
       await (await MergePeople.getColumnContent("mid", "Biography")).getText()
     ).to.equal(EXAMPLE_PEOPLE.validLeft.biography)
-
-    await (
-      await MergePeople.getSelectButton("left", "Primary Position")
-    ).click()
-    expect(await MergePeople.getPreviousPositions("mid")).to.eql(
-      EXAMPLE_PEOPLE.validLeft.previousPositions
-    )
 
     if (hasCustomFields) {
       await (await MergePeople.getSelectButton("left", "Number field")).click()
@@ -617,6 +603,33 @@ describe("Merge people who are both non-users", () => {
     ).to.eq(true)
   })
 
+  it("Should have correctly set the primary position of the merged person from the left", async () => {
+    await (await MergePeople.getPrimaryPosition()).waitForExist()
+    await (await MergePeople.getPrimaryPosition()).waitForDisplayed()
+    expect(await (await MergePeople.getPrimaryPosition()).getText()).to.eq(
+      EXAMPLE_PEOPLE.validLeft.position
+    )
+  })
+
+  it("Should have correctly set the position history of the merged person from the left", async () => {
+    expect(await MergePeople.getPreviousPrimaryPositions()).to.eql(
+      EXAMPLE_PEOPLE.validLeft.previousPositions
+    )
+  })
+
+  it("Should have correctly set the current assigned person of the position of the merged person from the left", async () => {
+    await MergePeople.openPage(`/positions/${EXAMPLE_PEOPLE.validLeft.posUuid}`)
+    // eslint-disable-next-line no-unused-expressions
+    expect(
+      await (
+        await MergePeople.getUnoccupiedPositionPersonMessage()
+      ).isExisting()
+    ).to.be.false
+    expect(
+      await (await MergePeople.getPositionCurrentPersonName()).getText()
+    ).to.equal(EXAMPLE_PEOPLE.validLeft.fullName)
+  })
+
   it("Should have deleted the loser person", async () => {
     await MergePeople.openPage(`/people/${EXAMPLE_PEOPLE.validRight.perUuid}`)
     await (await MergePeople.getErrorTitle()).waitForExist()
@@ -629,9 +642,13 @@ describe("Merge people who are both non-users", () => {
     await MergePeople.openPage(
       `/positions/${EXAMPLE_PEOPLE.validRight.posUuid}`
     )
+    // eslint-disable-next-line no-unused-expressions
+    expect(
+      await (await MergePeople.getPositionCurrentPersonName()).isExisting()
+    ).to.be.false
     expect(
       await (await MergePeople.getUnoccupiedPositionPersonMessage()).getText()
-    ).to.equal("Chief of Merge People Test 2 is currently empty.")
+    ).to.equal(`${EXAMPLE_PEOPLE.validRight.position} is currently empty.`)
   })
 })
 
@@ -957,11 +974,49 @@ describe("Merge user with non-user", () => {
     )
   })
 
+  it("Should have correctly set the primary position of the merged person from the right", async () => {
+    await (await MergePeople.getPrimaryPosition()).waitForExist()
+    await (await MergePeople.getPrimaryPosition()).waitForDisplayed()
+    expect(await (await MergePeople.getPrimaryPosition()).getText()).to.eq(
+      EXAMPLE_PEOPLE.userRight.position
+    )
+  })
+
+  it("Should have correctly set the position history of the merged person from the right", async () => {
+    expect(await MergePeople.getPreviousPrimaryPositions()).to.eql(
+      EXAMPLE_PEOPLE.userRight.previousPositions
+    )
+  })
+
+  it("Should have correctly set the current assigned person of the position of the merged person from the right", async () => {
+    await MergePeople.openPage(`/positions/${EXAMPLE_PEOPLE.userRight.posUuid}`)
+    // eslint-disable-next-line no-unused-expressions
+    expect(
+      await (
+        await MergePeople.getUnoccupiedPositionPersonMessage()
+      ).isExisting()
+    ).to.be.false
+    expect(
+      await (await MergePeople.getPositionCurrentPersonName()).getText()
+    ).to.equal(EXAMPLE_PEOPLE.userRight.fullName)
+  })
+
   it("Should have deleted the loser person", async () => {
     await MergePeople.openPage(`/people/${EXAMPLE_PEOPLE.validLeft.perUuid}`)
     await (await MergePeople.getErrorTitle()).waitForExist()
     expect(await (await MergePeople.getErrorTitle()).getText()).to.equal(
       `User #${EXAMPLE_PEOPLE.validLeft.perUuid} not found.`
     )
+  })
+
+  it("Should have removed the loser from its position and position history", async () => {
+    await MergePeople.openPage(`/positions/${EXAMPLE_PEOPLE.validLeft.posUuid}`)
+    // eslint-disable-next-line no-unused-expressions
+    expect(
+      await (await MergePeople.getPositionCurrentPersonName()).isExisting()
+    ).to.be.false
+    expect(
+      await (await MergePeople.getUnoccupiedPositionPersonMessage()).getText()
+    ).to.equal(`${EXAMPLE_PEOPLE.validLeft.position} is currently empty.`)
   })
 })

--- a/client/tests/webdriver/baseSpecs/mergePeople.spec.js
+++ b/client/tests/webdriver/baseSpecs/mergePeople.spec.js
@@ -535,11 +535,12 @@ describe("Merge people who are both non-users", () => {
       await (await MergePeople.getColumnContent("mid", "Given name")).getText()
     ).to.eq(EXAMPLE_PEOPLE.validLeft.givenName)
 
+    // Pick position data from the right!
     await (
-      await MergePeople.getSelectButton("left", "Primary Position")
+      await MergePeople.getSelectButton("right", "Primary Position")
     ).click()
     await MergePeople.waitForColumnToChange(
-      EXAMPLE_PEOPLE.validLeft.position,
+      EXAMPLE_PEOPLE.validRight.position,
       "mid",
       "Primary Position"
     )
@@ -547,9 +548,9 @@ describe("Merge people who are both non-users", () => {
       await (
         await MergePeople.getColumnContent("mid", "Primary Position")
       ).getText()
-    ).to.equal(EXAMPLE_PEOPLE.validLeft.position)
+    ).to.equal(EXAMPLE_PEOPLE.validRight.position)
     expect(await MergePeople.getPreviousPositions("mid")).to.eql(
-      EXAMPLE_PEOPLE.validLeft.previousPositions
+      EXAMPLE_PEOPLE.validRight.previousPositions
     )
 
     await (await MergePeople.getSelectButton("left", "Email addresses")).click()
@@ -648,31 +649,33 @@ describe("Merge people who are both non-users", () => {
     ).to.eq(true)
   })
 
-  it("Should have correctly set the primary position of the merged person from the left", async () => {
+  it("Should have correctly set the primary position of the merged person from the right", async () => {
     await (await MergePeople.getPrimaryPosition()).waitForExist()
     await (await MergePeople.getPrimaryPosition()).waitForDisplayed()
     expect(await (await MergePeople.getPrimaryPosition()).getText()).to.eq(
-      EXAMPLE_PEOPLE.validLeft.position
+      EXAMPLE_PEOPLE.validRight.position
     )
   })
 
-  it("Should have correctly set the additional positions of the merged person from the left", async () => {
+  it("Should have correctly set the additional positions of the merged person from the right", async () => {
     expect(await MergePeople.getAdditionalPositions()).to.eql(
-      EXAMPLE_PEOPLE.validLeft.additionalPositions
+      EXAMPLE_PEOPLE.validRight.additionalPositions
     )
   })
 
-  it("Should have correctly set the position history of the merged person from the left", async () => {
+  it("Should have correctly set the position history of the merged person from the right", async () => {
     expect(await MergePeople.getPreviousPositionsElements(true)).to.eql(
-      EXAMPLE_PEOPLE.validLeft.previousPrimaryPositions
+      EXAMPLE_PEOPLE.validRight.previousPrimaryPositions
     )
     expect(await MergePeople.getPreviousPositionsElements(false)).to.eql(
-      EXAMPLE_PEOPLE.validLeft.previousAdditionalPositions
+      EXAMPLE_PEOPLE.validRight.previousAdditionalPositions
     )
   })
 
-  it("Should have correctly set the current assigned person of the primary position of the merged person from the left", async () => {
-    await MergePeople.openPage(`/positions/${EXAMPLE_PEOPLE.validLeft.posUuid}`)
+  it("Should have correctly set the current assigned person of the primary position of the merged person from the right", async () => {
+    await MergePeople.openPage(
+      `/positions/${EXAMPLE_PEOPLE.validRight.posUuid}`
+    )
     // eslint-disable-next-line no-unused-expressions
     expect(
       await (
@@ -684,8 +687,8 @@ describe("Merge people who are both non-users", () => {
     ).to.equal(EXAMPLE_PEOPLE.validLeft.fullName)
   })
 
-  it("Should have correctly set the current assigned person of the additional positions of the merged person from the left", async () => {
-    for (const addPosUuid of EXAMPLE_PEOPLE.validLeft.addPosUuids) {
+  it("Should have correctly set the current assigned person of the additional positions of the merged person from the right", async () => {
+    for (const addPosUuid of EXAMPLE_PEOPLE.validRight.addPosUuids) {
       await MergePeople.openPage(`/positions/${addPosUuid}`)
       // eslint-disable-next-line no-unused-expressions
       expect(
@@ -708,22 +711,20 @@ describe("Merge people who are both non-users", () => {
   })
 
   it("Should have removed the loser from their primary position and history", async () => {
-    await MergePeople.openPage(
-      `/positions/${EXAMPLE_PEOPLE.validRight.posUuid}`
-    )
+    await MergePeople.openPage(`/positions/${EXAMPLE_PEOPLE.validLeft.posUuid}`)
     // eslint-disable-next-line no-unused-expressions
     expect(
       await (await MergePeople.getPositionCurrentPersonName()).isExisting()
     ).to.be.false
     expect(
       await (await MergePeople.getUnoccupiedPositionPersonMessage()).getText()
-    ).to.equal(`${EXAMPLE_PEOPLE.validRight.position} is currently empty.`)
+    ).to.equal(`${EXAMPLE_PEOPLE.validLeft.position} is currently empty.`)
   })
 
   it("Should have removed the loser from their additional positions and history", async () => {
-    for (let i = 0; i < EXAMPLE_PEOPLE.validRight.addPosUuids.length; i++) {
+    for (let i = 0; i < EXAMPLE_PEOPLE.validLeft.addPosUuids.length; i++) {
       await MergePeople.openPage(
-        `/positions/${EXAMPLE_PEOPLE.validRight.addPosUuids[i]}`
+        `/positions/${EXAMPLE_PEOPLE.validLeft.addPosUuids[i]}`
       )
       // eslint-disable-next-line no-unused-expressions
       expect(
@@ -732,7 +733,7 @@ describe("Merge people who are both non-users", () => {
       expect(
         await (await MergePeople.getUnoccupiedPositionPersonMessage()).getText()
       ).to.equal(
-        `${EXAMPLE_PEOPLE.validRight.additionalPositions[i]} is currently empty.`
+        `${EXAMPLE_PEOPLE.validLeft.additionalPositions[i]} is currently empty.`
       )
     }
   })
@@ -892,9 +893,9 @@ describe("Merge user with non-user", () => {
       await (
         await MergePeople.getColumnContent("mid", "Primary Position")
       ).getText()
-    ).to.eq(EXAMPLE_PEOPLE.validLeft.position)
+    ).to.eq(EXAMPLE_PEOPLE.validRight.position)
     expect(await MergePeople.getPreviousPositions("mid")).to.eql(
-      EXAMPLE_PEOPLE.validLeft.previousPositions
+      EXAMPLE_PEOPLE.validRight.previousPositions
     )
     expect(
       await (await MergePeople.getColumnContent("mid", "Status")).getText()
@@ -1120,20 +1121,22 @@ describe("Merge user with non-user", () => {
   })
 
   it("Should have removed the loser from their primary position and history", async () => {
-    await MergePeople.openPage(`/positions/${EXAMPLE_PEOPLE.validLeft.posUuid}`)
+    await MergePeople.openPage(
+      `/positions/${EXAMPLE_PEOPLE.validRight.posUuid}`
+    )
     // eslint-disable-next-line no-unused-expressions
     expect(
       await (await MergePeople.getPositionCurrentPersonName()).isExisting()
     ).to.be.false
     expect(
       await (await MergePeople.getUnoccupiedPositionPersonMessage()).getText()
-    ).to.equal(`${EXAMPLE_PEOPLE.validLeft.position} is currently empty.`)
+    ).to.equal(`${EXAMPLE_PEOPLE.validRight.position} is currently empty.`)
   })
 
   it("Should have removed the loser from their additional positions and history", async () => {
-    for (let i = 0; i < EXAMPLE_PEOPLE.validLeft.addPosUuids.length; i++) {
+    for (let i = 0; i < EXAMPLE_PEOPLE.validRight.addPosUuids.length; i++) {
       await MergePeople.openPage(
-        `/positions/${EXAMPLE_PEOPLE.validLeft.addPosUuids[i]}`
+        `/positions/${EXAMPLE_PEOPLE.validRight.addPosUuids[i]}`
       )
       // eslint-disable-next-line no-unused-expressions
       expect(
@@ -1142,7 +1145,7 @@ describe("Merge user with non-user", () => {
       expect(
         await (await MergePeople.getUnoccupiedPositionPersonMessage()).getText()
       ).to.equal(
-        `${EXAMPLE_PEOPLE.validLeft.additionalPositions[i]} is currently empty.`
+        `${EXAMPLE_PEOPLE.validRight.additionalPositions[i]} is currently empty.`
       )
     }
   })

--- a/client/tests/webdriver/baseSpecs/mergePeople.spec.js
+++ b/client/tests/webdriver/baseSpecs/mergePeople.spec.js
@@ -12,7 +12,11 @@ const EXAMPLE_PEOPLE = {
     familyName: "Merged",
     givenName: "Duplicate Winner",
     user: "No",
+    perUuid: "3cb2076c-5317-47fe-86ad-76f298993917",
     position: "Chief of Merge People Test 1",
+    posUuid: "885dd6bf-4647-4ef7-9bc4-4dd2826064bb",
+    additionalPositions: ["Chief of Staff - MoD"],
+    addPosUuids: ["1a45ccd6-40e3-4c51-baf5-15e7e9b8f03d"],
     status: "ACTIVE",
     email: "Network Address\nInternet merged.winner@example.com",
     phone: "+1-234-5678",
@@ -23,12 +27,26 @@ const EXAMPLE_PEOPLE = {
       {
         name: "Primary\nChief of Merge People Test 1",
         date: `${moment("2020-01-01").format("D MMMM YYYY")} -`
+      },
+      {
+        name: "Chief of Staff - MoD",
+        date: `${moment("2020-01-01").format("D MMMM YYYY")} -`
+      }
+    ],
+    previousPrimaryPositions: [
+      {
+        name: "Chief of Merge People Test 1",
+        date: `${moment("2020-01-01").format("D MMMM YYYY")} -`
+      }
+    ],
+    previousAdditionalPositions: [
+      {
+        name: "Chief of Staff - MoD",
+        date: `${moment("2020-01-01").format("D MMMM YYYY")} -`
       }
     ],
     biography: "Winner is a test person who will be merged",
     notes: ["Merge one person note", "A really nice person to work with"],
-    perUuid: "3cb2076c-5317-47fe-86ad-76f298993917",
-    posUuid: "885dd6bf-4647-4ef7-9bc4-4dd2826064bb",
     colourOptions: "Red",
     numberField: "5",
     birthday: `${moment("2003-01-31T23:00:00.000Z").format("D MMMM YYYY")}`,
@@ -40,7 +58,11 @@ const EXAMPLE_PEOPLE = {
     familyName: "Merged",
     givenName: "Duplicate Loser",
     user: "No",
+    perUuid: "c725aef3-cdd1-4baf-ac72-f28219b234e9",
     position: "Chief of Merge People Test 2",
+    posUuid: "4dc40a27-19ae-4e03-a4f3-55b2c768725f",
+    additionalPositions: ["Director of Budgeting - MoD"],
+    addPosUuids: ["61371573-eefc-4b85-81a0-27d6c0b78c58"],
     status: "ACTIVE",
     email: "No email addresses available",
     phone: "",
@@ -51,12 +73,26 @@ const EXAMPLE_PEOPLE = {
       {
         name: "Primary\nChief of Merge People Test 2",
         date: `${moment("2020-01-01").format("D MMMM YYYY")} -`
+      },
+      {
+        name: "Director of Budgeting - MoD",
+        date: `${moment("2020-01-01").format("D MMMM YYYY")} -`
+      }
+    ],
+    previousPrimaryPositions: [
+      {
+        name: "Chief of Merge People Test 2",
+        date: `${moment("2020-01-01").format("D MMMM YYYY")} -`
+      }
+    ],
+    previousAdditionalPositions: [
+      {
+        name: "Director of Budgeting - MoD",
+        date: `${moment("2020-01-01").format("D MMMM YYYY")} -`
       }
     ],
     biography: "Loser is a test person who will be merged",
     notes: ["Merge two person note"],
-    perUuid: "c725aef3-cdd1-4baf-ac72-f28219b234e9",
-    posUuid: "4dc40a27-19ae-4e03-a4f3-55b2c768725f",
     colourOptions: "Red",
     numberField: "6",
     birthday: `${moment("2010-11-11T23:00:00.000Z").format("D MMMM YYYY")}`,
@@ -68,7 +104,11 @@ const EXAMPLE_PEOPLE = {
     familyName: "Anderson",
     givenName: "Andrew",
     user: "Yes",
+    perUuid: "1a557db0-5af5-4ea3-b926-28b5f2e88bf7",
     position: "EF 1 Manager",
+    posUuid: "38274eea-3438-40f7-8f1e-6529fd4f6191",
+    additionalPositions: [],
+    addPosUuids: [],
     status: "ACTIVE",
     email: "Network Address\nInternet andrew@example.com\nNS andrew@example.ns",
     phone: "+1-412-7324",
@@ -81,10 +121,15 @@ const EXAMPLE_PEOPLE = {
         date: `${moment("2020-01-01").format("D MMMM YYYY")} -`
       }
     ],
+    previousPrimaryPositions: [
+      {
+        name: "EF 1 Manager",
+        date: `${moment("2020-01-01").format("D MMMM YYYY")} -`
+      }
+    ],
+    previousAdditionalPositions: [],
     biography: "Andrew is the EF 1 Manager",
     notes: ["A really nice person to work with"],
-    perUuid: "1a557db0-5af5-4ea3-b926-28b5f2e88bf7",
-    posUuid: "38274eea-3438-40f7-8f1e-6529fd4f6191",
     colourOptions: "",
     numberField: "",
     birthday: "",
@@ -611,13 +656,22 @@ describe("Merge people who are both non-users", () => {
     )
   })
 
-  it("Should have correctly set the position history of the merged person from the left", async () => {
-    expect(await MergePeople.getPreviousPrimaryPositions()).to.eql(
-      EXAMPLE_PEOPLE.validLeft.previousPositions
+  it("Should have correctly set the additional positions of the merged person from the left", async () => {
+    expect(await MergePeople.getAdditionalPositions()).to.eql(
+      EXAMPLE_PEOPLE.validLeft.additionalPositions
     )
   })
 
-  it("Should have correctly set the current assigned person of the position of the merged person from the left", async () => {
+  it("Should have correctly set the position history of the merged person from the left", async () => {
+    expect(await MergePeople.getPreviousPositionsElements(true)).to.eql(
+      EXAMPLE_PEOPLE.validLeft.previousPrimaryPositions
+    )
+    expect(await MergePeople.getPreviousPositionsElements(false)).to.eql(
+      EXAMPLE_PEOPLE.validLeft.previousAdditionalPositions
+    )
+  })
+
+  it("Should have correctly set the current assigned person of the primary position of the merged person from the left", async () => {
     await MergePeople.openPage(`/positions/${EXAMPLE_PEOPLE.validLeft.posUuid}`)
     // eslint-disable-next-line no-unused-expressions
     expect(
@@ -630,6 +684,21 @@ describe("Merge people who are both non-users", () => {
     ).to.equal(EXAMPLE_PEOPLE.validLeft.fullName)
   })
 
+  it("Should have correctly set the current assigned person of the additional positions of the merged person from the left", async () => {
+    for (const addPosUuid of EXAMPLE_PEOPLE.validLeft.addPosUuids) {
+      await MergePeople.openPage(`/positions/${addPosUuid}`)
+      // eslint-disable-next-line no-unused-expressions
+      expect(
+        await (
+          await MergePeople.getUnoccupiedPositionPersonMessage()
+        ).isExisting()
+      ).to.be.false
+      expect(
+        await (await MergePeople.getPositionCurrentPersonName()).getText()
+      ).to.equal(EXAMPLE_PEOPLE.validLeft.fullName)
+    }
+  })
+
   it("Should have deleted the loser person", async () => {
     await MergePeople.openPage(`/people/${EXAMPLE_PEOPLE.validRight.perUuid}`)
     await (await MergePeople.getErrorTitle()).waitForExist()
@@ -638,7 +707,7 @@ describe("Merge people who are both non-users", () => {
     )
   })
 
-  it("Should have removed the loser from its position and position history", async () => {
+  it("Should have removed the loser from their primary position and history", async () => {
     await MergePeople.openPage(
       `/positions/${EXAMPLE_PEOPLE.validRight.posUuid}`
     )
@@ -649,6 +718,23 @@ describe("Merge people who are both non-users", () => {
     expect(
       await (await MergePeople.getUnoccupiedPositionPersonMessage()).getText()
     ).to.equal(`${EXAMPLE_PEOPLE.validRight.position} is currently empty.`)
+  })
+
+  it("Should have removed the loser from their additional positions and history", async () => {
+    for (let i = 0; i < EXAMPLE_PEOPLE.validRight.addPosUuids.length; i++) {
+      await MergePeople.openPage(
+        `/positions/${EXAMPLE_PEOPLE.validRight.addPosUuids[i]}`
+      )
+      // eslint-disable-next-line no-unused-expressions
+      expect(
+        await (await MergePeople.getPositionCurrentPersonName()).isExisting()
+      ).to.be.false
+      expect(
+        await (await MergePeople.getUnoccupiedPositionPersonMessage()).getText()
+      ).to.equal(
+        `${EXAMPLE_PEOPLE.validRight.additionalPositions[i]} is currently empty.`
+      )
+    }
   })
 })
 
@@ -982,13 +1068,22 @@ describe("Merge user with non-user", () => {
     )
   })
 
-  it("Should have correctly set the position history of the merged person from the right", async () => {
-    expect(await MergePeople.getPreviousPrimaryPositions()).to.eql(
-      EXAMPLE_PEOPLE.userRight.previousPositions
+  it("Should have correctly set the additional positions of the merged person from the right", async () => {
+    expect(await MergePeople.getAdditionalPositions()).to.eql(
+      EXAMPLE_PEOPLE.userRight.additionalPositions
     )
   })
 
-  it("Should have correctly set the current assigned person of the position of the merged person from the right", async () => {
+  it("Should have correctly set the position history of the merged person from the right", async () => {
+    expect(await MergePeople.getPreviousPositionsElements(true)).to.eql(
+      EXAMPLE_PEOPLE.userRight.previousPrimaryPositions
+    )
+    expect(await MergePeople.getPreviousPositionsElements(false)).to.eql(
+      EXAMPLE_PEOPLE.userRight.previousAdditionalPositions
+    )
+  })
+
+  it("Should have correctly set the current assigned person of the primary position of the merged person from the right", async () => {
     await MergePeople.openPage(`/positions/${EXAMPLE_PEOPLE.userRight.posUuid}`)
     // eslint-disable-next-line no-unused-expressions
     expect(
@@ -1001,6 +1096,21 @@ describe("Merge user with non-user", () => {
     ).to.equal(EXAMPLE_PEOPLE.userRight.fullName)
   })
 
+  it("Should have correctly set the current assigned person of the additional positions of the merged person from the right", async () => {
+    for (const addPosUuid of EXAMPLE_PEOPLE.userRight.addPosUuids) {
+      await MergePeople.openPage(`/positions/${addPosUuid}`)
+      // eslint-disable-next-line no-unused-expressions
+      expect(
+        await (
+          await MergePeople.getUnoccupiedPositionPersonMessage()
+        ).isExisting()
+      ).to.be.false
+      expect(
+        await (await MergePeople.getPositionCurrentPersonName()).getText()
+      ).to.equal(EXAMPLE_PEOPLE.userRight.fullName)
+    }
+  })
+
   it("Should have deleted the loser person", async () => {
     await MergePeople.openPage(`/people/${EXAMPLE_PEOPLE.validLeft.perUuid}`)
     await (await MergePeople.getErrorTitle()).waitForExist()
@@ -1009,7 +1119,7 @@ describe("Merge user with non-user", () => {
     )
   })
 
-  it("Should have removed the loser from its position and position history", async () => {
+  it("Should have removed the loser from their primary position and history", async () => {
     await MergePeople.openPage(`/positions/${EXAMPLE_PEOPLE.validLeft.posUuid}`)
     // eslint-disable-next-line no-unused-expressions
     expect(
@@ -1018,5 +1128,22 @@ describe("Merge user with non-user", () => {
     expect(
       await (await MergePeople.getUnoccupiedPositionPersonMessage()).getText()
     ).to.equal(`${EXAMPLE_PEOPLE.validLeft.position} is currently empty.`)
+  })
+
+  it("Should have removed the loser from their additional positions and history", async () => {
+    for (let i = 0; i < EXAMPLE_PEOPLE.validLeft.addPosUuids.length; i++) {
+      await MergePeople.openPage(
+        `/positions/${EXAMPLE_PEOPLE.validLeft.addPosUuids[i]}`
+      )
+      // eslint-disable-next-line no-unused-expressions
+      expect(
+        await (await MergePeople.getPositionCurrentPersonName()).isExisting()
+      ).to.be.false
+      expect(
+        await (await MergePeople.getUnoccupiedPositionPersonMessage()).getText()
+      ).to.equal(
+        `${EXAMPLE_PEOPLE.validLeft.additionalPositions[i]} is currently empty.`
+      )
+    }
   })
 })

--- a/client/tests/webdriver/pages/mergePeople.page.js
+++ b/client/tests/webdriver/pages/mergePeople.page.js
@@ -49,6 +49,14 @@ class MergePeople extends Page {
     return browser.$('button[title="Show notes"]')
   }
 
+  async getPrimaryPosition() {
+    return browser.$("#position a.position-name")
+  }
+
+  async getPositionCurrentPersonName() {
+    return browser.$("h4.assigned-person-name")
+  }
+
   async getUnoccupiedPositionPersonMessage() {
     return browser.$("p.position-empty-message")
   }
@@ -87,12 +95,20 @@ class MergePeople extends Page {
     const previousPositionsElements = await browser.$$(
       `//div[@id="${side}-merge-per-col"]//div[text()="Previous Positions"]/following-sibling::div//table//tbody//tr`
     )
-    return await previousPositionsElements.map(async elem => {
-      return {
-        name: await (await elem.$$("td"))[0].getText(),
-        date: await (await elem.$$("td"))[1].getText()
-      }
-    })
+    return await previousPositionsElements.map(async elem => ({
+      name: await (await elem.$$("td"))[0].getText(),
+      date: await (await elem.$$("td"))[1].getText()
+    }))
+  }
+
+  async getPreviousPrimaryPositions() {
+    const previousPrimaryPositionsElements = await browser.$$(
+      "table#previous-positions tbody tr"
+    )
+    return await previousPrimaryPositionsElements.map(async elem => ({
+      name: `Primary\n${await (await elem.$$("td"))[0].getText()}`,
+      date: await (await elem.$$("td"))[1].getText()
+    }))
   }
 
   async waitForAdvancedSelectLoading(compareStr) {

--- a/client/tests/webdriver/pages/mergePeople.page.js
+++ b/client/tests/webdriver/pages/mergePeople.page.js
@@ -53,6 +53,15 @@ class MergePeople extends Page {
     return browser.$("#position a.position-name")
   }
 
+  async getAdditionalPositions() {
+    const additionalPositions = await browser.$$(
+      "#additionalPositions a.position-name"
+    )
+    return additionalPositions.map(
+      async additionalPosition => await additionalPosition.getText()
+    )
+  }
+
   async getPositionCurrentPersonName() {
     return browser.$("h4.assigned-person-name")
   }
@@ -101,12 +110,12 @@ class MergePeople extends Page {
     }))
   }
 
-  async getPreviousPrimaryPositions() {
+  async getPreviousPositionsElements(primary) {
     const previousPrimaryPositionsElements = await browser.$$(
-      "table#previous-positions tbody tr"
+      `${primary ? "#fg-prevPositions" : "#fg-prevAdditionalPositions"} table#previous-positions tbody tr`
     )
     return await previousPrimaryPositionsElements.map(async elem => ({
-      name: `Primary\n${await (await elem.$$("td"))[0].getText()}`,
+      name: `${await (await elem.$$("td"))[0].getText()}`,
       date: await (await elem.$$("td"))[1].getText()
     }))
   }

--- a/insertBaseData-psql.sql
+++ b/insertBaseData-psql.sql
@@ -908,10 +908,19 @@ INSERT INTO "positionRelationships" ("positionUuid_a", "positionUuid_b", "create
 INSERT INTO "peoplePositions" ("positionUuid", "personUuid", "createdAt") VALUES
   ((SELECT uuid from positions where name = 'Chief of Merge People Test 1'), '3cb2076c-5317-47fe-86ad-76f298993917', '2020-01-01');
 UPDATE positions SET "currentPersonUuid" = '3cb2076c-5317-47fe-86ad-76f298993917' WHERE name = 'Chief of Merge People Test 1';
+-- and in an additional position
+INSERT INTO "peoplePositions" ("positionUuid", "personUuid", "createdAt", "primary") VALUES
+  ((SELECT uuid from positions where name = 'Chief of Staff - MoD'), '3cb2076c-5317-47fe-86ad-76f298993917', '2020-01-01', FALSE);
+UPDATE positions SET "currentPersonUuid" = '3cb2076c-5317-47fe-86ad-76f298993917' WHERE name = 'Chief of Staff - MoD';
+
 -- Put Loser Duplicate in a Tashkil
 INSERT INTO "peoplePositions" ("positionUuid", "personUuid", "createdAt") VALUES
   ((SELECT uuid from positions where name = 'Chief of Merge People Test 2'), 'c725aef3-cdd1-4baf-ac72-f28219b234e9', '2020-01-01');
 UPDATE positions SET "currentPersonUuid" = 'c725aef3-cdd1-4baf-ac72-f28219b234e9' WHERE name = 'Chief of Merge People Test 2';
+-- and in an additional position
+INSERT INTO "peoplePositions" ("positionUuid", "personUuid", "createdAt", "primary") VALUES
+  ((SELECT uuid from positions where name = 'Director of Budgeting - MoD'), 'c725aef3-cdd1-4baf-ac72-f28219b234e9', '2020-01-01', FALSE);
+UPDATE positions SET "currentPersonUuid" = 'c725aef3-cdd1-4baf-ac72-f28219b234e9' WHERE name = 'Director of Budgeting - MoD';
 
 UPDATE positions SET "locationUuid" = (SELECT uuid from LOCATIONS where name = 'Kabul Police Academy') WHERE name = 'Chief of Police';
 UPDATE positions SET "locationUuid" = (SELECT uuid from LOCATIONS where name = 'MoD Headquarters Kabul') WHERE name = 'Cost Adder - MoD';

--- a/insertBaseData-psql.sql
+++ b/insertBaseData-psql.sql
@@ -307,7 +307,7 @@ WHERE uuid='178dfbba-f15a-400b-9135-6ff800246be0';
 -- Create advisor positions
 INSERT INTO positions (uuid, name, type, "superuserType", role, status, "currentPersonUuid", "locationUuid", "createdAt", "updatedAt") VALUES
   (uuid_generate_v4(), 'ANET Administrator', 3, NULL, 0, 0, NULL, 'c8fdb53f-6f93-46fc-b0fa-f005c7b49667', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
-  (uuid_generate_v4(), 'EF 1 Manager', 2, 0, 2, 0, NULL, 'cc49bb27-4d8f-47a8-a9ee-af2b68b992ac', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+  ('38274eea-3438-40f7-8f1e-6529fd4f6191', 'EF 1 Manager', 2, 0, 2, 0, NULL, 'cc49bb27-4d8f-47a8-a9ee-af2b68b992ac', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
   (uuid_generate_v4(), 'EF 1.1 Advisor A', 0, NULL, 0, 0, NULL, 'cc49bb27-4d8f-47a8-a9ee-af2b68b992ac', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
   (uuid_generate_v4(), 'EF 1.1 Advisor B', 0, NULL, 0, 0, NULL, 'cc49bb27-4d8f-47a8-a9ee-af2b68b992ac', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
   (uuid_generate_v4(), 'EF 1.1 Advisor C', 0, NULL, 0, 0, NULL, 'cc49bb27-4d8f-47a8-a9ee-af2b68b992ac', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),

--- a/src/main/java/mil/dds/anet/database/PersonDao.java
+++ b/src/main/java/mil/dds/anet/database/PersonDao.java
@@ -340,8 +340,12 @@ public class PersonDao extends AnetSubscribableObjectDao<Person, PersonSearchQue
       updateForMerge("attachments", "authorUuid", winnerUuid, loserUuid);
 
       if (useWinnerPositionHistory) {
+        // Clear out loser's positions and history
         updatePosition(handle, null, loserUuid, loserUuid);
       } else {
+        // Clear out winner's positions and history
+        updatePosition(handle, null, winnerUuid, winnerUuid);
+        // Move loser's positions to the winner
         updatePosition(handle, winnerUuid, loserUuid, winnerUuid);
         // Move loser's position history to winner
         updateForMerge("peoplePositions", "personUuid", winnerUuid, loserUuid);

--- a/src/test/java/mil/dds/anet/test/resources/merge/PersonMergeTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/merge/PersonMergeTest.java
@@ -209,10 +209,10 @@ class PersonMergeTest extends AbstractResourceTest {
     deleteSubscription(subscribeToWinner, loserSubscriptionUuid);
     deleteSubscription(false, winnerSubscriptionUuid);
 
-    // Assert that the position is empty.
-    Position winnerPos =
+    // Assert that the loser's position is now empty.
+    Position loserPos =
         withCredentials(adminUser, t -> queryExecutor.position(POSITION_FIELDS, created.getUuid()));
-    assertThat(winnerPos.getPerson()).isNull();
+    assertThat(loserPos.getPerson()).isNull();
 
     // Assert that winner has correct country
     assertThat(mergedPerson.getCountry()).isNotNull();
@@ -243,10 +243,10 @@ class PersonMergeTest extends AbstractResourceTest {
       // OK
     }
 
-    // Assert that the winner is in the position.
-    winnerPos = withCredentials(adminUser,
-        t -> queryExecutor.position(POSITION_FIELDS, createdPos2.getUuid()));
-    assertThat(winnerPos.getPerson().getUuid()).isEqualTo(winner.getUuid());
+    // Assert that the winner is in the loser's position.
+    loserPos =
+        withCredentials(adminUser, t -> queryExecutor.position(POSITION_FIELDS, created.getUuid()));
+    assertThat(loserPos.getPerson().getUuid()).isEqualTo(winner.getUuid());
   }
 
   @Test


### PR DESCRIPTION
When merging two people and using one of the "Use All" buttons to pick everything from one side, after the merge, the position assignment would be inconsistent. The same situation would occur when picking everything except the positions from one side, and the positions from the other side. This is now corrected.

Closes [AB#1628](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1628)

#### User changes
- None

#### Superuser changes
- None

#### Admin changes
- Merging people now always ends up with the correct position assignment.

#### System admin changes
- [ ] application.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
- [x] described the user behavior in PR body
- [x] referenced/updated all related issues
- [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
- [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
- [x] added and/or updated unit tests
- [x] added and/or updated e2e tests
- [ ] added and/or updated data migrations
- [ ] updated documentation
- [x] resolved all build errors and warnings
- [ ] opened debt issues for anything not resolved here