### PR TITLE
Add reportType to customFields when importing MART reports

### DIFF
--- a/anet-dictionary.yml
+++ b/anet-dictionary.yml
@@ -2089,6 +2089,10 @@ dashboards:
     data: /data/dashboards/decisives.json
     type: decisives
 
+martReportImport:
+  customFields:
+    reportType: lmt
+
 martDictionaryExport:
   tasks:
     domainUuid: f07beca6-153e-49da-8aaa-3e29c2a1f4bc

--- a/src/main/java/mil/dds/anet/services/MartReportImporterService.java
+++ b/src/main/java/mil/dds/anet/services/MartReportImporterService.java
@@ -58,6 +58,7 @@ import tools.jackson.core.JacksonException;
 import tools.jackson.databind.DeserializationFeature;
 import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.cfg.DateTimeFeature;
+import tools.jackson.databind.node.ObjectNode;
 
 @Component
 public class MartReportImporterService implements IMartReportImporterService {
@@ -68,6 +69,7 @@ public class MartReportImporterService implements IMartReportImporterService {
   private final ObjectMapper ignoringMapper = MapperUtils.getDefaultMapper().rebuild()
       .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
       .disable(DateTimeFeature.WRITE_DATES_AS_TIMESTAMPS).build();
+  private static final ObjectMapper mapper = MapperUtils.getDefaultMapper();
 
   private final OrganizationDao organizationDao;
   private final ReportDao reportDao;
@@ -81,7 +83,9 @@ public class MartReportImporterService implements IMartReportImporterService {
   private final CommentDao commentDao;
 
   private final int martNewPositionDaysInThePast;
+  private final Map<String, Object> martImportCustomFields;
 
+  @SuppressWarnings("unchecked")
   public MartReportImporterService(AnetDictionary dict, ReportDao reportDao, PersonDao personDao,
       PositionDao positionDao, TaskDao taskDao, OrganizationDao organizationDao,
       LocationDao locationDao, MartImportedReportDao martImportedReportDao,
@@ -99,6 +103,8 @@ public class MartReportImporterService implements IMartReportImporterService {
 
     this.martNewPositionDaysInThePast =
         (int) dict.getDictionaryEntry("martNewPositionDaysInThePast");
+    this.martImportCustomFields =
+        (Map<String, Object>) dict.getDictionaryEntry("martReportImport.customFields");
   }
 
   @Override
@@ -307,6 +313,9 @@ public class MartReportImporterService implements IMartReportImporterService {
     anetReport.setReportText(Utils.isEmptyHtml(anetReport.getReportText()) ? null
         : Utils.sanitizeHtml(anetReport.getReportText()));
 
+    // Add dictionary-defined customFields
+    addDictionaryCustomFields(anetReport, martImportCustomFields);
+
     // Insert report
     try {
       anetReport = reportDao.insertWithExistingUuid(anetReport);
@@ -349,6 +358,23 @@ public class MartReportImporterService implements IMartReportImporterService {
         martImportedReport.setState(MartImportedReport.State.NOT_SUBMITTED);
       }
     }
+  }
+
+  public static void addDictionaryCustomFields(Report anetReport,
+      Map<String, Object> dictionaryCustomFields) {
+    if (anetReport == null || dictionaryCustomFields == null) {
+      return;
+    }
+    final String customFields = anetReport.getCustomFields();
+    final String safeCustomFields =
+        Utils.isEmptyOrNull(Utils.trimStringReturnNull(customFields)) ? "{}" : customFields;
+    final ObjectNode customFieldsJson = mapper.readTree(safeCustomFields).asObject();
+    dictionaryCustomFields.forEach((k, v) -> {
+      if (!customFieldsJson.has(k)) {
+        customFieldsJson.putPOJO(k, v);
+      }
+    });
+    anetReport.setCustomFields(mapper.writeValueAsString(customFieldsJson));
   }
 
   private String getClassificationFromReport(ReportDto martReport, List<String> errors) {

--- a/src/main/resources/anet-schema.yml
+++ b/src/main/resources/anet-schema.yml
@@ -1527,6 +1527,17 @@ properties:
         description: Used in the application to set the initial delay after which the first deactivation (warning) checks will occur;
                      when not specified, it will use the checkIntervalInSecs setting.
 
+  martReportImport:
+    title: Definition of extra fields to be added when importing MART reports
+    type: object
+    additionalProperties: false
+    required:
+      - customFields
+    properties:
+      customFields:
+        title: Custom fields to be added when importing MART reports
+        type: object
+
   martDictionaryExport:
     title: Configuration of MART ANET dictionary export
     type: object

--- a/src/test/java/mil/dds/anet/test/integration/mart/MartDictionaryServiceTest.java
+++ b/src/test/java/mil/dds/anet/test/integration/mart/MartDictionaryServiceTest.java
@@ -4,12 +4,24 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 import java.util.Map;
+import mil.dds.anet.beans.Report;
+import mil.dds.anet.database.mappers.MapperUtils;
 import mil.dds.anet.services.IMartDictionaryService;
+import mil.dds.anet.services.MartReportImporterService;
 import mil.dds.anet.test.resources.AbstractResourceTest;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.StringNode;
 
 class MartDictionaryServiceTest extends AbstractResourceTest {
+
+  private static final ObjectMapper mapper = MapperUtils.getDefaultMapper();
 
   @Autowired
   private IMartDictionaryService martDictionaryService;
@@ -75,5 +87,53 @@ class MartDictionaryServiceTest extends AbstractResourceTest {
     assertThat(locations.get(0)).containsEntry("townAlbanian", "Baballoq");
     assertThat(locations.get(0)).containsEntry("townSerbian", "Babaloc");
     assertThat(locations.get(0)).containsEntry("mgrs", "34TDN46550404");
+  }
+
+  @ParameterizedTest
+  @NullSource
+  @ValueSource(strings = {"", " ", "{}"})
+  void testDictionaryCustomFieldsWithoutReportType(String testCustomFields) {
+    checkReportType(testCustomFields, "lmt");
+  }
+
+  @Test
+  void testDictionaryCustomFieldsWithSameReportType() {
+    checkReportType("{ \"reportType\": \"lmt\" }", "lmt");
+  }
+
+  @Test
+  void testDictionaryCustomFieldsWithDifferentReportType() {
+    checkReportType("{ \"reportType\": \"engagement\" }", "engagement");
+  }
+
+  @Test
+  void testDictionaryCustomFieldsWithAdditionalField() {
+    final Report anetReport = checkReportType("{ \"someField\": \"someValue\" }", "lmt");
+    final ObjectNode jsonTree = mapper.readTree(anetReport.getCustomFields()).asObject();
+    final JsonNode someField = jsonTree.get("someField");
+    assertThat(someField).isInstanceOf(StringNode.class);
+    assertThat(someField.stringValue()).isEqualTo("someValue");
+  }
+
+  private Report checkReportType(String testCustomFields, String lmt) {
+    final Report anetReport = new Report();
+    anetReport.setCustomFields(testCustomFields);
+    addReportType(anetReport);
+    assertReportType(anetReport, lmt);
+    return anetReport;
+  }
+
+  private void addReportType(Report anetReport) {
+    @SuppressWarnings("unchecked")
+    final Map<String, Object> dictionaryCustomFields =
+        (Map<String, Object>) dict.getDictionaryEntry("martReportImport.customFields");
+    MartReportImporterService.addDictionaryCustomFields(anetReport, dictionaryCustomFields);
+  }
+
+  private void assertReportType(Report anetReport, String expectedReportType) {
+    final ObjectNode jsonTree = mapper.readTree(anetReport.getCustomFields()).asObject();
+    final JsonNode reportType = jsonTree.get("reportType");
+    assertThat(reportType).isInstanceOf(StringNode.class);
+    assertThat(reportType.stringValue()).isEqualTo(expectedReportType);
   }
 }

--- a/src/test/java/mil/dds/anet/test/integration/mart/MartReportImporterWorkerTest.java
+++ b/src/test/java/mil/dds/anet/test/integration/mart/MartReportImporterWorkerTest.java
@@ -49,14 +49,18 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.cfg.DateTimeFeature;
+import tools.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.node.StringNode;
 
 class MartReportImporterWorkerTest extends AbstractResourceTest {
   private static final String ATTACHMENT_NAME = "default_avatar.png";
   private final ObjectMapper ignoringMapper = MapperUtils.getDefaultMapper().rebuild()
       .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
       .disable(DateTimeFeature.WRITE_DATES_AS_TIMESTAMPS).build();
+  private static final ObjectMapper mapper = MapperUtils.getDefaultMapper();
 
   @Autowired
   protected AnetConfig config;
@@ -214,6 +218,7 @@ class MartReportImporterWorkerTest extends AbstractResourceTest {
     assertThat(createdGoodReport.getTasks().getFirst().getLongName()).isEqualTo("Intelligence");
     assertThat(createdGoodReport.getClassification()).isEqualTo("NU");
     assertThat(createdGoodReport.getState()).isEqualTo(ReportState.PENDING_APPROVAL);
+    assertReportType(createdGoodReport);
     // Now we will edit and approve goodReport, we should not lose the advisorOrg of the report
     // Edit the report
     createdGoodReport.setAtmosphereDetails("Everybody was super nice! Again!");
@@ -240,6 +245,7 @@ class MartReportImporterWorkerTest extends AbstractResourceTest {
         withCredentials("arthur", t -> queryExecutor.report(ReportResourceTest.FIELDS,
             goodOldReportWithDifferentUser.getUuid()));
     createdGoodOldReportWithDifferentUser.setAtmosphereDetails("Everybody was super nice! Again!");
+    assertReportType(createdGoodOldReportWithDifferentUser);
     final Report editedGoodOldReportWithDifferentUser =
         withCredentials("arthur", t -> mutationExecutor.updateReport(ReportResourceTest.FIELDS,
             false, getReportInput(createdGoodOldReportWithDifferentUser), true));
@@ -253,6 +259,7 @@ class MartReportImporterWorkerTest extends AbstractResourceTest {
     assertThat(createdReportWithWarnings.getComments().size()).isOne();
     assertThat(createdReportWithWarnings.getComments().getFirst().getText()).isEqualTo(
         "While importing report 34faac7c-8c85-4dec-8e9f-57d9254b5ae2:<ul><li>Security marking is missing</li><li>Can not find task: 'does not exist' with uuid: does not exist</li></ul>");
+    assertReportType(createdReportWithWarnings);
 
     // New records in MartImportedReports, verify them
     AnetBeanList<MartImportedReport> martImportedReportsList =
@@ -428,5 +435,12 @@ class MartReportImporterWorkerTest extends AbstractResourceTest {
 
     when(emailMessageMock.getAttachments()).thenReturn(attachmentCollection, attachmentCollection);
     return emailMessageMock;
+  }
+
+  private void assertReportType(Report anetReport) {
+    final ObjectNode jsonTree = mapper.readTree(anetReport.getCustomFields()).asObject();
+    final JsonNode reportType = jsonTree.get("reportType");
+    assertThat(reportType).isInstanceOf(StringNode.class);
+    assertThat(reportType.stringValue()).isEqualTo("lmt");
   }
 }

--- a/testDictionaries/no-custom-fields.yml
+++ b/testDictionaries/no-custom-fields.yml
@@ -1618,6 +1618,10 @@ dashboards:
     data: /data/dashboards/decisives.json
     type: decisives
 
+martReportImport:
+  customFields:
+    reportType: lmt
+
 martDictionaryExport:
   tasks:
     domainUuid: f07beca6-153e-49da-8aaa-3e29c2a1f4bc


### PR DESCRIPTION
When importing MART reports, sometimes additional customFields need to be added/set, e.g. the reportType. Which customFields need to be added can be defined in the dictionary.

Closes [AB#1649](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1649)

#### User changes
- None

#### Superuser changes
- None

#### Admin changes
- None

#### System admin changes
- [x] application.yml or anet-dictionary.yml needs change
  Add the following to the dictionary:
  ```yaml
  […]

  martReportImport:
    customFields:
      reportType: lmt

  martDictionaryExport:
    […]
  ```
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
- [x] described the user behavior in PR body
- [x] referenced/updated all related issues
- [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
- [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
- [x] added and/or updated unit tests
- [ ] added and/or updated e2e tests
- [ ] added and/or updated data migrations
- [ ] updated documentation
- [x] resolved all build errors and warnings
- [ ] opened debt issues for anything not resolved here