### PR TITLE
Search events by attendee ranks

### DIFF
--- a/client/src/components/SearchFilters.tsx
+++ b/client/src/components/SearchFilters.tsx
@@ -13,6 +13,9 @@ import CheckboxFilter, {
 import DateRangeFilter, {
   deserialize as deserializeDateRangeFilter
 } from "components/advancedSearch/DateRangeFilter"
+import EventAttendeeRanksFilter, {
+  deserialize as deserializeEventAttendeeRanksFilter
+} from "components/advancedSearch/EventAttendeeRanksFilter"
 import LocationFilter, {
   deserialize as deserializeLocationFilter
 } from "components/advancedSearch/LocationFilter"
@@ -751,6 +754,13 @@ export const searchFilters = function (
         deserializer: deserializeDateRangeFilter,
         props: {
           queryKey: "endDate"
+        }
+      },
+      "Attendee Ranks": {
+        component: EventAttendeeRanksFilter,
+        deserializer: deserializeEventAttendeeRanksFilter,
+        props: {
+          queryKey: "attendeeRanks"
         }
       },
       [`Within ${Settings.fields.event.ownerOrg.label}`]: {

--- a/client/src/components/advancedSearch/EventAttendeeRanksFilter.tsx
+++ b/client/src/components/advancedSearch/EventAttendeeRanksFilter.tsx
@@ -1,0 +1,97 @@
+import useSearchFilter from "components/advancedSearch/hooks"
+import _map from "lodash/map"
+import React from "react"
+import { Form } from "react-bootstrap"
+import Settings from "settings"
+
+interface EventAttendeeRanksFilterProps {
+  queryKey: string
+  value?: {
+    attendeeRanks?: string[]
+    toQuery?: (...args: unknown[]) => unknown
+  }
+  onChange?: (...args: unknown[]) => unknown
+  asFormField?: boolean
+}
+
+const EventAttendeeRanksFilter = ({
+  asFormField = true,
+  queryKey,
+  value: inputValue = {},
+  onChange
+}: EventAttendeeRanksFilterProps) => {
+  const ranks = Settings.fields.person.ranks || []
+
+  const defaultValue = {
+    attendeeRanks: inputValue.attendeeRanks || []
+  }
+
+  const toQuery = val => ({
+    attendeeRanks: val.attendeeRanks ?? []
+  })
+
+  const [value, setValue] = useSearchFilter(
+    asFormField,
+    onChange,
+    inputValue,
+    defaultValue,
+    toQuery
+  )
+
+  const filterDisplay =
+    value.attendeeRanks.length === 0
+      ? "All ranks"
+      : value.attendeeRanks.join(" or ")
+
+  return !asFormField ? (
+    filterDisplay
+  ) : (
+    <Form.Group>
+      <Form.Select
+        id={queryKey}
+        multiple
+        value={value.attendeeRanks}
+        onChange={handleChange}
+      >
+        {ranks.map(rank => (
+          <option key={rank.value} value={rank.value}>
+            {rank.value}
+          </option>
+        ))}
+      </Form.Select>
+    </Form.Group>
+  )
+
+  function handleChange(event) {
+    const selectedOptions =
+      event.target.selectedOptions ||
+      Array.from(event.target.options).filter(o => o.selected)
+
+    setValue(prevValue => ({
+      ...prevValue,
+      attendeeRanks: _map(selectedOptions, o => o.value)
+    }))
+  }
+}
+
+export const deserialize = (props, query, key) => {
+  if (!query.attendeeRanks) {
+    return null
+  }
+
+  const value = {
+    attendeeRanks: Array.isArray(query.ranks)
+      ? query.attendeeRanks
+      : [query.attendeeRanks]
+  }
+
+  return {
+    key,
+    value: {
+      ...value,
+      toQuery: value
+    }
+  }
+}
+
+export default EventAttendeeRanksFilter

--- a/client/src/components/advancedSearch/EventAttendeeRanksFilter.tsx
+++ b/client/src/components/advancedSearch/EventAttendeeRanksFilter.tsx
@@ -38,10 +38,7 @@ const EventAttendeeRanksFilter = ({
     toQuery
   )
 
-  const filterDisplay =
-    value.attendeeRanks.length === 0
-      ? "All ranks"
-      : value.attendeeRanks.join(" or ")
+  const filterDisplay = value.attendeeRanks.join(" or ")
 
   return !asFormField ? (
     filterDisplay
@@ -79,11 +76,7 @@ export const deserialize = (props, query, key) => {
     return null
   }
 
-  const value = {
-    attendeeRanks: Array.isArray(query.ranks)
-      ? query.attendeeRanks
-      : [query.attendeeRanks]
-  }
+  const value = { attendeeRanks: query.attendeeRanks }
 
   return {
     key,

--- a/src/main/java/mil/dds/anet/beans/search/EventSearchQuery.java
+++ b/src/main/java/mil/dds/anet/beans/search/EventSearchQuery.java
@@ -6,6 +6,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import mil.dds.anet.beans.Report;
 
 public class EventSearchQuery extends AbstractCommonEventSearchQuery<EventSearchSortBy> {
   @GraphQLQuery
@@ -41,6 +42,9 @@ public class EventSearchQuery extends AbstractCommonEventSearchQuery<EventSearch
   @GraphQLQuery
   @GraphQLInputField
   String eventTypeUuid;
+  @GraphQLQuery
+  @GraphQLInputField
+  List<String> attendeeRanks;
 
   public EventSearchQuery() {
     super(EventSearchSortBy.START_DATE);
@@ -135,10 +139,19 @@ public class EventSearchQuery extends AbstractCommonEventSearchQuery<EventSearch
     this.endDateEnd = endDateEnd;
   }
 
+  public List<String> getAttendeeRanks() {
+    return attendeeRanks;
+  }
+
+  public void setAttendeeRanks(List<String> attendeeRanks) {
+    this.attendeeRanks = attendeeRanks;
+  }
+
   @Override
   public int hashCode() {
     return Objects.hash(super.hashCode(), eventSeriesUuid, locationUuid, taskUuid, includeDate,
-        startDate, endDate, startDateStart, startDateEnd, endDateStart, endDateEnd, eventTypeUuid);
+        startDate, endDate, startDateStart, startDateEnd, endDateStart, endDateEnd, eventTypeUuid,
+        attendeeRanks);
   }
 
   @Override
@@ -156,7 +169,8 @@ public class EventSearchQuery extends AbstractCommonEventSearchQuery<EventSearch
         && Objects.equals(getStartDateEnd(), other.getStartDateEnd())
         && Objects.equals(getEndDateStart(), other.getEndDateStart())
         && Objects.equals(getEndDateEnd(), other.getEndDateEnd())
-        && Objects.equals(getEventTypeUuid(), other.getEventTypeUuid());
+        && Objects.equals(getEventTypeUuid(), other.getEventTypeUuid())
+        && Objects.equals(getAttendeeRanks(), other.getAttendeeRanks());
   }
 
   @Override

--- a/src/main/java/mil/dds/anet/beans/search/EventSearchQuery.java
+++ b/src/main/java/mil/dds/anet/beans/search/EventSearchQuery.java
@@ -182,6 +182,9 @@ public class EventSearchQuery extends AbstractCommonEventSearchQuery<EventSearch
     if (taskUuid != null) {
       clone.setTaskUuid(new ArrayList<>(taskUuid));
     }
+    if (attendeeRanks != null) {
+      clone.setAttendeeRanks(new ArrayList<>(attendeeRanks));
+    }
     return clone;
   }
 }

--- a/src/main/java/mil/dds/anet/search/AbstractEventSearcher.java
+++ b/src/main/java/mil/dds/anet/search/AbstractEventSearcher.java
@@ -87,6 +87,10 @@ public abstract class AbstractEventSearcher extends AbstractSearcher<Event, Even
         query.getEndDateStart(), "endEndDate", "events.\"endDate\"", Comparison.BEFORE,
         query.getEndDateEnd());
 
+    if (!Utils.isEmptyOrNull(query.getAttendeeRanks())) {
+      addAttendeeRanksQuery(query);
+    }
+
     addOrderByClauses(qb, query);
   }
 
@@ -145,6 +149,12 @@ public abstract class AbstractEventSearcher extends AbstractSearcher<Event, Even
       qb.addRecursiveClause(null, "et", "\"taskUuid\"", "parent_tasks", "tasks",
           "\"parentTaskUuid\"", "parentTaskUuid", query.getTaskUuid(), true, null);
     }
+  }
+
+  protected void addAttendeeRanksQuery(EventSearchQuery query) {
+    qb.addFromClause("INNER JOIN \"eventPeople\" ep ON ep.\"eventUuid\" = events.uuid");
+    qb.addFromClause("INNER JOIN \"people\" people ON ep.\"personUuid\" = people.uuid");
+    qb.addInListClause("attendeeRanks", "people.rank", query.getAttendeeRanks());
   }
 
   protected void addOrderByClauses(AbstractSearchQueryBuilder<?, ?> qb, EventSearchQuery query) {

--- a/src/test/java/mil/dds/anet/test/resources/EventResourceTest.java
+++ b/src/test/java/mil/dds/anet/test/resources/EventResourceTest.java
@@ -114,6 +114,16 @@ public class EventResourceTest extends AbstractResourceTest {
     assertThat(searchObjects3).isNotNull();
     assertThat(searchObjects3.getList()).isNotEmpty();
     assertThat(searchObjects3.getList()).hasSize(1);
+
+    // Search filtering by rank of attendees
+    final EventSearchQueryInput query4 =
+        EventSearchQueryInput.builder().withAttendeeRanks(List.of("CIV")).build();
+
+    final AnetBeanList_Event searchObjects4 =
+        withCredentials(adminUser, t -> queryExecutor.eventList(getListFields(FIELDS), query4));
+    assertThat(searchObjects4).isNotNull();
+    assertThat(searchObjects4.getList()).isNotEmpty();
+    assertThat(searchObjects4.getList()).hasSize(1);
   }
 
   @Test

--- a/src/test/resources/anet.graphql
+++ b/src/test/resources/anet.graphql
@@ -633,6 +633,7 @@ input EventInput {
 input EventSearchQueryInput {
   adminOrgUuid: [String]
   anyOrgUuid: [String]
+  attendeeRanks: [String]
   emailNetwork: String
   endDate: Instant
   endDateEnd: Instant


### PR DESCRIPTION
When searching events there is a new filter that allows selecting multiple ranks. If used only the events that have attendees with these ranks will be displayed.

Closes [AB#1645](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1645)

#### User changes
- Has a new event search filter available, attendee ranks implementing the logic described above.

#### Superuser changes
- None

#### Admin changes
- None

#### System admin changes
- [ ] application.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [x] graphql schema has changed

### Checklist
- [x] described the user behavior in PR body
- [x] referenced/updated all related issues
- [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
- [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
- [x] added and/or updated unit tests
- [ ] added and/or updated e2e tests
- [ ] added and/or updated data migrations
- [ ] updated documentation
- [x] resolved all build errors and warnings
- [ ] opened debt issues for anything not resolved here
