### PR TITLE
Change week header format in calendar view

### DIFF
--- a/client/src/components/Calendar.tsx
+++ b/client/src/components/Calendar.tsx
@@ -5,6 +5,7 @@ import dayGridPlugin from "@fullcalendar/daygrid"
 import interactionPlugin from "@fullcalendar/interaction"
 import listPlugin from "@fullcalendar/list"
 import timeGridPlugin from "@fullcalendar/timegrid"
+import moment from "moment"
 import React from "react"
 import Settings from "settings"
 import "./Calendar.css"
@@ -35,6 +36,10 @@ const Calendar = ({
     initialView="dayGridMonth"
     views={{
       timeGridWeek: {
+        // Note: dayHeaderFormat: { weekday: "short", day: "numeric" } doesn't work, prints e.g. "3 Mon" instead of "Mon 3"
+        dayHeaderContent: args => {
+          return moment(args.date).format("ddd D")
+        },
         moreLinkClick: "day"
       },
       dayGrid: {

--- a/client/src/components/aggregations/CalendarWidget.tsx
+++ b/client/src/components/aggregations/CalendarWidget.tsx
@@ -8,6 +8,7 @@ import {
 import _isEmpty from "lodash/isEmpty"
 import React, { useRef } from "react"
 import { useNavigate } from "react-router"
+import Settings from "settings"
 import "../Calendar.css"
 
 const DATE_FORMAT = "YYYY-MM-DD"
@@ -56,6 +57,9 @@ const CalendarWidget = ({
       }}
       height="auto" // assume a natural height, no scrollbars will be used
       aspectRatio={3} // ratio of width-to-height
+      fixedWeekCount={false}
+      firstDay={Settings.useISO8601 ? 1 : 0}
+      weekNumberCalculation={Settings.useISO8601 ? "ISO" : "local"}
       ref={calendarComponentRef}
       events={events}
       eventClick={info => {


### PR DESCRIPTION
Only show the day of the week and the day number in the header of the weekly calendar view.
Also honour the `useISO8601` setting in the aggregated calendar widget.

Closes [AB#1650](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1650)

#### User changes
- Weekly calendar views no longer show the (redundant) month in the header.

#### Superuser changes
- None

#### Admin changes
- None

#### System admin changes
- [ ] application.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
- [x] described the user behavior in PR body
- [x] referenced/updated all related issues
- [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
- [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
- [ ] added and/or updated unit tests
- [ ] added and/or updated e2e tests
- [ ] added and/or updated data migrations
- [ ] updated documentation
- [x] resolved all build errors and warnings
- [ ] opened debt issues for anything not resolved here