### PR TITLE
 Prevent new or unverified users from viewing or downloading attachments by uuid

### DIFF
--- a/src/main/java/mil/dds/anet/resources/AttachmentResource.java
+++ b/src/main/java/mil/dds/anet/resources/AttachmentResource.java
@@ -238,9 +238,14 @@ public class AttachmentResource {
   }
 
   @GetMapping(path = "/download/{uuid}", produces = MediaType.APPLICATION_OCTET_STREAM_VALUE)
-  public ResponseEntity<StreamingResponseBody> downloadAttachment(final Principal ignoredPrincipal,
+  public ResponseEntity<StreamingResponseBody> downloadAttachment(final Principal principal,
       @PathVariable(name = "uuid") String uuid) {
     assertAttachmentEnabled();
+    final Person user = SecurityUtils.getPersonFromPrincipal(principal);
+    if (DaoUtils.isNewUser(user) || Boolean.TRUE.equals(user.getPendingVerification())) {
+      // New or unverified users are denied access
+      throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Permission denied");
+    }
     final Attachment attachment = getAttachment(uuid);
     final HttpHeaders headers = new HttpHeaders();
     headers.setContentDisposition(getContentDisposition("attachment", attachment));
@@ -249,9 +254,14 @@ public class AttachmentResource {
   }
 
   @GetMapping(path = "/view/{uuid}")
-  public ResponseEntity<StreamingResponseBody> viewAttachment(final Principal ignoredPrincipal,
+  public ResponseEntity<StreamingResponseBody> viewAttachment(final Principal principal,
       @PathVariable(name = "uuid") String uuid) {
     assertAttachmentEnabled();
+    final Person user = SecurityUtils.getPersonFromPrincipal(principal);
+    if (DaoUtils.isNewUser(user) || Boolean.TRUE.equals(user.getPendingVerification())) {
+      // New or unverified users are denied access
+      throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Permission denied");
+    }
     final Attachment attachment = getAttachment(uuid);
     final HttpHeaders headers = new HttpHeaders();
     headers.setContentDisposition(getContentDisposition("inline", attachment));


### PR DESCRIPTION
Closes [AB#1640](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1640)

#### User changes
- New or unverified users can no longer view or download attachments by uuid.

#### Superuser changes
- None

#### Admin changes
- None

#### System admin changes
- [ ] application.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
- [x] described the user behavior in PR body
- [x] referenced/updated all related issues
- [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
- [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
- [ ] added and/or updated unit tests
- [ ] added and/or updated e2e tests
- [ ] added and/or updated data migrations
- [ ] updated documentation
- [x] resolved all build errors and warnings
- [ ] opened debt issues for anything not resolved here