### PR TITLE
Allow override of report keyOutcomes maxLength

### DIFF
--- a/anet-dictionary.yml
+++ b/anet-dictionary.yml
@@ -485,6 +485,7 @@ fields:
     keyOutcomes:
       label: Key outcomes
       placeholder: Fill in the key outcomes of this engagement
+      maxLength: 1000
       exclude: false
       optional: false
     reportText:

--- a/client/src/pages/reports/Form.tsx
+++ b/client/src/pages/reports/Form.tsx
@@ -1111,19 +1111,24 @@ const ReportForm = ({
                           )
                           validateFieldDebounced("keyOutcomes")
                         }}
-                        maxLength={Settings.maxTextFieldLength}
+                        maxLength={utils.getMaxTextFieldLength(
+                          Settings.fields.report.keyOutcomes
+                        )}
                         onKeyUp={event =>
                           countCharsLeft(
                             "keyOutcomesCharsLeft",
-                            Settings.maxTextFieldLength,
+                            utils.getMaxTextFieldLength(
+                              Settings.fields.report.keyOutcomes
+                            ),
                             event
                           )
                         }
                         extraColElem={
                           <>
                             <span id="keyOutcomesCharsLeft">
-                              {Settings.maxTextFieldLength -
-                                initialValues.keyOutcomes.length}
+                              {utils.getMaxTextFieldLength(
+                                Settings.fields.report.keyOutcomes
+                              ) - initialValues.keyOutcomes.length}
                             </span>{" "}
                             characters remaining
                           </>

--- a/testDictionaries/no-custom-fields.yml
+++ b/testDictionaries/no-custom-fields.yml
@@ -465,6 +465,7 @@ fields:
     keyOutcomes:
       label: Key outcomes
       placeholder: Fill in the key outcomes of this engagement
+      maxLength: 1000
       exclude: false
       optional: false
     reportText:


### PR DESCRIPTION
The report keyOutcomes maxLength was limited to the dictionary-wide default (`maxTextFieldLength`, which is mostly set to 250). It is now possible to override this.

Closes [AB#1648](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1648)

#### User changes
- None

#### Superuser changes
- None

#### Admin changes
- None

#### System admin changes
- [x] application.yml or anet-dictionary.yml needs change
  You can add this to the dictionary:
  ```yaml
  fields:
    report:
      […]
      keyOutcomes:
        label: Key outcomes
        placeholder: Fill in the key outcomes of this engagement
        maxLength: 1000
        […]
  ```
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
- [x] described the user behavior in PR body
- [x] referenced/updated all related issues
- [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
- [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
- [ ] added and/or updated unit tests
- [ ] added and/or updated e2e tests
- [ ] added and/or updated data migrations
- [ ] updated documentation
- [x] resolved all build errors and warnings
- [ ] opened debt issues for anything not resolved here