### PR TITLE
Hide invisible custom fields on show pages

### DIFF
--- a/client/src/components/CustomFields.tsx
+++ b/client/src/components/CustomFields.tsx
@@ -1391,6 +1391,10 @@ export const ReadonlyCustomFields = ({
     values,
     parentFieldName
   )
+  const invisibleFields = useMemo(
+    () => getInvisibleFields(fieldsConfig, parentFieldName, values),
+    [fieldsConfig, parentFieldName, values]
+  )
 
   useEffect(() => {
     if (setShowCustomFields) {
@@ -1402,6 +1406,9 @@ export const ReadonlyCustomFields = ({
     <>
       {Object.entries(deprecatedFieldsFiltered).map(([key, fieldConfig]) => {
         const fieldName = `${parentFieldName}.${key}`
+        if (invisibleFields.includes(fieldName)) {
+          return null
+        }
         const fieldProps = getFieldPropsFromFieldConfig(fieldConfig)
         const { type } = fieldConfig
         let extraProps = {}

--- a/client/src/pages/eventSeries/New.tsx
+++ b/client/src/pages/eventSeries/New.tsx
@@ -1,5 +1,4 @@
 import { DEFAULT_SEARCH_PROPS, PAGE_PROPS_NO_NAV } from "actions"
-import { initInvisibleFields } from "components/CustomFields"
 import {
   mapPageDispatchersToProps,
   PageDispatchersPropType,
@@ -9,7 +8,6 @@ import {
 import { EventSeries } from "models"
 import React from "react"
 import { legacy_connect as connect } from "react-redux"
-import Settings from "settings"
 import EventSeriesForm from "./Form"
 
 interface EventSeriesNewProps {
@@ -25,8 +23,6 @@ const EventSeriesNew = ({ pageDispatchers }: EventSeriesNewProps) => {
   usePageTitle("New Event Series")
 
   const eventSeries = new EventSeries()
-  // mutates the object
-  initInvisibleFields(location, Settings.fields.location.customFields)
   return (
     <EventSeriesForm
       initialValues={eventSeries}

--- a/client/src/pages/events/New.tsx
+++ b/client/src/pages/events/New.tsx
@@ -1,7 +1,6 @@
 import { gql } from "@apollo/client"
 import { DEFAULT_SEARCH_PROPS, PAGE_PROPS_NO_NAV } from "actions"
 import API from "api"
-import { initInvisibleFields } from "components/CustomFields"
 import {
   mapPageDispatchersToProps,
   PageDispatchersPropType,
@@ -12,7 +11,6 @@ import { Event, EventSeries } from "models"
 import React from "react"
 import { legacy_connect as connect } from "react-redux"
 import { useLocation } from "react-router"
-import Settings from "settings"
 import utils from "utils"
 import EventForm from "./Form"
 
@@ -105,8 +103,6 @@ const EventNewConditional = ({
     event.hostRelatedObjects = data.eventSeries.hostRelatedObjects
     event.adminOrg = data.eventSeries.adminOrg
   }
-  // mutates the object
-  initInvisibleFields(event, Settings.fields.organization.customFields)
   return (
     <EventForm
       pageDispatchers={pageDispatchers}

--- a/client/src/pages/locations/Show.tsx
+++ b/client/src/pages/locations/Show.tsx
@@ -78,10 +78,14 @@ const LocationShow = ({ pageDispatchers }: LocationShowProps) => {
     searchProps: DEFAULT_SEARCH_PROPS,
     pageDispatchers
   })
-  const location = useMemo(
-    () => new Location(data?.location ?? {}),
-    [data?.location]
-  )
+  const location = useMemo(() => {
+    if (data?.location) {
+      data.location[DEFAULT_CUSTOM_FIELDS_PARENT] = utils.parseJsonSafe(
+        data.location.customFields
+      )
+    }
+    return new Location(data?.location ?? {})
+  }, [data?.location])
 
   const { shapes, markers } = useMemo(() => {
     const shapes = location?.geoJson
@@ -107,11 +111,6 @@ const LocationShow = ({ pageDispatchers }: LocationShowProps) => {
   }, [location])
   if (done) {
     return result
-  }
-  if (data) {
-    data.location[DEFAULT_CUSTOM_FIELDS_PARENT] = utils.parseJsonSafe(
-      data.location.customFields
-    )
   }
   const isAdmin = currentUser?.isAdmin()
   const canEdit = currentUser?.isSuperuser()

--- a/client/tests/webdriver/customFieldsSpecs/customFields.spec.js
+++ b/client/tests/webdriver/customFieldsSpecs/customFields.spec.js
@@ -169,29 +169,6 @@ describe("When working with custom fields for different anet objects", () => {
       ).to.include(VALID_NUMBER_INPUT.toString())
     })
 
-    it("Should discard invisible fields after saving even if it is valid", async () => {
-      await (await CreateReport.getEditButton()).click()
-      await (await CreateReport.getForm()).waitForExist()
-      await (await CreateReport.getForm()).waitForDisplayed()
-
-      const trainButton = await CreateReport.getEngagementTypesButtonByName(
-        TRAIN_ENGAGEMENT_BUTTON
-      )
-      // give valid input before making invisible
-      await CreateReport.deleteInput(CreateReport.getNumberTrainedField())
-      await (
-        await CreateReport.getNumberTrainedField()
-      ).setValue(VALID_NUMBER_INPUT)
-      // goes invisible
-      await trainButton.click()
-      await CreateReport.submitForm()
-      await CreateReport.waitForAlertToLoad()
-
-      expect(
-        await (await CreateReport.getNumberTrainedFieldShowed()).getText()
-      ).to.not.include(VALID_NUMBER_INPUT.toString())
-    })
-
     it("Should logout", async () => {
       await CreateReport.logout()
     })


### PR DESCRIPTION
Custom fields with conditions to hide them were always being displayed on the show pages; they are now hidden when appropriate, just like in the forms.

Closes [AB#1643](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1643)

#### User changes
- Custom fields that should not be visible are now also hidden on the show pages.

#### Superuser changes
- None

#### Admin changes
- None

#### System admin changes
- [ ] application.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
- [x] described the user behavior in PR body
- [x] referenced/updated all related issues
- [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
- [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
- [ ] added and/or updated unit tests
- [x] added and/or updated e2e tests
- [ ] added and/or updated data migrations
- [ ] updated documentation
- [x] resolved all build errors and warnings
- [ ] opened debt issues for anything not resolved here