### PR TITLE
Clarify which merge field sets the UUID

### DIFF
--- a/client/src/components/MergeField.tsx
+++ b/client/src/components/MergeField.tsx
@@ -1,4 +1,5 @@
 import styled from "@emotion/styled"
+import classNames from "classnames"
 import _get from "lodash/get"
 import _has from "lodash/has"
 import _isEqual from "lodash/isEqual"
@@ -15,6 +16,7 @@ const alignOptions: string[] = Object.values(ALIGN_OPTIONS)
 interface MergeFieldProps {
   label: string
   fieldName: string
+  fieldSetsUuid?: boolean
   value?: React.ReactNode
   align: (typeof alignOptions)[number]
   action?: (...args: unknown[]) => unknown
@@ -28,6 +30,7 @@ interface MergeFieldProps {
 const MergeField = ({
   label,
   fieldName,
+  fieldSetsUuid,
   value,
   align,
   action,
@@ -96,6 +99,7 @@ const MergeField = ({
 
   return (
     <MergeFieldBox
+      className={classNames({ "bg-info-subtle": fieldSetsUuid })}
       align={align}
       ref={fieldRef}
       /* We first let its height be auto to get the natural height */

--- a/client/src/mergeUtils.tsx
+++ b/client/src/mergeUtils.tsx
@@ -325,27 +325,56 @@ export function areAllSet(...args) {
   })
 }
 
+export function isMergeFieldSelected(
+  mergeState: any,
+  fieldName: string,
+  mergeSide?: (typeof MERGE_SIDES)[keyof typeof MERGE_SIDES]
+) {
+  return mergeState?.selectedMap?.[fieldName] === mergeSide
+}
+
+export function isMergeFieldEmpty(mergeState: any, fieldName: string) {
+  return !mergeState?.selectedMap?.[fieldName]
+}
+
+export function isMergeFieldSelectedOrEmpty(
+  mergeState: any,
+  fieldName: string,
+  mergeSide?: (typeof MERGE_SIDES)[keyof typeof MERGE_SIDES]
+) {
+  return (
+    isMergeFieldSelected(mergeState, fieldName, mergeSide) ||
+    isMergeFieldEmpty(mergeState, fieldName)
+  )
+}
+
 export function getActionButton(
-  onClickAction,
-  align,
-  mergeState,
-  fieldName,
-  disabled = false,
-  text = ""
+  onClickAction: () => void,
+  mergeSide: (typeof MERGE_SIDES)[keyof typeof MERGE_SIDES],
+  mergeState: any,
+  fieldName: string,
+  disabled: boolean = false,
+  text: string = ""
 ) {
   return (
     <small>
       <Button
         variant={
-          mergeState?.selectedMap?.[fieldName] === align ? "success" : "primary"
+          isMergeFieldSelected(mergeState, fieldName, mergeSide)
+            ? "success"
+            : "primary"
         }
         onClick={onClickAction}
         disabled={disabled}
         style={{ textAlign: "center" }}
       >
-        {align === "right" && <Icon icon={IconNames.DOUBLE_CHEVRON_LEFT} />}
+        {mergeSide === MERGE_SIDES.RIGHT && (
+          <Icon icon={IconNames.DOUBLE_CHEVRON_LEFT} />
+        )}
         {text}
-        {align !== "right" && <Icon icon={IconNames.DOUBLE_CHEVRON_RIGHT} />}
+        {mergeSide !== MERGE_SIDES.RIGHT && (
+          <Icon icon={IconNames.DOUBLE_CHEVRON_RIGHT} />
+        )}
       </Button>
     </small>
   )

--- a/client/src/pages/admin/merge/MergeEventSeries.tsx
+++ b/client/src/pages/admin/merge/MergeEventSeries.tsx
@@ -437,6 +437,7 @@ const EventSeriesColumn = ({
             wrappedComponent={MergeField}
             dictProps={Settings.fields.eventSeries.name}
             fieldName="name"
+            fieldSetsUuid
             value={eventSeries.name}
             align={align}
             action={() => {

--- a/client/src/pages/admin/merge/MergeEventSeries.tsx
+++ b/client/src/pages/admin/merge/MergeEventSeries.tsx
@@ -209,6 +209,7 @@ const MergeEventSeries = ({ pageDispatchers }: MergeEventSeriesProps) => {
                 value={mergedEventSeries.name}
                 align={ALIGN_OPTIONS.CENTER}
                 fieldName="name"
+                fieldSetsUuid={!!mergeState?.merged?.uuid}
                 mergeState={mergeState}
                 dispatchMergeActions={dispatchMergeActions}
               />
@@ -437,7 +438,10 @@ const EventSeriesColumn = ({
             wrappedComponent={MergeField}
             dictProps={Settings.fields.eventSeries.name}
             fieldName="name"
-            fieldSetsUuid
+            fieldSetsUuid={
+              !mergeState?.merged?.uuid ||
+              mergeState?.merged?.uuid === eventSeries.uuid
+            }
             value={eventSeries.name}
             align={align}
             action={() => {

--- a/client/src/pages/admin/merge/MergeEventSeries.tsx
+++ b/client/src/pages/admin/merge/MergeEventSeries.tsx
@@ -34,6 +34,8 @@ import useMergeObjects, {
   areAllSet,
   getActionButton,
   getOtherSide,
+  isMergeFieldEmpty,
+  isMergeFieldSelectedOrEmpty,
   MERGE_SIDES,
   selectAllFields,
   setAMergedField,
@@ -175,6 +177,15 @@ const MergeEventSeries = ({ pageDispatchers }: MergeEventSeriesProps) => {
           {areAllSet(eventSeries1, eventSeries2, mergedEventSeries) && (
             <fieldset>
               <MergeField
+                label="UUID"
+                value={mergedEventSeries.uuid}
+                align={ALIGN_OPTIONS.CENTER}
+                fieldName="uuid"
+                fieldSetsUuid={!isMergeFieldEmpty(mergeState, "uuid")}
+                mergeState={mergeState}
+                dispatchMergeActions={dispatchMergeActions}
+              />
+              <MergeField
                 label="Avatar"
                 value={
                   <EntityAvatarDisplay
@@ -209,7 +220,6 @@ const MergeEventSeries = ({ pageDispatchers }: MergeEventSeriesProps) => {
                 value={mergedEventSeries.name}
                 align={ALIGN_OPTIONS.CENTER}
                 fieldName="name"
-                fieldSetsUuid={!!mergeState?.merged?.uuid}
                 mergeState={mergeState}
                 dispatchMergeActions={dispatchMergeActions}
               />
@@ -394,6 +404,24 @@ const EventSeriesColumn = ({
       {areAllSet(eventSeries) && (
         <fieldset>
           <MergeField
+            label="UUID"
+            fieldName="uuid"
+            fieldSetsUuid={isMergeFieldSelectedOrEmpty(
+              mergeState,
+              "uuid",
+              align
+            )}
+            value={eventSeries.uuid}
+            align={align}
+            action={() => {
+              dispatchMergeActions(
+                setAMergedField("uuid", eventSeries.uuid, align)
+              )
+            }}
+            mergeState={mergeState}
+            dispatchMergeActions={dispatchMergeActions}
+          />
+          <MergeField
             label="Avatar"
             fieldName="entityAvatar"
             value={
@@ -438,18 +466,11 @@ const EventSeriesColumn = ({
             wrappedComponent={MergeField}
             dictProps={Settings.fields.eventSeries.name}
             fieldName="name"
-            fieldSetsUuid={
-              !mergeState?.merged?.uuid ||
-              mergeState?.merged?.uuid === eventSeries.uuid
-            }
             value={eventSeries.name}
             align={align}
             action={() => {
               dispatchMergeActions(
                 setAMergedField("name", eventSeries.name, align)
-              )
-              dispatchMergeActions(
-                setAMergedField("uuid", eventSeries.uuid, align)
               )
             }}
             autoMerge

--- a/client/src/pages/admin/merge/MergeEventSeries.tsx
+++ b/client/src/pages/admin/merge/MergeEventSeries.tsx
@@ -426,9 +426,6 @@ const EventSeriesColumn = ({
             align={align}
             action={() => {
               dispatchMergeActions(
-                setAMergedField("uuid", eventSeries.uuid, align)
-              )
-              dispatchMergeActions(
                 setAMergedField("status", eventSeries.status, align)
               )
             }}
@@ -444,10 +441,10 @@ const EventSeriesColumn = ({
             align={align}
             action={() => {
               dispatchMergeActions(
-                setAMergedField("uuid", eventSeries.uuid, align)
+                setAMergedField("name", eventSeries.name, align)
               )
               dispatchMergeActions(
-                setAMergedField("name", eventSeries.name, align)
+                setAMergedField("uuid", eventSeries.uuid, align)
               )
             }}
             autoMerge
@@ -461,9 +458,6 @@ const EventSeriesColumn = ({
             value={<RichTextEditor readOnly value={eventSeries.description} />}
             align={align}
             action={() => {
-              dispatchMergeActions(
-                setAMergedField("uuid", eventSeries.uuid, align)
-              )
               dispatchMergeActions(
                 setAMergedField("description", eventSeries.description, align)
               )
@@ -481,9 +475,6 @@ const EventSeriesColumn = ({
             }
             align={align}
             action={() => {
-              dispatchMergeActions(
-                setAMergedField("uuid", eventSeries.uuid, align)
-              )
               dispatchMergeActions(
                 setAMergedField("ownerOrg", eventSeries.ownerOrg, align)
               )
@@ -520,9 +511,6 @@ const EventSeriesColumn = ({
             }
             align={align}
             action={() => {
-              dispatchMergeActions(
-                setAMergedField("uuid", eventSeries.uuid, align)
-              )
               dispatchMergeActions(
                 setAMergedField("adminOrg", eventSeries.adminOrg, align)
               )

--- a/client/src/pages/admin/merge/MergeLocations.tsx
+++ b/client/src/pages/admin/merge/MergeLocations.tsx
@@ -537,6 +537,7 @@ const LocationColumn = ({
             wrappedComponent={MergeField}
             dictProps={Settings.fields.location.name}
             fieldName="name"
+            fieldSetsUuid
             value={location.name}
             align={align}
             action={() => {

--- a/client/src/pages/admin/merge/MergeLocations.tsx
+++ b/client/src/pages/admin/merge/MergeLocations.tsx
@@ -213,6 +213,7 @@ const MergeLocations = ({ pageDispatchers }: MergeLocationsProps) => {
                 value={mergedLocation.name}
                 align={ALIGN_OPTIONS.CENTER}
                 fieldName="name"
+                fieldSetsUuid={!!mergeState?.merged?.uuid}
                 mergeState={mergeState}
                 dispatchMergeActions={dispatchMergeActions}
               />
@@ -537,7 +538,10 @@ const LocationColumn = ({
             wrappedComponent={MergeField}
             dictProps={Settings.fields.location.name}
             fieldName="name"
-            fieldSetsUuid
+            fieldSetsUuid={
+              !mergeState?.merged?.uuid ||
+              mergeState?.merged?.uuid === location.uuid
+            }
             value={location.name}
             align={align}
             action={() => {

--- a/client/src/pages/admin/merge/MergeLocations.tsx
+++ b/client/src/pages/admin/merge/MergeLocations.tsx
@@ -651,11 +651,9 @@ const LocationColumn = ({
             }
             align={align}
             action={() => {
-              if (location.geoJson) {
-                dispatchMergeActions(
-                  setAMergedField("geoJson", location.geoJson, align)
-                )
-              }
+              dispatchMergeActions(
+                setAMergedField("geoJson", location.geoJson, align)
+              )
             }}
             mergeState={mergeState}
             autoMerge

--- a/client/src/pages/admin/merge/MergeLocations.tsx
+++ b/client/src/pages/admin/merge/MergeLocations.tsx
@@ -35,6 +35,8 @@ import useMergeObjects, {
   areAllSet,
   getActionButton,
   getOtherSide,
+  isMergeFieldEmpty,
+  isMergeFieldSelectedOrEmpty,
   LeafletMap,
   LeafletMode,
   MERGE_SIDES,
@@ -188,6 +190,15 @@ const MergeLocations = ({ pageDispatchers }: MergeLocationsProps) => {
           {areAllSet(location1, location2, mergedLocation) && (
             <fieldset>
               <MergeField
+                label="UUID"
+                value={mergedLocation.uuid}
+                align={ALIGN_OPTIONS.CENTER}
+                fieldName="uuid"
+                fieldSetsUuid={!isMergeFieldEmpty(mergeState, "uuid")}
+                mergeState={mergeState}
+                dispatchMergeActions={dispatchMergeActions}
+              />
+              <MergeField
                 label="Avatar"
                 value={
                   <EntityAvatarDisplay
@@ -213,7 +224,6 @@ const MergeLocations = ({ pageDispatchers }: MergeLocationsProps) => {
                 value={mergedLocation.name}
                 align={ALIGN_OPTIONS.CENTER}
                 fieldName="name"
-                fieldSetsUuid={!!mergeState?.merged?.uuid}
                 mergeState={mergeState}
                 dispatchMergeActions={dispatchMergeActions}
               />
@@ -509,6 +519,24 @@ const LocationColumn = ({
       {areAllSet(location) && (
         <fieldset>
           <MergeField
+            label="UUID"
+            fieldName="uuid"
+            fieldSetsUuid={isMergeFieldSelectedOrEmpty(
+              mergeState,
+              "uuid",
+              align
+            )}
+            value={location.uuid}
+            align={align}
+            action={() => {
+              dispatchMergeActions(
+                setAMergedField("uuid", location.uuid, align)
+              )
+            }}
+            mergeState={mergeState}
+            dispatchMergeActions={dispatchMergeActions}
+          />
+          <MergeField
             label="Avatar"
             fieldName="entityAvatar"
             value={
@@ -538,18 +566,11 @@ const LocationColumn = ({
             wrappedComponent={MergeField}
             dictProps={Settings.fields.location.name}
             fieldName="name"
-            fieldSetsUuid={
-              !mergeState?.merged?.uuid ||
-              mergeState?.merged?.uuid === location.uuid
-            }
             value={location.name}
             align={align}
             action={() => {
               dispatchMergeActions(
                 setAMergedField("name", location.name, align)
-              )
-              dispatchMergeActions(
-                setAMergedField("uuid", location.uuid, align)
               )
             }}
             mergeState={mergeState}

--- a/client/src/pages/admin/merge/MergeOrganizations.tsx
+++ b/client/src/pages/admin/merge/MergeOrganizations.tsx
@@ -623,6 +623,7 @@ const OrganizationColumn = ({
             wrappedComponent={MergeField}
             dictProps={Settings.fields.organization.shortName}
             fieldName="shortName"
+            fieldSetsUuid
             value={organization.shortName}
             align={align}
             action={() => {

--- a/client/src/pages/admin/merge/MergeOrganizations.tsx
+++ b/client/src/pages/admin/merge/MergeOrganizations.tsx
@@ -282,6 +282,7 @@ const MergeOrganizations = ({ pageDispatchers }: MergeOrganizationsProps) => {
                 value={mergedOrganization.shortName}
                 align={ALIGN_OPTIONS.CENTER}
                 fieldName="shortName"
+                fieldSetsUuid={!!mergeState?.merged?.uuid}
                 mergeState={mergeState}
                 dispatchMergeActions={dispatchMergeActions}
               />
@@ -623,7 +624,10 @@ const OrganizationColumn = ({
             wrappedComponent={MergeField}
             dictProps={Settings.fields.organization.shortName}
             fieldName="shortName"
-            fieldSetsUuid
+            fieldSetsUuid={
+              !mergeState?.merged?.uuid ||
+              mergeState?.merged?.uuid === organization.uuid
+            }
             value={organization.shortName}
             align={align}
             action={() => {

--- a/client/src/pages/admin/merge/MergeOrganizations.tsx
+++ b/client/src/pages/admin/merge/MergeOrganizations.tsx
@@ -45,6 +45,8 @@ import useMergeObjects, {
   areAllSet,
   getActionButton,
   getOtherSide,
+  isMergeFieldEmpty,
+  isMergeFieldSelectedOrEmpty,
   LeafletMap,
   MERGE_SIDES,
   mergedOrganizationIsValid,
@@ -257,6 +259,15 @@ const MergeOrganizations = ({ pageDispatchers }: MergeOrganizationsProps) => {
           {areAllSet(organization1, organization2, mergedOrganization) && (
             <fieldset>
               <MergeField
+                label="UUID"
+                value={mergedOrganization.uuid}
+                align={ALIGN_OPTIONS.CENTER}
+                fieldName="uuid"
+                fieldSetsUuid={!isMergeFieldEmpty(mergeState, "uuid")}
+                mergeState={mergeState}
+                dispatchMergeActions={dispatchMergeActions}
+              />
+              <MergeField
                 label="Avatar"
                 value={
                   <EntityAvatarDisplay
@@ -282,7 +293,6 @@ const MergeOrganizations = ({ pageDispatchers }: MergeOrganizationsProps) => {
                 value={mergedOrganization.shortName}
                 align={ALIGN_OPTIONS.CENTER}
                 fieldName="shortName"
-                fieldSetsUuid={!!mergeState?.merged?.uuid}
                 mergeState={mergeState}
                 dispatchMergeActions={dispatchMergeActions}
               />
@@ -591,6 +601,24 @@ const OrganizationColumn = ({
       {areAllSet(organization) && (
         <fieldset>
           <MergeField
+            label="UUID"
+            fieldName="uuid"
+            fieldSetsUuid={isMergeFieldSelectedOrEmpty(
+              mergeState,
+              "uuid",
+              align
+            )}
+            value={organization.uuid}
+            align={align}
+            action={() => {
+              dispatchMergeActions(
+                setAMergedField("uuid", organization.uuid, align)
+              )
+            }}
+            mergeState={mergeState}
+            dispatchMergeActions={dispatchMergeActions}
+          />
+          <MergeField
             label="Avatar"
             fieldName="entityAvatar"
             value={
@@ -624,16 +652,9 @@ const OrganizationColumn = ({
             wrappedComponent={MergeField}
             dictProps={Settings.fields.organization.shortName}
             fieldName="shortName"
-            fieldSetsUuid={
-              !mergeState?.merged?.uuid ||
-              mergeState?.merged?.uuid === organization.uuid
-            }
             value={organization.shortName}
             align={align}
             action={() => {
-              dispatchMergeActions(
-                setAMergedField("uuid", organization.uuid, align)
-              )
               dispatchMergeActions(
                 setAMergedField("shortName", organization.shortName, align)
               )

--- a/client/src/pages/admin/merge/MergePeople.tsx
+++ b/client/src/pages/admin/merge/MergePeople.tsx
@@ -642,6 +642,7 @@ const PersonColumn = ({
             wrappedComponent={MergeField}
             dictProps={Settings.fields.person.familyName}
             fieldName="familyName"
+            fieldSetsUuid
             value={person.familyName}
             align={align}
             action={() => {

--- a/client/src/pages/admin/merge/MergePeople.tsx
+++ b/client/src/pages/admin/merge/MergePeople.tsx
@@ -246,6 +246,7 @@ const MergePeople = ({ pageDispatchers }: MergePeopleProps) => {
                 value={mergedPerson.familyName}
                 align={ALIGN_OPTIONS.CENTER}
                 fieldName="familyName"
+                fieldSetsUuid={!!mergeState?.merged?.uuid}
                 mergeState={mergeState}
                 dispatchMergeActions={dispatchMergeActions}
               />
@@ -642,7 +643,10 @@ const PersonColumn = ({
             wrappedComponent={MergeField}
             dictProps={Settings.fields.person.familyName}
             fieldName="familyName"
-            fieldSetsUuid
+            fieldSetsUuid={
+              !mergeState?.merged?.uuid ||
+              mergeState?.merged?.uuid === person.uuid
+            }
             value={person.familyName}
             align={align}
             action={() => {

--- a/client/src/pages/admin/merge/MergePeople.tsx
+++ b/client/src/pages/admin/merge/MergePeople.tsx
@@ -37,6 +37,9 @@ import useMergeObjects, {
   areAllSet,
   getActionButton,
   getOtherSide,
+  isMergeFieldEmpty,
+  isMergeFieldSelected,
+  isMergeFieldSelectedOrEmpty,
   MERGE_SIDES,
   mergedPersonIsValid,
   selectAllFields,
@@ -221,6 +224,15 @@ const MergePeople = ({ pageDispatchers }: MergePeopleProps) => {
           {areAllSet(person1, person2, mergedPerson) && (
             <fieldset>
               <MergeField
+                label="UUID"
+                value={mergedPerson.uuid}
+                align={ALIGN_OPTIONS.CENTER}
+                fieldName="uuid"
+                fieldSetsUuid={!isMergeFieldEmpty(mergeState, "uuid")}
+                mergeState={mergeState}
+                dispatchMergeActions={dispatchMergeActions}
+              />
+              <MergeField
                 label="Avatar"
                 value={
                   <EntityAvatarDisplay
@@ -246,7 +258,6 @@ const MergePeople = ({ pageDispatchers }: MergePeopleProps) => {
                 value={mergedPerson.familyName}
                 align={ALIGN_OPTIONS.CENTER}
                 fieldName="familyName"
-                fieldSetsUuid={!!mergeState?.merged?.uuid}
                 mergeState={mergeState}
                 dispatchMergeActions={dispatchMergeActions}
               />
@@ -614,6 +625,22 @@ const PersonColumn = ({
       {areAllSet(person) && (
         <fieldset>
           <MergeField
+            label="UUID"
+            fieldName="uuid"
+            fieldSetsUuid={isMergeFieldSelectedOrEmpty(
+              mergeState,
+              "uuid",
+              align
+            )}
+            value={person.uuid}
+            align={align}
+            action={() => {
+              dispatchMergeActions(setAMergedField("uuid", person.uuid, align))
+            }}
+            mergeState={mergeState}
+            dispatchMergeActions={dispatchMergeActions}
+          />
+          <MergeField
             label="Avatar"
             fieldName="entityAvatar"
             value={
@@ -643,17 +670,12 @@ const PersonColumn = ({
             wrappedComponent={MergeField}
             dictProps={Settings.fields.person.familyName}
             fieldName="familyName"
-            fieldSetsUuid={
-              !mergeState?.merged?.uuid ||
-              mergeState?.merged?.uuid === person.uuid
-            }
             value={person.familyName}
             align={align}
             action={() => {
               dispatchMergeActions(
                 setAMergedField("familyName", person.familyName, align)
               )
-              dispatchMergeActions(setAMergedField("uuid", person.uuid, align))
             }}
             mergeState={mergeState}
             dispatchMergeActions={dispatchMergeActions}

--- a/client/src/pages/admin/merge/MergePositions.tsx
+++ b/client/src/pages/admin/merge/MergePositions.tsx
@@ -706,6 +706,7 @@ const PositionColumn = ({
           <MergeField
             label="Person"
             fieldName="person"
+            fieldSetsUuid
             value={<LinkTo modelType="Person" model={position.person} />}
             align={align}
             action={() => {

--- a/client/src/pages/admin/merge/MergePositions.tsx
+++ b/client/src/pages/admin/merge/MergePositions.tsx
@@ -316,6 +316,7 @@ const MergePositions = ({ pageDispatchers }: MergePositionsProps) => {
                 }
                 align={ALIGN_OPTIONS.CENTER}
                 fieldName="person"
+                fieldSetsUuid={!!mergeState?.merged?.uuid}
                 mergeState={mergeState}
                 dispatchMergeActions={dispatchMergeActions}
               />
@@ -706,7 +707,10 @@ const PositionColumn = ({
           <MergeField
             label="Person"
             fieldName="person"
-            fieldSetsUuid
+            fieldSetsUuid={
+              !mergeState?.merged?.uuid ||
+              mergeState?.merged?.uuid === position.uuid
+            }
             value={<LinkTo modelType="Person" model={position.person} />}
             align={align}
             action={() => {

--- a/client/src/pages/admin/merge/MergePositions.tsx
+++ b/client/src/pages/admin/merge/MergePositions.tsx
@@ -34,6 +34,8 @@ import useMergeObjects, {
   areAllSet,
   getActionButton,
   getOtherSide,
+  isMergeFieldEmpty,
+  isMergeFieldSelectedOrEmpty,
   LeafletMap,
   MERGE_SIDES,
   selectAllFields,
@@ -172,6 +174,15 @@ const MergePositions = ({ pageDispatchers }: MergePositionsProps) => {
           )}
           {areAllSet(position1, position2, mergedPosition) && (
             <fieldset>
+              <MergeField
+                label="UUID"
+                value={mergedPosition.uuid}
+                align={ALIGN_OPTIONS.CENTER}
+                fieldName="uuid"
+                fieldSetsUuid={!isMergeFieldEmpty(mergeState, "uuid")}
+                mergeState={mergeState}
+                dispatchMergeActions={dispatchMergeActions}
+              />
               <MergeField
                 label="Avatar"
                 value={
@@ -316,7 +327,6 @@ const MergePositions = ({ pageDispatchers }: MergePositionsProps) => {
                 }
                 align={ALIGN_OPTIONS.CENTER}
                 fieldName="person"
-                fieldSetsUuid={!!mergeState?.merged?.uuid}
                 mergeState={mergeState}
                 dispatchMergeActions={dispatchMergeActions}
               />
@@ -531,6 +541,24 @@ const PositionColumn = ({
       {areAllSet(position) && (
         <fieldset>
           <MergeField
+            label="UUID"
+            fieldName="uuid"
+            fieldSetsUuid={isMergeFieldSelectedOrEmpty(
+              mergeState,
+              "uuid",
+              align
+            )}
+            value={position.uuid}
+            align={align}
+            action={() => {
+              dispatchMergeActions(
+                setAMergedField("uuid", position.uuid, align)
+              )
+            }}
+            mergeState={mergeState}
+            dispatchMergeActions={dispatchMergeActions}
+          />
+          <MergeField
             label="Avatar"
             fieldName="entityAvatar"
             value={
@@ -707,19 +735,11 @@ const PositionColumn = ({
           <MergeField
             label="Person"
             fieldName="person"
-            fieldSetsUuid={
-              !mergeState?.merged?.uuid ||
-              mergeState?.merged?.uuid === position.uuid
-            }
             value={<LinkTo modelType="Person" model={position.person} />}
             align={align}
             action={() => {
               dispatchMergeActions(
                 setAMergedField("person", position.person, align)
-              )
-              // setting person should also set uuid so we select the position's uuid with person assigned
-              dispatchMergeActions(
-                setAMergedField("uuid", position.uuid, align)
               )
             }}
             mergeState={mergeState}

--- a/client/src/pages/admin/merge/MergeTasks.tsx
+++ b/client/src/pages/admin/merge/MergeTasks.tsx
@@ -468,6 +468,7 @@ const TaskColumn = ({
             wrappedComponent={MergeField}
             dictProps={Settings.fields.task.shortName}
             fieldName="shortName"
+            fieldSetsUuid
             value={task.shortName}
             align={align}
             action={() => {

--- a/client/src/pages/admin/merge/MergeTasks.tsx
+++ b/client/src/pages/admin/merge/MergeTasks.tsx
@@ -40,6 +40,8 @@ import useMergeObjects, {
   areAllSet,
   getActionButton,
   getOtherSide,
+  isMergeFieldEmpty,
+  isMergeFieldSelectedOrEmpty,
   MERGE_SIDES,
   selectAllFields,
   setAMergedField,
@@ -219,13 +221,21 @@ const MergeTasks = ({ pageDispatchers }: MergeTasksProps) => {
           )}
           {areAllSet(task1, task2, mergedTask) && (
             <fieldset>
+              <MergeField
+                label="UUID"
+                value={mergedTask.uuid}
+                align={ALIGN_OPTIONS.CENTER}
+                fieldName="uuid"
+                fieldSetsUuid={!isMergeFieldEmpty(mergeState, "uuid")}
+                mergeState={mergeState}
+                dispatchMergeActions={dispatchMergeActions}
+              />
               <DictionaryField
                 wrappedComponent={MergeField}
                 dictProps={Settings.fields.task.shortName}
                 value={mergedTask.shortName}
                 align={ALIGN_OPTIONS.CENTER}
                 fieldName="shortName"
-                fieldSetsUuid={!!mergeState?.merged?.uuid}
                 mergeState={mergeState}
                 dispatchMergeActions={dispatchMergeActions}
               />
@@ -465,18 +475,29 @@ const TaskColumn = ({
       </ColTitle>
       {areAllSet(task) && (
         <fieldset>
+          <MergeField
+            label="UUID"
+            fieldName="uuid"
+            fieldSetsUuid={isMergeFieldSelectedOrEmpty(
+              mergeState,
+              "uuid",
+              align
+            )}
+            value={task.uuid}
+            align={align}
+            action={() => {
+              dispatchMergeActions(setAMergedField("uuid", task.uuid, align))
+            }}
+            mergeState={mergeState}
+            dispatchMergeActions={dispatchMergeActions}
+          />
           <DictionaryField
             wrappedComponent={MergeField}
             dictProps={Settings.fields.task.shortName}
             fieldName="shortName"
-            fieldSetsUuid={
-              !mergeState?.merged?.uuid ||
-              mergeState?.merged?.uuid === task.uuid
-            }
             value={task.shortName}
             align={align}
             action={() => {
-              dispatchMergeActions(setAMergedField("uuid", task.uuid, align))
               dispatchMergeActions(
                 setAMergedField("shortName", task.shortName, align)
               )

--- a/client/src/pages/admin/merge/MergeTasks.tsx
+++ b/client/src/pages/admin/merge/MergeTasks.tsx
@@ -225,6 +225,7 @@ const MergeTasks = ({ pageDispatchers }: MergeTasksProps) => {
                 value={mergedTask.shortName}
                 align={ALIGN_OPTIONS.CENTER}
                 fieldName="shortName"
+                fieldSetsUuid={!!mergeState?.merged?.uuid}
                 mergeState={mergeState}
                 dispatchMergeActions={dispatchMergeActions}
               />
@@ -468,7 +469,10 @@ const TaskColumn = ({
             wrappedComponent={MergeField}
             dictProps={Settings.fields.task.shortName}
             fieldName="shortName"
-            fieldSetsUuid
+            fieldSetsUuid={
+              !mergeState?.merged?.uuid ||
+              mergeState?.merged?.uuid === task.uuid
+            }
             value={task.shortName}
             align={align}
             action={() => {

--- a/client/tests/webdriver/baseSpecs/mergeEventSeries.spec.js
+++ b/client/tests/webdriver/baseSpecs/mergeEventSeries.spec.js
@@ -4,16 +4,19 @@ import MergeEventSeries from "../pages/mergeEventSeries.page"
 const EXAMPLE_EVENT_SERIES = {
   validLeft: {
     search: "Merged Duplicated Winner",
+    uuid: "19a98fee-4864-4b04-a983-b837aadbfe8c",
     name: "Merged Duplicated Winner",
     status: "ACTIVE"
   },
   validRight: {
     search: "Merged Duplicated Loser",
+    uuid: "071ce130-78fa-4c81-951f-9175b677c7b1",
     name: "Merged Duplicated Loser",
     description: "Loser test event series that will be merged",
     status: "ACTIVE"
   },
   result: {
+    uuid: "19a98fee-4864-4b04-a983-b837aadbfe8c",
     name: "Merged Duplicated Winner",
     description: "Loser test event series that will be merged",
     ownerOrganization: "EF 2.2",
@@ -80,12 +83,17 @@ describe("Merge event series page", () => {
       EXAMPLE_EVENT_SERIES.validLeft.name
     )
     await (await MergeEventSeries.getItemFromAdvancedSelect()).click()
-    await browser.pause(500)
+    await browser.pause(500) // wait for the rendering of custom fields
+    // Check if the fields displayed properly after selecting from left side.
     await MergeEventSeries.waitForColumnToChange(
-      EXAMPLE_EVENT_SERIES.validLeft.name,
+      EXAMPLE_EVENT_SERIES.validLeft.uuid,
       "left",
-      "Name"
+      "UUID"
     )
+
+    expect(
+      await (await MergeEventSeries.getColumnContent("left", "UUID")).getText()
+    ).to.eq(EXAMPLE_EVENT_SERIES.validLeft.uuid)
     expect(
       await (await MergeEventSeries.getColumnContent("left", "Name")).getText()
     ).to.eq(EXAMPLE_EVENT_SERIES.validLeft.name)
@@ -115,12 +123,17 @@ describe("Merge event series page", () => {
       EXAMPLE_EVENT_SERIES.validRight.name
     )
     await (await MergeEventSeries.getItemFromAdvancedSelect()).click()
-    await browser.pause(500)
+    await browser.pause(500) // wait for the rendering of custom fields
+    // Check if the fields displayed properly after selecting from right side.
     await MergeEventSeries.waitForColumnToChange(
-      EXAMPLE_EVENT_SERIES.validRight.name,
+      EXAMPLE_EVENT_SERIES.validRight.uuid,
       "right",
-      "Name"
+      "UUID"
     )
+
+    expect(
+      await (await MergeEventSeries.getColumnContent("right", "UUID")).getText()
+    ).to.eq(EXAMPLE_EVENT_SERIES.validRight.uuid)
     expect(
       await (await MergeEventSeries.getColumnContent("right", "Name")).getText()
     ).to.eq(EXAMPLE_EVENT_SERIES.validRight.name)
@@ -137,13 +150,17 @@ describe("Merge event series page", () => {
 
   it("Should be able to select all fields from left event series", async () => {
     await (await MergeEventSeries.getUseAllButton("left")).click()
-    await browser.pause(500)
-
+    await browser.pause(500) // wait for the rendering of custom fields
+    // Check if the fields displayed properly after selecting from left side.
     await MergeEventSeries.waitForColumnToChange(
-      EXAMPLE_EVENT_SERIES.validLeft.name,
+      EXAMPLE_EVENT_SERIES.validLeft.uuid,
       "mid",
-      "Name"
+      "UUID"
     )
+
+    expect(
+      await (await MergeEventSeries.getColumnContent("mid", "UUID")).getText()
+    ).to.eq(EXAMPLE_EVENT_SERIES.validLeft.uuid)
     expect(
       await (await MergeEventSeries.getColumnContent("mid", "Name")).getText()
     ).to.eq(EXAMPLE_EVENT_SERIES.validLeft.name)
@@ -151,28 +168,32 @@ describe("Merge event series page", () => {
 
   it("Should be able to select all fields from right event series", async () => {
     await (await MergeEventSeries.getUseAllButton("right")).click()
-    await browser.pause(500)
-
+    await browser.pause(500) // wait for the rendering of custom fields
+    // Check if the fields displayed properly after selecting from right side.
     await MergeEventSeries.waitForColumnToChange(
-      EXAMPLE_EVENT_SERIES.validRight.name,
+      EXAMPLE_EVENT_SERIES.validRight.uuid,
       "mid",
-      "Name"
+      "UUID"
     )
+
+    expect(
+      await (await MergeEventSeries.getColumnContent("mid", "UUID")).getText()
+    ).to.eq(EXAMPLE_EVENT_SERIES.validRight.uuid)
     expect(
       await (await MergeEventSeries.getColumnContent("mid", "Name")).getText()
     ).to.eq(EXAMPLE_EVENT_SERIES.validRight.name)
   })
 
   it("Should be able to select from both left and right side", async () => {
-    await (await MergeEventSeries.getLeftEventSeriesField()).click()
-    await (
-      await MergeEventSeries.getLeftEventSeriesField()
-    ).setValue(EXAMPLE_EVENT_SERIES.validLeft.search)
-    await MergeEventSeries.waitForAdvancedSelectLoading(
-      EXAMPLE_EVENT_SERIES.validLeft.name
+    await (await MergeEventSeries.getSelectButton("left", "UUID")).click()
+    await MergeEventSeries.waitForColumnToChange(
+      EXAMPLE_EVENT_SERIES.validLeft.uuid,
+      "mid",
+      "UUID"
     )
-    await (await MergeEventSeries.getItemFromAdvancedSelect()).click()
-    await browser.pause(500)
+    expect(
+      await (await MergeEventSeries.getColumnContent("mid", "UUID")).getText()
+    ).to.eq(EXAMPLE_EVENT_SERIES.validLeft.uuid)
 
     await (await MergeEventSeries.getSelectButton("left", "Name")).click()
     await MergeEventSeries.waitForColumnToChange(

--- a/client/tests/webdriver/baseSpecs/mergeLocations.spec.js
+++ b/client/tests/webdriver/baseSpecs/mergeLocations.spec.js
@@ -19,6 +19,7 @@ const EXAMPLE_LOCATIONS = {
     type: "Point location",
     fullName: "Merge Location Winner",
     latLon: "38.58809, -28.71611",
+    geoJson: "No shape defined",
     status: "ACTIVE",
     parentLocations: "Name Type\nPortugal\nCountry",
     planningApprovalSteps:
@@ -32,6 +33,7 @@ const EXAMPLE_LOCATIONS = {
     type: "Country",
     fullName: "Andorra",
     latLon: "",
+    geoJson: "No shape defined",
     status: "ACTIVE",
     parentLocations: "No locations found",
     digram: "AN",
@@ -46,6 +48,7 @@ const EXAMPLE_LOCATIONS = {
     type: "Point location",
     fullName: "Merge Location Loser",
     latLon: "-46.4035948, 51.69093",
+    geoJson: "No shape defined",
     status: "ACTIVE",
     parentLocations: "Name Type\nFrench Southern Territories\nCountry",
     planningApprovalSteps:
@@ -234,6 +237,17 @@ describe("Merge locations page", () => {
     expect(
       await (await MergeLocations.getColumnContent("mid", "Status")).getText()
     ).to.eq(EXAMPLE_LOCATIONS.right.status)
+
+    expect(
+      await (
+        await MergeLocations.getColumnContent("mid", "Shape (GeoJSON)")
+      ).getText()
+    ).to.eq(EXAMPLE_LOCATIONS.leftCountry.geoJson)
+    expect(
+      await (
+        await MergeLocations.getColumnContent("mid", "Shape (GeoJSON)")
+      ).getText()
+    ).to.eq(EXAMPLE_LOCATIONS.right.geoJson)
   })
 
   it("Should be able to select all fields from left location", async () => {

--- a/client/tests/webdriver/baseSpecs/mergeLocations.spec.js
+++ b/client/tests/webdriver/baseSpecs/mergeLocations.spec.js
@@ -14,6 +14,7 @@ const EXAMPLE_LOCATIONS = {
   },
   left: {
     search: "Location Winner",
+    uuid: "64795e03-ba83-4bc3-b647-d37fcb1c0694",
     name: "Merge Location Winner",
     type: "Point location",
     fullName: "Merge Location Winner",
@@ -40,8 +41,9 @@ const EXAMPLE_LOCATIONS = {
   },
   right: {
     search: "Location Loser",
-    type: "Point location",
+    uuid: "4694bb3c-275a-4e74-9197-033e8e9c53ed",
     name: "Merge Location Loser",
+    type: "Point location",
     fullName: "Merge Location Loser",
     latLon: "-46.4035948, 51.69093",
     status: "ACTIVE",
@@ -162,6 +164,7 @@ describe("Merge locations page", () => {
     )
     await (await MergeLocations.getFirstItemFromAdvancedSelect()).click()
     await browser.pause(500) // wait for the rendering of custom fields
+    // Check if the fields displayed properly after selecting from left side.
     await MergeLocations.waitForColumnToChange(
       EXAMPLE_LOCATIONS.leftCountry.name,
       "left",
@@ -200,12 +203,16 @@ describe("Merge locations page", () => {
     )
     await (await MergeLocations.getFirstItemFromAdvancedSelect()).click()
     await browser.pause(500) // wait for the rendering of custom fields
+    // Check if the fields displayed properly after selecting from right side.
     await MergeLocations.waitForColumnToChange(
-      EXAMPLE_LOCATIONS.right.name,
+      EXAMPLE_LOCATIONS.right.uuid,
       "right",
-      "Name"
+      "UUID"
     )
 
+    expect(
+      await (await MergeLocations.getColumnContent("right", "UUID")).getText()
+    ).to.eq(EXAMPLE_LOCATIONS.right.uuid)
     expect(
       await (await MergeLocations.getColumnContent("right", "Name")).getText()
     ).to.eq(EXAMPLE_LOCATIONS.right.name)
@@ -223,17 +230,16 @@ describe("Merge locations page", () => {
   it("Should autoMerge some identical fields from both locations", async () => {
     expect(
       await (await MergeLocations.getColumnContent("mid", "Status")).getText()
-    ).to.eq(EXAMPLE_LOCATIONS.left.status)
+    ).to.eq(EXAMPLE_LOCATIONS.leftCountry.status)
     expect(
-      await (
-        await MergeLocations.getColumnContent("mid", "Status")
-      ).getText(MergeLocations)
+      await (await MergeLocations.getColumnContent("mid", "Status")).getText()
     ).to.eq(EXAMPLE_LOCATIONS.right.status)
   })
 
   it("Should be able to select all fields from left location", async () => {
     await (await MergeLocations.getUseAllButton("left")).click()
     await browser.pause(500) // wait for the rendering of custom fields
+    // Check if the fields displayed properly after selecting from left side.
     await MergeLocations.waitForColumnToChange(
       EXAMPLE_LOCATIONS.leftCountry.name,
       "mid",
@@ -300,12 +306,16 @@ describe("Merge locations page", () => {
   it("Should be able to select all fields from right location", async () => {
     await (await MergeLocations.getUseAllButton("right")).click()
     await browser.pause(500) // wait for the rendering of custom fields
+    // Check if the fields displayed properly after selecting from right side.
     await MergeLocations.waitForColumnToChange(
-      EXAMPLE_LOCATIONS.right.name,
+      EXAMPLE_LOCATIONS.right.uuid,
       "mid",
-      "Name"
+      "UUID"
     )
 
+    expect(
+      await (await MergeLocations.getColumnContent("mid", "UUID")).getText()
+    ).to.eq(EXAMPLE_LOCATIONS.right.uuid)
     expect(
       await (await MergeLocations.getColumnContent("mid", "Name")).getText()
     ).to.eq(EXAMPLE_LOCATIONS.right.name)
@@ -356,12 +366,16 @@ describe("Merge locations page", () => {
     )
     await (await MergeLocations.getFirstItemFromAdvancedSelect()).click()
     await browser.pause(500) // wait for the rendering of custom fields
+    // Check if the fields displayed properly after selecting from left side.
     await MergeLocations.waitForColumnToChange(
-      EXAMPLE_LOCATIONS.left.name,
+      EXAMPLE_LOCATIONS.left.uuid,
       "left",
-      "Name"
+      "UUID"
     )
 
+    expect(
+      await (await MergeLocations.getColumnContent("left", "UUID")).getText()
+    ).to.eq(EXAMPLE_LOCATIONS.left.uuid)
     expect(
       await (await MergeLocations.getColumnContent("left", "Name")).getText()
     ).to.eq(EXAMPLE_LOCATIONS.left.name)
@@ -393,6 +407,16 @@ describe("Merge locations page", () => {
   })
 
   it("Should be able to select from both left and right side", async () => {
+    await (await MergeLocations.getSelectButton("left", "UUID")).click()
+    await MergeLocations.waitForColumnToChange(
+      EXAMPLE_LOCATIONS.left.uuid,
+      "mid",
+      "UUID"
+    )
+    expect(
+      await (await MergeLocations.getColumnContent("mid", "UUID")).getText()
+    ).to.eq(EXAMPLE_LOCATIONS.left.uuid)
+
     await (await MergeLocations.getSelectButton("left", "Name")).click()
     await MergeLocations.waitForColumnToChange(
       EXAMPLE_LOCATIONS.left.name,

--- a/client/tests/webdriver/baseSpecs/mergeOrganizations.spec.js
+++ b/client/tests/webdriver/baseSpecs/mergeOrganizations.spec.js
@@ -15,6 +15,7 @@ const EXAMPLE_ORGANIZATIONS = {
   },
   validLeft: {
     search: "Merge Org 1",
+    uuid: "381d5435-8852-45d2-91b1-530560ca9d8c",
     shortName: "Merge Org 1",
     longName: "Long Merge 1 Name",
     status: "ACTIVE",
@@ -24,6 +25,7 @@ const EXAMPLE_ORGANIZATIONS = {
   },
   validRight: {
     search: "Merge Org 2",
+    uuid: "e706f443-7d4d-4356-82bc-1456f55e3d75",
     shortName: "Merge Org 2",
     longName: "Long Merge 2 Name",
     status: "ACTIVE",
@@ -145,12 +147,19 @@ describe("Merge organizations page", () => {
       EXAMPLE_ORGANIZATIONS.validLeft.displayedName
     )
     await (await MergeOrganizations.getFirstItemFromAdvancedSelect()).click()
-    await browser.pause(500)
+    await browser.pause(500) // wait for the rendering of custom fields
+    // Check if the fields displayed properly after selecting from left side.
     await MergeOrganizations.waitForColumnToChange(
-      EXAMPLE_ORGANIZATIONS.validLeft.shortName,
+      EXAMPLE_ORGANIZATIONS.validLeft.uuid,
       "left",
-      "Name"
+      "UUID"
     )
+
+    expect(
+      await (
+        await MergeOrganizations.getColumnContent("left", "UUID")
+      ).getText()
+    ).to.eq(EXAMPLE_ORGANIZATIONS.validLeft.uuid)
     expect(
       await (
         await MergeOrganizations.getColumnContent("left", "Name")
@@ -193,12 +202,19 @@ describe("Merge organizations page", () => {
       EXAMPLE_ORGANIZATIONS.validRight.displayedName
     )
     await (await MergeOrganizations.getFirstItemFromAdvancedSelect()).click()
-    await browser.pause(500)
+    await browser.pause(500) // wait for the rendering of custom fields
+    // Check if the fields displayed properly after selecting from right side.
     await MergeOrganizations.waitForColumnToChange(
-      EXAMPLE_ORGANIZATIONS.validRight.shortName,
+      EXAMPLE_ORGANIZATIONS.validRight.uuid,
       "right",
-      "Name"
+      "UUID"
     )
+
+    expect(
+      await (
+        await MergeOrganizations.getColumnContent("right", "UUID")
+      ).getText()
+    ).to.eq(EXAMPLE_ORGANIZATIONS.validRight.uuid)
     expect(
       await (
         await MergeOrganizations.getColumnContent("right", "Name")
@@ -246,13 +262,17 @@ describe("Merge organizations page", () => {
 
   it("Should be able to select all fields from left organization", async () => {
     await (await MergeOrganizations.getUseAllButton("left")).click()
-    await browser.pause(500)
-
+    await browser.pause(500) // wait for the rendering of custom fields
+    // Check if the fields displayed properly after selecting from left side.
     await MergeOrganizations.waitForColumnToChange(
-      EXAMPLE_ORGANIZATIONS.validLeft.shortName,
+      EXAMPLE_ORGANIZATIONS.validLeft.uuid,
       "mid",
-      "Name"
+      "UUID"
     )
+
+    expect(
+      await (await MergeOrganizations.getColumnContent("mid", "UUID")).getText()
+    ).to.eq(EXAMPLE_ORGANIZATIONS.validLeft.uuid)
     expect(
       await (await MergeOrganizations.getColumnContent("mid", "Name")).getText()
     ).to.eq(EXAMPLE_ORGANIZATIONS.validLeft.shortName)
@@ -266,13 +286,17 @@ describe("Merge organizations page", () => {
 
   it("Should be able to select all fields from right organization", async () => {
     await (await MergeOrganizations.getUseAllButton("right")).click()
-    await browser.pause(500)
-
+    await browser.pause(500) // wait for the rendering of custom fields
+    // Check if the fields displayed properly after selecting from right side.
     await MergeOrganizations.waitForColumnToChange(
-      EXAMPLE_ORGANIZATIONS.validRight.shortName,
+      EXAMPLE_ORGANIZATIONS.validRight.uuid,
       "mid",
-      "Name"
+      "UUID"
     )
+
+    expect(
+      await (await MergeOrganizations.getColumnContent("mid", "UUID")).getText()
+    ).to.eq(EXAMPLE_ORGANIZATIONS.validRight.uuid)
     expect(
       await (await MergeOrganizations.getColumnContent("mid", "Name")).getText()
     ).to.eq(EXAMPLE_ORGANIZATIONS.validRight.shortName)
@@ -285,6 +309,7 @@ describe("Merge organizations page", () => {
   })
 
   it("Should be able to select from both left and right side", async () => {
+    // Perform a fresh search to clear the merge state
     await (await MergeOrganizations.getLeftOrganizationField()).click()
     await (
       await MergeOrganizations.getLeftOrganizationField()
@@ -294,6 +319,16 @@ describe("Merge organizations page", () => {
     )
     await (await MergeOrganizations.getFirstItemFromAdvancedSelect()).click()
     await browser.pause(500)
+
+    await (await MergeOrganizations.getSelectButton("left", "UUID")).click()
+    await MergeOrganizations.waitForColumnToChange(
+      EXAMPLE_ORGANIZATIONS.validLeft.uuid,
+      "mid",
+      "UUID"
+    )
+    expect(
+      await (await MergeOrganizations.getColumnContent("mid", "UUID")).getText()
+    ).to.eq(EXAMPLE_ORGANIZATIONS.validLeft.uuid)
 
     await (await MergeOrganizations.getSelectButton("left", "Name")).click()
     await MergeOrganizations.waitForColumnToChange(

--- a/client/tests/webdriver/baseSpecs/mergePeople.spec.js
+++ b/client/tests/webdriver/baseSpecs/mergePeople.spec.js
@@ -8,6 +8,7 @@ const hasCustomFields = !!Settings?.fields?.person?.customFields
 const EXAMPLE_PEOPLE = {
   validLeft: {
     search: "winner",
+    uuid: "3cb2076c-5317-47fe-86ad-76f298993917",
     fullName: "CIV Duplicate Winner Merged",
     familyName: "Merged",
     givenName: "Duplicate Winner",
@@ -54,6 +55,7 @@ const EXAMPLE_PEOPLE = {
   },
   validRight: {
     search: "loser",
+    uuid: "c725aef3-cdd1-4baf-ac72-f28219b234e9",
     fullName: "CTR Duplicate Loser Merged",
     familyName: "Merged",
     givenName: "Duplicate Loser",
@@ -100,6 +102,7 @@ const EXAMPLE_PEOPLE = {
   },
   userRight: {
     search: "andrew",
+    uuid: "1a557db0-5af5-4ea3-b926-28b5f2e88bf7",
     fullName: "CIV Andrew Anderson",
     familyName: "Anderson",
     givenName: "Andrew",
@@ -194,13 +197,16 @@ describe("Merge people who are both non-users", () => {
     )
     await (await MergePeople.getFirstItemFromAdvancedSelect()).click()
     await browser.pause(500) // wait for the rendering of custom fields
-    // Check if the fields displayed properly after selecting a person from left side.
+    // Check if the fields displayed properly after selecting from left side.
     await MergePeople.waitForColumnToChange(
-      EXAMPLE_PEOPLE.validLeft.familyName,
+      EXAMPLE_PEOPLE.validLeft.uuid,
       "left",
-      "Family name"
+      "UUID"
     )
 
+    expect(
+      await (await MergePeople.getColumnContent("left", "UUID")).getText()
+    ).to.eq(EXAMPLE_PEOPLE.validLeft.uuid)
     expect(
       await (
         await MergePeople.getColumnContent("left", "Family name")
@@ -272,13 +278,16 @@ describe("Merge people who are both non-users", () => {
     )
     await (await MergePeople.getFirstItemFromAdvancedSelect()).click()
     await browser.pause(500) // wait for the rendering of custom fields
-    // Check if the fields displayed properly after selecting a person from left side.
+    // Check if the fields displayed properly after selecting from right side.
     await MergePeople.waitForColumnToChange(
-      EXAMPLE_PEOPLE.validRight.familyName,
+      EXAMPLE_PEOPLE.validRight.uuid,
       "right",
-      "Family name"
+      "UUID"
     )
 
+    expect(
+      await (await MergePeople.getColumnContent("right", "UUID")).getText()
+    ).to.eq(EXAMPLE_PEOPLE.validRight.uuid)
     expect(
       await (
         await MergePeople.getColumnContent("right", "Family name")
@@ -391,12 +400,16 @@ describe("Merge people who are both non-users", () => {
   it("Should be able to select all fields from left person", async () => {
     await (await MergePeople.getUseAllButton("left")).click()
     await browser.pause(500) // wait for the rendering of custom fields
+    // Check if the fields displayed properly after selecting from left side.
     await MergePeople.waitForColumnToChange(
-      EXAMPLE_PEOPLE.validLeft.familyName,
+      EXAMPLE_PEOPLE.validLeft.uuid,
       "mid",
-      "Family name"
+      "UUID"
     )
 
+    expect(
+      await (await MergePeople.getColumnContent("mid", "UUID")).getText()
+    ).to.eq(EXAMPLE_PEOPLE.validLeft.uuid)
     expect(
       await (await MergePeople.getColumnContent("mid", "Family name")).getText()
     ).to.eq(EXAMPLE_PEOPLE.validLeft.familyName)
@@ -454,12 +467,16 @@ describe("Merge people who are both non-users", () => {
   it("Should be able to select all fields from right person", async () => {
     await (await MergePeople.getUseAllButton("right")).click()
     await browser.pause(500) // wait for the rendering of custom fields
+    // Check if the fields displayed properly after selecting from right side.
     await MergePeople.waitForColumnToChange(
-      EXAMPLE_PEOPLE.validRight.familyName,
+      EXAMPLE_PEOPLE.validRight.uuid,
       "mid",
-      "Family name"
+      "UUID"
     )
 
+    expect(
+      await (await MergePeople.getColumnContent("mid", "UUID")).getText()
+    ).to.eq(EXAMPLE_PEOPLE.validRight.uuid)
     expect(
       await (await MergePeople.getColumnContent("mid", "Family name")).getText()
     ).to.eq(EXAMPLE_PEOPLE.validRight.familyName)
@@ -515,6 +532,16 @@ describe("Merge people who are both non-users", () => {
   })
 
   it("Should be able to select from both left and right side", async () => {
+    await (await MergePeople.getSelectButton("left", "UUID")).click()
+    await MergePeople.waitForColumnToChange(
+      EXAMPLE_PEOPLE.validLeft.uuid,
+      "mid",
+      "UUID"
+    )
+    expect(
+      await (await MergePeople.getColumnContent("mid", "UUID")).getText()
+    ).to.eq(EXAMPLE_PEOPLE.validLeft.uuid)
+
     await (await MergePeople.getSelectButton("left", "Family name")).click()
     await MergePeople.waitForColumnToChange(
       EXAMPLE_PEOPLE.validLeft.familyName,

--- a/client/tests/webdriver/baseSpecs/mergePositions.spec.js
+++ b/client/tests/webdriver/baseSpecs/mergePositions.spec.js
@@ -5,6 +5,7 @@ import MergePositions from "../pages/mergePositions.page"
 const EXAMPLE_POSITIONS = {
   validLeft: {
     search: "merge one",
+    uuid: "25fe500c-3503-4ba8-a9a4-09b29b50c1f1",
     name: "Merge One",
     fullName: "Merge One, MOD-M1-HQ-00001",
     organization: "MoD | Ministry of Defense",
@@ -28,6 +29,7 @@ const EXAMPLE_POSITIONS = {
   },
   validRight: {
     search: "merge two",
+    uuid: "e87f0f60-ad13-4c1c-96f7-672c595b81c7",
     name: "Merge Two",
     fullName: "Merge Two, MOD-M2-HQ-00001",
     organization: "MoD | Ministry of Defense",
@@ -110,10 +112,14 @@ describe("Merge positions page", () => {
     await browser.pause(500) // wait for the rendering of custom fields
     // Check if the fields displayed properly after selecting a position from left side.
     await MergePositions.waitForColumnToChange(
-      EXAMPLE_POSITIONS.validLeft.name,
+      EXAMPLE_POSITIONS.validLeft.uuid,
       "left",
-      "Position Name"
+      "UUID"
     )
+
+    expect(
+      await (await MergePositions.getColumnContent("left", "UUID")).getText()
+    ).to.eq(EXAMPLE_POSITIONS.validLeft.uuid)
     expect(
       await (
         await MergePositions.getColumnContent("left", "Position Name")
@@ -190,10 +196,14 @@ describe("Merge positions page", () => {
     await browser.pause(500) // wait for the rendering of custom fields
     // Check if the fields displayed properly after selecting a position from left side.
     await MergePositions.waitForColumnToChange(
-      EXAMPLE_POSITIONS.validRight.name,
+      EXAMPLE_POSITIONS.validRight.uuid,
       "right",
-      "Position Name"
+      "UUID"
     )
+
+    expect(
+      await (await MergePositions.getColumnContent("right", "UUID")).getText()
+    ).to.eq(EXAMPLE_POSITIONS.validRight.uuid)
     expect(
       await (
         await MergePositions.getColumnContent("right", "Position Name")
@@ -250,12 +260,16 @@ describe("Merge positions page", () => {
   it("Should be able to select all fields from left position", async () => {
     await (await MergePositions.getUseAllButton("left")).click()
     await browser.pause(500) // wait for the rendering of custom fields
-
+    // Check if the fields displayed properly after selecting a position from left side.
     await MergePositions.waitForColumnToChange(
-      EXAMPLE_POSITIONS.validLeft.name,
+      EXAMPLE_POSITIONS.validLeft.uuid,
       "mid",
-      "Position Name"
+      "UUID"
     )
+
+    expect(
+      await (await MergePositions.getColumnContent("mid", "UUID")).getText()
+    ).to.eq(EXAMPLE_POSITIONS.validLeft.uuid)
     expect(
       await (
         await MergePositions.getColumnContent("mid", "Position Name")
@@ -299,12 +313,16 @@ describe("Merge positions page", () => {
   it("Should be able to select all fields from right position", async () => {
     await (await MergePositions.getUseAllButton("right")).click()
     await browser.pause(500) // wait for the rendering of custom fields
-
+    // Check if the fields displayed properly after selecting a position from left side.
     await MergePositions.waitForColumnToChange(
-      EXAMPLE_POSITIONS.validRight.name,
+      EXAMPLE_POSITIONS.validRight.uuid,
       "mid",
-      "Position Name"
+      "UUID"
     )
+
+    expect(
+      await (await MergePositions.getColumnContent("mid", "UUID")).getText()
+    ).to.eq(EXAMPLE_POSITIONS.validRight.uuid)
     expect(
       await (
         await MergePositions.getColumnContent("mid", "Position Name")
@@ -346,6 +364,16 @@ describe("Merge positions page", () => {
   })
 
   it("Should be able to select from both left and right side", async () => {
+    await (await MergePositions.getSelectButton("left", "UUID")).click()
+    await MergePositions.waitForColumnToChange(
+      EXAMPLE_POSITIONS.validLeft.uuid,
+      "mid",
+      "UUID"
+    )
+    expect(
+      await (await MergePositions.getColumnContent("mid", "UUID")).getText()
+    ).to.eq(EXAMPLE_POSITIONS.validLeft.uuid)
+
     await (
       await MergePositions.getSelectButton("left", "Position Name")
     ).click()

--- a/client/tests/webdriver/baseSpecs/mergeTasks.spec.js
+++ b/client/tests/webdriver/baseSpecs/mergeTasks.spec.js
@@ -14,6 +14,7 @@ const EXAMPLE_TASKS = {
   },
   validLeft: {
     search: "Merge Task 1",
+    uuid: "cb18b0c1-17d6-417e-951f-9db8b2f39b25",
     shortName: "Merge Task 1",
     longName: "Long Merge 1 Name",
     status: "ACTIVE",
@@ -22,6 +23,7 @@ const EXAMPLE_TASKS = {
   },
   validRight: {
     search: "Merge Task 2",
+    uuid: "867ff6b6-07f7-4448-b2a3-a1bdc9b423be",
     shortName: "Merge Task 2",
     longName: "Long Merge 2 Name",
     status: "ACTIVE",
@@ -133,12 +135,17 @@ describe("Merge tasks page", () => {
       EXAMPLE_TASKS.validLeft.displayedName
     )
     await (await MergeTasks.getItemFromAdvancedSelect()).click()
-    await browser.pause(500)
+    await browser.pause(500) // wait for the rendering of custom fields
+    // Check if the fields displayed properly after selecting from left side.
     await MergeTasks.waitForColumnToChange(
-      EXAMPLE_TASKS.validLeft.shortName,
+      EXAMPLE_TASKS.validLeft.uuid,
       "left",
-      "Short name"
+      "UUID"
     )
+
+    expect(
+      await (await MergeTasks.getColumnContent("left", "UUID")).getText()
+    ).to.eq(EXAMPLE_TASKS.validLeft.uuid)
     expect(
       await (await MergeTasks.getColumnContent("left", "Short name")).getText()
     ).to.eq(EXAMPLE_TASKS.validLeft.shortName)
@@ -173,12 +180,17 @@ describe("Merge tasks page", () => {
       EXAMPLE_TASKS.validRight.displayedName
     )
     await (await MergeTasks.getItemFromAdvancedSelect()).click()
-    await browser.pause(500)
+    await browser.pause(500) // wait for the rendering of custom fields
+    // Check if the fields displayed properly after selecting from right side.
     await MergeTasks.waitForColumnToChange(
-      EXAMPLE_TASKS.validRight.shortName,
+      EXAMPLE_TASKS.validRight.uuid,
       "right",
-      "Short name"
+      "UUID"
     )
+
+    expect(
+      await (await MergeTasks.getColumnContent("right", "UUID")).getText()
+    ).to.eq(EXAMPLE_TASKS.validRight.uuid)
     expect(
       await (await MergeTasks.getColumnContent("right", "Short name")).getText()
     ).to.eq(EXAMPLE_TASKS.validRight.shortName)
@@ -211,13 +223,17 @@ describe("Merge tasks page", () => {
 
   it("Should be able to select all fields from left task", async () => {
     await (await MergeTasks.getUseAllButton("left")).click()
-    await browser.pause(500)
-
+    await browser.pause(500) // wait for the rendering of custom fields
+    // Check if the fields displayed properly after selecting from left side.
     await MergeTasks.waitForColumnToChange(
-      EXAMPLE_TASKS.validLeft.shortName,
+      EXAMPLE_TASKS.validLeft.uuid,
       "mid",
-      "Short name"
+      "UUID"
     )
+
+    expect(
+      await (await MergeTasks.getColumnContent("mid", "UUID")).getText()
+    ).to.eq(EXAMPLE_TASKS.validLeft.uuid)
     expect(
       await (await MergeTasks.getColumnContent("mid", "Short name")).getText()
     ).to.eq(EXAMPLE_TASKS.validLeft.shortName)
@@ -225,19 +241,24 @@ describe("Merge tasks page", () => {
 
   it("Should be able to select all fields from right task", async () => {
     await (await MergeTasks.getUseAllButton("right")).click()
-    await browser.pause(500)
-
+    await browser.pause(500) // wait for the rendering of custom fields
+    // Check if the fields displayed properly after selecting from right side.
     await MergeTasks.waitForColumnToChange(
-      EXAMPLE_TASKS.validRight.shortName,
+      EXAMPLE_TASKS.validRight.uuid,
       "mid",
-      "Short name"
+      "UUID"
     )
+
+    expect(
+      await (await MergeTasks.getColumnContent("mid", "UUID")).getText()
+    ).to.eq(EXAMPLE_TASKS.validRight.uuid)
     expect(
       await (await MergeTasks.getColumnContent("mid", "Short name")).getText()
     ).to.eq(EXAMPLE_TASKS.validRight.shortName)
   })
 
   it("Should be able to select from both left and right side", async () => {
+    // Perform a fresh search to clear the merge state
     await (await MergeTasks.getLeftTaskField()).click()
     await (
       await MergeTasks.getLeftTaskField()
@@ -247,6 +268,16 @@ describe("Merge tasks page", () => {
     )
     await (await MergeTasks.getItemFromAdvancedSelect()).click()
     await browser.pause(500)
+
+    await (await MergeTasks.getSelectButton("left", "UUID")).click()
+    await MergeTasks.waitForColumnToChange(
+      EXAMPLE_TASKS.validLeft.uuid,
+      "mid",
+      "UUID"
+    )
+    expect(
+      await (await MergeTasks.getColumnContent("mid", "UUID")).getText()
+    ).to.eq(EXAMPLE_TASKS.validLeft.uuid)
 
     await (await MergeTasks.getSelectButton("left", "Short name")).click()
     await MergeTasks.waitForColumnToChange(


### PR DESCRIPTION
It was unclear to admins how the uuid of the merged object is determined from the two selected objects. Make this clear in the UI by allowing admins to pick which uuid will be used by the merged object, using a background colour for the chosen uuid field.

Closes [AB#1658](https://dev.azure.com/ncia-anet/2aa083a5-af3d-44e1-8c7b-6e9e6b124d91/_workitems/edit/1658)

#### User changes
- None

#### Superuser changes
- None

#### Admin changes
- There's a new MergeField which determines the uuid of the merged object, with a subtle background colour indicating which uuid will be used by the merged object.

#### System admin changes
- [ ] application.yml or anet-dictionary.yml needs change
- [ ] db needs migration
- [ ] documentation has changed
- [ ] graphql schema has changed

### Checklist
- [x] described the user behavior in PR body
- [x] referenced/updated all related issues
- [x] commits follow a `repo#issue: Title` title format and [these 7 rules](https://chris.beams.io/posts/git-commit/)
- [x] commits have a [clean history](https://epage.github.io/dev/commits/), otherwise PR may be squash-merged
- [ ] added and/or updated unit tests
- [x] added and/or updated e2e tests
- [ ] added and/or updated data migrations
- [ ] updated documentation
- [x] resolved all build errors and warnings
- [ ] opened debt issues for anything not resolved here