### PR TITLE
Prevent regular users from searching audit trail on empty relatedObjectUuid

### DIFF
--- a/src/main/java/mil/dds/anet/search/AbstractAuditTrailSearcher.java
+++ b/src/main/java/mil/dds/anet/search/AbstractAuditTrailSearcher.java
@@ -46,7 +46,7 @@ public abstract class AbstractAuditTrailSearcher
           query.getPersonUuid());
     }
 
-    if (query.getRelatedObjectUuid() != null) {
+    if (!Utils.isEmptyOrNull(Utils.trimStringReturnNull(query.getRelatedObjectUuid()))) {
       qb.addStringEqualsClause("relatedObjectUuid", quotedTableName + ".\"relatedObjectUuid\"",
           query.getRelatedObjectUuid());
     } else {

--- a/src/test/java/mil/dds/anet/test/resources/AuditTrailResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/AuditTrailResourceTest.java
@@ -1,0 +1,54 @@
+package mil.dds.anet.test.resources;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import mil.dds.anet.test.client.AnetBeanList_AuditTrail;
+import mil.dds.anet.test.client.AuditTrailSearchQueryInput;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class AuditTrailResourceTest extends AbstractResourceTest {
+
+  @Test
+  void testAuditTrailAsUserWithNullRelatedObjectUuid() {
+    final AuditTrailSearchQueryInput query =
+        AuditTrailSearchQueryInput.builder().withRelatedObjectUuid(null).build();
+    assertThatThrownBy(() -> withCredentials(jackUser,
+        t -> queryExecutor.auditTrailList(getListFields("{ uuid }"), query)))
+        .isInstanceOf(Exception.class);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"", " "})
+  void testAuditTrailAsUserWithEmptyRelatedObjectUuid(String relatedObjectUuid) {
+    final AuditTrailSearchQueryInput query =
+        AuditTrailSearchQueryInput.builder().withRelatedObjectUuid(relatedObjectUuid).build();
+    assertThatThrownBy(() -> withCredentials(jackUser,
+        t -> queryExecutor.auditTrailList(getListFields("{ uuid }"), query)))
+        .isInstanceOf(Exception.class);
+  }
+
+  @Test
+  void testAuditTrailAsAdminWithNullRelatedObjectUuid() {
+    final AuditTrailSearchQueryInput query =
+        AuditTrailSearchQueryInput.builder().withRelatedObjectUuid(null).build();
+    final AnetBeanList_AuditTrail result = withCredentials(adminUser,
+        t -> queryExecutor.auditTrailList(getListFields("{ uuid }"), query));
+    assertThat(result).isNotNull();
+    assertThat(result.getTotalCount()).isGreaterThan(0);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"", " "})
+  void testAuditTrailAsAdminWithEmptyRelatedObjectUuid(String relatedObjectUuid) {
+    final AuditTrailSearchQueryInput query =
+        AuditTrailSearchQueryInput.builder().withRelatedObjectUuid(relatedObjectUuid).build();
+    final AnetBeanList_AuditTrail result = withCredentials(adminUser,
+        t -> queryExecutor.auditTrailList(getListFields("{ uuid }"), query));
+    assertThat(result).isNotNull();
+    assertThat(result.getTotalCount()).isGreaterThan(0);
+  }
+
+}


### PR DESCRIPTION
Closes [AB#1638](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1638)

#### User changes
- Users can only see the audit trail with a specified relatedObjectUuid.

#### Superuser changes
- Superusers can only see the audit trail with a specified relatedObjectUuid.

#### Admin changes
- None; admins can still see the entire audit trail, regardless of relatedObjectUuid.

#### System admin changes
- [ ] application.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
- [x] described the user behavior in PR body
- [x] referenced/updated all related issues
- [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
- [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
- [x] added and/or updated unit tests
- [ ] added and/or updated e2e tests
- [ ] added and/or updated data migrations
- [ ] updated documentation
- [x] resolved all build errors and warnings
- [ ] opened debt issues for anything not resolved here