### PR TITLE
Be able to search events in date range

### DIFF
--- a/client/src/components/SearchFilters.tsx
+++ b/client/src/components/SearchFilters.tsx
@@ -739,6 +739,20 @@ export const searchFilters = function (
           queryKey: "eventSeriesUuid"
         }
       },
+      "Start Date": {
+        component: DateRangeFilter,
+        deserializer: deserializeDateRangeFilter,
+        props: {
+          queryKey: "startDate"
+        }
+      },
+      "End Date": {
+        component: DateRangeFilter,
+        deserializer: deserializeDateRangeFilter,
+        props: {
+          queryKey: "endDate"
+        }
+      },
       [`Within ${Settings.fields.event.ownerOrg.label}`]: {
         component: OrganizationMultiFilter,
         deserializer: deserializeOrganizationMultiFilter,

--- a/src/main/java/mil/dds/anet/beans/search/EventSearchQuery.java
+++ b/src/main/java/mil/dds/anet/beans/search/EventSearchQuery.java
@@ -28,6 +28,18 @@ public class EventSearchQuery extends AbstractCommonEventSearchQuery<EventSearch
   Instant endDate;
   @GraphQLQuery
   @GraphQLInputField
+  Instant startDateStart;
+  @GraphQLQuery
+  @GraphQLInputField
+  Instant startDateEnd;
+  @GraphQLQuery
+  @GraphQLInputField
+  Instant endDateStart;
+  @GraphQLQuery
+  @GraphQLInputField
+  Instant endDateEnd;
+  @GraphQLQuery
+  @GraphQLInputField
   String eventTypeUuid;
 
   public EventSearchQuery() {
@@ -91,10 +103,42 @@ public class EventSearchQuery extends AbstractCommonEventSearchQuery<EventSearch
     this.eventTypeUuid = eventTypeUuid;
   }
 
+  public Instant getStartDateStart() {
+    return startDateStart;
+  }
+
+  public void setStartDateStart(Instant startDateStart) {
+    this.startDateStart = startDateStart;
+  }
+
+  public Instant getStartDateEnd() {
+    return startDateEnd;
+  }
+
+  public void setStartDateEnd(Instant startDateEnd) {
+    this.startDateEnd = startDateEnd;
+  }
+
+  public Instant getEndDateStart() {
+    return endDateStart;
+  }
+
+  public void setEndDateStart(Instant endDateStart) {
+    this.endDateStart = endDateStart;
+  }
+
+  public Instant getEndDateEnd() {
+    return endDateEnd;
+  }
+
+  public void setEndDateEnd(Instant endDateEnd) {
+    this.endDateEnd = endDateEnd;
+  }
+
   @Override
   public int hashCode() {
     return Objects.hash(super.hashCode(), eventSeriesUuid, locationUuid, taskUuid, includeDate,
-        startDate, endDate, eventTypeUuid);
+        startDate, endDate, startDateStart, startDateEnd, endDateStart, endDateEnd, eventTypeUuid);
   }
 
   @Override
@@ -108,6 +152,10 @@ public class EventSearchQuery extends AbstractCommonEventSearchQuery<EventSearch
         && Objects.equals(getIncludeDate(), other.getIncludeDate())
         && Objects.equals(getStartDate(), other.getStartDate())
         && Objects.equals(getEndDate(), other.getEndDate())
+        && Objects.equals(getStartDateStart(), other.getStartDateStart())
+        && Objects.equals(getStartDateEnd(), other.getStartDateEnd())
+        && Objects.equals(getEndDateStart(), other.getEndDateStart())
+        && Objects.equals(getEndDateEnd(), other.getEndDateEnd())
         && Objects.equals(getEventTypeUuid(), other.getEventTypeUuid());
   }
 

--- a/src/main/java/mil/dds/anet/search/AbstractEventSearcher.java
+++ b/src/main/java/mil/dds/anet/search/AbstractEventSearcher.java
@@ -78,6 +78,15 @@ public abstract class AbstractEventSearcher extends AbstractSearcher<Event, Even
         query.getIncludeDate());
     qb.addDateRangeClause("startDate", "events.\"endDate\"", Comparison.AFTER, query.getStartDate(),
         "endDate", "events.\"startDate\"", Comparison.BEFORE, query.getEndDate());
+
+    qb.addDateRangeClause("startStartDate", "events.\"startDate\"", Comparison.AFTER,
+        query.getStartDateStart(), "endStartDate", "events.\"startDate\"", Comparison.BEFORE,
+        query.getStartDateEnd());
+
+    qb.addDateRangeClause("startEndDate", "events.\"endDate\"", Comparison.AFTER,
+        query.getEndDateStart(), "endEndDate", "events.\"endDate\"", Comparison.BEFORE,
+        query.getEndDateEnd());
+
     addOrderByClauses(qb, query);
   }
 

--- a/src/test/java/mil/dds/anet/test/resources/EventResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/EventResourceTest.java
@@ -4,6 +4,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
 import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.Month;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
@@ -19,6 +21,7 @@ import mil.dds.anet.test.client.GenericRelatedObjectInput;
 import mil.dds.anet.test.client.Organization;
 import mil.dds.anet.test.client.Status;
 import mil.dds.anet.test.utils.UtilsTest;
+import mil.dds.anet.utils.DaoUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.junit.jupiter.api.Test;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
@@ -75,13 +78,42 @@ public class EventResourceTest extends AbstractResourceTest {
     assertThat(updated.getPeople()).hasSize(1);
     assertThat(updated.getTasks()).hasSize(1);
 
-    // Search
+    // Search filtering by text
     final EventSearchQueryInput query =
         EventSearchQueryInput.builder().withText("NMI PDT 2024-01").build();
     final AnetBeanList_Event searchObjects =
         withCredentials(adminUser, t -> queryExecutor.eventList(getListFields(FIELDS), query));
     assertThat(searchObjects).isNotNull();
     assertThat(searchObjects.getList()).isNotEmpty();
+    assertThat(searchObjects.getList()).hasSize(1);
+
+    // Search filtering by start date
+    final EventSearchQueryInput query2 = EventSearchQueryInput.builder()
+        .withStartDateStart(LocalDateTime.of(2024, Month.JANUARY, 7, 0, 0)
+            .atZone(DaoUtils.getServerNativeZoneId()).toInstant())
+        .withStartDateEnd(LocalDateTime.of(2024, Month.JANUARY, 10, 0, 0)
+            .atZone(DaoUtils.getServerNativeZoneId()).toInstant())
+        .build();
+
+    final AnetBeanList_Event searchObjects2 =
+        withCredentials(adminUser, t -> queryExecutor.eventList(getListFields(FIELDS), query2));
+    assertThat(searchObjects2).isNotNull();
+    assertThat(searchObjects2.getList()).isNotEmpty();
+    assertThat(searchObjects2.getList()).hasSize(1);
+
+    // Search filtering by end date
+    final EventSearchQueryInput query3 = EventSearchQueryInput.builder()
+        .withEndDateStart(LocalDateTime.of(2024, Month.JANUARY, 11, 0, 0)
+            .atZone(DaoUtils.getServerNativeZoneId()).toInstant())
+        .withEndDateEnd(LocalDateTime.of(2024, Month.JANUARY, 13, 0, 0)
+            .atZone(DaoUtils.getServerNativeZoneId()).toInstant())
+        .build();
+
+    final AnetBeanList_Event searchObjects3 =
+        withCredentials(adminUser, t -> queryExecutor.eventList(getListFields(FIELDS), query3));
+    assertThat(searchObjects3).isNotNull();
+    assertThat(searchObjects3.getList()).isNotEmpty();
+    assertThat(searchObjects3.getList()).hasSize(1);
   }
 
   @Test

--- a/src/test/resources/anet.graphql
+++ b/src/test/resources/anet.graphql
@@ -641,6 +641,8 @@ input EventSearchQueryInput {
   anyOrgUuid: [String]
   emailNetwork: String
   endDate: Instant
+  endDateEnd: Instant
+  endDateStart: Instant
   eventSeriesUuid: String
   eventTaskUuid: [String]
   eventTypeUuid: String
@@ -654,6 +656,8 @@ input EventSearchQueryInput {
   sortBy: EventSearchSortBy
   sortOrder: SortOrder
   startDate: Instant
+  startDateEnd: Instant
+  startDateStart: Instant
   status: Status
   subscribed: Boolean
   taskUuid: [String]


### PR DESCRIPTION
Allow users to  search for events where either start date or end date falls in a given range.

Closes [AB#1641](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1641)

#### User changes
- In the search bar when selecting Event, add another filter, start date and end date filters are available.

#### Superuser changes
- None

#### Admin changes
- None

#### System admin changes
- [ ] application.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [x] graphql schema has changed

### Checklist
- [x] described the user behavior in PR body
- [x] referenced/updated all related issues
- [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
- [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
- [x] added and/or updated unit tests
- [ ] added and/or updated e2e tests
- [ ] added and/or updated data migrations
- [ ] updated documentation
- [x] resolved all build errors and warnings
- [ ] opened debt issues for anything not resolved here
