### PR TITLE
Improve transmission log logic

### DIFF
--- a/client/src/pages/admin/martImporter/MartImportedReportTable.tsx
+++ b/client/src/pages/admin/martImporter/MartImportedReportTable.tsx
@@ -87,7 +87,7 @@ const MartImportedReportTable = ({
   usePageTitle("MART reports imported")
   const [pageNum, setPageNum] = useState(0)
   const [pageSize, setPageSize] = useState(DEFAULT_PAGESIZE)
-  const [sortBy, setSortBy] = useState("RECEIVED_AT")
+  const [sortBy, setSortBy] = useState("SEQUENCE")
   const [sortOrder, setSortOrder] = useState("DESC")
   const [selectedState, setSelectedState] = useState(undefined)
   const [selectedAuthor, setSelectedAuthor] = useState(null)

--- a/src/main/java/mil/dds/anet/beans/search/MartImportedReportSearchQuery.java
+++ b/src/main/java/mil/dds/anet/beans/search/MartImportedReportSearchQuery.java
@@ -22,7 +22,7 @@ public class MartImportedReportSearchQuery
   private List<Long> sequences;
 
   public MartImportedReportSearchQuery() {
-    super(MartImportedReportSearchSortBy.RECEIVED_AT);
+    super(MartImportedReportSearchSortBy.SEQUENCE);
     this.setSortOrder(SortOrder.DESC);
     this.setPageSize(0);
   }

--- a/src/main/java/mil/dds/anet/search/AbstractMartImportedReportSearcher.java
+++ b/src/main/java/mil/dds/anet/search/AbstractMartImportedReportSearcher.java
@@ -33,35 +33,33 @@ public abstract class AbstractMartImportedReportSearcher
 
   @Override
   protected void buildQuery(final MartImportedReportSearchQuery query) {
+    final String tableName = String.format("\"%s\"", MartImportedReportDao.TABLE_NAME);
     final boolean applyGrouping = applyGrouping(query);
-    qb.addSelectClause((applyGrouping ? "ON (\"martImportedReports\".\"reportUuid\") " : "")
+    qb.addSelectClause((applyGrouping ? "ON (" + tableName + ".\"reportUuid\") " : "")
         + MartImportedReportDao.MART_IMPORTED_REPORTS_FIELDS);
-    qb.addFromClause("\"martImportedReports\"");
+    qb.addFromClause(tableName);
 
     // Add the count for each imported report
-    qb.addWithClause("mir2 AS "
-        + "(SELECT COUNT(*), \"reportUuid\" FROM \"martImportedReports\" GROUP BY \"reportUuid\")");
+    qb.addWithClause(
+        "mir2 AS (SELECT COUNT(*), \"reportUuid\" FROM " + tableName + " GROUP BY \"reportUuid\")");
     qb.addSelectClause("mir2.count AS \"martImportedReports_historyCount\"");
     qb.addFromClause(", mir2");
-    qb.addWhereClause("mir2.\"reportUuid\" = \"martImportedReports\".\"reportUuid\"");
+    qb.addWhereClause("mir2.\"reportUuid\" = " + tableName + ".\"reportUuid\"");
 
     if (!Utils.isEmptyOrNull(query.getPersonUuid())) {
-      qb.addStringEqualsClause("personUuid", "\"martImportedReports\".\"personUuid\"",
-          query.getPersonUuid());
+      qb.addStringEqualsClause("personUuid", tableName + ".\"personUuid\"", query.getPersonUuid());
     }
     if (!Utils.isEmptyOrNull(query.getReportUuid())) {
-      qb.addStringEqualsClause("reportUuid", "\"martImportedReports\".\"reportUuid\"",
-          query.getReportUuid());
+      qb.addStringEqualsClause("reportUuid", tableName + ".\"reportUuid\"", query.getReportUuid());
     }
     if (query.getState() != null) {
-      qb.addEnumEqualsClause("state", "\"martImportedReports\".state", query.getState());
+      qb.addEnumEqualsClause("state", tableName + ".state", query.getState());
     }
     if (!Utils.isEmptyOrNull(query.getSequences())) {
-      qb.addInListClause("sequence", "\"martImportedReports\".sequence", query.getSequences());
+      qb.addInListClause("sequence", tableName + ".sequence", query.getSequences());
     }
     if (applyGrouping) {
-      qb.addInnerOrderByClause(
-          "\"martImportedReports\".\"reportUuid\", \"martImportedReports\".sequence DESC");
+      qb.addInnerOrderByClause(tableName + ".\"reportUuid\", " + tableName + ".sequence DESC");
     }
     addOrderByClauses(qb, query);
   }

--- a/src/main/java/mil/dds/anet/search/AbstractMartImportedReportSearcher.java
+++ b/src/main/java/mil/dds/anet/search/AbstractMartImportedReportSearcher.java
@@ -33,9 +33,9 @@ public abstract class AbstractMartImportedReportSearcher
 
   @Override
   protected void buildQuery(final MartImportedReportSearchQuery query) {
-    qb.addSelectClause(
-        (Utils.isEmptyOrNull(query.getReportUuid()) ? "ON (\"martImportedReports\".\"reportUuid\") "
-            : "") + MartImportedReportDao.MART_IMPORTED_REPORTS_FIELDS);
+    final boolean applyGrouping = applyGrouping(query);
+    qb.addSelectClause((applyGrouping ? "ON (\"martImportedReports\".\"reportUuid\") " : "")
+        + MartImportedReportDao.MART_IMPORTED_REPORTS_FIELDS);
     qb.addFromClause("\"martImportedReports\"");
 
     // Add the count for each imported report
@@ -59,8 +59,7 @@ public abstract class AbstractMartImportedReportSearcher
     if (!Utils.isEmptyOrNull(query.getSequences())) {
       qb.addInListClause("sequence", "\"martImportedReports\".sequence", query.getSequences());
     }
-
-    if (Utils.isEmptyOrNull(query.getReportUuid())) {
+    if (applyGrouping) {
       qb.addInnerOrderByClause(
           "\"martImportedReports\".\"reportUuid\", \"martImportedReports\".sequence DESC");
     }
@@ -88,5 +87,9 @@ public abstract class AbstractMartImportedReportSearcher
         break;
     }
     qb.addAllOrderByClauses(getOrderBy(query.getSortOrder(), "martImportedReports_sequence"));
+  }
+
+  private boolean applyGrouping(MartImportedReportSearchQuery query) {
+    return Utils.isEmptyOrNull(query.getReportUuid()) && Utils.isEmptyOrNull(query.getSequences());
   }
 }

--- a/src/main/java/mil/dds/anet/search/AbstractMartImportedReportSearcher.java
+++ b/src/main/java/mil/dds/anet/search/AbstractMartImportedReportSearcher.java
@@ -35,9 +35,12 @@ public abstract class AbstractMartImportedReportSearcher
   protected void buildQuery(final MartImportedReportSearchQuery query) {
     final String tableName = String.format("\"%s\"", MartImportedReportDao.TABLE_NAME);
     final boolean applyGrouping = applyGrouping(query);
-    qb.addSelectClause((applyGrouping ? "ON (" + tableName + ".\"reportUuid\") " : "")
-        + MartImportedReportDao.MART_IMPORTED_REPORTS_FIELDS);
-    qb.addFromClause(tableName);
+    qb.addSelectClause(MartImportedReportDao.MART_IMPORTED_REPORTS_FIELDS);
+    qb.addFromClause(
+        (applyGrouping
+            ? "(SELECT DISTINCT ON (\"reportUuid\") * FROM " + tableName
+                + " ORDER BY \"reportUuid\", sequence DESC) AS "
+            : "") + tableName);
 
     // Add the count for each imported report
     qb.addWithClause(

--- a/src/main/java/mil/dds/anet/services/EwsReceiver.java
+++ b/src/main/java/mil/dds/anet/services/EwsReceiver.java
@@ -68,7 +68,7 @@ public class EwsReceiver implements IMailReceiver {
               mailClientConfiguration.getTrustedSender()));
 
       // Get oldest e-mails first, process in sequence
-      view.getOrderBy().add(ItemSchema.DateTimeReceived, SortDirection.Ascending);
+      view.getOrderBy().add(ItemSchema.DateTimeSent, SortDirection.Ascending);
       final FindItemsResults<Item> findResults =
           exchangeService.findItems(WellKnownFolderName.Inbox, filterUnreadEmails, view);
 

--- a/src/main/java/mil/dds/anet/services/IMartTransmissionLogImporterService.java
+++ b/src/main/java/mil/dds/anet/services/IMartTransmissionLogImporterService.java
@@ -1,7 +1,8 @@
 package mil.dds.anet.services;
 
+import java.time.Instant;
 import microsoft.exchange.webservices.data.property.complex.FileAttachment;
 
 public interface IMartTransmissionLogImporterService {
-  void processTransmissionLog(FileAttachment attachment);
+  void processTransmissionLog(FileAttachment attachment, Instant emailReceivedDate);
 }

--- a/src/main/java/mil/dds/anet/services/MartTransmissionLogImporterService.java
+++ b/src/main/java/mil/dds/anet/services/MartTransmissionLogImporterService.java
@@ -35,7 +35,8 @@ public class MartTransmissionLogImporterService implements IMartTransmissionLogI
   }
 
   @Override
-  public void processTransmissionLog(FileAttachment martTransmissionLogAttachment) {
+  public void processTransmissionLog(FileAttachment martTransmissionLogAttachment,
+      Instant emailReceivedTime) {
     try {
       // Get the transmission log JSON from the attachment
       martTransmissionLogAttachment.load();
@@ -59,7 +60,7 @@ public class MartTransmissionLogImporterService implements IMartTransmissionLogI
           martImportedReport.setSequence(logDto.getSequence());
           martImportedReport.setState(MartImportedReport.State.NOT_RECEIVED);
           martImportedReport.setSubmittedAt(logDto.getSubmittedAt());
-          martImportedReport.setReceivedAt(Instant.now());
+          martImportedReport.setReceivedAt(emailReceivedTime);
           martImportedReport.setReportUuid(logDto.getReportUuid());
           if (logDto.getState() == LogDto.LogState.FAILED_TO_SEND_EMAIL.getCode()) {
             martImportedReport.setErrors(

--- a/src/main/java/mil/dds/anet/threads/mart/MartImporterWorker.java
+++ b/src/main/java/mil/dds/anet/threads/mart/MartImporterWorker.java
@@ -5,6 +5,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import microsoft.exchange.webservices.data.core.exception.service.local.ServiceLocalException;
 import microsoft.exchange.webservices.data.core.service.item.EmailMessage;
 import microsoft.exchange.webservices.data.property.complex.FileAttachment;
 import mil.dds.anet.beans.JobHistory;
@@ -81,9 +82,21 @@ public class MartImporterWorker extends AbstractWorker {
       // If transmission log in email process
       attachments.stream()
           .filter(attachment -> attachment.getName().equalsIgnoreCase(TRANSMISSION_LOG_ATTACHMENT))
-          .findFirst().ifPresent(this.transmissionLogImporter::processTransmissionLog);
+          .findFirst().ifPresent(attachment -> transmissionLogImporter
+              .processTransmissionLog(attachment, getEmailReceivedTime(email)));
     } catch (Exception e) {
       logger.error("Could not load information from email", e);
+    }
+  }
+
+  private Instant getEmailReceivedTime(EmailMessage email) {
+    final Instant fallback = Instant.now();
+    try {
+      return email.getDateTimeReceived() != null ? email.getDateTimeReceived().toInstant()
+          : fallback;
+    } catch (ServiceLocalException e) {
+      logger.warn("Could not determine email received time. Using current time instead.", e);
+      return fallback;
     }
   }
 }

--- a/src/test/java/mil/dds/anet/test/integration/mart/MartTransmissionLogImporterWorkerTest.java
+++ b/src/test/java/mil/dds/anet/test/integration/mart/MartTransmissionLogImporterWorkerTest.java
@@ -1,0 +1,190 @@
+package mil.dds.anet.test.integration.mart;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static org.mockito.Mockito.when;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import microsoft.exchange.webservices.data.core.exception.service.local.ServiceLocalException;
+import microsoft.exchange.webservices.data.core.service.item.EmailMessage;
+import microsoft.exchange.webservices.data.core.service.item.Item;
+import microsoft.exchange.webservices.data.property.complex.Attachment;
+import microsoft.exchange.webservices.data.property.complex.AttachmentCollection;
+import microsoft.exchange.webservices.data.property.complex.FileAttachment;
+import mil.dds.anet.beans.lists.AnetBeanList;
+import mil.dds.anet.beans.mart.LogDto;
+import mil.dds.anet.beans.mart.MartImportedReport;
+import mil.dds.anet.beans.mart.ReportDto;
+import mil.dds.anet.beans.search.MartImportedReportSearchQuery;
+import mil.dds.anet.config.AnetConfig;
+import mil.dds.anet.config.AnetDictionary;
+import mil.dds.anet.database.JobHistoryDao;
+import mil.dds.anet.database.MartImportedReportDao;
+import mil.dds.anet.database.mappers.MapperUtils;
+import mil.dds.anet.services.IMailReceiver;
+import mil.dds.anet.services.IMartReportImporterService;
+import mil.dds.anet.services.IMartTransmissionLogImporterService;
+import mil.dds.anet.test.integration.config.AnetTestConfiguration;
+import mil.dds.anet.test.resources.AbstractResourceTest;
+import mil.dds.anet.threads.mart.MartImporterWorker;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.cfg.DateTimeFeature;
+
+class MartTransmissionLogImporterWorkerTest extends AbstractResourceTest {
+  private final ObjectMapper ignoringMapper = MapperUtils.getDefaultMapper().rebuild()
+      .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+      .disable(DateTimeFeature.WRITE_DATES_AS_TIMESTAMPS).build();
+
+  @Autowired
+  protected AnetConfig config;
+  @Autowired
+  protected AnetDictionary dict;
+  @Autowired
+  private JobHistoryDao jobHistoryDao;
+  @Autowired
+  private MartImportedReportDao martImportedReportDao;
+  @Autowired
+  private IMartReportImporterService martReportImporterService;
+  @Autowired
+  private IMartTransmissionLogImporterService martTransmissionLogImporterService;
+
+  private MartImporterWorker martReportImporterWorker = null;
+
+  private static final String TEST_REPORT_UUID = "transmissionLogTestReportUuid";
+  private static final long SEQUENCE_ERROR = 2137;
+  private static final long SEQUENCE_OK = 2138;
+
+  @BeforeAll
+  void setUp() throws Exception {
+    final boolean executeMartReportImporterTests = Boolean.parseBoolean(
+        AnetTestConfiguration.getConfiguration().get("martReportImporterTestsExecute").toString());
+    assumeTrue(executeMartReportImporterTests, "Mart importer tests configured to be skipped.");
+
+    // Transmission logs
+    final EmailMessage reportMessage1 =
+        createReportMockEmail(createMartReportForTransmissionLogTest());
+    final EmailMessage transmissionLogMessage = createTransmissionLogMockEmail(
+        createTransmissionLog(Instant.now().minus(2, ChronoUnit.DAYS)));
+    final EmailMessage transmissionLogMessage2 = createTransmissionLogMockEmail(
+        createTransmissionLog(Instant.now().minus(3, ChronoUnit.DAYS)));
+    final EmailMessage transmissionLogMessage3 = createTransmissionLogMockEmail(
+        createTransmissionLog(Instant.now().minus(4, ChronoUnit.DAYS)));
+    final EmailMessage transmissionLogMessage4 = createTransmissionLogMockEmail(
+        createTransmissionLog(Instant.now().minus(5, ChronoUnit.DAYS)));
+    // Mock the mail exchange server
+    final IMailReceiver mailReceiverMock = Mockito.mock();
+    when(mailReceiverMock.downloadEmails())
+        .thenReturn(List.of(reportMessage1, transmissionLogMessage, transmissionLogMessage2,
+            transmissionLogMessage3, transmissionLogMessage4));
+
+    martReportImporterWorker = new MartImporterWorker(dict, jobHistoryDao, mailReceiverMock,
+        martReportImporterService, martTransmissionLogImporterService);
+  }
+
+  @AfterEach
+  void cleanImportLog() {
+    final MartImportedReportSearchQuery query = new MartImportedReportSearchQuery();
+    query.setSequences(List.of(SEQUENCE_ERROR, SEQUENCE_OK));
+    martImportedReportDao.search(query).getList().forEach(r -> {
+      martImportedReportDao.delete(r);
+    });
+  }
+
+  @Test
+  void testWorker() {
+    martReportImporterWorker.run();
+
+    AnetBeanList<MartImportedReport> martImportedReportsList =
+        martImportedReportDao.search(new MartImportedReportSearchQuery());
+    Optional<MartImportedReport> martImportedReportOpt = martImportedReportsList.getList().stream()
+        .filter(mir -> mir.getReportUuid().equals(TEST_REPORT_UUID)).findFirst();
+    assertThat(martImportedReportOpt.isPresent());
+    MartImportedReport martImportedReport = martImportedReportOpt.get();
+    assertThat(martImportedReport.getSequence()).isEqualTo(SEQUENCE_OK);
+    assertThat(martImportedReport.getHistoryCount()).isEqualTo(2);
+
+    MartImportedReportSearchQuery searchQuery = new MartImportedReportSearchQuery();
+    searchQuery.setReportUuid(TEST_REPORT_UUID);
+    martImportedReportsList = martImportedReportDao.search(searchQuery);
+    assertThat(martImportedReportsList.getTotalCount()).isEqualTo(2);
+  }
+
+  private EmailMessage createTransmissionLogMockEmail(List<LogDto> transmissionLog)
+      throws ServiceLocalException {
+    final AttachmentCollection attachmentCollection = Mockito.mock(AttachmentCollection.class);
+    final EmailMessage emailMessageMock = Mockito.mock();
+
+    FileAttachment mockAttachmentJson = Mockito.mock(FileAttachment.class);
+    when(mockAttachmentJson.getOwner()).thenReturn(Mockito.mock(Item.class));
+    when(mockAttachmentJson.getContent()).thenReturn(
+        ignoringMapper.writeValueAsString(transmissionLog).getBytes(StandardCharsets.UTF_8));
+    when(mockAttachmentJson.getName()).thenReturn(MartImporterWorker.TRANSMISSION_LOG_ATTACHMENT);
+
+    List<Attachment> attachmentList = new ArrayList<>();
+    attachmentList.add(mockAttachmentJson);
+
+    when(attachmentCollection.iterator()).thenReturn(attachmentList.iterator());
+
+    when(emailMessageMock.getAttachments()).thenReturn(attachmentCollection, attachmentCollection);
+    return emailMessageMock;
+  }
+
+  private EmailMessage createReportMockEmail(ReportDto reportDto) throws ServiceLocalException {
+    final AttachmentCollection attachmentCollection = Mockito.mock(AttachmentCollection.class);
+    final EmailMessage emailMessageMock = Mockito.mock();
+    FileAttachment mockAttachmentJson = Mockito.mock(FileAttachment.class);
+    when(mockAttachmentJson.getOwner()).thenReturn(Mockito.mock(Item.class));
+    when(mockAttachmentJson.getContent())
+        .thenReturn(ignoringMapper.writeValueAsString(reportDto).getBytes(StandardCharsets.UTF_8));
+    when(mockAttachmentJson.getName()).thenReturn(MartImporterWorker.REPORT_JSON_ATTACHMENT);
+    List<Attachment> attachmentList = new ArrayList<>();
+    attachmentList.add(mockAttachmentJson);
+    when(attachmentCollection.iterator()).thenReturn(attachmentList.iterator());
+    when(emailMessageMock.getAttachments()).thenReturn(attachmentCollection, attachmentCollection);
+    return emailMessageMock;
+  }
+
+  public static List<LogDto> createTransmissionLog(Instant submittedAt) {
+    final List<LogDto> transmissionLog = new ArrayList<>();
+    final LogDto logDto1 = new LogDto();
+    logDto1.setState(LogDto.LogState.SENT.getCode());
+    logDto1.setSequence(SEQUENCE_ERROR);
+    logDto1.setErrors("SMTP error sending email in MART");
+    logDto1.setSubmittedAt(submittedAt);
+    logDto1.setReportUuid(TEST_REPORT_UUID);
+    final LogDto logDto2 = new LogDto();
+    logDto2.setState(LogDto.LogState.SENT.getCode());
+    logDto2.setSequence(SEQUENCE_OK);
+    logDto2.setSubmittedAt(submittedAt);
+    logDto2.setReportUuid(TEST_REPORT_UUID);
+    transmissionLog.add(logDto1);
+    transmissionLog.add(logDto2);
+    return transmissionLog;
+  }
+
+  public static ReportDto createMartReportForTransmissionLogTest() {
+    final ReportDto reportDto = new ReportDto();
+    // User Info
+    reportDto.setSequence(SEQUENCE_OK);
+    reportDto.setUuid(TEST_REPORT_UUID);
+    reportDto.setOrganizationUuid("9a35caa7-a095-4963-ac7b-b784fde4d583");
+    reportDto.setOrganizationName("Planning Programming, Budgeting and Execution");
+    reportDto.setRank("OF-6");
+    reportDto.setEmail("mart-user@kfor.nato.int");
+    reportDto.setFirstName("Larry");
+    reportDto.setLastName("Bird");
+    reportDto.setPositionName("MART Team Member");
+    return reportDto;
+  }
+}


### PR DESCRIPTION
Addresses the following issues:
* Duplicated sequences in the MART imported reports table
* When fetching MART imported reports grouped by reportUuid it is not picking the highest sequence number

Closes [AB#1636](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1636)

#### User changes
- None

#### Superuser changes
- None

#### Admin changes
- The MART imported reports table will not contain duplicated sequences anymore, the latest sequence number per report uuid will be always displayed

#### System admin changes
- [ ] application.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
- [x] described the user behavior in PR body
- [x] referenced/updated all related issues
- [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
- [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
- [x] added and/or updated unit tests
- [ ] added and/or updated e2e tests
- [ ] added and/or updated data migrations
- [ ] updated documentation
- [x] resolved all build errors and warnings
- [ ] opened debt issues for anything not resolved here
